### PR TITLE
run: move descriptions to long definition

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -44,8 +44,9 @@ func getRunOpts(cmdCtxTemp cmdcontext.CmdCtx) *running.RunOpts {
 // NewRunCmd creates run command.
 func NewRunCmd() *cobra.Command {
 	var runCmd = &cobra.Command{
-		Use: "run [APPLICATION_NAME]",
-		Short: "Run tarantool instance\n" +
+		Use:   "run [APPLICATION_NAME]",
+		Short: "Run tarantool instance",
+		Long: "Run tarantool instance\n" +
 			"Flags processed within the application\n" +
 			"are passed after: '--'",
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Moved description of '--' flag to long definition of tt run.

Follow up #29