### PR TITLE
cfg: repo description fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ file format:
   them to get deleted.)
 * ``restart_on_failure`` (bool) - should it restart on failure.
 
-**app**
+**repo**
 
 * ``rocks`` (string) - directory that stores rocks files.
 * ``distfiles`` (string) - directory that stores installation files.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -23,6 +23,9 @@ type Config struct {
 //     restart_on_failure: bool
 //     bin_dir: path
 //     inc_dir: path
+//   repo:
+//     rocks: path
+//     distfiles: path
 //   ee:
 //     credential_path: path
 


### PR DESCRIPTION
This patch fixes `repo` description in Readme and config.go.