### PR TITLE
install: fix static build

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = */rocks/third_party,*/cartridge/third_party
+skip = */rocks/third_party,*/cartridge/third_party,tarantool-static-build.patch
 count =
 quiet-level = 3

--- a/cli/install/extra/bump-libunwind-new.patch
+++ b/cli/install/extra/bump-libunwind-new.patch
@@ -1,0 +1,15 @@
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+index f76fcaf58..6f8172cee 100644
+--- a/static-build/CMakeLists.txt
++++ b/static-build/CMakeLists.txt
+@@ -16,8 +16,8 @@ set(NCURSES_VERSION 6.2)
+ set(NCURSES_HASH e812da327b1c2214ac1aed440ea3ae8d)
+ set(READLINE_VERSION 8.0)
+ set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
+-set(UNWIND_VERSION 1.3-rc1)
+-set(UNWIND_HASH f09b670de5db6430a3de666e6aed60e3)
++set(UNWIND_VERSION 1.6.2)
++set(UNWIND_HASH f625b6a98ac1976116c71708a73dc44a)
+ set(BACKUP_STORAGE https://distrib.hb.bizmrg.com)
+ 
+ # Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C

--- a/cli/install/extra/bump-libunwind-old.patch
+++ b/cli/install/extra/bump-libunwind-old.patch
@@ -1,0 +1,13 @@
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+index 9a2f85052..bc73496e5 100644
+--- a/static-build/CMakeLists.txt
++++ b/static-build/CMakeLists.txt
+@@ -12,7 +12,7 @@ set(OPENSSL_VERSION 1.1.1f)
+ set(ZLIB_VERSION 1.2.11)
+ set(NCURSES_VERSION 6.2)
+ set(READLINE_VERSION 8.0)
+-set(UNWIND_VERSION 1.3-rc1)
++set(UNWIND_VERSION 1.6.2)
+ 
+ # Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C
+ # compiler to find header files installed with an SDK.

--- a/cli/install/extra/bump-libunwind.patch
+++ b/cli/install/extra/bump-libunwind.patch
@@ -1,0 +1,15 @@
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+index 598c42bbc..e853f3364 100644
+--- a/static-build/CMakeLists.txt
++++ b/static-build/CMakeLists.txt
+@@ -16,8 +16,8 @@ set(NCURSES_VERSION 6.2)
+ set(NCURSES_HASH e812da327b1c2214ac1aed440ea3ae8d)
+ set(READLINE_VERSION 8.0)
+ set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
+-set(UNWIND_VERSION 1.3-rc1)
+-set(UNWIND_HASH f09b670de5db6430a3de666e6aed60e3)
++set(UNWIND_VERSION 1.6.2)
++set(UNWIND_HASH f625b6a98ac1976116c71708a73dc44a)
+ 
+ # Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C
+ # compiler to find header files installed with an SDK.

--- a/cli/install/extra/gh-6686-fix-build-with-glibc-2-34.patch
+++ b/cli/install/extra/gh-6686-fix-build-with-glibc-2-34.patch
@@ -1,0 +1,19 @@
+diff --git a/test/unit/guard.cc b/test/unit/guard.cc
+index a2953b829..4762d5611 100644
+--- a/test/unit/guard.cc
++++ b/test/unit/guard.cc
+@@ -28,13 +28,11 @@ stack_break_f(char *ptr)
+ 	return sum;
+ }
+ 
+-static char stack_buf[SIGSTKSZ];
+-
+ static int
+ main_f(va_list ap)
+ {
+ 	stack_t stack;
+-	stack.ss_sp = stack_buf;
++	stack.ss_sp = malloc(SIGSTKSZ);
+ 	stack.ss_size = SIGSTKSZ;
+ 	stack.ss_flags = 0;
+ 	sigaltstack(&stack, NULL);

--- a/cli/install/extra/openssl-symbols-1.10.14.patch
+++ b/cli/install/extra/openssl-symbols-1.10.14.patch
@@ -1,0 +1,73 @@
+diff --git a/extra/exports b/extra/exports
+index ef411a8c2..17140ecbf 100644
+--- a/extra/exports
++++ b/extra/exports
+@@ -363,6 +363,8 @@ tnt_HMAC_CTX_new
+ tnt_HMAC_Init_ex
+ tnt_HMAC_Update
+ tnt_HMAC_Final
++tnt_EVP_get_digestbyname
++tnt_EVP_get_cipherbyname
+ tnt_iconv
+ tnt_iconv_close
+ tnt_iconv_open
+diff --git a/src/lua/crypto.c b/src/lua/crypto.c
+index 27b07191d..63882420b 100644
+--- a/src/lua/crypto.c
++++ b/src/lua/crypto.c
+@@ -153,3 +153,15 @@ tnt_HMAC_Final(tnt_HMAC_CTX *ctx, unsigned char *md, unsigned int *len,
+ 	return rc;
+ #endif
+ }
++
++const EVP_MD *
++tnt_EVP_get_digestbyname(const char *name)
++{
++	return EVP_get_digestbyname(name);
++}
++
++const EVP_CIPHER *
++tnt_EVP_get_cipherbyname(const char *name)
++{
++    return EVP_get_cipherbyname(name);
++}
+diff --git a/src/lua/crypto.lua b/src/lua/crypto.lua
+index 800ccdb34..63f515fbd 100644
+--- a/src/lua/crypto.lua
++++ b/src/lua/crypto.lua
+@@ -19,7 +19,7 @@ ffi.cdef[[
+     int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+     int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+     int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+-    const EVP_MD *EVP_get_digestbyname(const char *name);
++    const EVP_MD *tnt_EVP_get_digestbyname(const char *name);
+ 
+     typedef struct {} tnt_HMAC_CTX;
+     tnt_HMAC_CTX *tnt_HMAC_CTX_new(void);
+@@ -48,7 +48,7 @@ ffi.cdef[[
+     int tnt_EVP_CIPHER_key_length(const EVP_CIPHER *cipher);
+ 
+     int tnt_EVP_CIPHER_block_size(const EVP_CIPHER *cipher);
+-    const EVP_CIPHER *EVP_get_cipherbyname(const char *name);
++    const EVP_CIPHER *tnt_EVP_get_cipherbyname(const char *name);
+ ]]
+ 
+ ffi.C.tnt_openssl_init();
+@@ -63,7 +63,7 @@ for class, name in pairs({
+     sha = 'SHA', sha1 = 'SHA1', sha224 = 'SHA224',
+     sha256 = 'SHA256', sha384 = 'SHA384', sha512 = 'SHA512',
+     dss = 'DSS', dss1 = 'DSS1', mdc2 = 'MDC2', ripemd160 = 'RIPEMD160'}) do
+-    local digest = ffi.C.EVP_get_digestbyname(class)
++    local digest = ffi.C.tnt_EVP_get_digestbyname(class)
+     if digest ~= nil then
+         digests[class] = digest
+     end
+@@ -222,7 +222,7 @@ for algo, algo_name in pairs({des = 'DES', aes128 = 'AES-128',
+     for mode, mode_name in pairs({cfb = 'CFB', ofb = 'OFB',
+         cbc = 'CBC', ecb = 'ECB'}) do
+             local cipher =
+-                ffi.C.EVP_get_cipherbyname(algo_name .. '-' .. mode_name)
++                ffi.C.tnt_EVP_get_cipherbyname(algo_name .. '-' .. mode_name)
+             if cipher ~= nil then
+                 algo_api[mode] = cipher
+             end

--- a/cli/install/extra/openssl-symbols.patch
+++ b/cli/install/extra/openssl-symbols.patch
@@ -1,0 +1,70 @@
+diff --git a/extra/exports b/extra/exports
+index b08cbc771..e131e1653 100644
+--- a/extra/exports
++++ b/extra/exports
+@@ -374,3 +374,5 @@ uri_format
+ uri_parse
+ uuid_nil
+ _say
++tnt_EVP_get_digestbyname
++tnt_EVP_get_cipherbyname
+diff --git a/src/lua/crypto.c b/src/lua/crypto.c
+index 80adaca78..53a6a0254 100644
+--- a/src/lua/crypto.c
++++ b/src/lua/crypto.c
+@@ -71,3 +71,15 @@ void tnt_HMAC_CTX_free(HMAC_CTX *ctx)
+ 	HMAC_CTX_free(ctx);
+ #endif
+ }
++
++const EVP_MD *
++tnt_EVP_get_digestbyname(const char *name)
++{
++	return EVP_get_digestbyname(name);
++}
++
++const EVP_CIPHER *
++tnt_EVP_get_cipherbyname(const char *name)
++{
++    return EVP_get_cipherbyname(name);
++}
+diff --git a/src/lua/crypto.lua b/src/lua/crypto.lua
+index cd1c78541..146926715 100644
+--- a/src/lua/crypto.lua
++++ b/src/lua/crypto.lua
+@@ -19,7 +19,7 @@ ffi.cdef[[
+     int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+     int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+     int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+-    const EVP_MD *EVP_get_digestbyname(const char *name);
++    const EVP_MD *tnt_EVP_get_digestbyname(const char *name);
+ 
+     typedef struct {} HMAC_CTX;
+     HMAC_CTX *tnt_HMAC_CTX_new(void);
+@@ -46,7 +46,7 @@ ffi.cdef[[
+     int tnt_EVP_CIPHER_key_length(const EVP_CIPHER *cipher);
+ 
+     int EVP_CIPHER_block_size(const EVP_CIPHER *cipher);
+-    const EVP_CIPHER *EVP_get_cipherbyname(const char *name);
++    const EVP_CIPHER *tnt_EVP_get_cipherbyname(const char *name);
+ ]]
+ 
+ ffi.C.tnt_openssl_init();
+@@ -61,7 +61,7 @@ for class, name in pairs({
+     sha = 'SHA', sha1 = 'SHA1', sha224 = 'SHA224',
+     sha256 = 'SHA256', sha384 = 'SHA384', sha512 = 'SHA512',
+     dss = 'DSS', dss1 = 'DSS1', mdc2 = 'MDC2', ripemd160 = 'RIPEMD160'}) do
+-    local digest = ffi.C.EVP_get_digestbyname(class)
++    local digest = ffi.C.tnt_EVP_get_digestbyname(class)
+     if digest ~= nil then
+         digests[class] = digest
+     end
+@@ -217,7 +217,7 @@ for algo, algo_name in pairs({des = 'DES', aes128 = 'AES-128',
+     for mode, mode_name in pairs({cfb = 'CFB', ofb = 'OFB',
+         cbc = 'CBC', ecb = 'ECB'}) do
+             local cipher =
+-                ffi.C.EVP_get_cipherbyname(algo_name .. '-' .. mode_name)
++                ffi.C.tnt_EVP_get_cipherbyname(algo_name .. '-' .. mode_name)
+             if cipher ~= nil then
+                 algo_api[mode] = cipher
+             end

--- a/cli/install/extra/tarantool-static-build.patch
+++ b/cli/install/extra/tarantool-static-build.patch
@@ -1,0 +1,349 @@
+commit 62d096a7ec7bdff7db3c0f2718466ac78e4a8261
+Author: Pavel Balaev <balaev@tarantool.org>
+Date:   Fri Oct 7 12:51:47 2022 +0300
+
+    backport static build
+
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+new file mode 100644
+index 0000000..a067704
+--- /dev/null
++++ b/static-build/CMakeLists.txt
+@@ -0,0 +1,276 @@
++cmake_minimum_required(VERSION 3.1)
++
++# Detect system compilers for further dependencies configuring to be
++# built with these compilers. This is used to build tarantool and
++# it's dependencies by using one compiler system (for example libicu
++# by default uses clang if it exists when others uses gcc/g++ on
++# linux machine).
++project(tarantool-static C CXX)
++
++include(ExternalProject)
++set(LIBICU_VERSION release-71-1/icu4c-71_1)
++set(LIBICU_HASH e06ffc96f59762bd3c929b217445aaec)
++set(LIBICONV_VERSION 1.17)
++set(LIBICONV_HASH d718cd5a59438be666d1575855be72c3)
++set(OPENSSL_VERSION 1.1.1q)
++set(OPENSSL_HASH c685d239b6a6e1bd78be45624c092f51)
++set(ZLIB_VERSION 1.2.12)
++set(ZLIB_HASH 5fc414a9726be31427b440b434d05f78)
++set(NCURSES_VERSION 6.3-20220716)
++set(NCURSES_HASH 2b7a0e31ebbd8144680f985d61f5bbd5)
++set(READLINE_VERSION 8.0)
++set(READLINE_HASH 7e6c1f16aee3244a69aba6e438295ca3)
++set(BACKUP_STORAGE https://distrib.hb.bizmrg.com)
++
++# Pass -isysroot=<SDK_PATH> option on Mac OS to a preprocessor and a C
++# compiler to find header files installed with an SDK.
++#
++# The idea is to set these (DEPENDENCY_*) variables to corresponding
++# environment variables at each depenency configure script.
++#
++# Note: Passing of CPPFLAGS / CFLAGS explicitly discards using of
++# corresponsing environment variables. So pass empty LDFLAGS to discard
++# using of corresponding environment variable. It is possible that a
++# linker flag assumes that some compilation flag is set. We don't pass
++# CFLAGS from environment, so we should not do it for LDFLAGS too.
++set(DEPENDENCY_CFLAGS "")
++set(DEPENDENCY_CXXFLAGS "")
++set(DEPENDENCY_CPPFLAGS "")
++set(DEPENDENCY_LDFLAGS)
++if (APPLE)
++    set(DEPENDENCY_CFLAGS   "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
++    set(DEPENDENCY_CXXFLAGS "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
++    set(DEPENDENCY_CPPFLAGS "${CMAKE_C_SYSROOT_FLAG} ${CMAKE_OSX_SYSROOT}")
++endif()
++
++# Install all libraries required by tarantool at current build dir
++
++#
++# OpenSSL
++#
++# Patched to build on Mac OS. See
++# https://github.com/openssl/openssl/issues/18720
++#
++ExternalProject_Add(openssl
++    URL ${BACKUP_STORAGE}/openssl/openssl-${OPENSSL_VERSION}.tar.gz
++    URL_MD5 ${OPENSSL_HASH}
++    CONFIGURE_COMMAND <SOURCE_DIR>/config
++        CC=${CMAKE_C_COMPILER}
++        CXX=${CMAKE_CXX_COMPILER}
++        CFLAGS=${DEPENDENCY_CFLAGS}
++        CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++        LDFLAGS=${DEPENDENCY_LDFLAGS}
++
++        --prefix=<INSTALL_DIR>
++        --libdir=lib
++        no-shared
++    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install_sw
++    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 <
++        "${CMAKE_CURRENT_SOURCE_DIR}/openssl-111q-gh-18720.patch"
++)
++
++#
++# ICU
++#
++ExternalProject_Add(icu
++    URL https://github.com/unicode-org/icu/releases/download/${LIBICU_VERSION}-src.tgz
++    URL_MD5 ${LIBICU_HASH}
++    # By default libicu is built by using clang/clang++ compiler (if it
++    # exists). Here is a link for detecting compilers at libicu configure
++    # script: https://github.com/unicode-org/icu/blob/7c7b8bd5702310b972f888299169bc3cc88bf0a6/icu4c/source/configure.ac#L135
++    # This will cause the problem on linux machine: tarantool is built
++    # with gcc/g++ and libicu is built with clang/clang++ (if it exists)
++    # so at linking stage `rellocation` errors will occur. To solve this,
++    # we can set CC/CXX to CMAKE_C_COMPILER/CMAKE_CXX_COMPILER variables
++    # manually which are detected above (by cmake `project()` command)
++    CONFIGURE_COMMAND <SOURCE_DIR>/source/configure
++        CC=${CMAKE_C_COMPILER}
++        CXX=${CMAKE_CXX_COMPILER}
++        CFLAGS=${DEPENDENCY_CFLAGS}
++        CXXFLAGS=${DEPENDENCY_CXXFLAGS}
++        CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++        LDFLAGS=${DEPENDENCY_LDFLAGS}
++
++        --with-data-packaging=static
++        --prefix=<INSTALL_DIR>
++        --disable-shared
++        --enable-static
++)
++
++#
++# ZLIB
++#
++ExternalProject_Add(zlib
++    URL ${BACKUP_STORAGE}/zlib/zlib-${ZLIB_VERSION}.tar.gz
++    URL_MD5 ${ZLIB_HASH}
++    CONFIGURE_COMMAND env
++        CC=${CMAKE_C_COMPILER}
++        CFLAGS=${DEPENDENCY_CFLAGS}
++        CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++        LDFLAGS=${DEPENDENCY_LDFLAGS}
++        <SOURCE_DIR>/configure
++        --prefix=<INSTALL_DIR>
++        --static
++)
++
++#
++# Ncurses
++#
++ExternalProject_Add(ncurses
++    URL ${BACKUP_STORAGE}/ncurses/ncurses-${NCURSES_VERSION}.tgz
++    URL_MD5 ${NCURSES_HASH}
++    CONFIGURE_COMMAND <SOURCE_DIR>/configure
++        CC=${CMAKE_C_COMPILER}
++        CXX=${CMAKE_CXX_COMPILER}
++        CFLAGS=${DEPENDENCY_CFLAGS}
++        CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++        LDFLAGS=${DEPENDENCY_LDFLAGS}
++
++        --prefix=<INSTALL_DIR>
++
++        # This flag enables creation of libcurses.a as a symlink to libncurses.a
++        # and disables subdir creation `ncurses` at <install_dir>/include. It is
++        # necessary for correct work of FindCurses.cmake module (this module is
++        # builtin at cmake package) which used in cmake/FindReadline.cmake
++        --enable-overwrite
++
++        # enable building libtinfo to prevent linking with libtinfo from system
++        # directories
++        --with-termlib
++
++        # set search paths for terminfo db
++        --with-terminfo-dirs=/lib/terminfo:/usr/share/terminfo:/etc/terminfo
++
++        # disable install created terminfo db, use db from system
++        --disable-db-install
++        --without-progs
++        --without-manpages
++)
++
++#
++# ReadLine
++#
++# Patched to fix file descriptor leak with zero-length history file.
++#
++ExternalProject_Add(readline
++    URL https://ftp.gnu.org/gnu/readline/readline-${READLINE_VERSION}.tar.gz
++    URL_MD5 ${READLINE_HASH}
++    CONFIGURE_COMMAND <SOURCE_DIR>/configure
++        CC=${CMAKE_C_COMPILER}
++        CFLAGS=${DEPENDENCY_CFLAGS}
++        CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++        LDFLAGS=${DEPENDENCY_LDFLAGS}
++
++        --prefix=<INSTALL_DIR>
++        --disable-shared
++    PATCH_COMMAND patch -d <SOURCE_DIR> -p0 <
++        "${CMAKE_CURRENT_SOURCE_DIR}/readline80-001.patch"
++)
++
++#
++# ICONV
++#
++if (APPLE)
++    ExternalProject_Add(iconv
++        URL https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${LIBICONV_VERSION}.tar.gz
++        URL_MD5 ${LIBICONV_HASH}
++        CONFIGURE_COMMAND <SOURCE_DIR>/configure
++            CC=${CMAKE_C_COMPILER}
++            CFLAGS=${DEPENDENCY_CFLAGS}
++            CPPFLAGS=${DEPENDENCY_CPPFLAGS}
++            LDFLAGS=${DEPENDENCY_LDFLAGS}
++
++            --prefix=<INSTALL_DIR>
++            --disable-shared
++            --enable-static
++            --with-gnu-ld
++        STEP_TARGETS download
++    )
++else()
++    # In linux iconv is embedded into glibc
++    # So we find system header and copy it locally
++    find_path(ICONV_INCLUDE_DIR iconv.h)
++    if(NOT ICONV_INCLUDE_DIR)
++        message(FATAL_ERROR "iconv include header not found")
++    endif()
++
++    set(ICONV_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/iconv-prefix")
++
++    add_custom_command(
++        OUTPUT "${ICONV_INSTALL_PREFIX}/include/iconv.h"
++        COMMAND ${CMAKE_COMMAND} -E make_directory
++            "${ICONV_INSTALL_PREFIX}/include"
++        COMMAND ${CMAKE_COMMAND} -E copy
++            "${ICONV_INCLUDE_DIR}/iconv.h"
++            "${ICONV_INSTALL_PREFIX}/include/iconv.h"
++    )
++    add_custom_target(iconv
++        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/iconv-prefix/include/iconv.h"
++    )
++    # This is a hack for further getting install directory of library
++    # by ExternalProject_Get_Property
++    set_target_properties(iconv
++        PROPERTIES _EP_INSTALL_DIR ${ICONV_INSTALL_PREFIX}
++    )
++endif()
++
++# Get install directories of builded libraries for building
++# tarantool with custon CMAKE_PREFIX_PATH
++foreach(PROJ openssl icu zlib ncurses readline iconv)
++    ExternalProject_Get_Property(${PROJ} install_dir)
++    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}:${install_dir})
++    set(TARANTOOL_DEPENDS ${PROJ} ${TARANTOOL_DEPENDS})
++    message(STATUS "Add external project ${PROJ} in ${install_dir}")
++endforeach()
++
++ExternalProject_Add(tarantool
++    DEPENDS ${TARANTOOL_DEPENDS}
++    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..
++    LIST_SEPARATOR :
++    CMAKE_ARGS
++        # Override LOCALSTATEDIR to avoid cmake "special" cases:
++        # https://cmake.org/cmake/help/v3.4/module/GNUInstallDirs.html#special-cases
++        -DCMAKE_INSTALL_LOCALSTATEDIR=<INSTALL_DIR>/var
++        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
++        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
++        -DOPENSSL_USE_STATIC_LIBS=TRUE
++        -DBUILD_STATIC=TRUE
++        -DENABLE_DIST=TRUE
++        -DENABLE_BACKTRACE=TRUE
++        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
++        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
++        ${CMAKE_TARANTOOL_ARGS}
++    STEP_TARGETS build
++    BUILD_COMMAND $(MAKE)
++    BUILD_ALWAYS TRUE
++)
++
++enable_testing()
++ExternalProject_Get_Property(tarantool install_dir)
++SET(TARANTOOL_BINARY ${install_dir}/bin/tarantool)
++
++add_test(
++    NAME check-dependencies
++    COMMAND ${CMAKE_COMMAND}
++        -D FILE=${TARANTOOL_BINARY}
++        -P CheckDependencies.cmake
++    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test
++)
++
++add_test(
++    NAME check-exports
++    COMMAND ${TARANTOOL_BINARY}
++            ${CMAKE_CURRENT_SOURCE_DIR}/test/static-build/exports.test.lua
++)
++
++add_test(
++    NAME check-traceback
++    COMMAND ${TARANTOOL_BINARY}
++            ${CMAKE_CURRENT_SOURCE_DIR}/test/static-build/traceback.test.lua
++)
++
++add_test(
++    NAME check-luarocks
++    COMMAND ${TARANTOOL_BINARY}
++            ${CMAKE_CURRENT_SOURCE_DIR}/test/static-build/luarocks.test.lua
++)
+diff --git a/static-build/openssl-111q-gh-18720.patch b/static-build/openssl-111q-gh-18720.patch
+new file mode 100644
+index 0000000..5b64b54
+--- /dev/null
++++ b/static-build/openssl-111q-gh-18720.patch
+@@ -0,0 +1,11 @@
++diff -ru a/test/v3ext.c b/test/v3ext.c
++--- a/test/v3ext.c	2022-07-05 12:08:33.000000000 +0300
+++++ b/test/v3ext.c	2022-07-14 21:07:10.586081541 +0300
++@@ -8,6 +8,7 @@
++  */
++ 
++ #include <stdio.h>
+++#include <string.h>
++ #include <openssl/x509.h>
++ #include <openssl/x509v3.h>
++ #include <openssl/pem.h>
+diff --git a/static-build/readline80-001.patch b/static-build/readline80-001.patch
+new file mode 100644
+index 0000000..aa72a9d
+--- /dev/null
++++ b/static-build/readline80-001.patch
+@@ -0,0 +1,38 @@
++			   READLINE PATCH REPORT
++			   =====================
++
++Readline-Release: 8.0
++Patch-ID: readline80-001
++
++Bug-Reported-by:	chet.ramey@case.edu
++Bug-Reference-ID:
++Bug-Reference-URL:
++
++Bug-Description:
++
++The history file reading code doesn't close the file descriptor open to
++the history file when it encounters a zero-length file.
++
++Patch (apply with `patch -p0'):
++
++*** ../readline-8.0-patched/histfile.c	2018-06-11 09:14:52.000000000 -0400
++--- histfile.c	2019-05-16 15:55:57.000000000 -0400
++***************
++*** 306,309 ****
++--- 312,316 ----
++      {
++        free (input);
+++       close (file);
++        return 0;	/* don't waste time if we don't have to */
++      }
++*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
++--- patchlevel	2014-03-21 08:28:40.000000000 -0400
++***************
++*** 1,3 ****
++  # Do not edit -- exists only for use by patch
++  
++! 0
++--- 1,3 ----
++  # Do not edit -- exists only for use by patch
++  
++! 1

--- a/cli/install/extra/zlib-backup-old.patch
+++ b/cli/install/extra/zlib-backup-old.patch
@@ -1,0 +1,13 @@
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+index 9a2f85052..3d302e9f7 100644
+--- a/static-build/CMakeLists.txt
++++ b/static-build/CMakeLists.txt
+@@ -83,7 +83,7 @@ ExternalProject_Add(icu
+ # ZLIB
+ #
+ ExternalProject_Add(zlib
+-    URL https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
++    URL https://distrib.hb.bizmrg.com/zlib/zlib-${ZLIB_VERSION}.tar.gz
+     CONFIGURE_COMMAND env
+         CC=${CMAKE_C_COMPILER}
+         CFLAGS=${DEPENDENCY_CFLAGS}

--- a/cli/install/extra/zlib-backup.patch
+++ b/cli/install/extra/zlib-backup.patch
@@ -1,0 +1,13 @@
+diff --git a/static-build/CMakeLists.txt b/static-build/CMakeLists.txt
+index 598c42bbc..a0aef08a4 100644
+--- a/static-build/CMakeLists.txt
++++ b/static-build/CMakeLists.txt
+@@ -89,7 +89,7 @@ ExternalProject_Add(icu
+ # ZLIB
+ #
+ ExternalProject_Add(zlib
+-    URL https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
++    URL https://distrib.hb.bizmrg.com/zlib/zlib-${ZLIB_VERSION}.tar.gz
+     URL_MD5 ${ZLIB_HASH}
+     CONFIGURE_COMMAND env
+         CC=${CMAKE_C_COMPILER}

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -290,29 +290,6 @@ func checkExisting(version string, dst string) bool {
 	}
 }
 
-// ExecuteCommand executes program with given args in verbose or quiet mode.
-func ExecuteCommand(program string, isVerbose bool, logFile *os.File, workDir string,
-	args ...string) error {
-	cmd := exec.Command(program, args...)
-	if isVerbose {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-	} else {
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-	}
-	if workDir == "" {
-		workDir, _ = os.Getwd()
-	}
-	cmd.Dir = workDir
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-	err = cmd.Wait()
-	return err
-}
-
 // downloadRepo downloads git repository.
 func downloadRepo(repoLink string, tag string, dst string,
 	logFile *os.File, verbose bool) error {

--- a/cli/install/patch.go
+++ b/cli/install/patch.go
@@ -1,0 +1,121 @@
+package install
+
+import (
+	"os"
+
+	"github.com/tarantool/tt/cli/util"
+	"github.com/tarantool/tt/cli/version"
+)
+
+type patcher interface {
+	isApplicable(ver version.Version) bool
+	apply(srcPath string, verbose bool, logFile *os.File) error
+}
+
+type defaultPatchApplier struct {
+	patch []byte
+}
+
+func (applier defaultPatchApplier) apply(srcPath string, verbose bool, logFile *os.File) error {
+	err := util.ExecuteCommandStdin("git", verbose, logFile,
+		srcPath, applier.patch, "apply")
+
+	return err
+}
+
+type patchRange_1_to_2_6_1 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_1_to_2_6_1) isApplicable(ver version.Version) bool {
+	return (ver.Major == 2 && ver.Minor == 6 && ver.Patch < 1) || ver.Major == 1
+}
+
+type patch_1_10_14 struct {
+	defaultPatchApplier
+}
+
+func (patch_1_10_14) isApplicable(ver version.Version) bool {
+	return ver.Major == 1 && ver.Minor == 10 && ver.Patch == 14
+}
+
+type patch_2_8_4 struct {
+	defaultPatchApplier
+}
+
+func (patch_2_8_4) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 8 && ver.Patch == 4
+}
+
+type patch_2_10_beta struct {
+	defaultPatchApplier
+}
+
+func (patch_2_10_beta) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 10 && ver.Release.Type == version.TypeBeta
+}
+
+type patch_2_10_0_rc1 struct {
+	defaultPatchApplier
+}
+
+func (patch_2_10_0_rc1) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 10 && ver.Patch == 0 &&
+		ver.Release.Type == version.TypeBeta && ver.Release.Num == 1
+}
+
+type patchRange_1_to_1_10_12 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_1_to_1_10_12) isApplicable(ver version.Version) bool {
+	return ver.Major == 1 && ver.Minor == 10 && ver.Patch < 12
+}
+
+type patchRange_2_7_to_2_7_2 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_2_7_to_2_7_2) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 7 && ver.Patch < 2
+}
+
+type patchRange_2_7_2_to_2_7_4 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_2_7_2_to_2_7_4) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 7 && (ver.Patch > 1 && ver.Patch < 4)
+}
+
+type patchRange_2_8_1_to_2_8_4 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_2_8_1_to_2_8_4) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 8 && (ver.Patch > 0 && ver.Patch < 4)
+}
+
+type patchRange_1_to_1_10_14 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_1_to_1_10_14) isApplicable(ver version.Version) bool {
+	return ver.Major == 1 && ver.Minor == 10 && ver.Patch < 14
+}
+
+type patchRange_2_8_to_2_8_3 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_2_8_to_2_8_3) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor == 8 && ver.Patch < 3
+}
+
+type patchRange_2_to_2_8 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_2_to_2_8) isApplicable(ver version.Version) bool {
+	return ver.Major == 2 && ver.Minor < 8
+}

--- a/cli/install/patch_test.go
+++ b/cli/install/patch_test.go
@@ -1,0 +1,78 @@
+package install
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/util"
+	"github.com/tarantool/tt/cli/version"
+)
+
+type patchRange_1_0_to_2_9 struct {
+	defaultPatchApplier
+}
+
+func (patchRange_1_0_to_2_9) isApplicable(ver version.Version) bool {
+	return (ver.Major == 2 && ver.Minor < 10) || ver.Major == 1
+}
+
+func (applier patchRange_1_0_to_2_9) apply(srcPath string, verbose bool, logFile *os.File) error {
+	err := util.ExecuteCommandStdin("patch", verbose, logFile,
+		srcPath, applier.patch)
+
+	return err
+}
+
+type patcherInput struct {
+	ver version.Version
+}
+
+type patcherOutput struct {
+	result *[]byte
+}
+
+func TestPatcher(t *testing.T) {
+	assert := assert.New(t)
+	testDir, err := ioutil.TempDir("/tmp", "tt-unit")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(testDir)
+
+	targetData := []byte("aaa\n")
+	patchData := []byte("--- testdata.old	2022-10-11 10:32:28.011753821 +0300\n" +
+		"+++ testdata	2022-10-11 10:32:34.811754169 +0300\n" + "@@ -1 +1,2 @@\n aaa\n+bbb\n")
+	targetPath := testDir + "/testdata"
+
+	testCases := make(map[patcherInput]patcherOutput)
+
+	patchResult0 := []byte("aaa\nbbb\n")
+	testCases[patcherInput{version.Version{Major: 1, Minor: 2}}] = patcherOutput{&patchResult0}
+
+	patchResult1 := []byte("aaa\n")
+	testCases[patcherInput{version.Version{Major: 3, Minor: 0}}] = patcherOutput{&patchResult1}
+
+	for input, output := range testCases {
+		targetFile, err := os.Create(targetPath)
+		require.NoError(t, err)
+
+		_, err = targetFile.Write(targetData)
+		require.NoError(t, err)
+		targetFile.Close()
+
+		patch := patchRange_1_0_to_2_9{defaultPatchApplier{patchData}}
+
+		if patch.isApplicable(input.ver) {
+			patch.apply(testDir, false, nil)
+		}
+
+		patchedData, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+
+		assert.Equal(*output.result, patchedData)
+
+		os.Remove(targetPath)
+	}
+}

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -643,6 +643,9 @@ func ExecuteCommand(program string, isVerbose bool, logFile *os.File, workDir st
 	args ...string) error {
 	cmd := exec.Command(program, args...)
 	if isVerbose {
+		log.Infof("Run: %s\n", cmd)
+	}
+	if isVerbose {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	} else {


### PR DESCRIPTION
Backported static build system for versions 1.10.
    
For the successful assembly of older versions,
additional patches have been applied:
    
    * openssl-symbols.patch - Fix missing OpenSSL symbols.
    * gh-6686-fix-build-with-glibc-2-34.patch - Necessary
      for building with >= glibc-2.34.
    * zlib-backup.patch - zlib version 1.2.11 is no longer
      available for download.
    * bump-libunwind.patch - Old version of the libunwind
      doesn't compile under GCC > 10.
    
Closes #175