### PR TITLE
ci: add license checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Codespell checks
         run: mage codespell
 
+      - name: License checker
+        run: |
+          go install github.com/uw-labs/lichen@latest
+          mage checklicenses
+
       - name: Go Linter
         uses: golangci/golangci-lint-action@v3
         with:
@@ -184,6 +189,11 @@ jobs:
 
       - name: Codespell checks
         run: mage codespell
+
+      - name: License checker
+        run: |
+          go install github.com/uw-labs/lichen@latest
+          mage checklicenses
 
       - name: Go Linter
         uses: golangci/golangci-lint-action@v3

--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,0 +1,7 @@
+allow:
+  - "MIT"
+  - "Apache-2.0"
+  - "BSD-3-Clause"
+  - "BSD-2-Clause"
+  - "MPL-2.0"
+  - "CC-BY-SA-4.0"

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ To run tests:
 * `flake8-isort <https://pypi.org/project/flake8-isort/>`_
 * `flake8-unused-arguments <https://pypi.org/project/flake8-unused-arguments/>`_
 * `golangci-lint <https://golangci-lint.run/usage/install/#local-installation>`_
+* `lichen <https://github.com/uw-labs/lichen#install>`_
 
 ~~~~~
 Build

--- a/magefile.go
+++ b/magefile.go
@@ -166,6 +166,22 @@ func Build() error {
 	return nil
 }
 
+// Run license checker.
+func CheckLicenses() error {
+	fmt.Println("Running license checker...")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	if err := sh.RunV(home+"/go/bin/lichen", "--config", ".lichen.yaml", "tt"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Run golang and python linters.
 func Lint() error {
 	fmt.Println("Running golangci-lint...")
@@ -230,7 +246,7 @@ func Codespell() error {
 
 // Run all tests together.
 func Test() {
-	mg.SerialDeps(Lint, Unit, Integration)
+	mg.SerialDeps(Lint, CheckLicenses, Unit, Integration)
 }
 
 // Cleanup directory.


### PR DESCRIPTION
We need to check the licenses of modules that came from dependencies. CI should return an error if the licenses are not in the list:

BSD-2
MIT
Apache-2.0
BSD
MPL-2.0

Close #205