### PR TITLE
create: add pre-defined variables

### DIFF
--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -48,6 +48,7 @@ func Run(createCtx *cmdcontext.CreateCtx) error {
 	}
 
 	stepsChain := []steps.Step{
+		steps.SetPredefinedVariables{},
 		steps.LoadVarsFile{},
 		steps.FillTemplateVarsFromCli{},
 		steps.CreateAppDirectory{},

--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -48,8 +48,8 @@ func Run(createCtx *cmdcontext.CreateCtx) error {
 	}
 
 	stepsChain := []steps.Step{
-		steps.FillTemplateVarsFromCli{},
 		steps.LoadVarsFile{},
+		steps.FillTemplateVarsFromCli{},
 		steps.CreateAppDirectory{},
 		steps.CopyAppTemplate{},
 		steps.LoadManifest{},

--- a/cli/create/internal/steps/load_vars_file.go
+++ b/cli/create/internal/steps/load_vars_file.go
@@ -39,10 +39,8 @@ func (LoadVarsFile) Run(ctx *cmdcontext.CreateCtx,
 		if err != nil {
 			return fmt.Errorf("Failed to load vars from %s: %s", varsDefFileFullPath, err)
 		}
-		if _, found := templateCtx.Vars[varDef.name]; !found {
-			log.Debugf("Setting var from vars file: %s = %s", varDef.name, varDef.value)
-			templateCtx.Vars[varDef.name] = varDef.value
-		}
+		log.Debugf("Setting var from vars file: %s = %s", varDef.name, varDef.value)
+		templateCtx.Vars[varDef.name] = varDef.value
 	}
 
 	if err = scanner.Err(); err != nil {

--- a/cli/create/internal/steps/load_vars_file_test.go
+++ b/cli/create/internal/steps/load_vars_file_test.go
@@ -27,7 +27,7 @@ func TestLoadVarsFileVariablesAlreadySet(t *testing.T) {
 	createCtx.VarsFile = "testdata/vars-file.txt"
 	loadVarsFile := LoadVarsFile{}
 	require.NoError(t, loadVarsFile.Run(&createCtx, &templateCtx))
-	require.Equal(t, map[string]string{"user-name": "root", "password": "weak_pwd"},
+	require.Equal(t, map[string]string{"user-name": "admin", "password": "weak_pwd"},
 		templateCtx.Vars)
 }
 

--- a/cli/create/internal/steps/set_predefined_variables.go
+++ b/cli/create/internal/steps/set_predefined_variables.go
@@ -1,0 +1,15 @@
+package steps
+
+import (
+	"github.com/tarantool/tt/cli/cmdcontext"
+)
+
+// SetPredefinedVariables represents a step for setting pre-defined variables.
+type SetPredefinedVariables struct {
+}
+
+// Run sets predefined variables values.
+func (SetPredefinedVariables) Run(createCtx *cmdcontext.CreateCtx, templateCtx *TemplateCtx) error {
+	templateCtx.Vars["name"] = createCtx.AppName
+	return nil
+}

--- a/cli/create/internal/steps/set_predefined_variables_test.go
+++ b/cli/create/internal/steps/set_predefined_variables_test.go
@@ -1,0 +1,17 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/cmdcontext"
+)
+
+func TestSetPredefinedVariables(t *testing.T) {
+	createCtx := cmdcontext.CreateCtx{}
+	createCtx.AppName = "app1"
+	templateCtx := NewTemplateContext()
+	setPredefinedVars := SetPredefinedVariables{}
+	require.NoError(t, setPredefinedVars.Run(&createCtx, &templateCtx))
+	require.Equal(t, map[string]string{"name": "app1"}, templateCtx.Vars)
+}

--- a/test/integration/create/templates/basic/MANIFEST.yaml
+++ b/test/integration/create/templates/basic/MANIFEST.yaml
@@ -21,6 +21,7 @@ pre-hook: ./hooks/pre-gen.sh
 post-hook: ./hooks/post-gen.sh
 include:
   - '{{.user_name}}.txt'
+  - '{{.name}}.cfg'
   - config.lua
   - pre-script-invoked
   - post-script-invoked

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -86,6 +86,9 @@ def test_create_basic_functionality(tt_cmd, tmpdir):
         # Check default Dockerfile is created.
         assert os.path.exists(os.path.join(app_path, "Dockerfile.build.tt"))
 
+        # Check "--name" value is used in file name.
+        assert os.path.exists(os.path.join(app_path, "app1.cfg"))
+
         # Check output.
         out_lines = tt_process.stdout.readlines()
 
@@ -431,3 +434,24 @@ def test_app_create_missing_required_args(tt_cmd, tmpdir):
     assert tt_process.returncode == 1
     first_out_line = tt_process.stdout.readline()
     assert first_out_line.find('Error: required flag(s) "name" not set') != -1
+
+
+def test_default_var_can_be_overwritten(tt_cmd, tmpdir):
+    create_tnt_env_in_dir(tmpdir)
+
+    create_cmd = [tt_cmd, "create", "basic", "--var", "password=pwd", "--non-interactive",
+                "--name", "app1", "--var", "name=my_name"]
+    tt_process = subprocess.Popen(
+        create_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True
+    )
+    tt_process.stdin.close()
+    tt_process.wait()
+    assert tt_process.returncode == 0
+
+    app_path = os.path.join(tmpdir, "app1")
+    assert os.path.exists(os.path.join(app_path, "my_name.cfg"))


### PR DESCRIPTION
It is convenient to have some template variables with pre-defined values. "name" var is added. Its value is an application name passed using --name flag.