### PR TITLE
Implement box.cfg() wrapper

### DIFF
--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -34,6 +34,9 @@ type RunningCtx struct {
 	LogDir string
 	// Log is the name of log file.
 	Log string
+	// DataDir is the directory where all the instance artifacts
+	// are stored.
+	DataDir string
 	// LogMaxSize is the maximum size in megabytes of the log file
 	// before it gets rotated. It defaults to 100 megabytes.
 	LogMaxSize int

--- a/cli/modules/config.go
+++ b/cli/modules/config.go
@@ -38,6 +38,7 @@ type appOpts struct {
 	InstancesAvailable string `mapstructure:"instances_available"`
 	RunDir             string `mapstructure:"run_dir"`
 	LogDir             string `mapstructure:"log_dir"`
+	DataDir            string `mapstructure:"data_dir"`
 	LogMaxSize         int    `mapstructure:"log_maxsize"`
 	LogMaxAge          int    `mapstructure:"log_maxage"`
 	LogMaxBackups      int    `mapstructure:"log_maxbackups"`
@@ -58,6 +59,7 @@ func getDefaultCliOpts() *CliOpts {
 		InstancesAvailable: "",
 		RunDir:             "",
 		LogDir:             "",
+		DataDir:            "",
 		LogMaxSize:         0,
 		LogMaxAge:          0,
 		LogMaxBackups:      0,

--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -22,6 +22,9 @@ type Instance struct {
 	tarantoolPath string
 	// appPath describes the path to the "init" file of an application.
 	appPath string
+	// dataDir describes the path to the directory
+	// where wal, vinyl and memtx files are stored.
+	dataDir string
 	// env describes the environment settled by a client.
 	env []string
 	// consoleSocket is a Unix domain socket to be used as "admin port".
@@ -36,7 +39,7 @@ type Instance struct {
 
 // NewInstance creates an Instance.
 func NewInstance(tarantoolPath string, appPath string, console_sock string,
-	env []string, logger *ttlog.Logger) (*Instance, error) {
+	env []string, logger *ttlog.Logger, dataDir string) (*Instance, error) {
 	// Check if tarantool binary exists.
 	if _, err := exec.LookPath(tarantoolPath); err != nil {
 		return nil, err
@@ -48,7 +51,8 @@ func NewInstance(tarantoolPath string, appPath string, console_sock string,
 	}
 
 	inst := Instance{tarantoolPath: tarantoolPath, appPath: appPath,
-		consoleSocket: console_sock, env: env, logger: logger}
+		consoleSocket: console_sock, env: env, logger: logger,
+		dataDir: dataDir}
 	return &inst, nil
 }
 
@@ -99,6 +103,10 @@ func (inst *Instance) Start() error {
 	inst.Cmd.Env = append(inst.Cmd.Env, "TARANTOOLCTL=true")
 	// Set the sign that the program is running under "tt".
 	inst.Cmd.Env = append(inst.Cmd.Env, "TT_CLI=true")
+	// Set the wal, memtx and vinyls dirs.
+	inst.Cmd.Env = append(inst.Cmd.Env, "TT_VINYL_DIR="+inst.dataDir)
+	inst.Cmd.Env = append(inst.Cmd.Env, "TT_WAL_DIR="+inst.dataDir)
+	inst.Cmd.Env = append(inst.Cmd.Env, "TT_MEMTX_DIR="+inst.dataDir)
 
 	// Start an Instance.
 	if err := inst.Cmd.Start(); err != nil {

--- a/cli/running/instance_test.go
+++ b/cli/running/instance_test.go
@@ -93,7 +93,7 @@ func TestInstanceLogger(t *testing.T) {
 	msgLen := int64(len(msg))
 	buf := bytes.NewBufferString("")
 	_, err := io.CopyN(buf, reader, msgLen)
-	assert.Equal(buf.String(), msg, "The message in the log is different from what was expected.")
+	assert.Equal(msg, buf.String(), "The message in the log is different from what was expected.")
 	assert.Nilf(err, `Can't read log output. Error: "%v".`, err)
 
 	err = inst.Stop(30 * time.Second)


### PR DESCRIPTION
If tarantool version is above 2.8.1 we use env variables to set wal, vinyl and memtx dirs, else we use cfg.wrapper to do it.

It allows to set memtx_dir vinyl_dir and wal_dir. if they are blank it creates datadirs in the app_path (instance_name_datadir).

Resolve #30