### PR TITLE
watchdog: add re-reading of cfg before restart

### DIFF
--- a/cli/ttlog/logger.go
+++ b/cli/ttlog/logger.go
@@ -63,3 +63,12 @@ func (logger *Logger) Rotate() error {
 
 	return logger.ljLogger.Rotate()
 }
+
+// Close implements io.Closer, and closes the current logfile.
+func (logger *Logger) Close() error {
+	if logger.ljLogger == nil {
+		return nil
+	}
+
+	return logger.ljLogger.Close()
+}


### PR DESCRIPTION
Refactored watchdog, so now watchdog creates instance, and
re-reads cfg each time instance is stopped.

Closes #31