### PR TITLE
connect: add language flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.8"]
+        tarantool-version: ["1.10", "2.10"]
       fail-fast: false
     steps:
       - uses: actions/checkout@master
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        sdk-version: ["2.8.2-0-gfc96d10f5-r421"]
+        sdk-version: ["2.10.2-0-gf4228cb7d-r508-linux-x86_64"]
       fail-fast: false
     steps:
       - uses: actions/checkout@master

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -20,6 +20,7 @@ var (
 	connectUser     string
 	connectPassword string
 	connectFile     string
+	connectLanguage string
 )
 
 // NewConnectCmd creates connect command.
@@ -42,6 +43,8 @@ func NewConnectCmd() *cobra.Command {
 	connectCmd.Flags().StringVarP(&connectPassword, "password", "p", "", "password")
 	connectCmd.Flags().StringVarP(&connectFile, "file", "f", "",
 		`file to read the script for evaluation. "-" - read the script from stdin`)
+	connectCmd.Flags().StringVarP(&connectLanguage, "language", "l",
+		connect.DefaultLanguage.String(), `language: lua or sql`)
 
 	return connectCmd
 }
@@ -100,6 +103,7 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	cmdCtx.Connect.Username = connectUser
 	cmdCtx.Connect.Password = connectPassword
 	cmdCtx.Connect.SrcFile = connectFile
+	cmdCtx.Connect.Language = connectLanguage
 
 	newArgs, err := resolveInstAddr(cmdCtx, cliOpts, args)
 	if err != nil {

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -89,6 +89,8 @@ type ConnectCtx struct {
 	Password string
 	// SrcFile describes the source of code for the evaluation.
 	SrcFile string
+	// Language to use for execution.
+	Language string
 }
 
 // CreateCtx contains information for creating applications from templates.

--- a/cli/connect/language.go
+++ b/cli/connect/language.go
@@ -1,0 +1,98 @@
+package connect
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/tarantool/tt/cli/connector"
+)
+
+const (
+	defaultStr = ""
+	luaStr     = "lua"
+	sqlStr     = "sql"
+)
+
+// Language defines a set of supported languages.
+type Language int
+
+const (
+	DefaultLanguage Language = iota
+	LuaLanguage
+	SQLLanguage
+)
+
+// ParseLanguage parses a language string representation. It supports mixed
+// case letters.
+func ParseLanguage(str string) (Language, bool) {
+	str = strings.ToLower(str)
+	switch str {
+	case defaultStr:
+		return DefaultLanguage, true
+	case luaStr:
+		return LuaLanguage, true
+	case sqlStr:
+		return SQLLanguage, true
+	}
+	return DefaultLanguage, false
+}
+
+// String returns a string representation of the language.
+func (l Language) String() string {
+	switch l {
+	case DefaultLanguage:
+		return defaultStr
+	case LuaLanguage:
+		return luaStr
+	case SQLLanguage:
+		return sqlStr
+	default:
+		panic("Unknown language")
+	}
+}
+
+// setLanguagePrefix is a prefix for a set language command.
+const setLanguagePrefix = "\\set language "
+
+// changeLanguage changes a language for a connection.
+func changeLanguage(conn *connector.Conn, lang Language) error {
+	if lang == DefaultLanguage {
+		return nil
+	}
+
+	languageCmd := setLanguagePrefix + lang.String()
+	req := connector.EvalReq(evalFuncBody, languageCmd)
+	res, err := conn.Exec(req)
+	if err != nil {
+		return err
+	}
+
+	var ret string
+	var ok bool
+	if ret, ok = res[0].(string); !ok {
+		return fmt.Errorf("Unexpected response %v", res)
+	}
+
+	var decoded interface{}
+	if err = yaml.Unmarshal([]byte(ret), &decoded); err != nil {
+		return fmt.Errorf("Unable to decode response: %s", err)
+	}
+
+	var decodedArray []interface{}
+	if decodedArray, ok = decoded.([]interface{}); !ok || len(decodedArray) != 1 {
+		return fmt.Errorf("Unexpected response: %s", ret)
+	}
+
+	var value bool
+	if value, ok = decodedArray[0].(bool); !ok {
+		return fmt.Errorf("Unexpected response: %s", ret)
+	}
+
+	if !value {
+		return fmt.Errorf("%s returns false", languageCmd)
+	}
+
+	return nil
+}

--- a/cli/connect/language_test.go
+++ b/cli/connect/language_test.go
@@ -1,0 +1,64 @@
+package connect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/tarantool/tt/cli/connect"
+)
+
+func TestLanguage_ParseLanguage(t *testing.T) {
+	cases := []struct {
+		str      string
+		expected Language
+		ok       bool
+	}{
+		{"", DefaultLanguage, true},
+		{"lua", LuaLanguage, true},
+		{"LuA", LuaLanguage, true},
+		{"LUA", LuaLanguage, true},
+		{"sql", SQLLanguage, true},
+		{"SqL", SQLLanguage, true},
+		{"SQL", SQLLanguage, true},
+		{".", DefaultLanguage, false},
+		{"12", DefaultLanguage, false},
+		{"luaasd", DefaultLanguage, false},
+		{"lua123", DefaultLanguage, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.str, func(t *testing.T) {
+			lang, ok := ParseLanguage(c.str)
+			assert.Equal(t, c.ok, ok, "Unexpected result")
+			if ok {
+				assert.Equal(t, c.expected, lang, "Unexpected language")
+			}
+		})
+	}
+}
+
+func TestLanguage_String(t *testing.T) {
+	cases := []struct {
+		language Language
+		expected string
+		panic    bool
+	}{
+		{DefaultLanguage, "", false},
+		{LuaLanguage, "lua", false},
+		{SQLLanguage, "sql", false},
+		{Language(666), "Unknown language", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expected, func(t *testing.T) {
+			if c.panic {
+				f := func() { _ = c.language.String() }
+				assert.PanicsWithValue(t, "Unknown language", f)
+			} else {
+				result := c.language.String()
+				assert.Equal(t, c.expected, result, "Unexpected result")
+			}
+		})
+	}
+}

--- a/test/integration/connect/test_file/hello.lua
+++ b/test/integration/connect/test_file/hello.lua
@@ -1,0 +1,1 @@
+return "Hello, world!"

--- a/test/integration/connect/test_file/hello.sql
+++ b/test/integration/connect/test_file/hello.sql
@@ -1,0 +1,1 @@
+VALUES ('hello');


### PR DESCRIPTION
The `-l` or `--language` flag allows a user to switch default
language for a connection. A value can be `lua` or `sql`.

Part of https://github.com/tarantool/tt/issues/58

The patchset also replaces Tarantool 2.8 to 2.10 on CI as a last release version.