### PR TITLE
install: support new tag format

### DIFF
--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -391,11 +391,14 @@ func installTt(version string, binDir string, flags InstallationFlag, distfiles 
 	}
 
 	// Check that the version exists.
+	// The tag format in tt is vX.Y.Z, but the user can use the X.Y.Z format
+	// and this option needs to be supported.
 	if ttVersion != "master" {
 		versionFound := false
 		for _, ver := range versions {
-			if ttVersion == ver.Str {
+			if ttVersion == ver.Str || (ttVersion[0:1] != "v" && "v"+ttVersion == ver.Str) {
 				versionFound = true
+				ttVersion = ver.Str
 				break
 			}
 		}

--- a/cli/version/version_tools.go
+++ b/cli/version/version_tools.go
@@ -45,7 +45,7 @@ func GetVersionDetails(verStr string) (Version, error) {
 	// Part 3 (optional) -> additional commits,
 	// Part 4 (optional) -> commit hash and revision.
 	re := regexp.MustCompile(
-		`^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)` +
+		`^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)` +
 			`(?:-(?P<release>entrypoint|rc|alpha|beta)(?P<releaseNum>\d+)?)?` +
 			`(?:-(?P<additional>\d+))?` +
 			`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?(?:-nogc64)?$`)

--- a/cli/version/version_tools_test.go
+++ b/cli/version/version_tools_test.go
@@ -103,6 +103,17 @@ func TestParseVersion(t *testing.T) {
 		nil,
 	}
 
+	testCases["v1.2.3"] = returnValueParseVersion{
+		Version{
+			Major:   1,
+			Minor:   2,
+			Patch:   3,
+			Release: Release{Type: TypeRelease},
+			Str:     "v1.2.3",
+		},
+		nil,
+	}
+
 	testCases["2.8"] = returnValueParseVersion{
 		Version{},
 		fmt.Errorf("Failed to parse version: format is not valid"),


### PR DESCRIPTION
The tag format in tt will be changed from X.Y.Z to vX.Y.Z. The old format also needs to be supported. For example:

`tt install tt=0.2.0` should install v0.2.0 if such a version exists.