### PR TITLE
Minor changes for cartridge and restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ``tt restart`` confirmation prompt. ``-y`` option is added to accept restart without prompting.
+
+### Changed
+
+- ``tt cartridge`` sub-commands ``create``, ``build``, ``pack`` are removed.
+
 ## [0.2.1] - 2022-11-24
 
 ### Fixed

--- a/cli/build/local.go
+++ b/cli/build/local.go
@@ -68,5 +68,7 @@ func buildLocal(cmdCtx *cmdcontext.CmdCtx, buildCtx *BuildCtx) error {
 		return fmt.Errorf("run post-build hook failed: %s", err)
 	}
 
+	log.Info("Application was successfully built")
+
 	return nil
 }

--- a/cli/cmd/cartridge.go
+++ b/cli/cmd/cartridge.go
@@ -13,9 +13,6 @@ func NewCartridgeCmd() *cobra.Command {
 	}
 
 	cartCliCmds := []*cobra.Command{
-		cc.CartridgeCliPack,
-		cc.CartridgeCliCreate,
-		cc.CartridgeCliBuild,
 		cc.CartridgeCliAdmin,
 		cc.CartridgeCliBench,
 		cc.CartridgeCliFailover,

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -1,10 +1,18 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	autoYes bool
 )
 
 // NewRestartCmd creates start command.
@@ -19,13 +27,32 @@ func NewRestartCmd() *cobra.Command {
 				log.Fatalf(err.Error())
 			}
 		},
+		Args: cobra.ExactArgs(1),
 	}
+
+	restartCmd.Flags().BoolVarP(&autoYes, "yes", "y", false,
+		`Automatic yes to confirmation prompt`)
 
 	return restartCmd
 }
 
 // internalRestartModule is a default restart module.
 func internalRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("restart accepts only 1 arg, received %d", len(args))
+	}
+
+	if !autoYes {
+		confirmed, err := util.AskConfirm(os.Stdin, fmt.Sprintf("Confirm restart of '%s'", args[0]))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			log.Info("Restart is cancelled.")
+			return nil
+		}
+	}
+
 	if err := internalStopModule(cmdCtx, args); err != nil {
 		return err
 	}

--- a/cli/create/internal/steps/move_app_dir.go
+++ b/cli/create/internal/steps/move_app_dir.go
@@ -38,5 +38,7 @@ func (MoveAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 		log.Warnf("Failed to remove temporary directory: %s", err)
 	}
 
+	log.Infof("Application '%s' created successfully", createCtx.AppName)
+
 	return nil
 }

--- a/test/integration/cartridge/test_cartridge.py
+++ b/test/integration/cartridge/test_cartridge.py
@@ -27,12 +27,12 @@ def stop_cartridge_app(tt_cmd, tmpdir):
 
 def test_cartridge_base_functionality(tt_cmd, tmpdir_with_cfg):
     tmpdir = tmpdir_with_cfg
-    create_cmd = [tt_cmd, "cartridge", "create", "--name", cartridge_name]
+    create_cmd = [tt_cmd, "create", "cartridge", "--name", cartridge_name]
     create_rc, create_out = run_command_and_get_output(create_cmd, cwd=tmpdir)
     assert create_rc == 0
-    assert re.search(r'Application "' + cartridge_name + '" created successfully', create_out)
+    assert re.search(r"Application '" + cartridge_name + "' created successfully", create_out)
 
-    build_cmd = [tt_cmd, "cartridge", "build", cartridge_name]
+    build_cmd = [tt_cmd, "build", cartridge_name]
     build_rc, build_out = run_command_and_get_output(build_cmd, cwd=tmpdir)
     assert build_rc == 0
     assert re.search(r'Application was successfully built', build_out)

--- a/test/integration/restart/test_app.lua
+++ b/test/integration/restart/test_app.lua
@@ -1,0 +1,7 @@
+local fiber = require('fiber')
+
+box.cfg({})
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -1,0 +1,100 @@
+import os
+import shutil
+import subprocess
+
+from utils import run_command_and_get_output, run_path, wait_file
+
+
+def app_cmd(tt_cmd, tmpdir_with_cfg, cmd, input):
+    start_cmd = [tt_cmd, *cmd]
+    tt_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmpdir_with_cfg,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True
+    )
+
+    tt_process.stdin.writelines(input)
+    tt_process.stdin.close()
+    rc = tt_process.wait()
+    assert rc == 0
+    return tt_process.stdout.readlines()
+
+
+def test_restart(tt_cmd, tmpdir_with_cfg):
+    shutil.copy(os.path.join(os.path.dirname(__file__), "test_app.lua"), tmpdir_with_cfg)
+    app_name = "test_app"
+    start_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["start", app_name], [])
+    assert "Starting an instance" in start_output[0]
+    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+    prev_pid = current_pid = 0
+
+    try:
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            prev_pid = int(pid_file.readline())
+
+        # Test confirmed restart.
+        restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", app_name], ["y\n"])
+        assert "Confirm restart of 'test_app' [y/n]" in restart_output[0]
+        assert "has been terminated" in restart_output[0]
+        assert "Starting an instance" in restart_output[1]
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            current_pid = int(pid_file.readline())
+            assert current_pid != prev_pid  # New pid after restart.
+            prev_pid = current_pid
+
+        # Test cancelled restart.
+        restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", app_name], ["n\n"])
+        assert "Confirm restart of 'test_app' [y/n]" in restart_output[0]
+        assert "Restart is cancelled" in restart_output[0]
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            assert int(pid_file.readline()) == prev_pid  # No restart, pid is the same.
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+
+
+def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
+    shutil.copy(os.path.join(os.path.dirname(__file__), "test_app.lua"), tmpdir_with_cfg)
+    app_name = "test_app"
+    start_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["start", app_name], [])
+    assert "Starting an instance" in start_output[0]
+    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+    prev_pid = current_pid = 0
+
+    try:
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            prev_pid = int(pid_file.readline())
+
+        restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", "-y", app_name], [])
+        assert "Confirm restart of 'test_app' [y/n]" not in restart_output[0]
+        assert "has been terminated" in restart_output[0]
+        assert "Starting an instance" in restart_output[1]
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            current_pid = int(pid_file.readline())
+            assert current_pid != prev_pid  # New pid after restart.
+            prev_pid = current_pid
+
+        restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", "--yes", app_name], [])
+        assert "Confirm restart of 'test_app' [y/n]" not in restart_output[0]
+        assert "has been terminated" in restart_output[0]
+        assert "Starting an instance" in restart_output[1]
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
+
+        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
+            current_pid = int(pid_file.readline())
+            assert current_pid != prev_pid  # New pid after restart.
+            prev_pid = current_pid
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -75,7 +75,7 @@ def test_restart(tt_cmd, tmpdir_with_cfg):
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
     # Restart the Instance.
-    restart_cmd = [tt_cmd, "restart", "test_app"]
+    restart_cmd = [tt_cmd, "restart", "-y", "test_app"]
     instance_process_2 = subprocess.Popen(
         restart_cmd,
         cwd=tmpdir,


### PR DESCRIPTION
- Added `tt restart` confirmation prompt. `-y` option is added to accept restart without prompting.
- `tt cartridge` sub-commands `create`, `build`, `pack` are removed. Some message from cartridge were added to `tt build` and `tt create`

Part of #246 