### PR TITLE
daemon: fix unit test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,7 +341,7 @@ Where:
 * ``pidfile`` (string) - name of file contains pid of daemon process.
   Default: ``tt_daemon.pid``.
 
-`TT daemon example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-tt-daemon>`_
+`TT daemon example <https://github.com/tarantool/tt/blob/master/doc/examples.rst#working-with-tt-daemon-experimental>`_
 
 Commands
 --------

--- a/cli/daemon/process_test.go
+++ b/cli/daemon/process_test.go
@@ -25,6 +25,12 @@ func TestProcessBase(t *testing.T) {
 	pid, err := readPID(TestProcessPidFile)
 	require.Nilf(t, err, `Can't read daemon PID. Error: "%v".`, err)
 
+	// Kill daemon if test fails.
+	defer func() {
+		syscall.Kill(pid, syscall.SIGINT)
+		waitProcessChanges()
+	}()
+
 	alive, err := IsDaemonAlive(pid)
 	require.Nilf(t, err, `Daemon is not alive. Error: "%v".`, err)
 	require.True(t, alive, "Can't start daemon.")

--- a/cli/daemon/process_test_helpers.go
+++ b/cli/daemon/process_test_helpers.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"syscall"
 	"time"
-
-	ps "github.com/mitchellh/go-ps"
 )
 
 const (
@@ -74,15 +72,6 @@ func IsDaemonAlive(pid int) (bool, error) {
 	err = proc.Signal(syscall.Signal(0))
 	if err != nil {
 		return false, err
-	}
-
-	pr, err := ps.FindProcess(pid)
-	if err != nil {
-		return false, err
-	}
-
-	if pr.PPid() != 1 {
-		return false, fmt.Errorf("Process is not daemonized")
 	}
 
 	return true, nil

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae // indirect
-	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -617,8 +617,6 @@ github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
-github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
Unit test failed for systemd because of check if
process is daemonized. Daemonization was checked
with PPID == 1. But PPID == 1 is no guarantee
that it is a daemon, for systemd daemon PPID is
systemd unit that managing daemon process.
But if proceess is detached from it's controlling
terminal, it is a daemon. But it is difficult to
check by means of Golang. This commit removes
daemonization check.
    
Closes #230