### PR TITLE
ci: run flake8 linter separately

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,11 +84,14 @@ jobs:
       - name: Codespell checks
         run: mage codespell
 
-      - name: Linter
+      - name: Go Linter
         uses: golangci/golangci-lint-action@v3
         with:
           args: --config=golangci-lint.yml --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
+
+      - name: Python Linter
+        run: python3 -m flake8 test
 
       - name: Unit tests
         run: mage unitfull
@@ -182,11 +185,14 @@ jobs:
       - name: Codespell checks
         run: mage codespell
 
-      - name: Linter
+      - name: Go Linter
         uses: golangci/golangci-lint-action@v3
         with:
           args: --config=golangci-lint.yml --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
+
+      - name: Python Linter
+        run: python3 -m flake8 test
 
       - name: Unit tests
         run: mage unit

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_local_folder=utils

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,10 @@ Prerequisites
 To run tests:
 
 * `Python3 <https://www.python.org/downloads/>`_
+* `pytest <https://docs.pytest.org/en/7.2.x/getting-started.html#get-started>`_
+* `flake8 <https://pypi.org/project/flake8/>`_
+* `flake8-isort <https://pypi.org/project/flake8-isort/>`_
+* `flake8-unused-arguments <https://pypi.org/project/flake8-unused-arguments/>`_
 * `golangci-lint <https://golangci-lint.run/usage/install/#local-installation>`_
 
 ~~~~~

--- a/cli/build/build.go
+++ b/cli/build/build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 )
 
