### PR TITLE
Rename "context" package

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 )
 
@@ -18,7 +18,7 @@ func NewCompletionCmd() *cobra.Command {
 		ValidArgs: []string{"bash", "zsh"},
 		Run: func(cmd *cobra.Command, args []string) {
 			args = modules.GetDefaultCmdArgs(cmd.Name())
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalCompletionCmd, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalCompletionCmd, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -46,7 +46,7 @@ func RootShellCompletionCommands(cmd *cobra.Command, args []string, toComplete s
 }
 
 // internalCompletionCmd is a default (internal) completion module function.
-func internalCompletionCmd(ctx *context.Ctx, args []string) error {
+func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	switch shell := args[0]; shell {
 	case "bash":
 		if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/util"
 )
@@ -19,7 +19,7 @@ type DefaultHelpFunc func(*cobra.Command, []string)
 // so that it can be external as well.
 // If the help is called for an external module
 // (for example `tt help version`), we try to get the help from it.
-func configureHelpCommand(ctx *context.Ctx, rootCmd *cobra.Command) error {
+func configureHelpCommand(cmdCtx *cmdcontext.CmdCtx, rootCmd *cobra.Command) error {
 	// Add information about external modules into help template.
 	rootCmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, getExternalCommandsString(&modulesInfo)))
 	defaultHelp := rootCmd.HelpFunc()
@@ -31,7 +31,7 @@ func configureHelpCommand(ctx *context.Ctx, rootCmd *cobra.Command) error {
 		}
 
 		args = modules.GetDefaultCmdArgs("help")
-		err := modules.RunCmd(ctx, "help", &modulesInfo, getInternalHelpFunc(cmd, defaultHelp), args)
+		err := modules.RunCmd(cmdCtx, "help", &modulesInfo, getInternalHelpFunc(cmd, defaultHelp), args)
 		if err != nil {
 			log.Fatalf(err.Error())
 		}
@@ -50,7 +50,7 @@ func configureHelpCommand(ctx *context.Ctx, rootCmd *cobra.Command) error {
 
 // getInternalHelpFunc returns a internal implementation of help module.
 func getInternalHelpFunc(cmd *cobra.Command, help DefaultHelpFunc) modules.InternalFunc {
-	return func(ctx *context.Ctx, args []string) error {
+	return func(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		switch module := modulesInfo[cmd.Name()]; {
 		// Cases when we have to run the "default" help:
 		// - `tt help` and no external help module.

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 )
 
@@ -13,7 +13,7 @@ func NewRestartCmd() *cobra.Command {
 		Use:   "restart [INSTANCE_NAME]",
 		Short: "restart tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalRestartModule, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalRestartModule, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -24,12 +24,12 @@ func NewRestartCmd() *cobra.Command {
 }
 
 // internalRestartModule is a default restart module.
-func internalRestartModule(ctx *context.Ctx, args []string) error {
-	if err := internalStopModule(ctx, args); err != nil {
+func internalRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if err := internalStopModule(cmdCtx, args); err != nil {
 		return err
 	}
 
-	if err := internalStartModule(ctx, args); err != nil {
+	if err := internalStartModule(cmdCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -24,7 +24,7 @@ func NewStartCmd() *cobra.Command {
 		Use:   "start [APPLICATION_NAME]",
 		Short: "Start tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalStartModule, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalStartModule, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -38,13 +38,13 @@ func NewStartCmd() *cobra.Command {
 }
 
 // internalStartModule is a default start module.
-func internalStartModule(ctx *context.Ctx, args []string) error {
-	cliOpts, err := modules.GetCliOpts(ctx.Cli.ConfigPath)
+func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	cliOpts, err := modules.GetCliOpts(cmdCtx.Cli.ConfigPath)
 	if err != nil {
 		return err
 	}
 
-	if err = running.FillCtx(cliOpts, ctx, args); err != nil {
+	if err = running.FillCtx(cliOpts, cmdCtx, args); err != nil {
 		return err
 	}
 
@@ -66,7 +66,7 @@ func internalStartModule(ctx *context.Ctx, args []string) error {
 	}
 
 	log.Info("Starting an instance...")
-	if err = running.Start(ctx); err != nil {
+	if err = running.Start(cmdCtx); err != nil {
 		return err
 	}
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -14,7 +14,7 @@ func NewStatusCmd() *cobra.Command {
 		Use:   "status [INSTANCE_NAME]",
 		Short: "Status of the tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalStatusModule, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalStatusModule, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -25,17 +25,17 @@ func NewStatusCmd() *cobra.Command {
 }
 
 // internalStatusModule is a default status module.
-func internalStatusModule(ctx *context.Ctx, args []string) error {
-	cliOpts, err := modules.GetCliOpts(ctx.Cli.ConfigPath)
+func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	cliOpts, err := modules.GetCliOpts(cmdCtx.Cli.ConfigPath)
 	if err != nil {
 		return err
 	}
 
-	if err = running.FillCtx(cliOpts, ctx, args); err != nil {
+	if err = running.FillCtx(cliOpts, cmdCtx, args); err != nil {
 		return err
 	}
 
-	log.Info(running.Status(ctx))
+	log.Info(running.Status(cmdCtx))
 
 	return nil
 }

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -14,7 +14,7 @@ func NewStopCmd() *cobra.Command {
 		Use:   "stop [INSTANCE_NAME]",
 		Short: "Stop tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalStopModule, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalStopModule, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -25,17 +25,17 @@ func NewStopCmd() *cobra.Command {
 }
 
 // internalStopModule is a default stop module.
-func internalStopModule(ctx *context.Ctx, args []string) error {
-	cliOpts, err := modules.GetCliOpts(ctx.Cli.ConfigPath)
+func internalStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	cliOpts, err := modules.GetCliOpts(cmdCtx.Cli.ConfigPath)
 	if err != nil {
 		return err
 	}
 
-	if err = running.FillCtx(cliOpts, ctx, args); err != nil {
+	if err = running.FillCtx(cliOpts, cmdCtx, args); err != nil {
 		return err
 	}
 
-	if err = running.Stop(ctx); err != nil {
+	if err = running.Stop(cmdCtx); err != nil {
 		return err
 	}
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/version"
 )
@@ -22,7 +22,7 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Show Tarantool CLI version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			args = modules.GetDefaultCmdArgs(cmd.Name())
-			err := modules.RunCmd(&ctx, cmd.Name(), &modulesInfo, internalVersionModule, args)
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalVersionModule, args)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -36,7 +36,7 @@ func NewVersionCmd() *cobra.Command {
 }
 
 // internalVersionModule is a default (internal) version module function.
-func internalVersionModule(ctx *context.Ctx, args []string) error {
+func internalVersionModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	fmt.Println(version.GetVersion(showShort, needCommit))
 	return nil
 }

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -1,8 +1,8 @@
-package context
+package cmdcontext
 
-// Ctx is the main structure of the program context.
+// CmdCtx is the main structure of the program context.
 // Contains within itself other structures of CLI modules.
-type Ctx struct {
+type CmdCtx struct {
 	Cli     CliCtx
 	Running RunningCtx
 }

--- a/cli/modules/modules.go
+++ b/cli/modules/modules.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 )
 
 const (
@@ -28,8 +28,8 @@ type ModuleInfo struct {
 type ModulesInfo map[string]*ModuleInfo
 
 // GetModulesInfo collects information about available modules (both external and internal).
-func GetModulesInfo(ctx *context.Ctx, subCommands []*cobra.Command, cliOpts *CliOpts) (ModulesInfo, error) {
-	modulesDir, err := getExternalModulesDir(ctx, cliOpts)
+func GetModulesInfo(cmdCtx *cmdcontext.CmdCtx, subCommands []*cobra.Command, cliOpts *CliOpts) (ModulesInfo, error) {
+	modulesDir, err := getExternalModulesDir(cmdCtx, cliOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -61,11 +61,11 @@ func GetModulesInfo(ctx *context.Ctx, subCommands []*cobra.Command, cliOpts *Cli
 }
 
 // getExternalModulesDir returns the directory where external modules are located.
-func getExternalModulesDir(ctx *context.Ctx, cliOpts *CliOpts) (string, error) {
+func getExternalModulesDir(cmdCtx *cmdcontext.CmdCtx, cliOpts *CliOpts) (string, error) {
 	// Configuraion file not detected - ignore and work on.
 	// TODO: Add warning in next patches, discussion
 	// what if the file exists, but access is denied, etc.
-	if _, err := os.Stat(ctx.Cli.ConfigPath); err != nil {
+	if _, err := os.Stat(cmdCtx.Cli.ConfigPath); err != nil {
 		if !os.IsNotExist(err) {
 			return "", fmt.Errorf("Failed to get access to configuration file: %s", err)
 		}

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -6,13 +6,13 @@ import (
 	"os/exec"
 
 	"github.com/apex/log"
-	"github.com/tarantool/tt/cli/context"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/util"
 )
 
 // InternalFunc is a type of function that implements
 // the external behavior of the module.
-type InternalFunc func(*context.Ctx, []string) error
+type InternalFunc func(*cmdcontext.CmdCtx, []string) error
 
 // RunCmd launches the required module.
 // It collects a list of available modules, and based on
@@ -25,14 +25,14 @@ type InternalFunc func(*context.Ctx, []string) error
 //
 // If the external module returns an error code,
 // then tt exit with this code.
-func RunCmd(ctx *context.Ctx, cmdName string, modulesInfo *ModulesInfo, internal InternalFunc, args []string) error {
+func RunCmd(cmdCtx *cmdcontext.CmdCtx, cmdName string, modulesInfo *ModulesInfo, internal InternalFunc, args []string) error {
 	info, found := (*modulesInfo)[cmdName]
 	if !found {
 		return fmt.Errorf("Module with specified name %s isn't found", cmdName)
 	}
 
-	if info.IsInternal || ctx.Cli.ForceInternal {
-		return internal(ctx, args)
+	if info.IsInternal || cmdCtx.Cli.ForceInternal {
+		return internal(cmdCtx, args)
 	}
 
 	if rc := RunExec(info.ExternalPath, args); rc != 0 {


### PR DESCRIPTION
Since "context" is one of the standard packages (https://go.dev/blog/context) I think it was a bad idea to use such name for our internal package, considering that we also plan to use the standard package "context" (this is not just my opinion https://github.com/cli/cli/blob/3e0db567e89fdc6fde158cfabee650187a34127d/context/context.go#L1).
Let's rename it to "cmdcontext".