### PR TITLE
tt: daemon module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Module ``tt init``, to create tt environment configuration file.
+- Module ``tt daemon``, to manage the ``tt`` daemon.
 
 ## [0.1.0] - 2022-10-12
 

--- a/README.rst
+++ b/README.rst
@@ -293,6 +293,56 @@ use the .rockspec.
 
 `Custom template example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-application-templates>`_
 
+Working with tt daemon (experimental)
+-------------------------------------
+
+``tt daemon`` module is used to manage ``tt``
+daemon on a given machine. This way instances
+can be operated remotely.
+Daemon can be configured with ``tt_daemon.yaml`` config.
+
+``tt_daemon.yaml`` file format:
+
+.. code-block:: yaml
+
+  daemon:
+        run_dir: path
+        log_dir: path
+        log_maxsize: num (MB)
+        log_maxage: num (Days)
+        log_maxbackups: num
+        log_file: string (file name)
+        listen_interface: string
+        port: num
+        pidfile: string (file name)
+
+Where:
+
+* ``run_dir`` (string) - path to directory that stores various instance
+  runtime artifacts like console socket, PID file, etc. Default: ``run``.
+* ``log_dir`` (string) - directory that stores log files. Default: ``log``.
+* ``log_maxsize`` (number) - the maximum size in MB of the log file before it gets
+  rotated. Default: 100 MB.
+* ``log_maxage`` (numder) - is the maximum number of days to retain old log files
+  based on the timestamp encoded in their filename. Note that a day is defined
+  as 24 hours and may not exactly correspond to calendar days due to daylight
+  savings, leap seconds, etc. Default: not to remove old log files based
+  on age.
+* ``log_maxbackups`` (number) - the maximum number of old log files to retain.
+  Default: to retain all old log files (though log_maxage may still cause
+  them to get deleted).
+* ``log_file`` (string) - name of file contains log of daemon process.
+  Default: ``tt_daemon.log``.
+* ``listen_interface`` (string) - network interface the IP address
+  should be found on to bind http server socket.
+  Default: loopback (``lo``/``lo0``).
+* ``port`` (number) - port number to be used for daemon http server.
+  Default: 1024.
+* ``pidfile`` (string) - name of file contains pid of daemon process.
+  Default: ``tt_daemon.pid``.
+
+`TT daemon example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-tt-daemon>`_
+
 Commands
 --------
 Common description. For a detailed description, use ``tt help command`` .
@@ -319,3 +369,4 @@ Common description. For a detailed description, use ``tt help command`` .
 * ``install`` - install tarantool/tt.
 * ``remove`` - remove tarantool/tt.
 * ``init`` - create tt environment configuration file.
+* ``daemon (experimental)`` - manage tt daemon.

