### PR TITLE
install: file name format changed

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/install"
 	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/search"
 )
 
 var (
@@ -40,7 +41,7 @@ func NewInstallCmd() *cobra.Command {
 			"tt - Tarantool CLI\n" +
 			"tarantool - Tarantool\n" +
 			"tarantool-ee - Tarantool enterprise edition\n" +
-			"Example: tt install tarantool | tarantool=version",
+			"Example: tt install tarantool | tarantool" + search.VersionCliSeparator + "version",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalInstallModule, args)
 			if err != nil {

--- a/cli/cmd/remove.go
+++ b/cli/cmd/remove.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/remove"
+	"github.com/tarantool/tt/cli/search"
 )
 
 // NewRemoveCmd creates remove command.
@@ -40,8 +41,8 @@ func InternalRemoveModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(args[0], "=") {
-		return fmt.Errorf("Incorrect usage.\n   e.g program=version")
+	if !strings.Contains(args[0], search.VersionCliSeparator) {
+		return fmt.Errorf("Incorrect usage.\n   e.g program%sversion", search.VersionCliSeparator)
 	}
 	err = remove.RemoveProgram(args[0], cliOpts.App.BinDir,
 		cliOpts.App.IncludeDir+"/include", cmdCtx)

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -360,7 +360,7 @@ func installTt(version string, binDir string, flags InstallationFlag, distfiles 
 	}
 
 	// Get latest version if it was not specified.
-	_, ttVersion, _ := strings.Cut(version, "=")
+	_, ttVersion, _ := strings.Cut(version, search.VersionCliSeparator)
 	if ttVersion == "" {
 		log.Infof("Getting latest tt version..")
 		if len(versions) == 0 {
@@ -405,7 +405,7 @@ func installTt(version string, binDir string, flags InstallationFlag, distfiles 
 		}
 	}
 
-	version = "tt=" + ttVersion
+	version = "tt" + search.VersionFsSeparator + ttVersion
 	// Check if that version is already installed.
 	log.Infof("Checking existing...")
 	if checkExisting(version, binDir) && !flags.Reinstall {
@@ -584,7 +584,7 @@ func installTarantool(version string, binDir string, incDir string, flags Instal
 	}
 
 	// Get latest version if it was not specified.
-	_, tarVersion, _ := strings.Cut(version, "=")
+	_, tarVersion, _ := strings.Cut(version, search.VersionCliSeparator)
 	if tarVersion == "" {
 		log.Infof("Getting latest tarantool version..")
 		if len(versions) == 0 {
@@ -632,7 +632,7 @@ func installTarantool(version string, binDir string, incDir string, flags Instal
 		}
 	}
 
-	version = "tarantool=" + tarVersion
+	version = "tarantool" + search.VersionFsSeparator + tarVersion
 	// Check if program is already installed.
 	if !flags.Reinstall {
 		log.Infof("Checking existing...")
@@ -762,7 +762,7 @@ func installTarantoolEE(version string, binDir string, includeDir string, flags 
 	}
 
 	// Get latest version if it was not specified.
-	_, tarVersion, _ := strings.Cut(version, "=")
+	_, tarVersion, _ := strings.Cut(version, search.VersionCliSeparator)
 	if tarVersion == "" {
 		log.Infof("Getting latest tarantool-ee version..")
 		if len(versions) == 0 {
@@ -817,7 +817,7 @@ func installTarantoolEE(version string, binDir string, includeDir string, flags 
 		}
 	}
 
-	version = "tarantool-ee=" + tarVersion
+	version = "tarantool-ee" + search.VersionFsSeparator + tarVersion
 	if !flags.Reinstall {
 		log.Infof("Checking existing...")
 		versionExists, err := checkExistingTarantool(version,
@@ -924,7 +924,9 @@ func Install(args []string, binDir string, includeDir string, flags Installation
 		return fmt.Errorf("Invalid number of parameters")
 	}
 
-	re := regexp.MustCompile("^(?P<prog>tt|tarantool|tarantool-ee)(?:=.*)?$")
+	re := regexp.MustCompile(
+		"^(?P<prog>tt|tarantool|tarantool-ee)(?:" + search.VersionCliSeparator + ".*)?$",
+	)
 	matches := util.FindNamedMatches(re, args[0])
 	if len(matches) == 0 {
 		return fmt.Errorf("Unknown application: %s", args[0])

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -20,6 +20,13 @@ const (
 	GitRepoTT        = "https://github.com/tarantool/tt.git"
 )
 
+const (
+	// VersionCliSeparator is used in commands to specify version. E.g: program=version.
+	VersionCliSeparator = "="
+	// VersionFsSeparator is used in file names to specify version. E.g: program_version.
+	VersionFsSeparator = "_"
+)
+
 // isDeprecated checks if the program version is lower than 1.10.0.
 func isDeprecated(version string) bool {
 	splitedVersion := strings.Split(version, ".")
@@ -113,7 +120,7 @@ func GetVersionsFromGitLocal(repo string) ([]version.Version, error) {
 
 // printVersion prints the version and label if the package is installed.
 func printVersion(bindir string, program string, version string) {
-	if _, err := os.Stat(filepath.Join(bindir, program+"="+version)); err == nil {
+	if _, err := os.Stat(filepath.Join(bindir, program+VersionFsSeparator+version)); err == nil {
 		fmt.Printf("%s [installed]\n", version)
 	} else {
 		fmt.Println(version)


### PR DESCRIPTION
Old format `program`=`version` resulted in escaping with quotes when working with a file from a shell.

New format is `program`_`version`.