### PR TITLE
tt: fix failure on non-executable files/dirs

### DIFF
--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -100,7 +100,7 @@ def test_launch_local_tt_executable(tt_cmd, tmpdir):
 
     for cmd in commands:
         rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
-        assert rc == 1
+        assert rc == 0
         assert tt_message not in output
 
     # tt found and executable.


### PR DESCRIPTION
tt searches for tt & tarantool binaries in an environment root dir. If it finds tt or tarantool files there and they are not executables, tt launch fails with the "permission denied" error. The solution is to warn about non-executables, but do not fail.