### PR TITLE
tt: working with a set of instances

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,10 @@ jobs:
       - name: Unit tests
         run: mage unit
 
+      # This server starts and listen on 8084 port that is used for tests.
+      - name: Stop Mono server
+        run: sudo systemctl kill mono-xsp4 || true
+
       - name: Integration tests
         run: mage integration
 
@@ -164,6 +168,10 @@ jobs:
 
       - name: Unit tests
         run: mage unit
+
+      # This server starts and listen on 8084 port that is used for tests.
+      - name: Stop Mono server
+        run: sudo systemctl kill mono-xsp4 || true
 
       - name: Integration tests
         run: mage integration

--- a/README.rst
+++ b/README.rst
@@ -160,18 +160,50 @@ You can generate autocompletion for ``bash`` or ``zsh`` shell:
 Enter ``tt``, press tab and you will see a list of available modules with
 descriptions. Also, autocomplete supports external modules.
 
+Working with a set of instances
+-------------------------------
+
+``tt`` can manage a set of instances based on one source file.
+
+To work with a set of instances, you need:
+a directory where the files will be located:
+``init.lua`` and ``instances.yml``.
+
+* ``init.lua`` - application source file.
+* ``instances.yml`` - description of instances.
+
+Instances are described in ``instances.yml`` with format:
+
+.. code-block:: yaml
+
+    instance_name:
+      parameter: value
+
+The dot and dash characters in instance names are reserved for system use.
+if it is necessary for a certain instance to work on a source file other
+than ``init.lua``, then you need to create a script with a name in the
+format: ``instance_name.init.lua``.
+
+The following environment variables are associated with each instance:
+
+* ``TARANTOOL_APP_NAME`` - application name (the name of the directory
+  where the application files are present).
+* ``TARANTOOL_INSTANCE_NAME`` - instance name.
+
+`Example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-a-set-of-instances>`_
+
 Commands
 --------
 Common description. For a detailed description, use ``tt help command`` .
 
-* ``start`` - start a tarantool instance.
-* ``stop`` - stop the tarantool instance.
-* ``status`` - get current status of the instance.
-* ``restart`` - restart the instance.
+* ``start`` - start a tarantool instance(s).
+* ``stop`` - stop the tarantool instance(s).
+* ``status`` - get current status of the instance(s).
+* ``restart`` - restart the instance(s).
 * ``version`` - show Tarantool CLI version information.
 * ``completion`` - generate autocomplete for a specified shell.
 * ``help`` - display help for any command.
-* ``logrotate`` - rotate logs of a started tarantool instance.
+* ``logrotate`` - rotate logs of a started tarantool instance(s).
 * ``check`` - check an application file for syntax errors.
 * ``connect`` -  connect to the tarantool instance.
 * ``rocks`` - LuaRocks package manager.

--- a/README.rst
+++ b/README.rst
@@ -212,3 +212,4 @@ Common description. For a detailed description, use ``tt help command`` .
 * ``coredump`` - pack/unpack/inspect tarantool coredump.
 * ``run`` - start a tarantool instance. 
 * ``search`` - show available tt/tarantool versions. 
+* ``clean`` -  clean instance(s) files.

