### PR TITLE
rocks: fix make command

### DIFF
--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -27,6 +27,8 @@ type CliCtx struct {
 	ConfigPath string
 	// Path to Tarantool executable (detected if CLI launch is local).
 	TarantoolExecutable string
+	// Tarantool version.
+	TarantoolVersion string
 }
 
 // RunningCtx contain information for running an application instance.

--- a/cli/rocks/extra/hardcoded.lua
+++ b/cli/rocks/extra/hardcoded.lua
@@ -5,9 +5,23 @@ local function get_cwd()
     return cwd
 end
 
+local function get_tarantool_path()
+    local path = os.getenv('TT_CLI_TARANTOOL_PATH')
+    if path ~= nil then
+        return path
+    end
+
+    return "/usr/bin"
+end
+
+local function get_tarantool_include_path()
+    return "/usr/include/tarantool"
+end
+
 return {
     PREFIX = [[/usr]],
-    LUA_BINDIR = [[/usr/bin]],
+    LUA_BINDIR = get_tarantool_path(),
+    LUA_INCDIR = get_tarantool_include_path(),
     LUA_MODULES_LIB_SUBDIR = [[/lib/tarantool]],
     LUA_MODULES_LUA_SUBDIR = [[/share/tarantool]],
     LUA_INTERPRETER = [[tarantool]],

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/util"
@@ -30,6 +31,14 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			cmd += fmt.Sprintf("'%s', ", arg)
 		}
 	}
+
+	version, err := util.GetTarantoolVersion(&cmdCtx.Cli)
+	if err != nil {
+		return err
+	}
+
+	os.Setenv("TT_CLI_TARANTOOL_VERSION", version)
+	os.Setenv("TT_CLI_TARANTOOL_PATH", filepath.Dir(cmdCtx.Cli.TarantoolExecutable))
 
 	rocks_cmd := fmt.Sprintf("t=require('extra.wrapper').exec('%s', %s)",
 		os.Args[0], cmd)

--- a/test/integration/rocks/files/testapp-scm-1.rockspec
+++ b/test/integration/rocks/files/testapp-scm-1.rockspec
@@ -1,0 +1,13 @@
+package = 'testapp'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+
+dependencies = {
+    'tarantool',
+    'luagraphqlparser == 0.2.0-1', 
+}
+build = {
+    type = 'none';
+}

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 
 from utils import create_tt_config, run_command_and_get_output
 
@@ -56,3 +57,11 @@ def test_rocks_module(tt_cmd, tmpdir):
             cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
     assert rc == 0
     assert "Removal successful.\n" in output
+
+    test_app_path = os.path.join(os.path.dirname(__file__), "files", "testapp-scm-1.rockspec")
+    shutil.copy(test_app_path, tmpdir)
+    rc, output = run_command_and_get_output(
+            [tt_cmd, "rocks", "make", "testapp-scm-1.rockspec"],
+            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert "testapp scm-1 is now installed" in output


### PR DESCRIPTION
When the spec file contains a tarantool dependency, luarocks
checks the tarantool version against the _TARANTOOL global variable.
Since luarocks ran inside the tarantool in tarantoolctl, there were
no problems with this. Luarocks launched from tt
is served by gopher-lua and has no direct access to tarantool variables,
accordingly, a new way of checking dependencies was added, namely:

Added variables TT_CLI_TARANTOOL_PATH and TT_CLI_TARANTOOL_VERSION.

This will allow luarocks to correctly add tarantool to the list of
dependencies and run the correct version of tarantool for internal needs.

Also in this patch are outlines for solving the problem with the correct
determination of the path to the directory with the header files of the
tarantool.

`tt rocks make` test was added.

Also, to solve this problem, a commit was made in luarocks:
https://github.com/tarantool/luarocks/pull/12

Closes #114