### PR TITLE
ps ax|grep tarantool showes lua code

### DIFF
--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -1,18 +1,6 @@
 --- This is a launch script that does the necessary preparation
 -- before launching an instance.
 
--- The script is delivered inside the "tt" binary and is launched
--- to execution via the `-e` flag when starting the application instance.
--- AFAIU, due to such method of launching, we can reach the limit of the
--- command line length ("ARG_MAX") and in this case we will have to create
--- a file with the appropriate code. But, in the real world this limit is
--- quite high (I looked at it on several machines - it equals 2097152)
--- and we can not create a workaround for this situation yet.
---
--- Several useful links:
--- https://porkmail.org/era/unix/arg-max.html
--- https://unix.stackexchange.com/a/120842
-
 local os = require('os')
 local console = require('console')
 local log = require('log')


### PR DESCRIPTION
Previously instance launch code was passed to tarantool
using "-e" flag, so it showed code in ps.
To solve it i passed code through stdin pipe using
"-" flag.