### PR TITLE
Add `-f` flag for evaluation

### DIFF
--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -66,4 +66,6 @@ type ConnectCtx struct {
 	Username string
 	// Password of the tarantool.user.
 	Password string
+	// SrcFile describes the source of code for the evaluation.
+	SrcFile string
 }


### PR DESCRIPTION
This patch changes the behavior of `connect` so that the source for the code evaluation is now passed by using the `-f` flag.

Part of #58