### PR TITLE
ci: fix no line numbers shown for golangci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --config=golangci-lint.yml
+          args: --config=golangci-lint.yml --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
 
       - name: Unit tests
@@ -159,7 +159,7 @@ jobs:
       - name: Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          args: --config=golangci-lint.yml
+          args: --config=golangci-lint.yml --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
 
       - name: Unit tests


### PR DESCRIPTION
Solution is taken from:
golangci/golangci-lint-action#119 (comment)