--- a/cli/cmd/daemon.go
+++ b/cli/cmd/daemon.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/configure"
+	"github.com/tarantool/tt/cli/daemon"
+	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/process_utils"
+)
+
+// NewDaemonCmd creates daemon command.
+func NewDaemonCmd() *cobra.Command {
+	var daemonCmd = &cobra.Command{
+		Use:   "daemon",
+		Short: "Perform manipulations with the tt daemon (experimental)",
+	}
+
+	var startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "start tt daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				log.Fatalf("Wrong number of arguments")
+			}
+
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo,
+				internalDaemonStartModule, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	var stopCmd = &cobra.Command{
+		Use:   "stop",
+		Short: "stop tt daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				log.Fatalf("Wrong number of arguments")
+			}
+
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo,
+				internalDaemonStopModule, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	var statusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "status of tt daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				log.Fatalf("Wrong number of arguments")
+			}
+
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo,
+				internalDaemonStatusModule, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	var restartCmd = &cobra.Command{
+		Use:   "restart",
+		Short: "restart tt daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				log.Fatalf("Wrong number of arguments")
+			}
+
+			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo,
+				internalDaemonRestartModule, args)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	daemonSubCommands := []*cobra.Command{
+		startCmd,
+		stopCmd,
+		statusCmd,
+		restartCmd,
+	}
+
+	for _, cmd := range daemonSubCommands {
+		daemonCmd.AddCommand(cmd)
+	}
+
+	return daemonCmd
+}
+
+// internalDaemonRestartModule is a default restart module.
+func internalDaemonRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if err := internalDaemonStopModule(cmdCtx, args); err != nil {
+		return err
+	}
+
+	if err := internalDaemonStartModule(cmdCtx, args); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// internalDaemonStartModule is a default start module.
+func internalDaemonStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	opts, err := configure.GetDaemonOpts(cmdCtx.Cli.DaemonCfgPath)
+	if err != nil {
+		return err
+	}
+
+	daemonCtx := daemon.NewDaemonCtx(opts)
+	if err := daemon.RunHTTPServerOnBackground(daemonCtx); err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	return nil
+}
+
+// internalDaemonStopModule is a default stop module.
+func internalDaemonStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	opts, err := configure.GetDaemonOpts(cmdCtx.Cli.DaemonCfgPath)
+	if err != nil {
+		return err
+	}
+
+	daemonCtx := daemon.NewDaemonCtx(opts)
+	if err := daemon.StopDaemon(daemonCtx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// internalDaemonStatusModule is a default status module.
+func internalDaemonStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	opts, err := configure.GetDaemonOpts(cmdCtx.Cli.DaemonCfgPath)
+	if err != nil {
+		return err
+	}
+
+	daemonCtx := daemon.NewDaemonCtx(opts)
+	log.Info(process_utils.ProcessStatus(daemonCtx.PIDFile))
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -117,6 +117,7 @@ func NewCmdRoot() *cobra.Command {
 		NewRemoveCmd(),
 		NewPackCmd(),
 		NewInitCmd(),
+		NewDaemonCmd(),
 	)
 	if err := injectCmds(rootCmd); err != nil {
 		panic(err.Error())

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -69,8 +69,6 @@ func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			newArgs := []string{"start", "--watchdog", appName}
 
 			wdCmd := exec.Command(ttBin, newArgs...)
-			wdCmd.Stdout = os.Stdout
-			wdCmd.Stderr = os.Stderr
 
 			if err := wdCmd.Start(); err != nil {
 				return err

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -21,6 +21,8 @@ type CliCtx struct {
 	LocalLaunchDir string
 	// Path to Tarantool CLI (tarantool.yaml) config.
 	ConfigPath string
+	// Path to tt daemon (tt_daemon.yaml) config.
+	DaemonCfgPath string
 	// Path to Tarantool executable (detected if CLI launch is local).
 	TarantoolExecutable string
 	// Tarantool version.

--- a/cli/config/daemon_cfg.go
+++ b/cli/config/daemon_cfg.go
@@ -1,0 +1,52 @@
+package config
+
+// DaemonCfg used to store all information from the
+// tt_daemon.yaml configuration file.
+type DaemonCfg struct {
+	DaemonConfig *DaemonOpts `mapstructure:"daemon" yaml:"daemon"`
+}
+
+// DaemonOpts stores information about tt daemon configuration.
+// Filled in when parsing the tt_daemon.yaml configuration file.
+//
+// tt_daemon.yaml file format:
+// daemon:
+//
+//	run_dir: path
+//	log_dir: path
+//	log_maxsize: num (MB)
+//	log_maxage: num (Days)
+//	log_maxbackups: num
+//	log_file: string (file name)
+//	listen_interface: string
+//	port: num
+//	pidfile: string (file name)
+type DaemonOpts struct {
+	// PIDFile is name of file contains pid of daemon process.
+	PIDFile string `mapstructure:"pidfile"`
+	// Port is a port number to be used for daemon http server.
+	Port int `mapstructure:"port"`
+	// LogDir is a directory that stores log files.
+	LogDir string `mapstructure:"log_dir"`
+	// LogFile is a name of file contains log of daemon process.
+	LogFile string `mapstructure:"log_file"`
+	// LogMaxSize is a maximum size in MB of the log file before
+	// it gets rotated.
+	LogMaxSize int `mapstructure:"log_maxsize"`
+	// LogMaxAge is the maximum number of days to retain old log files
+	// based on the timestamp encoded in their filename. Note that a
+	// day is defined as 24 hours and may not exactly correspond to
+	// calendar days due to daylight savings, leap seconds, etc. The
+	// default is not to remove old log files based on age.
+	LogMaxAge int `mapstructure:"log_maxage"`
+	// LogMaxBackups is the maximum number of old log files to retain.
+	// The default is to retain all old log files (though LogMaxAge may
+	// still cause them to get deleted).
+	LogMaxBackups int `mapstructure:"log_maxbackups"`
+	// ListenInterface is a network interface the IP address
+	// should be found on to bind http server socket.
+	ListenInterface string `mapstructure:"listen_interface"`
+	// RunDir is a path to directory that stores various instance
+	// runtime artifacts like console socket, PID file, etc.
+	RunDir string `mapstructure:"run_dir" yaml:"run_dir"`
+}

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/tarantool/tt/cli/ttlog"
+)
+
+// DaemonHandler is used to communicate with the daemon over HTTP.
+type DaemonHandler struct {
+	cmdPath string
+	logger  *ttlog.Logger
+}
+
+// resResult describes a failure during the command execution.
+type resResult struct {
+	Res interface{} `json:"res"`
+}
+
+// errorResult describes a failure during the command execution.
+type errorResult struct {
+	Err string `json:"err"`
+}
+
+// callCommand invokes the command and returns the execution result.
+func (handler *DaemonHandler) callCommand(ttCmd *command) (string, error) {
+	newArgs := append([]string{ttCmd.Name}, ttCmd.Params...)
+
+	cmd := exec.Command(handler.cmdPath, newArgs...)
+
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		err = fmt.Errorf(fmt.Sprint(err) + ": " + stderr.String())
+	}
+
+	return stdout.String() + stderr.String(), err
+}
+
+// NewDaemonHandler creates DaemonHandler.
+func NewDaemonHandler(cmdPath string) *DaemonHandler {
+	return &DaemonHandler{
+		cmdPath: cmdPath,
+		logger:  ttlog.NewCustomLogger(io.Discard, "", 0),
+	}
+}
+
+// Logger sets logger for DaemonHandler.
+func (handler *DaemonHandler) Logger(logger *ttlog.Logger) *DaemonHandler {
+	handler.logger = logger
+	return handler
+}
+
+// getClientIP gets the IP address of the client for an incoming HTTP request.
+func (handler *DaemonHandler) getClientIP(req *http.Request) (string, error) {
+	// Get IP from the X-REAL-IP header.
+	// X-REAL-IP header contains only one
+	// IP address of the client machine.
+	// Note: this header can easily be spoofed
+	// by the client.
+	ip := req.Header.Get("X-REAL-IP")
+	// Check IP is correct.
+	netIP := net.ParseIP(ip)
+	if netIP != nil {
+		return ip, nil
+	}
+
+	// Get IP from X-FORWARDED-FOR header.
+	// X-FORWARDED-FOR is a list of IP
+	// addresses – proxy chaining.
+	// Note: it can also be easily spoofed
+	// by the client.
+	ips := req.Header.Get("X-FORWARDED-FOR")
+	splitIps := strings.Split(ips, ",")
+	for _, ip := range splitIps {
+		// Check IP is correct
+		netIP := net.ParseIP(ip)
+		if netIP != nil {
+			return ip, nil
+		}
+	}
+
+	// Get IP from RemoteAddr attr.
+	// RemoteAddr contains the IP address that
+	// the response will be sent to. But in case the
+	// client is connected through a proxy it will
+	// give the IP address of the proxy.
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return "", err
+	}
+
+	// Check IP is correct.
+	netIP = net.ParseIP(ip)
+	if netIP != nil {
+		return req.RemoteAddr, nil
+	}
+
+	return "", fmt.Errorf("No valid IP found")
+}
+
+// ServeHTTP handles requests to the tt daemon.
+func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
+	// Parse, check and call the command.
+	var res interface{}
+	var status int
+	var cmd command
+
+	// Construct client IP msg.
+	var clientIpMsg string
+	if ip, err := handler.getClientIP(req); err != nil {
+		clientIpMsg = err.Error()
+	} else {
+		clientIpMsg = ip
+	}
+
+	rawBody, err := parseCommand(req.Body, &cmd)
+	if err != nil {
+		status = http.StatusBadRequest
+		res = &errorResult{err.Error()}
+	} else {
+		status = http.StatusOK
+		commandRes, err := handler.callCommand(&cmd)
+		if err != nil {
+			res = &errorResult{err.Error()}
+		} else {
+			res = &resResult{commandRes}
+		}
+	}
+
+	// Construct json response.
+	var jsonResMsg string
+	if jsonRes, err := json.Marshal(res); err != nil {
+		jsonResMsg = err.Error()
+	} else {
+		jsonResMsg = string(jsonRes)
+	}
+
+	// Log client IP, raw json request body, raw json response body.
+	handler.logger.Printf("Client IP: %s; Request body: %s; Response body: %s",
+		clientIpMsg, rawBody, jsonResMsg)
+
+	// Write the result.
+	wr.Header().Set("Content-Type", "application/json")
+	wr.WriteHeader(status)
+	if err := json.NewEncoder(wr).Encode(res); err != nil {
+		handler.logger.Printf("An error occurred while encoding the response: \"%v\"\n", err)
+	}
+}