-//BuildCtx contains information for application building.
+// BuildCtx contains information for application building.
 type BuildCtx struct {
 	// BuildDir is an application directory.
 	BuildDir string

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -62,8 +62,8 @@ type Console struct {
 	connOpts connector.ConnectOpts
 	conn     connector.Connector
 
-	executor  func(in string)
-	completer func(in prompt.Document) []prompt.Suggest
+	executor   func(in string)
+	completer  func(in prompt.Document) []prompt.Suggest
 	validators map[Language]ValidateCloser
 
 	prompt *prompt.Prompt
@@ -283,12 +283,11 @@ func getCompleter(console *Console) prompt.Completer {
 			return nil
 		}
 
-
 		var suggestionsTexts []string
 		args := []interface{}{lastWord, len(lastWord)}
 		opts := connector.RequestOpts{
 			ReadTimeout: 3 * time.Second,
-			ResData: &suggestionsTexts,
+			ResData:     &suggestionsTexts,
 		}
 
 		if _, err := console.conn.Eval(getSuggestionsFuncBody, args, opts); err != nil {

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -65,8 +65,8 @@ func Connect(opts ConnectOpts) (Connector, error) {
 
 		addr := fmt.Sprintf("%s://%s", opts.Network, opts.Address)
 		conn, err := tarantool.Connect(addr, tarantool.Opts{
-			User: opts.Username,
-			Pass: opts.Password,
+			User:       opts.Username,
+			Pass:       opts.Password,
 			SkipSchema: true, // We don't need a schema for eval requests.
 		})
 		if err != nil {

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -141,9 +141,10 @@ func writeToPlainTextConn(conn net.Conn, data string) error {
 // ---
 // - '
 //
-//   ...
+//	...
 //
-//   '
+//	'
+//
 // ...
 //
 // If Lua output is set, the end of input is just ";".

--- a/cli/connector/protocol_test.go
+++ b/cli/connector/protocol_test.go
@@ -89,4 +89,3 @@ func TestGetProtocol(t *testing.T) {
 		})
 	}
 }
-

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -23,10 +23,12 @@ import (
 
 // Backported cmake rules for static build.
 // Static build has appeared since version 2.6.1.
+//
 //go:embed extra/tarantool-static-build.patch
 var staticBuildPatch []byte
 
 // Fix missing OpenSSL symbols.
+//
 //go:embed extra/openssl-symbols.patch
 var opensslSymbolsPatch []byte
 
@@ -35,11 +37,13 @@ var opensslSymbolsPatch14 []byte
 
 // Necessary for building with >= glibc-2.34.
 // Not actual for >= (1.10.11, 2.8.3).
+//
 //go:embed extra/gh-6686-fix-build-with-glibc-2-34.patch
 var glibcPatch []byte
 
 // zlib version 1.2.11 is no longer available for download.
 // Not actual for >= 2.10.0-rc1, 2.8.4.
+//
 //go:embed extra/zlib-backup-old.patch
 var zlibPatchOld []byte
 
@@ -48,6 +52,7 @@ var zlibPatch []byte
 
 // Old version of the libunwind doesn't compile under GCC 10.
 // Not actual for >= 2.10.0-rc1.
+//
 //go:embed extra/bump-libunwind-old.patch
 var unwindPatchOld []byte
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -503,14 +503,16 @@ func createPIDFile(pidFileName string) error {
 
 // makePath make application path with rules:
 // * if path is not set:
-//     * if single instance application: baseBath + application name.
-//     * else : baseBath + application name + instance name.
+//   - if single instance application: baseBath + application name.
+//   - else : baseBath + application name + instance name.
+//
 // * if path is set and it is absolute:
-//    * if single instance application: path + application name
-//    * else: path + application name + instance name.
+//   - if single instance application: path + application name
+//   - else: path + application name + instance name.
+//
 // * if path is set and it is relative:
-//    * if single instance application: basePath + path + application name.
-//    * else: basePath + path + application name + instance name.
+//   - if single instance application: basePath + path + application name.
+//   - else: basePath + path + application name + instance name.
 func makePath(path string, basePath string, inst *InstanceCtx) string {
 	res := ""
 

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -108,7 +108,7 @@ func (wd *Watchdog) Start() {
 	}
 }
 
-//startSignalHandling starts signal handling in a separate goroutine.
+// startSignalHandling starts signal handling in a separate goroutine.
 func (wd *Watchdog) startSignalHandling() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan)

--- a/golangci-lint.yml
+++ b/golangci-lint.yml
@@ -3,11 +3,14 @@ linters:
   enable:
     - lll
     - govet
+    - gofmt
 
 linters-settings:
   lll:
     line-length: 100
     tab-width: 4
+  gofmt:
+    simplify: false
 
 issues:
   exclude-rules:

--- a/test/integration/cartridge/test_cartridge.py
+++ b/test/integration/cartridge/test_cartridge.py
@@ -1,6 +1,6 @@
 import re
-import time
 import subprocess
+import time
 
 from utils import run_command_and_get_output, wait_file
 

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -4,6 +4,7 @@ import tempfile
 
 import pytest
 import yaml
+
 from utils import (create_external_module, create_tt_config,
                    run_command_and_get_output)
 

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 
 import pytest
+
 from utils import run_command_and_get_output, wait_file
 
 

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -1,4 +1,5 @@
 import pytest
+
 from utils import (create_external_module, create_tt_config,
                    run_command_and_get_output)
 

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1,13 +1,15 @@
 import os
 import shutil
 import tarfile
-import yaml
-from utils import run_command_and_get_output
 
+import yaml
+
+from utils import run_command_and_get_output
 
 # ##### #
 # Tests #
 # ##### #
+
 
 def assert_bundle_structure(path):
     assert os.path.isfile(os.path.join(path, "tarantool.yaml"))

--- a/test/integration/play/test_play.py
+++ b/test/integration/play/test_play.py
@@ -3,6 +3,7 @@ import re
 import shutil
 
 import pytest
+
 from utils import (TarantoolTestInstance, kill_child_process,
                    run_command_and_get_output)
 

--- a/test/integration/remove/test_remove.py
+++ b/test/integration/remove/test_remove.py
@@ -1,6 +1,6 @@
+import os
 import re
 import subprocess
-import os
 
 
 def test_remove_tt(tt_cmd, tmpdir):

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+
 import yaml
 
 from utils import (kill_child_process, run_command_and_get_output, wait_file,
@@ -201,7 +202,7 @@ def test_clean(tt_cmd, tmpdir_with_cfg):
     assert os.path.exists(logfile) is False
 
 
-def test_running_base_functionality_working_dir_app(tt_cmd, tmpdir_with_cfg):
+def test_running_base_functionality_working_dir_app(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
 
     # Default temporary directory may have very long path. This can cause socket path buffer
@@ -209,7 +210,6 @@ def test_running_base_functionality_working_dir_app(tt_cmd, tmpdir_with_cfg):
     with tempfile.TemporaryDirectory() as tmpdir:
         test_app_path = os.path.join(tmpdir, "app")
         shutil.copytree(test_app_path_src, test_app_path)
-
 
         for subdir in ["", "app"]:
             if subdir != "":
@@ -230,7 +230,7 @@ def test_running_base_functionality_working_dir_app(tt_cmd, tmpdir_with_cfg):
             for instName in ["master", "replica", "router"]:
                 print(os.path.join(test_app_path, "run", "app", instName))
                 file = wait_file(os.path.join(test_app_path, "run", "app", instName),
-                                instName + ".pid", [])
+                                 instName + ".pid", [])
                 assert file != ""
 
             status_cmd = [tt_cmd, "status", "app"]
@@ -249,7 +249,7 @@ def test_running_base_functionality_working_dir_app(tt_cmd, tmpdir_with_cfg):
             assert instance_process_rc == 0
 
 
-def test_running_instance_from_multi_inst_app(tt_cmd, tmpdir_with_cfg):
+def test_running_instance_from_multi_inst_app(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
 
     # Default temporary directory may have very long path. This can cause socket path buffer
@@ -296,7 +296,7 @@ def test_running_instance_from_multi_inst_app(tt_cmd, tmpdir_with_cfg):
         assert instance_process_rc == 0
 
 
-def test_running_multi_inst_app_error_cases(tt_cmd, tmpdir_with_cfg):
+def test_running_multi_inst_app_error_cases(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
 
     # Default temporary directory may have very long path. This can cause socket path buffer
@@ -342,7 +342,7 @@ def test_running_reread_config(tt_cmd, tmpdir):
     # Create test config with restart_on_failure true.
     with open(config_path, "w") as file:
         yaml.dump({"tt": {"app": {"restart_on_failure": True,
-            "log_maxsize": 10, "log_maxage": 1}}}, file)
+                   "log_maxsize": 10, "log_maxage": 1}}}, file)
 
     # Start an instance.
     start_cmd = [tt_cmd, "start", inst_name, "--cfg", config_path]
@@ -394,7 +394,7 @@ def test_running_reread_config(tt_cmd, tmpdir):
 
     with open(config_path, "w") as file:
         yaml.dump({"tt": {"app": {"restart_on_failure": False,
-            "log_maxsize": 10, "log_maxage": 1}}}, file)
+                   "log_maxsize": 10, "log_maxage": 1}}}, file)
 
     # Kill instance child process.
     killed_childrens = 0


### PR DESCRIPTION
Flake8 tests were forgotten when implementing golangci-lint.