--- a/cli/cartridge/extra/003_fix_work_paths.patch
+++ b/cli/cartridge/extra/003_fix_work_paths.patch
@@ -1,0 +1,147 @@
+diff --git a/cli/admin/common.go b/cli/admin/common.go
+index dcea75c..9058c16 100644
+--- a/cli/admin/common.go
++++ b/cli/admin/common.go
+@@ -2,7 +2,6 @@ package admin
+ 
+ import (
+ 	"fmt"
+-	"io/ioutil"
+ 	"os"
+ 	"path/filepath"
+ 	"sort"
+@@ -140,31 +139,30 @@ func getInstanceSocketPaths(ctx *context.Ctx) ([]string, error) {
+ 		return nil, fmt.Errorf("%s is not a directory", ctx.Running.RunDir)
+ 	}
+ 
+-	runFiles, err := ioutil.ReadDir(ctx.Running.RunDir)
+-	if err != nil {
+-		return nil, fmt.Errorf("Failed to list the run directory: %s", err)
+-	}
+-
+-	if len(runFiles) == 0 {
+-		return nil, fmt.Errorf("Run directory %s is empty", ctx.Running.RunDir)
+-	}
+-
+ 	instanceSocketPaths := []string{}
+ 
+-	appInstanceSocketPrefix := fmt.Sprintf("%s.", ctx.Project.Name)
+-	controlSocketSuffix := ".control"
+-	for _, runFile := range runFiles {
+-		runFileName := runFile.Name()
+-		if !strings.HasSuffix(runFileName, controlSocketSuffix) {
+-			continue
+-		}
+-
+-		if !strings.HasPrefix(runFileName, appInstanceSocketPrefix) {
+-			continue
+-		}
+-
+-		instanceSocketPath := filepath.Join(ctx.Running.RunDir, runFileName)
+-		instanceSocketPaths = append(instanceSocketPaths, instanceSocketPath)
++	err := filepath.Walk(ctx.Running.RunDir,
++		func(path string, info os.FileInfo, err error) error {
++			if err != nil {
++				return err
++			}
++			controlSocketSuffix := ".control"
++
++			if info.Mode()&os.ModeSocket == os.ModeSocket {
++				file := filepath.Base(path)
++				if !strings.HasSuffix(file, controlSocketSuffix) {
++					return nil
++				}
++
++				instanceSocketPath := filepath.Join(ctx.Running.RunDir,
++					filepath.Base(filepath.Dir(path)))
++				instanceSocketPath = filepath.Join(instanceSocketPath, file)
++				instanceSocketPaths = append(instanceSocketPaths, instanceSocketPath)
++			}
++			return nil
++		})
++	if err != nil {
++		return nil, err
+ 	}
+ 
+ 	if len(instanceSocketPaths) == 0 {
+diff --git a/cli/commands/create.go b/cli/commands/create.go
+index c3b5730..1282c47 100644
+--- a/cli/commands/create.go
++++ b/cli/commands/create.go
+@@ -11,6 +11,7 @@ import (
+ 	"github.com/tarantool/cartridge-cli/cli/common"
+ 	"github.com/tarantool/cartridge-cli/cli/create"
+ 	"github.com/tarantool/cartridge-cli/cli/create/templates"
++	"github.com/tarantool/cartridge-cli/cli/project"
+ )
+ 
+ var CartridgeCliCreate *cobra.Command
+@@ -50,7 +51,7 @@ func runCreateCommand(cmd *cobra.Command, args []string) error {
+ 
+ 	// get project path
+ 	basePath := cmd.Flags().Arg(0)
+-	ctx.Project.Path, err = getNewProjectPath(basePath)
++	ctx.Project.Path, err = getNewProjectPath(basePath, os.Getenv(project.EnvInstAvailable))
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -76,9 +77,14 @@ func runCreateCommand(cmd *cobra.Command, args []string) error {
+ 	return nil
+ }
+ 
+-func getNewProjectPath(basePath string) (string, error) {
++func getNewProjectPath(basePath string, instPath string) (string, error) {
+ 	var err error
+ 
++	// Parameter `instances_available` from tarantool.yaml has a priority.
++	if instPath != "" {
++		basePath = instPath
++	}
++
+ 	if basePath == "" {
+ 		basePath, err = os.Getwd()
+ 		if err != nil {
+diff --git a/cli/project/files.go b/cli/project/files.go
+index 4e1a12f..bd576d0 100644
+--- a/cli/project/files.go
++++ b/cli/project/files.go
+@@ -52,7 +52,7 @@ type FlagOpts struct {
+ }
+ 
+ func GetInstanceID(ctx *context.Ctx, instanceName string) string {
+-	return fmt.Sprintf("%s.%s", ctx.Project.Name, instanceName)
++	return fmt.Sprintf("%s/%s", instanceName, instanceName)
+ }
+ 
+ func GetInstanceWorkDir(ctx *context.Ctx, instanceName string) string {
+diff --git a/cli/project/project.go b/cli/project/project.go
+index d06ad10..551e56a 100644
+--- a/cli/project/project.go
++++ b/cli/project/project.go
+@@ -11,6 +11,8 @@ import (
+ 	"github.com/tarantool/cartridge-cli/cli/version"
+ )
+ 
++const EnvInstAvailable = "TT_INST_AVAILABLE"
++
+ func FillCtx(ctx *context.Ctx) error {
+ 	var err error
+ 
+@@ -23,8 +25,17 @@ func FillCtx(ctx *context.Ctx) error {
+ 		if err != nil {
+ 			return fmt.Errorf("Failed to get current directory: %s", err)
+ 		}
++		ctx.Running.AppDir = filepath.Join(ctx.Running.AppDir, ctx.Project.Name)
++	}
++
++	instAvail := os.Getenv(EnvInstAvailable)
++	if instAvail != "" {
++		ctx.Running.AppDir = filepath.Join(instAvail, ctx.Project.Name)
+ 	}
+ 
++	ctx.Replicasets.File = filepath.Join(ctx.Running.AppDir, "replicasets.yml")
++	ctx.Running.ConfPath = filepath.Join(ctx.Running.AppDir, "instances.yml")
++
+ 	if ctx.Running.AppDir, err = filepath.Abs(ctx.Running.AppDir); err != nil {
+ 		return fmt.Errorf("Failed to get application directory absolute path: %s", err)
+ 	}

--- a/cli/cartridge/extra/004_fix_warning.patch
+++ b/cli/cartridge/extra/004_fix_warning.patch
@@ -1,0 +1,15 @@
+diff --git a/cli/running/process.go b/cli/running/process.go
+index 9b56d17..e16dd14 100644
+--- a/cli/running/process.go
++++ b/cli/running/process.go
+@@ -136,10 +136,6 @@ func (process *Process) SetPidAndStatus() {
+ 		return
+ 	}
+ 
+-	if name != "tarantool" {
+-		log.Warnf("Process %s does not seem to be tarantool", name)
+-	}
+-
+ 	if err := process.osProcess.SendSignal(syscall.Signal(0)); err != nil {
+ 		process.Status = procStatusStopped
+ 	} else {

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -37,10 +37,28 @@ func internalCheckModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	if err := running.Check(cmdCtx); err != nil {
-		return err
+	// Сollect a list of instances with unique scripts.
+	uniqueInst := []cmdcontext.RunningCtx{}
+	for _, inst := range cmdCtx.Running {
+		found := false
+		for _, unique := range uniqueInst {
+			if inst.AppPath == unique.AppPath {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			uniqueInst = append(uniqueInst, inst)
+		}
 	}
-	log.Infof("Result of check: syntax of file '%s' is OK", cmdCtx.Running.AppPath)
+
+	for _, inst := range uniqueInst {
+		if err := running.Check(cmdCtx, &inst); err != nil {
+			return err
+		}
+		log.Infof("Result of check: syntax of file '%s' is OK", inst.AppPath)
+	}
 
 	return nil
 }

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/configure"
+	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/running"
+	"github.com/tarantool/tt/cli/util"
+)
+
+var forceRemove bool
+
+// NewCleanCmd creates clean command.
+func NewCleanCmd() *cobra.Command {
+	var cleanCmd = &cobra.Command{
+		Use:   "clean [INSTANCE_NAME]",
+		Short: "Clean instance(s) files",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalCleanModule, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	cleanCmd.Flags().BoolVarP(&forceRemove, "force", "f", false, "do not ask for confirmation")
+
+	return cleanCmd
+}
+
+func collectFiles(list []string, dirname string) ([]string, error) {
+	err := filepath.Walk(dirname,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() {
+				list = append(list, path)
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
+}
+
+func clean(run *cmdcontext.RunningCtx) error {
+	removeList := []string{}
+	confirm := false
+
+	removeList, err := collectFiles(removeList, run.LogDir)
+	if err != nil {
+		return err
+	}
+
+	removeList, err = collectFiles(removeList, run.DataDir)
+	if err != nil {
+		return err
+	}
+
+	if len(removeList) == 0 {
+		log.Infof("Already cleaned.\n")
+		return nil
+	}
+
+	log.Infof("List of files to delete:\n")
+	for _, file := range removeList {
+		log.Infof("%s", file)
+	}
+
+	if !forceRemove {
+		confirm, err = util.AskConfirm("\nConfirm")
+		if err != nil {
+			return err
+		}
+	}
+
+	if confirm || forceRemove {
+		for _, file := range removeList {
+			err = os.Remove(file)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("Canceled by user")
+}
+
+// internalCleanModule is a default clean module.
+func internalCleanModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	if err = running.FillCtx(cliOpts, cmdCtx, args); err != nil {
+		return err
+	}
+
+	for _, run := range cmdCtx.Running {
+		status := running.Status(cmdCtx, &run)
+		if status == running.InstStateStopped {
+			var statusMsg string
+
+			err = clean(&run)
+			if err != nil {
+				statusMsg = "[ERR] " + err.Error()
+			} else {
+				statusMsg = "[OK]"
+			}
+
+			log.Infof("%s: cleaning...\t%s", run.InstName, statusMsg)
+		} else {
+			log.Infof("instance `%s` must be stopped", run.InstName)
+		}
+	}
+
+	return nil
+}

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -13,7 +13,7 @@ import (
 func NewLogrotateCmd() *cobra.Command {
 	var logrotateCmd = &cobra.Command{
 		Use:   "logrotate <INSTANCE_NAME>",
-		Short: "Rotate logs of a started tarantool instance",
+		Short: "Rotate logs of a started tarantool instance(s)",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalLogrotateModule, args)
@@ -37,11 +37,13 @@ func internalLogrotateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	res, err := running.Logrotate(cmdCtx)
-	if err != nil {
-		return err
+	for _, run := range cmdCtx.Running {
+		res, err := running.Logrotate(cmdCtx, &run)
+		if err != nil {
+			return err
+		}
+		log.Info(res)
 	}
-	log.Info(res)
 
 	return nil
 }

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -11,7 +11,7 @@ import (
 func NewRestartCmd() *cobra.Command {
 	var restartCmd = &cobra.Command{
 		Use:   "restart <INSTANCE_NAME>",
-		Short: "Restart tarantool instance",
+		Short: "Restart tarantool instance(s)",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalRestartModule, args)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -145,6 +145,12 @@ func InitRoot() {
 		log.Fatalf("Failed to get Tarantool CLI configuration: %s", err)
 	}
 
+	// Setup TT_INST_AVAILABLE with instances_available path.
+	// Required for cartridge.
+	if cliOpts.App != nil {
+		os.Setenv("TT_INST_AVAILABLE", cliOpts.App.InstancesAvailable)
+	}
+
 	// Getting modules information.
 	modulesInfo, err = modules.GetModulesInfo(&cmdCtx, rootCmd.Commands(), cliOpts)
 	if err != nil {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -108,6 +108,7 @@ func NewCmdRoot() *cobra.Command {
 		NewCoredumpCmd(),
 		NewRunCmd(),
 		NewSearchCmd(),
+		NewCleanCmd(),
 	)
 	if err := injectCmds(rootCmd); err != nil {
 		panic(err.Error())

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -13,7 +13,7 @@ import (
 func NewStatusCmd() *cobra.Command {
 	var statusCmd = &cobra.Command{
 		Use:   "status <INSTANCE_NAME>",
-		Short: "Status of the tarantool instance",
+		Short: "Status of the tarantool instance(s)",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalStatusModule, args)
@@ -37,7 +37,9 @@ func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	log.Info(running.Status(cmdCtx))
+	for _, run := range cmdCtx.Running {
+		log.Infof("%s: %s", run.InstName, running.Status(cmdCtx, &run))
+	}
 
 	return nil
 }

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -13,7 +13,7 @@ import (
 func NewStopCmd() *cobra.Command {
 	var stopCmd = &cobra.Command{
 		Use:   "stop <INSTANCE_NAME>",
-		Short: "Stop tarantool instance",
+		Short: "Stop tarantool instance(s)",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalStopModule, args)
@@ -37,8 +37,10 @@ func internalStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	if err = running.Stop(cmdCtx); err != nil {
-		return err
+	for _, run := range cmdCtx.Running {
+		if err = running.Stop(cmdCtx, &run); err != nil {
+			log.Infof(err.Error())
+		}
 	}
 
 	return nil

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -7,7 +7,7 @@ type CmdCtx struct {
 	// Tarantool CLI and some other parameters.
 	Cli CliCtx
 	// Running contains information for running an application instance.
-	Running RunningCtx
+	Running []RunningCtx
 	// Connect contains information for connecting to the instance.
 	Connect ConnectCtx
 	// CommandName contains name of the command.
@@ -37,6 +37,8 @@ type RunningCtx struct {
 	AppPath string
 	// AppName contains the name of the application as it was passed on start.
 	AppName string
+	// Instance name.
+	InstName string
 	// Directory that stores various instance runtime artifacts like
 	// console socket, PID file, etc.
 	RunDir string
@@ -68,6 +70,8 @@ type RunningCtx struct {
 	Restartable bool
 	// Control UNIX socket for started instance.
 	ConsoleSocket string
+	// True if this is a single instance application (no instances.yml).
+	SingleApp bool
 }
 
 // ConnectCtx contains information for connecting to the instance.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -35,13 +35,13 @@ func getDefaultCliOpts() *config.CliOpts {
 	}
 	app := config.AppOpts{
 		InstancesAvailable: "",
-		RunDir:             "",
-		LogDir:             "",
+		RunDir:             "run",
+		LogDir:             "log",
 		LogMaxSize:         0,
 		LogMaxAge:          0,
 		LogMaxBackups:      0,
 		Restartable:        false,
-		DataDir:            "",
+		DataDir:            "data",
 	}
 	return &config.CliOpts{Modules: &modules, App: &app}
 }

--- a/cli/running/instance_test.go
+++ b/cli/running/instance_test.go
@@ -36,7 +36,7 @@ func startTestInstance(t *testing.T, app string, consoleSock string,
 	tarantoolBin, err := exec.LookPath("tarantool")
 	assert.Nilf(err, `Can't find a tarantool binary. Error: "%v".`, err)
 
-	inst, err := NewInstance(tarantoolBin, appPath, consoleSock, os.Environ(),
+	inst, err := NewInstance(tarantoolBin, appPath, "", "", consoleSock, os.Environ(),
 		logger, instTestDataDir)
 	assert.Nilf(err, `Can't create an instance. Error: "%v".`, err)
 

--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -139,6 +139,12 @@ local function start_instance()
         ffi.C.dup2(tonumber(os.getenv("TT_CLI_RUN_STDIN_FD")), 0)
     end
     -- Start the Instance.
+
+    -- Cartridge takes instance path from arg[0] and use this path
+    -- for a workaround for rocks loading in tarantool 1.10.
+    -- This can be removed when tarantool 1.10 is no longer supported.
+    arg[0] = instance_path
+
     local success, data = pcall(dofile, instance_path)
     if not success then
         log.error('Failed to run instance: %s', instance_path)

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -37,7 +37,7 @@ type providerTestImpl struct {
 
 // createInstance reads config and creates an Instance.
 func (provider *providerTestImpl) CreateInstance(logger *ttlog.Logger) (*Instance, error) {
-	return NewInstance(provider.tarantool, provider.appPath, "",
+	return NewInstance(provider.tarantool, provider.appPath, "", "", "",
 		os.Environ(), logger, provider.dataDir)
 }
 

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -283,3 +283,26 @@ func ReadEmbedFileBinary(fs embed.FS, path string) ([]byte, error) {
 	}
 	return content, nil
 }
+
+// AskConfirm asks the user for confirmation and returns true if yes.
+func AskConfirm(question string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf("%s [y/n]: ", question)
+
+		resp, err := reader.ReadString('\n')
+		resp = strings.ToLower(strings.TrimSpace(resp))
+		if err != nil {
+			return false, err
+		}
+
+		if resp == "y" || resp == "yes" {
+			return true, nil
+		}
+
+		if resp == "n" || resp == "no" {
+			return false, nil
+		}
+	}
+}

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,0 +1,78 @@
+========
+Examples
+========
+
+This file contains various examples of working with tt.
+
+--------
+Contents
+--------
+.. contents::
+  :local:
+
+Working with a set of instances
+-------------------------------
+
+For example, we want to launch two instances based on one ``init.lua`` file and one
+connected instance based on the ``router.lua`` file. In order to do this, we create
+a directory called ``demo`` with the content:
+
+``init.lua``:
+
+.. code-block:: lua
+
+    local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+    local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+    while true do
+        if app_name ~= nil and inst_name ~= nil then
+            print(app_name .. ":" .. inst_name)
+        else
+            print("unknown instance")
+        end
+        require("fiber").sleep(1)
+    end
+
+``router.init.lua``:
+
+.. code-block:: lua
+
+    local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+    local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+    while true do
+        print("custom init file...")
+        if app_name ~= nil and inst_name ~= nil then
+            print(app_name .. ":" .. inst_name)
+        else
+            print("unknown instance")
+        end
+        require("fiber").sleep(1)
+    end
+
+``instances.yml`` (The dot and dash characters in instance names
+are reserved for system use.):
+
+.. code-block:: yaml
+
+    router:
+
+    master:
+
+    replica:
+
+Now we can run all instances at once:
+
+.. code-block:: bash
+
+   $ tt start demo
+   • Starting an instance [router]...
+   • Starting an instance [master]...
+   • Starting an instance [replica]...
+
+Or just one of them:
+
+.. code-block:: bash
+
+   $ tt start demo:master
+   • Starting an instance [master]...

--- a/magefile.go
+++ b/magefile.go
@@ -103,6 +103,8 @@ func PatchCC() error {
 	patches := []string{
 		"001_make_cmd_public.patch",
 		"002_fix_admin_param.patch",
+		"003_fix_work_paths.patch",
+		"004_fix_warning.patch",
 	}
 
 	// Check that patch has been already applied.

--- a/test/integration/cartridge/test_cartridge.py
+++ b/test/integration/cartridge/test_cartridge.py
@@ -1,0 +1,79 @@
+import re
+import time
+import subprocess
+
+from utils import run_command_and_get_output, wait_file
+
+
+def test_cartridge_base_functionality(tt_cmd, tmpdir):
+    cartridge_name = "test_app"
+    create_cmd = [tt_cmd, "cartridge", "create", "--name", cartridge_name]
+    create_rc, create_out = run_command_and_get_output(create_cmd, cwd=tmpdir)
+    assert create_rc == 0
+    assert re.search(r'Application "' + cartridge_name + '" created successfully', create_out)
+
+    build_cmd = [tt_cmd, "cartridge", "build", cartridge_name]
+    build_rc, build_out = run_command_and_get_output(build_cmd, cwd=tmpdir)
+    assert build_rc == 0
+    assert re.search(r'Application was successfully built', build_out)
+
+    start_cmd = [tt_cmd, "start", cartridge_name]
+    subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+
+    instances = ["router", "stateboard", "s1-master", "s1-replica", "s2-master", "s2-replica"]
+
+    # Wait for the full start of the cartridge.
+    for inst in instances:
+        run_dir = str(tmpdir) + "/run/" + cartridge_name + "/" + inst + "/"
+        log_dir = str(tmpdir) + "/log/" + cartridge_name + "/" + inst + "/"
+        file = wait_file(run_dir, inst + '.pid', [], 10)
+        assert file != ""
+        file = wait_file(log_dir, inst + '.log', [], 10)
+        assert file != ""
+
+        started = False
+        trying = 0
+        while not started:
+            if inst == "stateboard":
+                started = True
+                break
+            if trying == 200:
+                break
+            with open(log_dir + inst + '.log', "r") as fp:
+                lines = fp.readlines()
+                lines = [line.rstrip() for line in lines]
+            for line in lines:
+                if re.search("Set default metrics endpoints", line):
+                    started = True
+                    break
+            fp.close()
+            time.sleep(0.05)
+            trying = trying + 1
+
+        assert started is True
+
+    setup_cmd = [tt_cmd, "cartridge", "replicasets", "setup",
+                 "--bootstrap-vshard",
+                 "--name", cartridge_name,
+                 "--run-dir", str(tmpdir) + "/run/" + cartridge_name]
+    setup_rc, setup_out = run_command_and_get_output(setup_cmd, cwd=tmpdir)
+    assert setup_rc == 0
+    assert re.search(r'Vshard is bootstrapped successfully', setup_out)
+
+    admin_cmd = [tt_cmd, "cartridge", "admin", "probe",
+                 "--name", cartridge_name,
+                 "--uri", "localhost:3301",
+                 "--run-dir", str(tmpdir) + "/run/" + cartridge_name]
+    admin_rc, admin_out = run_command_and_get_output(admin_cmd, cwd=tmpdir)
+    assert admin_rc == 0
+    assert re.search(r'Probe "localhost:3301": OK', admin_out)
+
+    stop_cmd = [tt_cmd, "stop", cartridge_name]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -148,3 +148,47 @@ def test_logrotate(tt_cmd, tmpdir):
     # Check that the process was terminated correctly.
     instance_process_rc = instance_process.wait(1)
     assert instance_process_rc == 0
+
+
+def test_clean(tt_cmd, tmpdir):
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+
+    # Start an instance.
+    start_cmd = [tt_cmd, "start", "test_app"]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = instance_process.stdout.readline()
+    assert re.search(r"Starting an instance", start_output)
+
+    # Check that clean warns about application is running.
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.pid', [])
+    assert file != ""
+
+    clean_cmd = [tt_cmd, "clean", "test_app", "--force"]
+    clean_rc, clean_out = run_command_and_get_output(clean_cmd, cwd=tmpdir)
+    assert clean_rc == 0
+    assert re.search(r"instance `test_app` must be stopped", clean_out)
+
+    # Stop the Instance.
+    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Instance \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    instance_process_rc = instance_process.wait(1)
+    assert instance_process_rc == 0
+
+    # Check that clean is working.
+    logfile = tmpdir + "/log/test_app/test_app.log"
+    clean_rc, clean_out = run_command_and_get_output(clean_cmd, cwd=tmpdir)
+    assert clean_rc == 0
+    assert re.search(r"• " + str(logfile), clean_out)
+
+    assert os.path.exists(logfile) is False

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -24,6 +24,8 @@ def test_running_base_functionality(tt_cmd, tmpdir):
     assert re.search(r"Starting an instance", start_output)
 
     # Check status.
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.pid', [])
+    assert file != ""
     status_cmd = [tt_cmd, "status", "test_app"]
     status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
     assert status_rc == 0
@@ -58,6 +60,8 @@ def test_restart(tt_cmd, tmpdir):
     assert re.search(r"Starting an instance", start_output)
 
     # Check status.
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.pid', [])
+    assert file != ""
     status_cmd = [tt_cmd, "status", "test_app"]
     status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
     assert status_rc == 0
@@ -82,6 +86,8 @@ def test_restart(tt_cmd, tmpdir):
     assert instance_process_rc == 0
 
     # Check status of the new Instance.
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.pid', [])
+    assert file != ""
     status_cmd = [tt_cmd, "status", "test_app"]
     status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
     assert status_rc == 0
@@ -115,6 +121,9 @@ def test_logrotate(tt_cmd, tmpdir):
     assert re.search(r"Starting an instance", start_output)
 
     # Check logrotate.
+
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.pid', [])
+    assert file != ""
     logrotate_cmd = [tt_cmd, "logrotate", "test_app"]
 
     # We use the first "logrotate" call to create the first log file (the problem is that the log
@@ -126,7 +135,7 @@ def test_logrotate(tt_cmd, tmpdir):
         assert logrotate_rc == 0
         assert re.search(r"Logs has been rotated. PID: \d+.", logrotate_out)
 
-        file = wait_file(tmpdir, 'test_app.*.log', exists_log_files)
+        file = wait_file(tmpdir + "/log/test_app/", 'test_app.*.log', exists_log_files)
         assert file != ""
         exists_log_files.append(file)
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -65,10 +65,14 @@ def wait_file(dir_name, file_pattern, exclude_list, timeout_sec=1):
     iter_count = 0
 
     while True:
-        files = os.listdir(dir_name)
-        for file in files:
-            if re.match(file_pattern, file) is not None and file not in exclude_list:
-                return file
+        try:
+            files = os.listdir(dir_name)
+        except OSError:
+            pass
+        else:
+            for file in files:
+                if re.match(file_pattern, file) is not None and file not in exclude_list:
+                    return file
 
         if (iter_count * iter_timeout_sec) > timeout_sec:
             break


### PR DESCRIPTION
This patch adds the ability to works with a set of instances.
For example, we want to launch two instances based on one init.lua
file and one connected instance based on the router.lua file.
In order to do this, we create a directory called demo with the content:

init.lua:

    local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
    local app_name = os.getenv('TARANTOOL_APP_NAME')

    while true do
        if app_name ~= nil and inst_name ~= nil then
            print(app_name .. ":" .. inst_name)
        else
            print("unknown instance")
        end
        require("fiber").sleep(1)
    end

router.init.lua:

    local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
    local app_name = os.getenv('TARANTOOL_APP_NAME')

    while true do
        print("custom init file...")
        if app_name ~= nil and inst_name ~= nil then
            print(app_name .. ":" .. inst_name)
        else
            print("unknown instance")
        end
        require("fiber").sleep(1)
    end

instances.yml (The dot and dash characters in instance names
are reserved for system use.):

    router:
    master:
    replica:

Now we can run all instances at once:

   $ tt start demo
   • Starting an instance [router]...
   • Starting an instance [master]...
   • Starting an instance [replica]...

Or just one of them:

   $ tt start demo:master
   • Starting an instance [master]...

Closes #79