--- a/cli/daemon/api/parser.go
+++ b/cli/daemon/api/parser.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// commandJSON describes the tt command sent using the HTTP API.
+type commandJSON struct {
+	// Name is a name of the command.
+	// Now available: start, stop, status, restart.
+	Name string `json:"command_name"`
+	// Params are command parameters.
+	Params []string `json:"params"`
+}
+
+// command describes the tt command.
+type command struct {
+	// Name is name of the command.
+	Name string
+	// Params are command parameters.
+	Params []string
+}
+
+// parseCommand decodes JSON, checks the parameters
+// and parses them to a "command" struct.
+func parseCommand(r io.Reader, cmd *command) (string, error) {
+	// Read data to log raw JSON request.
+	bodyBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err.Error(), fmt.Errorf(`Failed to read request body: %s`, err.Error())
+	}
+
+	rawBody := string(bodyBytes)
+
+	// Decode JSON.
+	decoder := json.NewDecoder(bytes.NewReader(bodyBytes))
+	decoder.DisallowUnknownFields()
+
+	var cmdJSON commandJSON
+	if err := decoder.Decode(&cmdJSON); err != nil {
+		return rawBody, err
+	}
+
+	// Parse cmdJSON to a "command" structure.
+	// Additionally, all types of parameters will be checked.
+	if err := mapstructure.Decode(cmdJSON, cmd); err != nil {
+		return rawBody, fmt.Errorf(`Failed to parse command params: "%v"`, err.Error())
+	}
+
+	return rawBody, nil
+}

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/process_utils"
+	"github.com/tarantool/tt/cli/ttlog"
+)
+
+// DaemonCtx contains information for running an daemon instance.
+type DaemonCtx struct {
+	// Port is a port number to be used for daemon http server.
+	Port int
+	// PIDFile is a path of a file contains pid of daemon process.
+	PIDFile string
+	// LogPath is a path to a file contains log of daemon process.
+	LogPath string
+	// LogMaxSize is the maximum size in megabytes of the log file
+	// before it gets rotated. It defaults to 100 megabytes.
+	LogMaxSize int
+	// LogMaxBackups is the maximum number of old log files to retain.
+	// The default is to retain all old log files (though LogMaxAge may
+	// still cause them to get deleted).
+	LogMaxBackups int
+	// LogMaxAge is the maximum number of days to retain old log files
+	// based on the timestamp encoded in their filename. Note that a
+	// day is defined as 24 hours and may not exactly correspond to
+	// calendar days due to daylight savings, leap seconds, etc. The
+	// default is not to remove old log files based on age.
+	LogMaxAge int
+	// ListenInterface is a network interface the IP address
+	// should be found on to bind http server socket.
+	ListenInterface string
+}
+
+// NewDaemonCtx creates the DaemonCtx context.
+func NewDaemonCtx(opts *config.DaemonOpts) *DaemonCtx {
+	return &DaemonCtx{
+		PIDFile:       filepath.Join(opts.RunDir, opts.PIDFile),
+		Port:          opts.Port,
+		LogPath:       filepath.Join(opts.LogDir, opts.LogFile),
+		LogMaxAge:     opts.LogMaxAge,
+		LogMaxBackups: opts.LogMaxBackups,
+		LogMaxSize:    opts.LogMaxSize,
+	}
+}
+
+// RunHTTPServerOnBackground starts http daemon process.
+func RunHTTPServerOnBackground(daemonCtx *DaemonCtx) error {
+	logOpts := ttlog.LoggerOpts{
+		Filename:   daemonCtx.LogPath,
+		MaxSize:    daemonCtx.LogMaxSize,
+		MaxBackups: daemonCtx.LogMaxBackups,
+		MaxAge:     daemonCtx.LogMaxAge,
+	}
+
+	args := []string{"daemon", "start"}
+	proc := NewProcess(NewHTTPServer(daemonCtx.ListenInterface, daemonCtx.Port),
+		daemonCtx.PIDFile, logOpts).CmdPath(os.Args[0]).CmdArgs(args)
+
+	if err := proc.Start(); err != nil {
+		return err
+	}
+
+	log.Printf("Starting tt daemon...")
+
+	return nil
+}
+
+// StopDaemon starts http daemon process.
+func StopDaemon(daemonCtx *DaemonCtx) error {
+	pid, err := process_utils.StopProcess(daemonCtx.PIDFile)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("The Daemon (PID = %v) has been terminated.\n", pid)
+
+	return nil
+}

