### PR TITLE
create: remove working directory change

### DIFF
--- a/cli/configure/configure_test.go
+++ b/cli/configure/configure_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/util"
 )
@@ -86,4 +87,13 @@ func TestConfigureCli(t *testing.T) {
 	}
 
 	assert.Equal(cmdCtx.Cli.ConfigPath, expectedConfigPath)
+}
+
+func TestAdjustPathWithConfigLocation(t *testing.T) {
+	require.Equal(t, adjustPathWithConfigLocation("", "/config/dir", "bin"),
+		"/config/dir/bin")
+	require.Equal(t, adjustPathWithConfigLocation("/bin_dir", "/config/dir", "bin"),
+		"/bin_dir")
+	require.Equal(t, adjustPathWithConfigLocation("./bin_dir", "/config/dir", "bin"),
+		"/config/dir/bin_dir")
 }

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -708,3 +708,13 @@ func CheckRequiredBinaries(binaries ...string) error {
 
 	return nil
 }
+
+// GetAbsPath returns absolute path of filePath.
+// If filePath is absolute, it is returned as is,
+// if filePath is relative, baseDir + filePath is returned.
+func GetAbsPath(baseDir, filePath string) string {
+	if filepath.IsAbs(filePath) {
+		return filePath
+	}
+	return filepath.Join(baseDir, filePath)
+}

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -191,3 +191,11 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 		os.Remove(tntBinPath)
 	}
 }
+
+func TestGetAbsPath(t *testing.T) {
+	require.Equal(t, GetAbsPath("/base/dir", "/abs/path"), "/abs/path")
+	require.Equal(t, GetAbsPath("/base/dir", "./abs/path"),
+		"/base/dir/abs/path")
+	require.Equal(t, GetAbsPath("/base/dir", "abs/path"),
+		"/base/dir/abs/path")
+}


### PR DESCRIPTION
Be default tt changes working directory to tarantool.yaml location. This causes a lot of issues with using relative paths in tt code. Changing working directory is removed.