### PR TITLE
tt: cli language refactoring

### DIFF
--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -30,7 +30,7 @@ var catFlags = checkpoint.Opts{
 // NewCatCmd creates a new cat command.
 func NewCatCmd() *cobra.Command {
 	var catCmd = &cobra.Command{
-		Use:   "cat FILE ..",
+		Use:   "cat <FILE>...",
 		Short: "Print into stdout the contents of .snap/.xlog files",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -12,7 +12,7 @@ import (
 // NewCheckCmd creates a new check command.
 func NewCheckCmd() *cobra.Command {
 	var checkCmd = &cobra.Command{
-		Use:   "check [APPLICATION_NAME]",
+		Use:   "check <APPLICATION_NAME>",
 		Short: "Check an application file for syntax errors",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -13,8 +13,8 @@ import (
 // NewCompletionCmd creates a new completion command.
 func NewCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "completion <shell type>",
-		Short:     "Generate autocomplete for a specified shell",
+		Use:       "completion <SHELL_TYPE>",
+		Short:     "Generate autocomplete for a specified shell. Supported shell type: bash | zsh",
 		ValidArgs: []string{"bash", "zsh"},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
@@ -49,6 +49,10 @@ func RootShellCompletionCommands(cmd *cobra.Command, args []string,
 
 // internalCompletionCmd is a default (internal) completion module function.
 func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("It is required to specify shell type.")
+	}
+
 	switch shell := args[0]; shell {
 	case "bash":
 		if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
@@ -58,6 +62,8 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err := rootCmd.GenZshCompletion(os.Stdout); err != nil {
 			return err
 		}
+	default:
+		return fmt.Errorf("Specified shell type is not is not supported. Available: bash | zsh")
 	}
 
 	return nil

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -26,8 +26,8 @@ var (
 // NewConnectCmd creates connect command.
 func NewConnectCmd() *cobra.Command {
 	var connectCmd = &cobra.Command{
-		Use: "connect (<INSTANCE_NAME> | <URI>) [<FILE> | <COMMAND>]\n" +
-			"  COMMAND | tt connect (<INSTANCE_NAME> | <URI>)",
+		Use: "connect (<INSTANCE_NAME> | <URI>) [<FILE> | <COMMAND>] [flags]\n" +
+			"  COMMAND | tt connect (<INSTANCE_NAME> | <URI>) [flags]",
 		Short: "Connect to the tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/coredump.go
+++ b/cli/cmd/coredump.go
@@ -14,11 +14,11 @@ func NewCoredumpCmd() *cobra.Command {
 	}
 
 	var packCmd = &cobra.Command{
-		Use:   "pack COREDUMP",
+		Use:   "pack <COREDUMP>",
 		Short: "pack tarantool coredump into tar.gz archive",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify COREDUMP")
+				log.Fatalf("Wrong number of arguments, please specify <COREDUMP> arg.")
 			}
 			if err := runCoredumpCommand(coredump.Pack, args[0]); err != nil {
 				log.Fatalf(err.Error())
@@ -27,11 +27,11 @@ func NewCoredumpCmd() *cobra.Command {
 	}
 
 	var unpackCmd = &cobra.Command{
-		Use:   "unpack ARCHIVE",
+		Use:   "unpack <ARCHIVE>",
 		Short: "unpack tarantool coredump tar.gz archive",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify ARCHIVE")
+				log.Fatalf("Wrong number of arguments, please specify <ARCHIVE> arg.")
 			}
 			if err := runCoredumpCommand(coredump.Unpack, args[0]); err != nil {
 				log.Fatalf(err.Error())
@@ -40,11 +40,11 @@ func NewCoredumpCmd() *cobra.Command {
 	}
 
 	var inspectCmd = &cobra.Command{
-		Use:   "inspect FOLDER",
+		Use:   "inspect <FOLDER>",
 		Short: "inspect tarantool coredump folder",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify FOLDER")
+				log.Fatalf("Wrong number of arguments, please specify <FOLDER> arg.")
 			}
 			if err := runCoredumpCommand(coredump.Inspect, args[0]); err != nil {
 				log.Fatalf(err.Error())

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -12,7 +12,7 @@ import (
 // NewLogrotateCmd creates logrotate command.
 func NewLogrotateCmd() *cobra.Command {
 	var logrotateCmd = &cobra.Command{
-		Use:   "logrotate [INSTANCE_NAME]",
+		Use:   "logrotate <INSTANCE_NAME>",
 		Short: "Rotate logs of a started tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -29,7 +29,7 @@ var playFlags = checkpoint.Opts{
 // NewPlayCmd creates a new play command.
 func NewPlayCmd() *cobra.Command {
 	var playCmd = &cobra.Command{
-		Use:   "play URI FILE ..",
+		Use:   "play <URI> <FILE>...",
 		Short: "Play the contents of .snap/.xlog files to another Tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -10,8 +10,8 @@ import (
 // NewRestartCmd creates start command.
 func NewRestartCmd() *cobra.Command {
 	var restartCmd = &cobra.Command{
-		Use:   "restart [INSTANCE_NAME]",
-		Short: "restart tarantool instance",
+		Use:   "restart <INSTANCE_NAME>",
+		Short: "Restart tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalRestartModule, args)

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -22,7 +22,7 @@ var (
 // NewStartCmd creates start command.
 func NewStartCmd() *cobra.Command {
 	var startCmd = &cobra.Command{
-		Use:   "start [APPLICATION_NAME]",
+		Use:   "start <APPLICATION_NAME>",
 		Short: "Start tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -12,7 +12,7 @@ import (
 // NewStatusCmd creates status command.
 func NewStatusCmd() *cobra.Command {
 	var statusCmd = &cobra.Command{
-		Use:   "status [INSTANCE_NAME]",
+		Use:   "status <INSTANCE_NAME>",
 		Short: "Status of the tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -12,7 +12,7 @@ import (
 // NewStopCmd creates stop command.
 func NewStopCmd() *cobra.Command {
 	var stopCmd = &cobra.Command{
-		Use:   "stop [INSTANCE_NAME]",
+		Use:   "stop <INSTANCE_NAME>",
 		Short: "Stop tarantool instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()


### PR DESCRIPTION
Refactoring of cli language that describe usage of tt commands.

Now a single notation is used to specify positional arguments through brackets `<>`, and 3 points `...` is also used to indicate the possibility of transmitting multiple parameters.

Fixed inaccuracies in the description of some parameters that must be not optional, but required.

Close #63