### PR TITLE
create: fix template file name rendering

### DIFF
--- a/cli/create/internal/steps/render_template.go
+++ b/cli/create/internal/steps/render_template.go
@@ -29,6 +29,7 @@ func render(templateCtx *TemplateCtx, templateFileNamePattern *regexp.Regexp,
 			if err := os.Remove(filePath); err != nil {
 				return fmt.Errorf("Error removing %s: %s", filePath, err)
 			}
+			filePath = resultFilePath
 		}
 		// Render file name.
 		newFileName, err := templateCtx.Engine.RenderText(filePath, templateCtx.Vars)

--- a/cli/create/internal/steps/render_template_test.go
+++ b/cli/create/internal/steps/render_template_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/cmdcontext"
 )
@@ -30,16 +31,24 @@ func TestTemplateRender(t *testing.T) {
 	renderTemplate := RenderTemplate{}
 	require.NoError(t, renderTemplate.Run(&createCtx, &templateCtx))
 
+	assert.FileExists(t, filepath.Join(workDir, "app1.yml"))
+
 	configFileName := filepath.Join(workDir, "config.lua")
 	require.FileExists(t, configFileName)
-	require.FileExists(t, filepath.Join(workDir, "app1.yml"))
-
 	buf, err := os.ReadFile(configFileName)
 	require.NoError(t, err)
 	const expectedText = `cluster_cookie = cookie
 login = admin
 `
 	require.Equal(t, expectedText, string(buf))
+
+	userFileName := filepath.Join(workDir, "admin.cfg")
+	require.FileExists(t, userFileName)
+	buf, err = os.ReadFile(userFileName)
+	require.NoError(t, err)
+	const userCfgExpectedText = `user=admin
+`
+	require.Equal(t, userCfgExpectedText, string(buf))
 }
 
 func TestTemplateRenderMissingVar(t *testing.T) {

--- a/cli/create/internal/steps/testdata/cartridge/{{.user_name}}.cfg.tt.template
+++ b/cli/create/internal/steps/testdata/cartridge/{{.user_name}}.cfg.tt.template
@@ -1,0 +1,1 @@
+user={{.user_name}}


### PR DESCRIPTION
If a file name is in <name>.tt.template format, it is renamed to the <name>. The issue is: if <name> also contains template variables like {{.var}} the instantiation engine tries to instantiate old file name (<name>.tt.template) and rename it. But this file does not exists after first renaming. So there is "no such file or directory error". The fix is to update file name after the first renaming.
Covered by unit test.