### PR TITLE
search: support nogc64 tarbolls

### DIFF
--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -114,10 +114,10 @@ func getVersions(data *[]byte) ([]version.Version, error) {
 		// Bundles without specifying the architecture are all x86_64.
 		if arch == "x86_64" {
 			matchRe = ".*>tarantool-enterprise-bundle-" +
-				"(.*-g[a-f0-9]+-r[0-9]{3})(?:-linux-x86_64)?\\.tar\\.gz<.*"
+				"(.*-g[a-f0-9]+-r[0-9]{3}(?:-nogc64)?)(?:-linux-x86_64)?\\.tar\\.gz<.*"
 		} else {
 			matchRe = ".*>tarantool-enterprise-bundle-" +
-				"(.*-g[a-f0-9]+-r[0-9]{3})(?:-linux-" + arch + ")\\.tar\\.gz<.*"
+				"(.*-g[a-f0-9]+-r[0-9]{3}(?:-nogc64)?)(?:-linux-" + arch + ")\\.tar\\.gz<.*"
 		}
 	case util.OsMacos:
 		// Bundles without specifying the architecture are all x86_64.
@@ -189,10 +189,10 @@ func FetchVersionsLocal(files []string) ([]version.Version, error) {
 		// Bundles without specifying the architecture are all x86_64.
 		if arch == "x86_64" {
 			matchRe = "^tarantool-enterprise-bundle-" +
-				"(.*-g[a-f0-9]+-r[0-9]{3})(?:-linux-x86_64)?\\.tar\\.gz$"
+				"(.*-g[a-f0-9]+-r[0-9]{3}(?:-nogc64)?)(?:-linux-x86_64)?\\.tar\\.gz$"
 		} else {
 			matchRe = "^tarantool-enterprise-bundle-" +
-				"(.*-g[a-f0-9]+-r[0-9]{3})(?:-linux-" + arch + ")\\.tar\\.gz$"
+				"(.*-g[a-f0-9]+-r[0-9]{3}(?:-nogc64)?)(?:-linux-" + arch + ")\\.tar\\.gz$"
 		}
 	case util.OsMacos:
 		// Bundles without specifying the architecture are all x86_64.

--- a/cli/version/version_tools.go
+++ b/cli/version/version_tools.go
@@ -48,7 +48,7 @@ func GetVersionDetails(verStr string) (Version, error) {
 		`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)` +
 			`(?:-(?P<release>entrypoint|rc|alpha|beta)(?P<releaseNum>\d+)?)?` +
 			`(?:-(?P<additional>\d+))?` +
-			`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?$`)
+			`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?(?:-nogc64)?$`)
 
 	matches := util.FindNamedMatches(re, verStr)
 	if len(matches) == 0 {


### PR DESCRIPTION
The tarantool-ee tarballs for Linux have nogc64 versions. We must support them.