### PR TITLE
crud: add csv parser customization for crud import

### DIFF
--- a/cli/cmd/crud.go
+++ b/cli/cmd/crud.go
@@ -37,6 +37,7 @@ var crudImportFlags = crud.ImportOpts{
 	Operation:       "insert",
 	OnError:         "stop",
 	NullVal:         "",
+	Delimiter:       ",",
 }
 
 // NewImportCmd creates a new import subcommand for crud command.
@@ -97,6 +98,11 @@ func NewImportCmd() *cobra.Command {
 		crudImportFlags.NullVal, "sets value to be interpreted as NULL when importing. "+
 			"By default, an empty value. Example for csv: field1val,,field3val, "+
 			"where field2val will be taken as NULL")
+	importCmd.Flags().StringVarP(&crudImportFlags.Delimiter, "delimiter", "",
+		crudImportFlags.Delimiter, "sets the symbol that will be defined as field delimiter. "+
+			"For csv by default is comma like RFC 4180. Cannot be <\\r>, <\\n>, "+
+			"or the unicode replacement character (0xFFFD). To use a tab character as delimiter, "+
+			"set this value as <tab>")
 
 	return importCmd
 }

--- a/cli/cmd/crud.go
+++ b/cli/cmd/crud.go
@@ -38,6 +38,7 @@ var crudImportFlags = crud.ImportOpts{
 	OnError:         "stop",
 	NullVal:         "",
 	Delimiter:       ",",
+	Quote:           `"`,
 }
 
 // NewImportCmd creates a new import subcommand for crud command.
@@ -103,6 +104,10 @@ func NewImportCmd() *cobra.Command {
 			"For csv by default is comma like RFC 4180. Cannot be <\\r>, <\\n>, "+
 			"or the unicode replacement character (0xFFFD). To use a tab character as delimiter, "+
 			"set this value as <tab>")
+	importCmd.Flags().StringVarP(&crudImportFlags.Quote, "quote", "",
+		crudImportFlags.Quote, "sets the symbol that will be defined as quote. "+
+			"For csv by default is double quotes like RFC 4180. "+
+			"Double symbol of this option acts as the escaping symbol within input data")
 
 	return importCmd
 }

--- a/cli/crud/dump.go
+++ b/cli/crud/dump.go
@@ -11,18 +11,47 @@ import (
 	"time"
 )
 
+// DumpSubsystemFiles contains file descriptors for the disk dump subsystem.
+type DumpSubsystemFiles struct {
+	// logs is file descriptor for writing logs about unsuccessful imported data.
+	Log *os.File
+	// errors is file descriptor for writing records that was not imported.
+	Error *os.File
+	// successes is file descriptor for writing records that was imported.
+	Success *os.File
+	// progress is file descriptor for writing import progress information.
+	Progress *os.File
+}
+
+// DumpSubsystemArgs contains args for runDumpSubsystem func.
+type DumpSubsystemArgs struct {
+	// batch contains context for the current batch.
+	batch *Batch
+	// caughtErr is error that occurred during work.
+	caughtErr error
+	// dumpSubsystemFiles contains file descriptors of disk dump subsystem.
+	dumpSubsystemFiles *DumpSubsystemFiles
+	// progressCtx contains current context for the progress file.
+	progressCtx *ProgressCtx
+	// crudImportFlags contains import options.
+	crudImportFlags *ImportOpts
+}
+
+// close performs closing of file descriptors of the disk dump subsystem.
+func (dumpSubsystemFiles *DumpSubsystemFiles) close() {
+	dumpSubsystemFiles.Log.Close()
+	dumpSubsystemFiles.Error.Close()
+	dumpSubsystemFiles.Success.Close()
+}
+
 // dumpLogFile implements the dumping of log file information to disk.
