### PR TITLE
tt: log luajit errors

### DIFF
--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -169,9 +169,9 @@ local function start_instance()
     -- This can be removed when tarantool 1.10 is no longer supported.
     arg[0] = instance_path
 
-    local success, data = pcall(dofile, instance_path)
-    if not success then
-        log.error('Failed to run instance: %s', instance_path)
+    local ok, err = pcall(dofile, instance_path)
+    if not ok then
+        log.error('Failed to run instance: %s, error: "%s"', instance_path, err)
         os.exit(1)
     end
     return 0


### PR DESCRIPTION
If an incorrect lua code is run, the user will not see an error. For example:

$ cat a.lua
print("test"
$ tarantool a.lua
LuajitError: a.lua:2: ')' expected (to close '(' at line 1) near '<eof>' fatal error, exiting the event loop
$ tt run a.lua
Failed to run instance: a.lua
   ⨯ exit status 1

After applying this patch:

$ tt run a.lua
Failed to run instance: a.lua, error: "a.lua:2: ')' expected (to close '(' at line 1) near '<eof>'"
   ⨯ exit status 1