### PR TITLE
ci: fix checkout with pull_request_target

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -68,7 +68,17 @@ jobs:
         sdk-version: ["2.10.2-0-gf4228cb7d-r508-linux-x86_64"]
       fail-fast: false
     steps:
+        # `ref` as merge request is needed for pull_request_target because this
+        # target runs in the context of the base commit of the pull request.
       - uses: actions/checkout@master
+        if: github.event_name == 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: actions/checkout@master
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,17 @@ jobs:
         sdk-version: ["2.10.2-0-gf4228cb7d-r508-linux-x86_64"]
       fail-fast: false
     steps:
+        # `ref` as merge request is needed for pull_request_target because this
+        # target runs in the context of the base commit of the pull request.
       - uses: actions/checkout@master
+        if: github.event_name == 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: actions/checkout@master
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
It is required to set `ref` and `repository` param for checkout in case of `pull_request_target` because the target runs in the context of the base commit.