### PR TITLE
tt: re-work executables search logic

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -142,6 +142,10 @@ func InitRoot() {
 	rootCmd = NewCmdRoot()
 	rootCmd.ParseFlags(os.Args)
 
+	if err := configure.ValidateCliOpts(&cmdCtx.Cli); err != nil {
+		log.Fatal(err.Error())
+	}
+
 	// Configure Tarantool CLI.
 	if err := configure.Cli(&cmdCtx); err != nil {
 		log.Fatalf("Failed to configure Tarantool CLI: %s", err)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -90,6 +90,8 @@ func NewCmdRoot() *cobra.Command {
 		false, "Use internal module")
 	rootCmd.PersistentFlags().StringVarP(&cmdCtx.Cli.ConfigPath, "cfg", "c",
 		"", "Path to configuration file")
+	rootCmd.PersistentFlags().BoolVarP(&cmdCtx.Cli.Verbose, "verbose", "V",
+		false, "Verbose output")
 
 	rootCmd.AddCommand(
 		NewVersionCmd(),

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -48,6 +48,8 @@ type CliCtx struct {
 	// WorkDir is stores original tt working directory, before making chdir
 	// to local launch directory.
 	WorkDir string
+	// Verbose logging flag. Enables debug log output.
+	Verbose bool
 }
 
 // RunningCtx contain information for running an application instance.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -2,13 +2,13 @@ package configure
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 
+	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
@@ -139,6 +139,10 @@ func GetCliOpts(configurePath string) (*config.CliOpts, error) {
 
 // Cli performs initial CLI configuration.
 func Cli(cmdCtx *cmdcontext.CmdCtx) error {
+	if cmdCtx.Cli.Verbose {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	if cmdCtx.Cli.ConfigPath != "" {
 		if _, err := os.Stat(cmdCtx.Cli.ConfigPath); err != nil {
 			return fmt.Errorf("Specified path to the configuration file is invalid: %s", err)
@@ -375,7 +379,7 @@ func configureDefaultCli(cmdCtx *cmdcontext.CmdCtx) error {
 	// 1) We use the "local" tarantool.
 	// 2) For our purpose, tarantool is not needed at all.
 	if err != nil {
-		log.Println("Can't set the default tarantool from the system")
+		log.Info("Can't set the default tarantool from the system")
 	}
 
 	// If neither the local start nor the system flag is specified,

--- a/cli/configure/testdata/bin_dir/tarantool
+++ b/cli/configure/testdata/bin_dir/tarantool
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Hello, I'm Tarantool!"

--- a/cli/configure/testdata/bin_dir/tt
+++ b/cli/configure/testdata/bin_dir/tt
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Hello, I'm Tarantool CLI!"

--- a/test/integration/remove/test_remove.py
+++ b/test/integration/remove/test_remove.py
@@ -36,7 +36,7 @@ def test_remove_tt(tt_cmd, tmpdir):
     run_output = installed_program_process.stdout.readline()
     assert re.search(r"Tarantool", run_output)
 
-    remove_cmd = [tt_cmd, "-S", "remove", "tt=master", "--cfg", configPath]
+    remove_cmd = [tt_cmd, "remove", "tt=master", "--cfg", configPath]
     remove_process = subprocess.Popen(
         remove_cmd,
         cwd=tmpdir,


### PR DESCRIPTION
- Verbose mode support is added. Use -V to see debug log output.
- Only one of -S, -L, --cfg options can be specified.
- If tarantool executable is missing in bin_dir, a default from /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/psergee/go/bin:/home/psergee/work/tarantool/build/extra/dist/
will be used if available.
- If tt executable is missing in bin_dir, current process is used.
- System config is not loaded if -L of --cfg options are specified and
local config is missing.

Closes #174