### PR TITLE
lint: fix linter errors in rocks tests

### DIFF
--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -29,7 +29,7 @@ def test_rocks_module(tt_cmd, tmpdir):
             cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
     assert rc == 0
     assert "Cloning into 'queue'...\n" in output
-    assert(os.path.isfile(f'{tmpdir}/.rocks/share/tarantool/queue/init.lua'))
+    assert os.path.isfile(f'{tmpdir}/.rocks/share/tarantool/queue/init.lua')
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "doc", "queue", "--list"],
@@ -43,14 +43,14 @@ def test_rocks_module(tt_cmd, tmpdir):
     assert rc == 0
     assert re.search("Packed: .*queue-.*[.]rock", output)
     rock_file = output.split("Packed: ")[1].strip()
-    assert(os.path.isfile(rock_file))
+    assert os.path.isfile(rock_file)
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "unpack", rock_file],
             cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
     assert rc == 0
     rock_dir = rock_file.split('.', 1)[0]
-    assert(os.path.isdir(rock_dir))
+    assert os.path.isdir(rock_dir)
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "remove", "queue"],


### PR DESCRIPTION
Without this patch a user catches an error when calling mage test:
```
test/integration/rocks/test_rocks.py:32:11: E275 missing whitespace after keyword
test/integration/rocks/test_rocks.py:46:11: E275 missing whitespace after keyword
test/integration/rocks/test_rocks.py:53:11: E275 missing whitespace after keyword
Error: running "python3 -m flake8 test" failed with exit code 1
```
In CI this linter rule is ignored.
Flake8 version: `4.0.1`

Follow up #14