### PR TITLE
connect: fix connect via URI

### DIFF
--- a/cli/cmd/connect_test.go
+++ b/cli/cmd/connect_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsURIValid(t *testing.T) {
+	uris := []string{
+		"localhost:123",
+		"tcp:localhost:123123",
+		"tcp:/anyhost:1",
+		"tcp://localhost:11",
+		"asd://localhost:111",
+		"123://localhost:123",
+		"123asd:localhost:222",
+		"host:123",
+		"123:123",
+		"./a",
+		"/1",
+		"unix:a",
+		"unix:/a",
+		"unix/:2",
+		"unix://.",
+	}
+
+	for _, uri := range uris {
+		t.Run(uri, func(t *testing.T) {
+			assert.True(t, isURI(uri), "URI must be valid")
+		})
+	}
+}
+
+func TestIsURIInvalid(t *testing.T) {
+	uris := []string{
+		"123",
+		"localhost",
+		"localhost:asd",
+		"tcp://localhost:asd",
+		"tcp:///localhost:11",
+		".",
+		".a",
+		"/",
+		"unix:",
+		"unix:/",
+		"unix/:",
+		"unix//:asd",
+		"unix/:/",
+		"unix://",
+		"unix:///",
+	}
+
+	for _, uri := range uris {
+		t.Run(uri, func(t *testing.T) {
+			assert.False(t, isURI(uri), "URI must be invalid")
+		})
+	}
+}

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -1,0 +1,149 @@
+import os
+import re
+import shutil
+import subprocess
+
+from utils import run_command_and_get_output, wait_file
+
+
+def try_execute_on_instance(tt_cmd, tmpdir, instance, file_path):
+    connect_cmd = [tt_cmd, "connect", instance, "-f", file_path]
+    instance_process = subprocess.Popen(
+        connect_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    output = instance_process.stdout.readline()
+    instance_process.communicate()
+    return instance_process.returncode == 0, output
+
+
+def test_connect_to_localhost_app(tt_cmd, tmpdir):
+    empty_file = "empty.lua"
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_localhost_app", "test_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+
+    # Copy the test file to the "run" directory.
+    empty_path = os.path.join(os.path.dirname(__file__), "test_file", empty_file)
+    shutil.copy(empty_path, tmpdir)
+
+    # Start an instance.
+    start_cmd = [tt_cmd, "start", "test_app"]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = instance_process.stdout.readline()
+    assert re.search(r"Starting an instance", start_output)
+
+    # Check for start.
+    file = wait_file(tmpdir, 'ready', [])
+    assert file != ""
+
+    # Connect to a wrong instance.
+    ret, output = try_execute_on_instance(tt_cmd, tmpdir, "localhost:6666", empty_file)
+    assert not ret
+    assert re.search(r"   ⨯ Unable to establish connection", output)
+
+    # Connect to the instance.
+    uris = ["localhost:3013", "tcp:localhost:3013", "tcp://localhost:3013"]
+    for uri in uris:
+        ret, output = try_execute_on_instance(tt_cmd, tmpdir, uri, empty_file)
+        assert ret
+
+    # Stop the Instance.
+    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+
+
+def test_connect_to_single_instance_app(tt_cmd, tmpdir):
+    empty_file = "empty.lua"
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_single_app", "test_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+
+    # Copy the test file to the "run" directory.
+    empty_path = os.path.join(os.path.dirname(__file__), "test_file", empty_file)
+    shutil.copy(empty_path, tmpdir)
+
+    # Start an instance.
+    start_cmd = [tt_cmd, "start", "test_app"]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = instance_process.stdout.readline()
+    assert re.search(r"Starting an instance", start_output)
+
+    # Check for start.
+    file = wait_file(tmpdir + "/run/test_app/", 'test_app.control', [])
+    assert file != ""
+
+    # Connect to a wrong instance.
+    ret, output = try_execute_on_instance(tt_cmd, tmpdir, "any_app", empty_file)
+    assert not ret
+    assert re.search(r"   ⨯ Can't find an application init file", output)
+
+    # Connect to the instance.
+    ret, output = try_execute_on_instance(tt_cmd, tmpdir, "test_app", empty_file)
+    assert ret
+
+    # Stop the Instance.
+    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+
+
+def test_connect_to_multi_instances_app(tt_cmd, tmpdir):
+    instances = ['master', 'replica', 'router']
+    app_name = "test_multi_app"
+    empty_file = "empty.lua"
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), app_name)
+    tmp_app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(test_app_path, tmp_app_path)
+    # Copy the test file to the "run" directory.
+    empty_path = os.path.join(os.path.dirname(__file__), "test_file", empty_file)
+    shutil.copy(empty_path, tmpdir)
+
+    # Start instances.
+    start_cmd = [tt_cmd, "start", app_name]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = instance_process.stdout.readline()
+    assert re.search(r"Starting an instance", start_output)
+
+    # Check for start.
+    for instance in instances:
+        master_run_path = os.path.join(tmpdir, "run", app_name, instance)
+        file = wait_file(master_run_path, instance + ".control", [])
+        assert file != ""
+
+    # Connect to a non-exist instance.
+    non_exist = app_name + ":" + "any_name"
+    ret, output = try_execute_on_instance(tt_cmd, tmpdir, non_exist, empty_file)
+    assert not ret
+    assert re.search(r"   ⨯ Can't find an application init file: instance\(s\) not found", output)
+
+    # Connect to instances.
+    for instance in instances:
+        full_name = app_name + ":" + instance
+        ret, _ = try_execute_on_instance(tt_cmd, tmpdir, full_name, empty_file)
+        assert ret
+
+    # Stop instances.
+    stop_cmd = [tt_cmd, "stop", app_name]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)

