### PR TITLE
create: fix missing hooks exec error

### DIFF
--- a/cli/create/internal/steps/run_hook.go
+++ b/cli/create/internal/steps/run_hook.go
@@ -32,6 +32,11 @@ func (hook RunHook) Run(ctx *cmdcontext.CreateCtx, templateCtx *TemplateCtx) err
 		return fmt.Errorf("Invalid hook type %s", hook.HookType)
 	}
 
+	// Check if hook is present.
+	if hookPath == "" {
+		return nil
+	}
+
 	executablePath := filepath.Join(templateCtx.AppPath, hookPath)
 	_, err := os.Stat(executablePath)
 	if err != nil {

--- a/cli/create/internal/steps/run_hook_test.go
+++ b/cli/create/internal/steps/run_hook_test.go
@@ -60,4 +60,11 @@ func TestRunHooksMissingScript(t *testing.T) {
 	require.EqualError(t, runPostHook.Run(&createCtx, &templateCtx),
 		fmt.Sprintf("Error access to %[1]s: stat %[1]s: no such file or directory",
 			filepath.Join(workDir, "post-gen.sh")))
+
+	// Emulate missing scripts in manifest file.
+	templateCtx.Manifest.PreHook = ""
+	templateCtx.Manifest.PostHook = ""
+
+	require.NoError(t, runPreHook.Run(&createCtx, &templateCtx))
+	require.NoError(t, runPostHook.Run(&createCtx, &templateCtx))
 }


### PR DESCRIPTION
Missing hooks currently gives an error: "permission denied", when trying to execute an application directory :)
Need to skip hook execution if it is not present in template manifest.
Unit test is added.