### PR TITLE
test: add free port auto resolve mechanism

### DIFF
--- a/test/integration/play/test_file/remote_instance_cfg.lua
+++ b/test/integration/play/test_file/remote_instance_cfg.lua
@@ -2,11 +2,15 @@
 -- will be transferred for testing tt play command.
 -- A test space 'tester' is being created, the data about which
 -- will be present in the transmitted .xlog file during testing tt play.
+-- Call require('utils').bind_free_port(arg[0]) is required for using
+-- TarantoolTestInstance class of test/utils.py.
 
 local box = require('box')
+-- The module below should be in a pytest temporary directory.
+local testutils = require('utils')
 
 local function configure_instance()
-    box.cfg{listen = 3301}
+    testutils.bind_free_port(arg[0]) -- arg[0] is 'remote_instance_cfg.lua'
     local tester = box.schema.space.create('tester', {id = 999})
     tester:format(
         {

--- a/test/integration/play/test_play.py
+++ b/test/integration/play/test_play.py
@@ -2,11 +2,23 @@ import os
 import re
 import shutil
 
-from utils import TarantoolTestInstance, run_command_and_get_output
+import pytest
+from utils import (TarantoolTestInstance, kill_child_process,
+                   run_command_and_get_output)
 
 # The name of instance config file within this integration tests.
 # This file should be in /test/integration/play/test_file/.
 INSTANCE_NAME = "remote_instance_cfg.lua"
+
+
+# In case of unsuccessful completion of tests, tarantool test instances may remain running.
+# This is autorun wrapper for each test case in this module.
+@pytest.fixture(autouse=True)
+def kill_remain_instance_wrapper():
+    # Run test.
+    yield
+    # Kill a test instance if it was not stopped due to a failed test.
+    kill_child_process()
 
 
 def test_play_unset_arg(tt_cmd, tmpdir):

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -1,0 +1,101 @@
+-- This module contains auxiliary functions for integration tests that use lua code.
+-- To use this module, you need to copy this file to the temp pytest directory for the duration
+-- of the integration tests, then use the lua require function in your instance cfg file.
+-- The copying of this file to pytest temdir is already implemented in class
+-- TarantoolTestInstance of test/utils.py module.
+-- Just use require('utils').bind_free_port(arg[0]) inside your cfg instance file.
+-- If you need to get the port value in the lua test instance cfg file,
+-- use require('utils').get_bound_port() after require('utils').bind_free_port(arg[0]).
+
+local box    = require('box')
+local ffi    = require('ffi')
+local socket = require('socket')
+
+local testutils = {}
+
+function testutils.get_bound_address_old_tarantool()
+    -- Get bound via box.cfg({listen = '127.0.0.1:0'}) socket addr for tarantool major version 1.
+    -- For tarantool major version higher then 1, this function can be replaced by box.info.listen.
+    -- Table res contains listening and client sockets.
+    local res = {}
+    for fd = 0, 65535 do
+        local addrinfo = socket.internal.name(fd)
+        -- Assume that the socket listens on 127.0.0.1.
+        local is_matched = addrinfo ~= nil and addrinfo.host == '127.0.0.1' and
+            addrinfo.family == 'AF_INET' and addrinfo.type == 'SOCK_STREAM' and
+            addrinfo.protocol == 'tcp' and type(addrinfo.port) == 'number'
+        if is_matched then
+            addrinfo.fd = fd
+            table.insert(res, addrinfo)
+        end
+    end
+
+    -- Table l_res contains listening sockets.
+    local l_res = {}
+    -- We need only listening, not client sockets.
+    -- Filters sockets with SO_REUSEADDR.
+    for _, sock in pairs(res) do
+        local value  = ffi.new('int[1]')
+        local len    = ffi.new('size_t[1]', ffi.sizeof('int'))
+        local level  = socket.internal.SOL_SOCKET
+        local status = ffi.C.getsockopt(
+            sock.fd,
+            level,
+            socket.internal.SO_OPT[level].SO_REUSEADDR.iname,
+            value, len
+        )
+        if status ~= 0 then
+            error('problem with calling getsockopt() function')
+        end
+        if value[0] > 0 then
+            table.insert(l_res, sock)
+        end
+    end
+
+    -- If there are several listening sockets, we don't know which one is iproto's one.
+    if #l_res ~= 1 then
+        error(('zero or more than one listening TCP sockets: %d'):format(#l_res))
+    end
+
+    return ('%s:%s'):format(l_res[1].host, l_res[1].port)
+end
+
+function testutils.get_bound_port()
+    -- Returns bound port.
+    -- Can be used after call testutils.bind_free_port() if you need to get the port value
+    -- in the lua test instance cfg file.
+    local address = box.info.listen
+    if address == nil then
+        -- In case of tarantool major version 1.
+        address = testutils.get_bound_address_old_tarantool()
+    end
+    -- Get port from address string '127.0.0.1:*'.
+    local port = address:match(':(.*)')
+
+    if port == nil then
+        error('unable to get bound port, perhaps forgot to call testutils.bind_free_port()')
+    end
+
+    return port
+end
+
+function testutils.dump_bound_port(instance_file_name)
+    -- Dump bound port to file for pytest.
+    -- It will be regular text file which name is 'instance_file_name.port'.
+    local file, err = io.open(instance_file_name .. '.port', 'w')
+    if file == nil then
+        error(err)
+    end
+
+    local port = testutils.get_bound_port()
+    file:write(port)
+    file:close()
+end
+
+function testutils.bind_free_port(instance_file_name)
+    -- Bind free port and save it to file for pytest.
+    box.cfg({listen = '127.0.0.1:0'})
+    testutils.dump_bound_port(instance_file_name)
+end
+
+return testutils

--- a/test/utils.py
+++ b/test/utils.py
@@ -88,7 +88,7 @@ def wait_file(dir_name, file_pattern, exclude_list, timeout_sec=1):
     return ""
 
 
-def kill_child_process(pid):
+def kill_child_process(pid=psutil.Process().pid):
     parent = psutil.Process(int(pid))
     procs = parent.children()
 


### PR DESCRIPTION
Added free port auto resolve mechanism for integration tests, which require the running of a tarantool instance:

The idea is using a `box.cfg({listen = '127.0.0.1:0'})` call in the test instance configuration file and get an automatically assigned port with [box.info.listen](https://github.com/tarantool/tarantool/commit/1f4b9afb9db740aeeba71d7667ce13905597430d). For tarantool v1 we use [snippet](https://github.com/tarantool/tt/pull/112#issuecomment-1209661575) below for getting assigned port with `SO_REUSEADDR` socket filter by [this](https://github.com/tarantool/tt/pull/112#issuecomment-1232949223) approach. 

Now the solution looks like this:

If the user needs to raise a test instance for integration tests, then the user writes the configuration file of the test instance (for example, `test/integration/play/test_file/remote_instance_cfg.lua`). Within this config, the user needs to call `require('testutils').bind_free_port(arg[0])`. After that, the free port will be assigned and saved to disk for pytest. If you need to get the port value in the lua test instance cfg file, you can use `require('utils').get_bound_port()` after `require('utils').bind_free_port(arg[0])`.

Next, in pytest the user call `TarantoolTestInstance()` from utils.py. This call returns the test instance object, then use method `start()`, that creates a subprocess. This class implementation also copies the file utils.lua with `bind_free_port` implementation to pytest temp dir with instance config file.

Also added mechanism for guaranteed instances termination after integration testing:

There was a problem in which when the test failed, the created instance may not stop, but remained in the system. Now a wrapper `@pytest.fixture(autouse=True) kill_remain_instance_wrapper()` in `test_play.py` was implemented, which is guaranteed to stop the instance for each test. This approach can be used in further tests that will require the creation of their own test instances.

Closes #71