-func dumpLogFile(
-	csvRowRec string,
-	csvRowPos uint32,
-	errorDesc string,
-	dumpSubsystemFd *DumpSubsystemFd,
-) error {
+func dumpLogFile(csvRowRec string, csvRowPos uint32, errorDesc string,
+	dumpSubsystemFiles *DumpSubsystemFiles) error {
 	var timeMsg string = "timestamp: " + time.Now().String() + "\n"
 	var lineMsg string = "line position: " + strconv.FormatUint(uint64(csvRowPos), 10) + "\n"
 	var recordMsg string = "problem record: " + csvRowRec + "\n"
 	var errorMsg string = "error description: " + errorDesc + "\n"
-	if _, err := dumpSubsystemFd.logFile.WriteString("...\n" + timeMsg + lineMsg + recordMsg +
+	if _, err := dumpSubsystemFiles.Log.WriteString("...\n" + timeMsg + lineMsg + recordMsg +
 		errorMsg + "...\n"); err != nil {
 		return err
 	}
@@ -31,8 +60,8 @@ func dumpLogFile(
 }
 
 // dumpErrorFile implements the dumping of error file information to disk.
-func dumpErrorFile(csvRowRec string, dumpSubsystemFd *DumpSubsystemFd) error {
-	if _, err := dumpSubsystemFd.errorFile.WriteString(csvRowRec + "\n"); err != nil {
+func dumpErrorFile(csvRowRec string, dumpSubsystemFiles *DumpSubsystemFiles) error {
+	if _, err := dumpSubsystemFiles.Error.WriteString(csvRowRec + "\n"); err != nil {
 		return err
 	}
 	importSummary.importedError++
@@ -41,8 +70,8 @@ func dumpErrorFile(csvRowRec string, dumpSubsystemFd *DumpSubsystemFd) error {
 }
 
 // dumpSuccessFile implements the dumping of success file information to disk.
-func dumpSuccessFile(csvRowRec string, dumpSubsystemFd *DumpSubsystemFd) error {
-	if _, err := dumpSubsystemFd.successFile.WriteString(csvRowRec + "\n"); err != nil {
+func dumpSuccessFile(csvRowRec string, dumpSubsystemFiles *DumpSubsystemFiles) error {
+	if _, err := dumpSubsystemFiles.Success.WriteString(csvRowRec + "\n"); err != nil {
 		return err
 	}
 	importSummary.importedSuccess++
@@ -51,17 +80,14 @@ func dumpSuccessFile(csvRowRec string, dumpSubsystemFd *DumpSubsystemFd) error {
 }
 
 // dumpProgressFile implements the dumping of current progress file information to disk.
-func dumpProgressFile(
-	dumpSubsystemFd *DumpSubsystemFd,
-	progressCtx *ProgressCtx,
-) error {
-	dumpSubsystemFd.progressFile.Truncate(0)
-	dumpSubsystemFd.progressFile.Seek(0, 0)
+func dumpProgressFile(dumpSubsystemFiles *DumpSubsystemFiles, progressCtx *ProgressCtx) error {
+	dumpSubsystemFiles.Progress.Truncate(0)
+	dumpSubsystemFiles.Progress.Seek(0, 0)
 	progressCtx.LastDumpTimestamp = time.Now().String()
 	if progressCtxBytes, err := json.Marshal(progressCtx); err != nil {
 		return nil
 	} else {
-		dumpSubsystemFd.progressFile.Write(progressCtxBytes)
+		dumpSubsystemFiles.Progress.Write(progressCtxBytes)
 	}
 
 	return nil
@@ -71,70 +97,59 @@ func dumpProgressFile(
 // Including work with files: error, success, log, progress.
 func runDumpSubsystem(dumpArgs *DumpSubsystemArgs) error {
 	for _, tuple := range dumpArgs.batch.Tuples {
-		if !tuple.CrudCtx.Imported && tuple.Number != 0 {
+		if !tuple.Record.ImportSuccess && tuple.Number != 0 {
 			dumpArgs.progressCtx.RetryPosition = append(dumpArgs.progressCtx.RetryPosition,
-				tuple.ParserCtx.CsvRecordPosition)
-			if err := dumpProgressFile(dumpArgs.dumpSubsystemFd, dumpArgs.progressCtx); err != nil {
+				tuple.Record.Position)
+			if err := dumpProgressFile(dumpArgs.dumpSubsystemFiles,
+				dumpArgs.progressCtx); err != nil {
 				return err
 			}
-			if err := dumpErrorFile(
-				tuple.ParserCtx.UnparsedCsvRecord,
-				dumpArgs.dumpSubsystemFd); err != nil {
+			if err := dumpErrorFile(tuple.Record.Raw, dumpArgs.dumpSubsystemFiles); err != nil {
 				return err
 			}
-			if !tuple.ParserCtx.ParsedSuccess {
+			if !tuple.Record.ParserSuccess {
 				// Dump with parsing level error.
-				if err := dumpLogFile(
-					tuple.ParserCtx.UnparsedCsvRecord,
-					tuple.ParserCtx.CsvRecordPosition,
-					tuple.ParserCtx.ErrorMsg,
-					dumpArgs.dumpSubsystemFd); err != nil {
+				if err := dumpLogFile(tuple.Record.Raw, tuple.Record.Position,
+					tuple.Record.ParserErr, dumpArgs.dumpSubsystemFiles); err != nil {
 					return err
 				}
-			} else if len(tuple.CrudCtx.Err) != 0 {
+			} else if len(tuple.Record.CrudErr) != 0 {
 				// Dump with crud level error.
-				if err := dumpLogFile(
-					tuple.ParserCtx.UnparsedCsvRecord,
-					tuple.ParserCtx.CsvRecordPosition,
-					tuple.CrudCtx.Err,
-					dumpArgs.dumpSubsystemFd); err != nil {
+				if err := dumpLogFile(tuple.Record.Raw, tuple.Record.Position,
+					tuple.Record.CrudErr, dumpArgs.dumpSubsystemFiles); err != nil {
 					return err
 				}
 			} else if dumpArgs.caughtErr != nil {
 				// Dump with else level error (for example, connection to router lost,
 				// description in caughtErr).
-				if err := dumpLogFile(
-					tuple.ParserCtx.UnparsedCsvRecord,
-					tuple.ParserCtx.CsvRecordPosition,
-					dumpArgs.caughtErr.Error(),
-					dumpArgs.dumpSubsystemFd); err != nil {
+				if err := dumpLogFile(tuple.Record.Raw, tuple.Record.Position,
+					dumpArgs.caughtErr.Error(), dumpArgs.dumpSubsystemFiles); err != nil {
 					return err
 				}
 			} else {
 				// Dump with unknown error (probably uncaught on router level).
-				if err := dumpLogFile(
-					tuple.ParserCtx.UnparsedCsvRecord,
-					tuple.ParserCtx.CsvRecordPosition,
+				if err := dumpLogFile(tuple.Record.Raw, tuple.Record.Position,
 					"unknown error, probably it was on router level",
-					dumpArgs.dumpSubsystemFd); err != nil {
+					dumpArgs.dumpSubsystemFiles); err != nil {
 					return err
 				}
 			}
-			if err := dumpProgressFile(dumpArgs.dumpSubsystemFd, dumpArgs.progressCtx); err != nil {
+			if err := dumpProgressFile(dumpArgs.dumpSubsystemFiles,
+				dumpArgs.progressCtx); err != nil {
 				return err
 			}
 		}
-		if tuple.CrudCtx.Imported && tuple.Number != 0 {
+		if tuple.Record.ImportSuccess && tuple.Number != 0 {
 			if err := dumpSuccessFile(
-				tuple.ParserCtx.UnparsedCsvRecord,
-				dumpArgs.dumpSubsystemFd); err != nil {
+				tuple.Record.Raw,
+				dumpArgs.dumpSubsystemFiles); err != nil {
 				return err
 			}
 		}
 	}
 	for _, tuple := range dumpArgs.batch.Tuples {
 		// Checking received from router batch for any errors.
-		if !tuple.CrudCtx.Imported && tuple.Number != 0 {
+		if !tuple.Record.ImportSuccess && tuple.Number != 0 {
 			if dumpArgs.crudImportFlags.OnError == "stop" {
 				stopOnError(dumpArgs.crudImportFlags)
 			}
@@ -144,23 +159,20 @@ func runDumpSubsystem(dumpArgs *DumpSubsystemArgs) error {
 	return nil
 }
 
-// initDumpSubsystemFd opens dump subsystem files and performs some initializing actions with them.
-func initDumpSubsystemFd(
-	logFileName string,
-	errorFileName string,
-	successFileName string,
-	progressCtx *ProgressCtx,
-) (*DumpSubsystemFd, error) {
+// initDumpSubsystemFiles opens dump subsystem files and performs initializing actions with them.
+func initDumpSubsystemFiles(logFileName string, errorFileName string, successFileName string,
+	progressCtx *ProgressCtx) (*DumpSubsystemFiles, error) {
 	var err error
-	var dumpSubsystemFd *DumpSubsystemFd = &DumpSubsystemFd{
-		logFile:      new(os.File),
-		errorFile:    new(os.File),
-		successFile:  new(os.File),
-		progressFile: new(os.File),
+	var dumpSubsystemFiles *DumpSubsystemFiles = &DumpSubsystemFiles{
+		Log:      new(os.File),
+		Error:    new(os.File),
+		Success:  new(os.File),
+		Progress: new(os.File),
 	}
 
-	dumpSubsystemFd.logFile, err = os.OpenFile(logFileName,
-		os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	// Opening for appending, file mode is -rw-r--r--.
+	dumpSubsystemFiles.Log, err = os.OpenFile(logFileName,
+		os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -172,46 +184,37 @@ func initDumpSubsystemFd(
 		"File description: this file contains logs information about occurred errors\n"
 	logFileInitMsg += "\t\t\t" +
 		"Note: errors are indicated relative to the space format, not relative to the header\n"
-	if _, err := dumpSubsystemFd.logFile.WriteString("\n\n\n" +
+	if _, err := dumpSubsystemFiles.Log.WriteString("\n\n\n" +
 		logFileInitMsg + "\n\n\n"); err != nil {
 		return nil, err
 	}
 
-	dumpSubsystemFd.errorFile, err = os.OpenFile(errorFileName,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	// Open with overwriting, file mode is -rw-r--r--.
+	dumpSubsystemFiles.Error, err = os.OpenFile(errorFileName,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}
 
-	dumpSubsystemFd.successFile, err = os.OpenFile(successFileName,
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	// Open with overwriting, file mode is -rw-r--r--.
+	dumpSubsystemFiles.Success, err = os.OpenFile(successFileName,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}
 
-	dumpSubsystemFd.progressFile, err = os.OpenFile("progress.json",
-		os.O_RDWR|os.O_CREATE, 0o644)
+	// Open without affecting the current file content, file mode is -rw-r--r--.
+	dumpSubsystemFiles.Progress, err = os.OpenFile("progress.json",
+		os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, err
 	}
 
-	return dumpSubsystemFd, nil
+	return dumpSubsystemFiles, nil
 }
 
-// logDumpSubsystemMalfunction logs information about dump log subsystem malfunction.
-func logDumpSubsystemMalfunction() {
-	// This subsystem is critical, work stops without it.
-	fmt.Println("Failure of the disk dump subsystem, emergency shutdown!")
-	fmt.Println("Work without the disk dump subsystem is impossible.")
-	fmt.Println("Possible damage of error.csv, success.csv, import.log, progress.json!")
-	fmt.Println("Consistency of the imported data in the storage is not guaranteed.")
-}
-
-// initProgressCtxPrevLaunch init progress context with progress file of last launch.
-func initProgressCtxPrevLaunch(
-	progressCtx *ProgressCtx,
-	dumpSubsystemFd *DumpSubsystemFd,
-) error {
+// setPrevLaunchData set progress context with progress file of last launch.
+func (ctx *ProgressCtx) setPrevLaunchData(dumpSubsystemFiles *DumpSubsystemFiles) error {
 	lastProgressFileBytes, err := os.ReadFile("progress.json")
 	if err != nil {
 		fmt.Println("Problem with reading progress.json file.")
@@ -223,10 +226,10 @@ func initProgressCtxPrevLaunch(
 		fmt.Println("Problem with deserialize progress.json file.")
 		return err
 	}
-	progressCtx.lastPositionPrevProgress = lastProgressFile.LastPosition
-	progressCtx.retryPositionPrevProgress = make([]uint32, len(lastProgressFile.RetryPosition))
-	copy(progressCtx.retryPositionPrevProgress, lastProgressFile.RetryPosition)
-	dumpSubsystemFd.progressFile.Truncate(0)
+	ctx.prevLastPosition = lastProgressFile.LastPosition
+	ctx.prevRetryPosition = make([]uint32, len(lastProgressFile.RetryPosition))
+	copy(ctx.prevRetryPosition, lastProgressFile.RetryPosition)
+	dumpSubsystemFiles.Progress.Truncate(0)
 
 	return nil
 }
@@ -234,8 +237,10 @@ func initProgressCtxPrevLaunch(
 // stopOnError stops the program and displays import summary.
 func stopOnError(crudImportFlags *ImportOpts) {
 	fmt.Printf("\n")
-	fmt.Println("\033[0;31m[on-error]: An error has occurred, the import has been stopped. " +
-		"See the details in the log, error, success and progress files.\033[0m")
+	fmt.Println("\033[0;31m" +
+		"[on-error]: An error has occurred, the import has been stopped. " +
+		"See the details in the log, error, success and progress files." +
+		"\033[0m")
 	fmt.Printf("\n")
 	printImportSummary(crudImportFlags)
 	os.Exit(1)

--- a/cli/crud/import.go
+++ b/cli/crud/import.go
@@ -141,6 +141,11 @@ func initReaders(inputFileName string, crudImportFlags *ImportOpts) (*ttcsv.Read
 	} else {
 		csvReader.Comma = rune(crudImportFlags.Delimiter[0])
 	}
+	if len(crudImportFlags.Quote) != 1 {
+		return nil, nil, nil, nil, fmt.Errorf("Quote must be one character.")
+	} else {
+		csvReader.Quote = rune(crudImportFlags.Quote[0])
+	}
 
 	// Init raw reader (auxiliary parser for getting unparsed records and their positions).
 	rawReaderFile, err := os.Open(inputFileName)

--- a/cli/crud/lua/import.lua
+++ b/cli/crud/lua/import.lua
@@ -104,19 +104,19 @@ local init_eval_upload_batch_from_parser = function()
             box.session.storage.crudimport_bin_batch_from_parser = json_batch_bin
             box.session.storage.crudimport_batch_table_for_import = json.decode(jsonstr)
             for tuple_num, tuple in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
-                if tuple['parserCtx']['parsedCsvRecord'] == nil then
+                if tuple['record']['parsed'] == nil then
                     -- Case of batch with tupleAmount < batchSize.
-                    tuple['parserCtx']['parsedCsvRecord'] = {}
+                    tuple['record']['parsed'] = {}
                 end
                 -- Logic of NULL value set.
-                for key, val in pairs(tuple['parserCtx']['parsedCsvRecord']) do
+                for key, val in pairs(tuple['record']['parsed']) do
                     if val == '' and box.session.storage.null_val_interpretation == nil then
                         box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][tuple_num]['parserCtx']['parsedCsvRecord'][key] = json.NULL
+                            ['tuples'][tuple_num]['record']['parsed'][key] = json.NULL
                     elseif val == box.session.storage.null_val_interpretation and
                             box.session.storage.null_val_interpretation ~= nil then
                                 box.session.storage.crudimport_batch_table_for_import
-                                    ['tuples'][tuple_num]['parserCtx']['parsedCsvRecord'][key] = json.NULL
+                                    ['tuples'][tuple_num]['record']['parsed'][key] = json.NULL
                     end
                 end
             end
@@ -143,12 +143,12 @@ local init_eval_swap_according_to_header = function()
         -- Actions to prevent indexing of null values.
         for parsed_tuple_num, _ in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
             box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'] = {}
+                ['tuples'][parsed_tuple_num]['record']['castedTuple'] = {}
             -- Case for batch with tupels amount < batchSize.
             if box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'] == nil then
+                ['tuples'][parsed_tuple_num]['record']['parsed'] == nil then
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'] = {}
+                        ['tuples'][parsed_tuple_num]['record']['parsed'] = {}
                 end
         end
 
@@ -186,7 +186,7 @@ local init_eval_swap_according_to_header = function()
 
         for parsed_tuple_num, _ in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
             if box.session.storage.crudimport_batch_table_for_import
-                    ['tuples'][parsed_tuple_num]['parserCtx']['parsedSuccess'] ~= true then
+                    ['tuples'][parsed_tuple_num]['record']['parserSuccess'] ~= true then
                         goto skip_tuple_mapping
             end
 
@@ -196,10 +196,10 @@ local init_eval_swap_according_to_header = function()
             end
             for i = 1, #box.session.storage.crudimport_targetspace_format do
                 if box.session.storage.crudimport_batch_table_for_import
-                    ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][permutation_match_map[i]] ~= nil then
+                    ['tuples'][parsed_tuple_num]['record']['parsed'][permutation_match_map[i]] ~= nil then
                     if permutation_match_map[i] ~= json.NULL then
                         candidate_tule[i] = box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][permutation_match_map[i]]
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][permutation_match_map[i]]
                     else
                         candidate_tule[i] = json.NULL
                     end
@@ -207,7 +207,7 @@ local init_eval_swap_according_to_header = function()
             end
 
             box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'] = candidate_tule
+                                ['tuples'][parsed_tuple_num]['record']['parsed'] = candidate_tule
 
             ::skip_tuple_mapping::
         end
@@ -225,22 +225,22 @@ local init_eval_cast_tuples_to_scapce_format = function()
         -- Actions to prevent indexing of null values.
         for parsed_tuple_num, _ in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
             box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'] = {}
+                ['tuples'][parsed_tuple_num]['record']['castedTuple'] = {}
             -- Case for batch with tupels amount < batchSize.
             if box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'] == nil then
+                ['tuples'][parsed_tuple_num]['record']['parsed'] == nil then
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'] = {}
+                        ['tuples'][parsed_tuple_num]['record']['parsed'] = {}
                 end
         end
 
         for parsed_tuple_num, parsed_tuple_val in
                 pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
-            for parsedTupleFIeldNum, parsedTupleFIeldVal in pairs(parsed_tuple_val['parserCtx']['parsedCsvRecord']) do
+            for parsedTupleFIeldNum, parsedTupleFIeldVal in pairs(parsed_tuple_val['record']['parsed']) do
                 if box.session.storage.crudimport_batch_table_for_import
-                    ['tuples'][parsed_tuple_num]['parserCtx']['parsedSuccess'] == true then
+                    ['tuples'][parsed_tuple_num]['record']['parserSuccess'] == true then
                         box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'][parsedTupleFIeldNum]
+                            ['tuples'][parsed_tuple_num]['record']['castedTuple'][parsedTupleFIeldNum]
                                 = parsedTupleFIeldVal
                 end
             end
@@ -248,7 +248,7 @@ local init_eval_cast_tuples_to_scapce_format = function()
 
         for parsed_tuple_num, _ in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
             if box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['parserCtx']['parsedSuccess'] ~= true then
+                ['tuples'][parsed_tuple_num]['record']['parserSuccess'] ~= true then
                     goto skip_tuple
                 end
                 for format_record_number, format_record in pairs(box.session.storage.crudimport_targetspace_format) do
@@ -260,16 +260,16 @@ local init_eval_cast_tuples_to_scapce_format = function()
                     )
                       and
                         type(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                                 == 'string' then
                         -- TODO: write separate function for th-sep.
                         local assump_number = box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number]
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number]
                         assump_number = assump_number:gsub(' ', '')
                         assump_number = assump_number:gsub('`', '')
                         if tonumber(assump_number) ~= nil then
                             box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'][format_record_number]
+                                ['tuples'][parsed_tuple_num]['record']['castedTuple'][format_record_number]
                                     = tonumber(assump_number)
                         end
                     end
@@ -280,16 +280,16 @@ local init_eval_cast_tuples_to_scapce_format = function()
                     )
                       and
                         type(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                                 == 'string' then
                         -- TODO: write separate function for th-sep.
                         local assump_number = tostring(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                         assump_number = assump_number:gsub(' ', '')
                         assump_number = assump_number:gsub('`', '')
                         if pcall(ffi.cast, 'double', tonumber(assump_number)) ~= false then
                             box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'][format_record_number] =
+                                ['tuples'][parsed_tuple_num]['record']['castedTuple'][format_record_number] =
                                                                             ffi.cast('double', tonumber(assump_number))
                         end
                     end
@@ -299,16 +299,16 @@ local init_eval_cast_tuples_to_scapce_format = function()
                     )
                       and
                         type(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                                 == 'string' then
                         -- TODO: write separate function for th-sep.
                         local assump_number = tostring(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                         assump_number = assump_number:gsub(' ', '')
                         assump_number = assump_number:gsub('`', '')
                         if pcall(decimal.new, assump_number) ~= false then
                             box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'][format_record_number] =
+                                ['tuples'][parsed_tuple_num]['record']['castedTuple'][format_record_number] =
                                                                                         decimal.new(assump_number)
                         end
                     end
@@ -318,12 +318,12 @@ local init_eval_cast_tuples_to_scapce_format = function()
                     )
                       and
                         toboolean(box.session.storage.crudimport_batch_table_for_import
-                            ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number]) ~= nil
+                            ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number]) ~= nil
                       then
                         box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple'][format_record_number] =
+                                ['tuples'][parsed_tuple_num]['record']['castedTuple'][format_record_number] =
                             toboolean(box.session.storage.crudimport_batch_table_for_import
-                                ['tuples'][parsed_tuple_num]['parserCtx']['parsedCsvRecord'][format_record_number])
+                                ['tuples'][parsed_tuple_num]['record']['parsed'][format_record_number])
                     end
                 end
             ::skip_tuple::
@@ -339,11 +339,11 @@ local init_eval_import_prepared_batch = function()
         local tupels_for_import = {}
         for parsed_tuple_num, _ in pairs(box.session.storage.crudimport_batch_table_for_import['tuples']) do
             if box.session.storage.crudimport_batch_table_for_import
-                ['tuples'][parsed_tuple_num]['parserCtx']['parsedSuccess'] == true then
+                ['tuples'][parsed_tuple_num]['record']['parserSuccess'] == true then
                     table.insert(
                     tupels_for_import,
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple']
+                        ['tuples'][parsed_tuple_num]['record']['castedTuple']
                     )
             end
         end
@@ -414,12 +414,12 @@ local init_eval_get_batch_final_ctx = function()
                 if box.session.storage.crud_import_is_tuples_equal(
                     imported_tuple_val,
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple']
+                        ['tuples'][parsed_tuple_num]['record']['castedTuple']
                     ) and
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['crudCtx']['imported'] == false
+                        ['tuples'][parsed_tuple_num]['record']['importSuccess'] == false
                     then
-                        batch_final_ctx['tuples'][parsed_tuple_num]['crudCtx']['imported'] = true
+                        batch_final_ctx['tuples'][parsed_tuple_num]['record']['importSuccess'] = true
                         -- Try to resist ambiguity, but a swap is still possible (at least we don't lose record).
                         box.session.storage.batch_insert_res['rows'][imported_tuple_num] = nil
                         goto resulted_tuple_found
@@ -429,12 +429,12 @@ local init_eval_get_batch_final_ctx = function()
                 if box.session.storage.crud_import_is_tuples_equal(
                     error_tuple_val['operation_data'],
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['crudCtx']['castedTuple']
+                        ['tuples'][parsed_tuple_num]['record']['castedTuple']
                     ) and
                     box.session.storage.crudimport_batch_table_for_import
-                        ['tuples'][parsed_tuple_num]['crudCtx']['imported'] == false
+                        ['tuples'][parsed_tuple_num]['record']['importSuccess'] == false
                     then
-                        batch_final_ctx['tuples'][parsed_tuple_num]['crudCtx']['err'] = error_tuple_val['str']
+                        batch_final_ctx['tuples'][parsed_tuple_num]['record']['crudErr'] = error_tuple_val['str']
                         -- Try to resist ambiguity, but a swap is still possible (at least we don't lose record).
                         box.session.storage.batch_insert_res['rows'][error_tuple_num] = nil
                         goto resulted_tuple_found

--- a/cli/crud/print.go
+++ b/cli/crud/print.go
@@ -8,6 +8,22 @@ import (
 	"time"
 )
 
+// ImportSummary contains information for the import summary.
+type ImportSummary struct {
+	// readTotal is counter of total iterations of the parser.
+	readTotal uint32
+	// ignoredDueToProgress is counter of skipped iterations of the parser due to progress file.
+	ignoredDueToProgress uint32
+	// parsedSuccess is counter of succsess iterations of the parser.
+	parsedSuccess uint32
+	// parsedError is counter of fail iterations of the parser.
+	parsedError uint32
+	// importedSuccess is counter of succsess iterations of crud stored procedure.
+	importedSuccess uint32
+	// importedError is counter of fail iterations of crud stored procedure.
+	importedError uint32
+}
+
 // printImportSummary prints the summary.
 func printImportSummary(crudImportFlags *ImportOpts) {
 	var speed float64 = float64(importSummary.readTotal) /
@@ -40,4 +56,13 @@ func printImportProgressBar() {
 		importSummary.parsedError,
 		importSummary.importedSuccess,
 		importSummary.importedError)
+}
+
+// printDumpSubsystemMalfunction logs information about dump log subsystem malfunction.
+func printDumpSubsystemMalfunction() {
+	// This subsystem is critical, work stops without it.
+	fmt.Println("Failure of the disk dump subsystem, emergency shutdown!")
+	fmt.Println("Work without the disk dump subsystem is impossible.")
+	fmt.Println("Possible damage of error.csv, success.csv, import.log, progress.json!")
+	fmt.Println("Consistency of the imported data in the storage is not guaranteed.")
 }

--- a/cli/crud/types.go
+++ b/cli/crud/types.go
@@ -37,6 +37,8 @@ type ImportOpts struct {
 	OnError string
 	// NullVal sets null interpretation for input data.
 	NullVal string
+	// Delimiter is the field delimiter in input data.
+	Delimiter string
 }
 
 // Record contains information that related to the parsing process and crud working.

--- a/cli/crud/types.go
+++ b/cli/crud/types.go
@@ -39,6 +39,8 @@ type ImportOpts struct {
 	NullVal string
 	// Delimiter is the field delimiter in input data.
 	Delimiter string
+	// Quote is the quote character in input data.
+	Quote string
 }
 
 // Record contains information that related to the parsing process and crud working.


### PR DESCRIPTION
The following points implemented within this PR:

* add `--dec-sep` option
* add `--th-sep` option
* add `--delimiter` option
* add `--quote` option and option `--escape` or some logic for escaping

Closes #84