--- a/cli/daemon/httpserver.go
+++ b/cli/daemon/httpserver.go
@@ -1,0 +1,147 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tarantool/tt/cli/daemon/api"
+	"github.com/tarantool/tt/cli/ttlog"
+)
+
+const (
+	defaultStopTimeout = 100 * time.Millisecond
+)
+
+// HTTPServer contains information for http server.
+type HTTPServer struct {
+	// listenIface is a network interface the IP address
+	// should be found on to bind http server socket.
+	listenIface string
+	// port is a port number to be used for http server.
+	port int
+	// srv is http.Server instance.
+	srv *http.Server
+	// timeout is the time that was provided
+	// to the HTTP server to shutdown correctly.
+	timeout time.Duration
+	// logger is  a log file the HTTP server will write to.
+	logger *ttlog.Logger
+}
+
+// listenIP discovers IP address on the specified interface.
+// If interface name is not specified returned value is 0.0.0.0;
+// returns the first discovered IP address on the specified interface.
+func (httpServer *HTTPServer) listenIP() (string, error) {
+	if httpServer.listenIface == "" {
+		return net.IPv4zero.String(), nil
+	}
+
+	iface, err := net.InterfaceByName(httpServer.listenIface)
+	if err != nil {
+		return "", err
+	}
+
+	if iface.Flags&net.FlagUp == 0 {
+		return "", fmt.Errorf("Interface down")
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+
+	// The socket will bind to the first discovered
+	// IP address on the specified interface.
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+
+		if ip == nil {
+			continue
+		}
+
+		// TODO: Support IPv6 by option
+		// Not an IPv4 address.
+		if ip.To4() == nil {
+			continue
+		}
+
+		return ip.String(), nil
+	}
+
+	return "", fmt.Errorf("listen IP is not available")
+}
+
+// NewHTTPServer creates new HTTPServer.
+func NewHTTPServer(listenInterface string, port int) *HTTPServer {
+	return &HTTPServer{
+		listenIface: listenInterface,
+		port:        port,
+		timeout:     defaultStopTimeout,
+	}
+}
+
+// Timeout sets the time that was provided to the HTTP server
+// to shutdown correctly.
+func (httpServer *HTTPServer) Timeout(timeout time.Duration) *HTTPServer {
+	httpServer.timeout = timeout
+	return httpServer
+}
+
+// SetLogger sets a log file the HTTP server will write to.
+func (httpServer *HTTPServer) SetLogger(logger *ttlog.Logger) {
+	httpServer.logger = logger
+}
+
+// Start starts HTTP server.
+func (httpServer *HTTPServer) Start(ttPath string) {
+	ip, err := httpServer.listenIP()
+	if err != nil {
+		httpServer.logger.Fatalf("Can't get IP")
+	}
+
+	httpServerAddr := ip + ":" + strconv.Itoa(httpServer.port)
+	httpServer.srv = &http.Server{
+		Addr: httpServerAddr,
+	}
+
+	// Prepare HTTP server.
+	daemonHandler := api.NewDaemonHandler(ttPath).Logger(httpServer.logger)
+	http.Handle("/tarantool", daemonHandler)
+
+	// Start HTTP server.
+	socket, err := net.Listen("tcp4", httpServer.srv.Addr)
+	if err != nil {
+		httpServer.logger.Fatal(err)
+	}
+
+	if err := httpServer.srv.Serve(socket); err != http.ErrServerClosed {
+		httpServer.logger.Fatalf("Can't start HTTP server")
+	}
+}
+
+// Stop stops HTTP server.
+func (httpServer *HTTPServer) Stop() error {
+	var err error
+
+	if httpServer.srv == nil {
+		return fmt.Errorf("Server is not started")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpServer.timeout)
+	if err = httpServer.srv.Shutdown(ctx); err != nil {
+		httpServer.logger.Printf(`HTTP server shutdown error: "%v"`, err)
+	}
+	cancel()
+
+	return err
+}

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/tarantool/tt/cli/process_utils"
+	"github.com/tarantool/tt/cli/ttlog"
+)
+
+const (
+	EnvName = "TT_CLI_DAEMON"
+)
+
+const (
+	stopDaemonMsg  = "Stopping tt daemon..."
+	startDaemonMsg = "Starting tt daemon..."
+)
+
+// Worker describes an interface of
+// a worker the process will manage.
+type Worker interface {
+	Start(ttPath string)
+	Stop() error
+	SetLogger(logger *ttlog.Logger)
+}
+
+// Process describes a running process.
+type Process struct {
+	// logOpts are options to create a logger.
+	logOpts ttlog.LoggerOpts
+	// logger is a log file the process will write to.
+	logger *ttlog.Logger
+	// pidFileName is a path to the process pid file.
+	pidFileName string
+	// cmdPath is a path to the command the process should perform.
+	cmdPath string
+	// cmdArgs are arguments to the command the process should perform.
+	cmdArgs []string
+	// worker is a worker the process will manage.
+	worker Worker
+	// DaemonTag is an env name to check the process is a child process.
+	DaemonTag string
+}
+
+// startSignalHandling adds "SIGTERM" and "SIGINT"
+// signal handling to terminate gracefully.
+func (process *Process) startSignalHandling() {
+	sigTermChan := make(chan os.Signal, 1)
+	signal.Notify(sigTermChan, syscall.SIGINT, syscall.SIGTERM)
+
+	for {
+		select {
+		case _ = <-sigTermChan:
+			process.Stop()
+		}
+	}
+}
+
+// NewProcess creates new Process.
+func NewProcess(worker Worker, pidFileName string, logOpts ttlog.LoggerOpts) *Process {
+	process := &Process{
+		logOpts:     logOpts,
+		pidFileName: pidFileName,
+		worker:      worker,
+		DaemonTag:   EnvName,
+		cmdPath:     os.Args[0],
+		cmdArgs:     os.Args[1:],
+	}
+
+	return process
+}
+
+// CmdPath sets a path to the command the process should perform.
+func (process *Process) CmdPath(cmdPath string) *Process {
+	process.cmdPath = cmdPath
+	return process
+}
+
+// CmdArgs sets arguments to the command the process should perform.
+func (process *Process) CmdArgs(cmdArgs []string) *Process {
+	process.cmdArgs = cmdArgs
+	return process
+}
+
+// IsChild checks a process is the child process.
+func (process *Process) IsChild() bool {
+	return os.Getenv(process.DaemonTag) == "true"
+}
+
+// Start starts the process.
+func (process *Process) Start() error {
+	if process.IsChild() {
+		process.logger = ttlog.NewLogger(&process.logOpts)
+
+		if err := process_utils.CreatePIDFile(process.pidFileName); err != nil {
+			return err
+		}
+
+		process.logger.Println(startDaemonMsg)
+		process.worker.SetLogger(process.logger)
+
+		go process.worker.Start(process.cmdPath)
+		process.startSignalHandling()
+		return nil
+	}
+
+	if err := process_utils.CheckPIDFile(process.pidFileName); err != nil {
+		return err
+	}
+
+	cmd := exec.Command(process.cmdPath, process.cmdArgs...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=true", process.DaemonTag))
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Process.Release()
+}
+
+// Stop stops the process.
+func (process *Process) Stop() {
+	process.logger.Println(stopDaemonMsg)
+	done := make(chan error, 1)
+	go func() {
+		done <- process.worker.Stop()
+	}()
+
+	os.Remove(process.pidFileName)
+	_ = os.Unsetenv(process.DaemonTag)
+
+	err := <-done
+
+	if err != nil {
+		process.logger.Println(err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cli/daemon/process_test.go
+++ b/cli/daemon/process_test.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessBase(t *testing.T) {
+	t.Cleanup(func() { cleanupDaemonFiles(TestProcessLogPath, TestProcessPidFile) })
+
+	// Start daemon.
+	cmd := exec.Command("go", "run", "test_process/test_process.go")
+	err := cmd.Run()
+	require.Nilf(t, err, `Can't start daemon. Error: "%v".`, err)
+
+	// Check is daemon alive.
+	waitProcessChanges()
+	pid, err := readPID(TestProcessPidFile)
+	require.Nilf(t, err, `Can't read daemon PID. Error: "%v".`, err)
+
+	alive, err := IsDaemonAlive(pid)
+	require.Nilf(t, err, `Daemon is not alive. Error: "%v".`, err)
+	require.True(t, alive, "Can't start daemon.")
+
+	// Stop daemon.
+	syscall.Kill(pid, syscall.SIGINT)
+
+	// Check is daemon alive.
+	waitProcessChanges()
+	alive, err = IsDaemonAlive(pid)
+	require.False(t, alive, "Can't stop daemon.")
+
+	_, err = os.Stat(TestProcessPidFile)
+	require.NotNil(t, err, `Pid file still exists.`)
+
+	// Check logger.
+	testLog, err := os.Open(TestProcessLogPath)
+	require.Nilf(t, err, `Can't open test log. Error: "%v".`, err)
+
+	buf := bytes.NewBufferString("")
+	_, err = io.Copy(buf, testLog)
+	require.Nilf(t, err, `Can't read log output. Error: "%v".`, err)
+
+	logContent := buf.String()
+	msgIdx1 := strings.Index(buf.String(), startDaemonMsg)
+	require.NotEqual(t, -1, msgIdx1,
+		"The message in the log is different from what was expected: %v", logContent)
+	msgIdx2 := strings.Index(buf.String(), StartTestWorkerMsg)
+	require.NotEqual(t, -1, msgIdx2,
+		"The message in the log is different from what was expected: %v", logContent)
+	require.Greater(t, msgIdx2, msgIdx1,
+		"The message in the log is different from what was expected: %v", logContent)
+	msgIdx3 := strings.Index(buf.String(), stopDaemonMsg)
+	require.NotEqual(t, -1, msgIdx3,
+		"The message in the log is different from what was expected: %v", logContent)
+	require.Greater(t, msgIdx3, msgIdx2,
+		"The message in the log is different from what was expected: %v", logContent)
+	msgIdx4 := strings.Index(buf.String(), StopTestWorkerMsg)
+	require.NotEqual(t, -1, msgIdx4,
+		"The message in the log is different from what was expected: %v", logContent)
+	require.Greater(t, msgIdx4, msgIdx3,
+		"The message in the log is different from what was expected: %v", logContent)
+}

--- a/cli/daemon/process_test_helpers.go
+++ b/cli/daemon/process_test_helpers.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+
+	ps "github.com/mitchellh/go-ps"
+)
+
+const (
+	StartTestWorkerMsg = "Test worker started"
+	StopTestWorkerMsg  = "Test worker stopped"
+)
+
+const (
+	TestProcessLogPath = "test_process.log"
+	TestProcessPidFile = "test_process.pid"
+)
+
+// waitProcessChanges waits for the new process to set signal handlers.
+func waitProcessChanges() {
+	// We need to wait for the new process (tarantool instance) to set handlers.
+	// It is necessary to update for more correct synchronization.
+	time.Sleep(500 * time.Millisecond)
+}
+
+// cleanupDaemonFiles cleans up daemon artifacts.
+func cleanupDaemonFiles(logFilename string, pidFilename string) {
+	if _, err := os.Stat(logFilename); !os.IsNotExist(err) {
+		os.Remove(logFilename)
+	}
+
+	if _, err := os.Stat(pidFilename); !os.IsNotExist(err) {
+		os.Remove(pidFilename)
+	}
+}
+
+// readPID reads pid from filePath.
+func readPID(filePath string) (int, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0, err
+	}
+
+	buf := bytes.NewBufferString("")
+	if _, err = io.Copy(buf, file); err != nil {
+		return 0, err
+	}
+
+	pid, err := strconv.Atoi(buf.String())
+	if err != nil {
+		return 0, err
+	}
+
+	return pid, nil
+}
+
+// IsDaemonAlive checks is daemon alive by process pid.
+func IsDaemonAlive(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %v", pid)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	err = proc.Signal(syscall.Signal(0))
+	if err != nil {
+		return false, err
+	}
+
+	pr, err := ps.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	if pr.PPid() != 1 {
+		return false, fmt.Errorf("Process is not daemonized")
+	}
+
+	return true, nil
+}

--- a/cli/daemon/test_process/test_process.go
+++ b/cli/daemon/test_process/test_process.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+
+	"github.com/tarantool/tt/cli/daemon"
+	"github.com/tarantool/tt/cli/ttlog"
+)
+
+// TestWorker represents simple worker.
+type TestWorker struct {
+	logger *ttlog.Logger
+	done   chan bool
+}
+
+// NewTestWorker creates new TestWorker.
+func NewTestWorker() *TestWorker {
+	return &TestWorker{
+		done: make(chan bool, 1),
+	}
+}
+
+// SetLogger sets worker logger.
+func (w *TestWorker) SetLogger(logger *ttlog.Logger) {
+	w.logger = logger
+}
+
+// Start starts worker.
+func (w *TestWorker) Start(ttPath string) {
+	w.logger.Println(daemon.StartTestWorkerMsg)
+
+	go func() {
+		for {
+			select {
+			case <-w.done:
+				return
+			}
+		}
+	}()
+}
+
+// Stop stops worker.
+func (w *TestWorker) Stop() error {
+	w.logger.Println(daemon.StopTestWorkerMsg)
+
+	w.done <- true
+	return nil
+}
+
+func main() {
+	logOpts := ttlog.LoggerOpts{
+		Filename:   daemon.TestProcessLogPath,
+		MaxSize:    0,
+		MaxBackups: 0,
+		MaxAge:     0,
+	}
+
+	proc := daemon.NewProcess(NewTestWorker(), daemon.TestProcessPidFile, logOpts)
+
+	if err := proc.Start(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -1,0 +1,193 @@
+package process_utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Create a new directory.
+// 0770:
+// user:   read/write/execute
+// group:  read/write/execute
+// others: nil
+const defaultDirPerms = 0770
+
+const (
+	ProcStateStopped = "NOT RUNNING."
+	ProcStateDead    = "ERROR. The process is dead."
+	ProcStateRunning = "RUNNING. PID: %v."
+)
+
+// GetPIDFromFile returns PID from the PIDFile.
+func GetPIDFromFile(pidFileName string) (int, error) {
+	if _, err := os.Stat(pidFileName); err != nil {
+		return 0, fmt.Errorf(`Can't "stat" the PID file. Error: "%v".`, err)
+	}
+
+	pidFile, err := os.Open(pidFileName)
+	if err != nil {
+		return 0, fmt.Errorf(`Can't open the PID file. Error: "%v".`, err)
+	}
+
+	pidBytes, err := ioutil.ReadAll(pidFile)
+	if err != nil {
+		return 0, fmt.Errorf(`Can't read the PID file. Error: "%v".`, err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		return 0,
+			fmt.Errorf(`PID file exists with unknown format. Error: "%s"`, err)
+	}
+
+	return pid, nil
+}
+
+// CheckPIDFile checks that the process PID file exists
+// and is readable. Or process is already exist.
+// Removes PID file if process is dead.
+func CheckPIDFile(pidFileName string) error {
+	if _, err := os.Stat(pidFileName); err == nil {
+		// The PID file already exists. We have to check if the process is alive.
+		pid, err := GetPIDFromFile(pidFileName)
+		if err != nil {
+			return fmt.Errorf(`PID file exists, but PID can't be read. Error: "%v".`, err)
+		}
+		if res, _ := IsProcessAlive(pid); res {
+			return fmt.Errorf("The process is already exists. PID: %d", pid)
+		} else {
+			os.Remove(pidFileName)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf(`Something went wrong while trying to read the PID file. Error: "%v".`,
+			err)
+	}
+
+	return nil
+}
+
+// CreatePIDFile checks that the instance PID file is absent or
+// deprecated and creates a new one. Returns an error on failure.
+func CreatePIDFile(pidFileName string) error {
+	if err := CheckPIDFile(pidFileName); err != nil {
+		return err
+	}
+
+	pidAbsDir := filepath.Dir(pidFileName)
+	if _, err := os.Stat(pidAbsDir); err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(pidAbsDir, defaultDirPerms)
+			if err != nil {
+				return fmt.Errorf(`can't crete PID file directory. Error: "%v".`, err)
+			}
+		} else {
+			return fmt.Errorf(`can't stat PID file directory. Error: "%v".`, err)
+		}
+	}
+
+	// Create a new PID file.
+	// 0644:
+	//    user:   read/write
+	//    group:  read
+	//    others: read
+	pidFile, err := os.OpenFile(pidFileName,
+		syscall.O_EXCL|syscall.O_CREAT|syscall.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf(`Can't create a new PID file. Error: "%v".`, err)
+	}
+	defer pidFile.Close()
+
+	if _, err = pidFile.WriteString(strconv.Itoa(os.Getpid())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StopProcess stops the process by pidFile.
+func StopProcess(pidFile string) (int, error) {
+	pid, err := GetPIDFromFile(pidFile)
+	if err != nil {
+		return 0, err
+	}
+
+	alive, err := IsProcessAlive(pid)
+	if !alive {
+		return 0, fmt.Errorf(`The process is already dead. Error: "%v".`, err)
+	}
+
+	if err = syscall.Kill(pid, syscall.SIGINT); err != nil {
+		return 0, fmt.Errorf(`Can't terminate the process. Error: "%v".`, err)
+	}
+
+	if res := waitProcessTermination(pid, 30*time.Second, 100*time.Millisecond); !res {
+		return 0, fmt.Errorf("Can't terminate the process.")
+	}
+
+	return pid, nil
+}
+
+// ProcessStatus returns the status of the process.
+func ProcessStatus(pidFile string) string {
+	pid, err := GetPIDFromFile(pidFile)
+	if err != nil {
+		return fmt.Sprintf(ProcStateStopped)
+	}
+
+	alive, err := IsProcessAlive(pid)
+	if !alive {
+		return fmt.Sprintf(ProcStateDead)
+	}
+
+	return fmt.Sprintf(ProcStateRunning, pid)
+}
+
+// IsProcessAlive checks if the process is alive.
+func IsProcessAlive(pid int) (bool, error) {
+	// The signal 0 is used to check if a process is alive.
+	// From `man 2 kill`:
+	// If  sig  is  0,  then  no  signal is sent, but existence and permission
+	// checks are still performed; this can be used to check for the existence
+	// of  a  process  ID  or process group ID that the caller is permitted to
+	// signal.
+	if err := syscall.Kill(pid, syscall.Signal(0)); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// waitProcessTermination waits while the process will be terminated.
+// Returns true if the process was terminated and false if is steel alive.
+func waitProcessTermination(pid int, timeout time.Duration,
+	checkPeriod time.Duration) bool {
+	if res, _ := IsProcessAlive(pid); !res {
+		return true
+	}
+
+	result := false
+	breakTimer := time.NewTimer(timeout)
+loop:
+	for {
+		select {
+		case <-breakTimer.C:
+			if res, _ := IsProcessAlive(pid); !res {
+				result = true
+			}
+			break loop
+		case <-time.After(checkPeriod):
+			if res, _ := IsProcessAlive(pid); !res {
+				result = true
+				break loop
+			}
+		}
+	}
+
+	return result
+}

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -282,3 +282,67 @@ For packing deb package call:
 
 Now the result package may be distributed and installed using dpkg command.
 The package will be installed in /usr/share/tarantool/package_name directory.
+
+Working with tt daemon (experimental)
+-------------------------------------
+
+``tt daemon`` module is used to manage ``tt`` running
+on the background on a given machine. This way instances
+can be operated remotely.
+Daemon can be configured with ``tt_daemon.yaml`` config.
+
+You can manage TT daemon with following commands:
+
+* ``tt daemon start`` - launch of a daemon
+* ``tt daemon stop`` - terminate of the daemon
+* ``tt daemon status`` - get daemon status
+* ``tt daemon restart`` - daemon restart
+
+Work scenario:
+
+First, TT daemon should be started on the server side:
+
+.. code-block:: bash
+
+   $ tt daemon start
+   • Starting tt daemon...
+
+After daemon launch you can check its status on the server side:
+
+.. code-block:: bash
+
+   $ tt daemon status
+   • RUNNING. PID: 6189.
+
+To send request to daemon you can use CURL. In this example the
+client sends a request to start ``test_app`` instance on the server side.
+Note: directory ``test_app`` (or file ``test_app.lua``) exists
+on the server side.
+
+.. code-block:: bash
+
+   $ curl --header "Content-Type: application/json" --request POST \
+   --data '{"command_name":"start", "params":["test_app"]}' \
+   http://127.0.0.1:1024/tarantool
+   {"res":"   • Starting an instance [test_app]...\n"}
+
+Below is an example of running a command with flags.
+
+Flag with argument:
+
+.. code-block:: bash
+
+   $ curl --header "Content-Type: application/json" --request POST \
+   --data '{"command_name":"version", "params":["-L", "/path/to/local/dir"]}' \
+   http://127.0.0.1:1024/tarantool
+   {"res":"Tarantool CLI version 0.1.0, darwin/amd64. commit: bf83f33\n"}
+
+Flag without argument:
+
+.. code-block:: bash
+
+   $ curl --header "Content-Type: application/json" --request POST \
+   --data '{"command_name":"version", "params":["-V"]}' \
+   http://127.0.0.1:1024/tarantool
+   {"res":"Tarantool CLI version 0.1.0, darwin/amd64. commit: bf83f33\n
+    • Tarantool executable found: '/usr/local/bin/tarantool'\n"}

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -617,6 +617,8 @@ github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/test/integration/daemon/test_app/test_app.lua
+++ b/test/integration/daemon/test_app/test_app.lua
@@ -1,0 +1,5 @@
+local fiber = require('fiber')
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/daemon/test_daemon.py
+++ b/test/integration/daemon/test_daemon.py
@@ -1,0 +1,306 @@
+import os
+import re
+import shutil
+import subprocess
+
+import psutil
+import pytest
+import requests
+
+import utils
+
+default_url = "http://127.0.0.1:1024/tarantool"
+var_dir = "var"
+run_dir = "run"
+default_run_path = os.path.join(var_dir, run_dir)
+
+
+# In case of unsuccessful completion of tests, tarantool test
+# daemon/instance may remain running.
+# This is autorun wrapper for each test case in this module.
+@pytest.fixture(autouse=True)
+def kill_remain_processes_wrapper(tt_cmd):
+    # Run test.
+    yield
+
+    # Kill a test daemon/instance if it was not stopped due to a failed test.
+    tt_proc = subprocess.Popen(
+        ['pgrep', '-f', tt_cmd],
+        stdout=subprocess.PIPE,
+        shell=False
+    )
+    response = tt_proc.communicate()[0]
+    procs = [psutil.Process(int(pid)) for pid in response.split()]
+
+    utils.kill_procs(procs)
+
+
+def test_daemon_base_functionality(tt_cmd, tmpdir):
+    # Start daemon.
+    start_cmd = [tt_cmd, "daemon", "start"]
+    daemon_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_out = daemon_process.stdout.readline()
+    assert re.search(r"Starting tt daemon...", start_out)
+
+    # Check status.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    # Daemon already exist.
+    daemon_process_2 = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_again_out = daemon_process_2.stdout.readline()
+    assert re.search(r"The process is already exists. PID: \d+.", start_again_out)
+
+    # Check status. PID has not been changed after second start.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out2 = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert status_out == status_out2
+
+    # Stop daemon.
+    stop_cmd = [tt_cmd, "daemon", "stop"]
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    daemon_process_rc = daemon_process.wait(1)
+    assert daemon_process_rc == 0
+
+
+def test_restart(tt_cmd, tmpdir):
+    # Start daemon.
+    start_cmd = [tt_cmd, "daemon", "start"]
+    daemon_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_out = daemon_process.stdout.readline()
+    assert re.search(r"Starting tt daemon...", start_out)
+
+    # Check status.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    # Restart daemon.
+    restart_cmd = [tt_cmd, "daemon", "restart"]
+    daemon_process_2 = subprocess.Popen(
+        restart_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    restart_out = daemon_process_2.stdout.readline()
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", restart_out)
+    restart_out = daemon_process_2.stdout.readline()
+    assert re.search(r"Starting tt daemon...", restart_out)
+
+    # Check status of the new daemon.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    # Stop the new daemon.
+    stop_cmd = [tt_cmd, "daemon", "stop"]
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process of new daemon was terminated correctly.
+    daemon_process_2_rc = daemon_process_2.wait(1)
+    assert daemon_process_2_rc == 0
+
+
+def test_daemon_with_cfg(tt_cmd, tmpdir):
+    with open(os.path.join(tmpdir, "tt_daemon.yaml"), "w") as tnt_env_file:
+        line = '''
+        daemon:
+            log_dir: "log"
+            pidfile: "daemon.pid"
+        '''
+        tnt_env_file.write(line)
+
+    # Start daemon.
+    start_cmd = [tt_cmd, "daemon", "start"]
+    daemon_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_out = daemon_process.stdout.readline()
+    assert re.search(r"Starting tt daemon...", start_out)
+
+    # Check status of the daemon.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    # Stop daemon.
+    stop_cmd = [tt_cmd, "daemon", "stop"]
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    daemon_process_rc = daemon_process.wait(1)
+    assert daemon_process_rc == 0
+
+
+def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+
+    # Start daemon.
+    start_cmd = [tt_cmd, "daemon", "start"]
+    daemon_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_out = daemon_process.stdout.readline()
+    assert re.search(r"Starting tt daemon...", start_out)
+
+    # Check status.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    body = {"command_name": "start", "params": ["test_app"]}
+    response = requests.post(default_url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"Starting an instance", response.json()["res"])
+
+    file = utils.wait_file(os.path.join(tmpdir, run_dir, "test_app"), 'test_app.pid', [])
+    assert file != ""
+
+    body = {"command_name": "status", "params": ["test_app"]}
+    response = requests.post(default_url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"RUNNING. PID: \d+.", response.json()["res"])
+
+    body = {"command_name": "stop", "params": ["test_app"]}
+    response = requests.post(default_url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"The Instance \(PID = \d+\) has been terminated.", response.json()["res"])
+
+    # Stop daemon.
+    stop_cmd = [tt_cmd, "daemon", "stop"]
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    daemon_process_rc = daemon_process.wait(1)
+    assert daemon_process_rc == 0
+
+
+def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+
+    iface = utils.get_test_iface()
+    port = utils.find_port()
+
+    with open(os.path.join(tmpdir, "tt_daemon.yaml"), "w") as tnt_env_file:
+        line = '''
+        daemon:
+            listen_interface: {}
+            port: {}
+        '''.format(iface, port)
+        tnt_env_file.write(line)
+
+    # Start daemon.
+    start_cmd = [tt_cmd, "daemon", "start"]
+    daemon_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_out = daemon_process.stdout.readline()
+    assert re.search(r"Starting tt daemon...", start_out)
+
+    # Check status.
+    file = utils.wait_file(os.path.join(tmpdir, default_run_path), 'tt_daemon.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "daemon", "status"]
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    conn = utils.get_process_conn(os.path.join(tmpdir, default_run_path, file), port)
+    assert conn is not None
+
+    url = "http://" + conn.laddr.ip + ":" + str(port) + "/tarantool"
+
+    body = {"command_name": "start", "params": ["test_app"]}
+    response = requests.post(url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"Starting an instance", response.json()["res"])
+
+    file = utils.wait_file(os.path.join(tmpdir, run_dir, "test_app"), 'test_app.pid', [])
+    assert file != ""
+
+    body = {"command_name": "status", "params": ["test_app"]}
+    response = requests.post(url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"RUNNING. PID: \d+.", response.json()["res"])
+
+    body = {"command_name": "stop", "params": ["test_app"]}
+    response = requests.post(url, json=body)
+    assert response.status_code == 200
+    assert re.search(r"The Instance \(PID = \d+\) has been terminated.", response.json()["res"])
+
+    # Stop daemon.
+    stop_cmd = [tt_cmd, "daemon", "stop"]
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert stop_rc == 0
+    assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    daemon_process_rc = daemon_process.wait(1)
+    assert daemon_process_rc == 0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,3 +7,4 @@ flake8-isort==4.0.0
 psutil==5.7.0
 pyyaml==5.4
 codespell==2.2.1
+netifaces==0.11.0


### PR DESCRIPTION
`tt daemon` module is used to manage HTTP server
running on the background. HTTP server can process
`tt` commands such as `start`, `status`, etc.
Daemon can be configurated with `tt_daemon.yaml` config.

`tt_daemon.yaml` file format:

```yaml
  daemon:
        run_dir: path
        log_dir: path
        log_maxsize: num (MB)
        log_maxage: num (Days)
        log_maxbackups: num
        log_file: string (file name)
        listen_interface: string
        port: num
        pidfile: string (file name)
```

The following set of commands is implemented:
    
* `tt daemon start` - launch of a daemon;
* `tt daemon stop` - terminate of the daemon;
* `tt daemon status` - get daemon status;
* `tt daemon restart` - daemon restart.

Closes #10 