### PR TITLE
tt: fix tarballs helper

### DIFF
--- a/.gen_tarballs.sh
+++ b/.gen_tarballs.sh
@@ -44,6 +44,8 @@ if [ $# == 0 ]; then
     die "Usage: ${0} -t <tag>"
 fi
 
+TAG_ORIG=${TAG}
+TAG=${TAG//v}
 TMPDIR="/tmp/gentoo_tarballs"
 TT_DIR="${TMPDIR}/tt-${TAG}"
 
@@ -52,7 +54,7 @@ test -d $TMPDIR && rm -rf $TMPDIR
 mkdir -p $TMPDIR/go-mod
 
 echo -n "* Download sources... "
-git clone https://github.com/tarantool/tt.git -b $TAG --depth=1 --recursive $TT_DIR \
+git clone https://github.com/tarantool/tt.git -b $TAG_ORIG --depth=1 --recursive $TT_DIR \
     > /dev/null 2>${TMPDIR}/log.txt
 if [ "$?" != 0 ]; then
     echo "Err: "


### PR DESCRIPTION
Tarballs helper script was fixed for working
with a new tag format (vX.Y.Z).