### PR TITLE
launcher: add support of all config variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Ubuntu 16.04 container.
 - Ability to use the `start/stop/restart/status/check` commands without
   arguments to interact with all instances of the environment simultaneously.
+- Starting from version 2.8.1, we can specify configuration parameters of
+  tarantool via special environment variables.
+  Added support for this feature when running older versions of tarantools via tt.
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,14 @@ Where:
 
 `TT daemon example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-tt-daemon-experimental>`_
 
+Setting Tarantool configuration parameters via environment variables
+-------------------------------------
+
+Using ``tt``, you can specify configuration parameters
+via special environment variables even on Tarantool versions that does not natively support it.
+The name of a variable should have the following pattern: ``TT_<NAME>``,
+where ``<NAME>`` is the uppercase name of the corresponding `box.cfg <https://www.tarantool.io/en/doc/latest/reference/configuration/#box-cfg-params-ref>`_ parameter.
+
 Commands
 --------
 Common description. For a detailed description, use ``tt help command`` .

--- a/test/integration/running/test_env_app/test_env_app.lua
+++ b/test/integration/running/test_env_app/test_env_app.lua
@@ -1,0 +1,7 @@
+local fiber = require('fiber')
+
+box.cfg()
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -524,3 +524,54 @@ def test_no_args_usage(tt_cmd):
             # Check that the process was terminated correctly.
             instance_process_rc = instance_process.wait(1)
             assert instance_process_rc == 0
+
+
+def test_running_env_variables(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    # Copy the test application to the "run" directory.
+    test_app_path = os.path.join(os.path.dirname(__file__), "test_env_app", "test_env_app.lua")
+    shutil.copy(test_app_path, tmpdir)
+    # Set environmental variable which changes log format to json.
+    my_env = os.environ.copy()
+    my_env["TT_LOG_FORMAT"] = "json"
+    # Start an instance with custom env.
+    start_cmd = [tt_cmd, "start", "test_env_app"]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=my_env
+    )
+    start_output = instance_process.stdout.readline()
+    assert re.search(r"Starting an instance", start_output)
+
+    # Check status.
+    file = wait_file(os.path.join(tmpdir, run_path, "test_env_app"), 'test_env_app.pid', [])
+    assert file != ""
+    status_cmd = [tt_cmd, "status", "test_env_app"]
+    status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"RUNNING. PID: \d+.", status_out)
+
+    # Stop the Instance.
+    stop_cmd = [tt_cmd, "stop", "test_env_app"]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    assert re.search(r"The Instance test_env_app \(PID = \d+\) has been terminated.", stop_out)
+
+    # Check that the process was terminated correctly.
+    instance_process_rc = instance_process.wait(1)
+    assert instance_process_rc == 0
+
+    # Check that log format is in json.
+    isJson = False
+    logPath = os.path.join(tmpdir, "var", "log", "test_env_app", "test_env_app.log")
+    with open(logPath, "r") as file:
+        for _, line in enumerate(file, start=1):
+            if "{" in line:
+                isJson = True
+                break
+
+    assert isJson


### PR DESCRIPTION
Starting from version 2.8.1, we can specify configuration parameters via special environment variables. Added support of all of them for the old tarantool.

Close #142 