--- a/test/integration/connect/test_localhost_app/test_app.lua
+++ b/test/integration/connect/test_localhost_app/test_app.lua
@@ -1,0 +1,12 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+box.cfg({listen = 'localhost:3013'})
+box.schema.user.grant('guest','read,write,execute,create,drop','universe')
+
+fh = fio.open('ready', {'O_WRONLY', 'O_CREAT'}, tonumber('644',8))
+fh:close()
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/connect/test_multi_app/init.lua
+++ b/test/integration/connect/test_multi_app/init.lua
@@ -1,0 +1,11 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+while true do
+    if app_name ~= nil and inst_name ~= nil then
+        print(app_name .. ":" .. inst_name)
+    else
+        print("unknown instance")
+    end
+    require("fiber").sleep(1)
+end

--- a/test/integration/connect/test_multi_app/instances.yml
+++ b/test/integration/connect/test_multi_app/instances.yml
@@ -1,0 +1,3 @@
+router:
+master:
+replica:

--- a/test/integration/connect/test_multi_app/router.init.lua
+++ b/test/integration/connect/test_multi_app/router.init.lua
@@ -1,0 +1,12 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+while true do
+    print("custom init file...")
+    if app_name ~= nil and inst_name ~= nil then
+        print(app_name .. ":" .. inst_name)
+    else
+        print("unknown instance")
+    end
+    require("fiber").sleep(1)
+end

--- a/test/integration/connect/test_single_app/test_app.lua
+++ b/test/integration/connect/test_single_app/test_app.lua
@@ -1,0 +1,5 @@
+local fiber = require('fiber')
+
+while true do
+    fiber.sleep(5)
+end


### PR DESCRIPTION
The patch fixes connection to a Tarantool instance via URI. The issue was introduced with a pull request to work with a set of intances [1]. The rules for determining the URI are similar to used by a connector [2].

1. https://github.com/tarantool/tt/pull/113
2. https://github.com/tarantool/tt/blob/da319ff9a1d0d7bd12e6f682d6ef906c965dbfa5/cli/connector/conn_opts.go#L47-L69

Closes #138

I was looking at the connector code to determine is a string a URI. But I want to suggest making rules to detect valid URI for `tt connect` more strict:

1. Left only `tcp://host:numeric_port` or `host:numeric_port` for tcp-socket connections.
2. Left only `unix://path/to/file` for unix-socket connections.

From my point of view it will simplify both our and users lives.