### PR TITLE
completion: search, install and uninstall keywords

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -55,7 +55,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	switch shell := args[0]; shell {
 	case "bash":
-		if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
+		if err := rootCmd.GenBashCompletionV2(os.Stdout, true); err != nil {
 			return err
 		}
 	case "zsh":

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -48,6 +48,7 @@ func NewInstallCmd() *cobra.Command {
 				log.Fatalf(err.Error())
 			}
 		},
+		ValidArgs: []string{"tt", "tarantool", "tarantool-ee"},
 	}
 	installCmd.Flags().BoolVarP(&Verbose, "verbose", "V", false, "print log to stderr")
 	installCmd.Flags().BoolVarP(&Force, "force", "f", false, "force requirements errors")

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -30,6 +30,7 @@ func NewSearchCmd() *cobra.Command {
 				log.Fatalf(err.Error())
 			}
 		},
+		ValidArgs: []string{"tt", "tarantool", "tarantool-ee"},
 	}
 	searchCmd.Flags().BoolVarP(&local, "local-repo", "", false,
 		"search in local files")

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -30,6 +30,13 @@ func NewUninstallCmd() *cobra.Command {
 				log.Fatalf(err.Error())
 			}
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return uninstall.GetList(&cmdCtx), cobra.ShellCompDirectiveNoFileComp
+		},
 		Example: `
 # To uninstall Tarantool:
 

--- a/cli/uninstall/uninstall_test.go
+++ b/cli/uninstall/uninstall_test.go
@@ -1,0 +1,54 @@
+package uninstall
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/search"
+)
+
+const testDirName = "uninstall-test-dir"
+
+func TestGetList(t *testing.T) {
+	assert := assert.New(t)
+	workDir, err := ioutil.TempDir("", testDirName)
+	require.NoError(t, err)
+	defer os.RemoveAll(workDir)
+
+	binDir := filepath.Join(workDir, "bin")
+	err = os.Mkdir(binDir, os.ModePerm)
+	require.NoError(t, err)
+
+	cfgData := []byte("tt:\n  app:\n    bin_dir: " + binDir)
+	cfgPath := filepath.Join(workDir, "tt.yaml")
+
+	err = os.WriteFile(cfgPath, cfgData, 0400)
+	require.NoError(t, err)
+
+	files := []string{
+		"tt" + search.VersionFsSeparator + "1.2.3",
+		"tarantool" + search.VersionFsSeparator + "1.2.10",
+		"tarantool-ee" + search.VersionFsSeparator + "master",
+	}
+	for _, file := range files {
+		f, err := os.Create(filepath.Join(binDir, file))
+		require.NoError(t, err)
+		f.Close()
+	}
+
+	expected := []string{
+		"tt" + search.VersionCliSeparator + "1.2.3",
+		"tarantool" + search.VersionCliSeparator + "1.2.10",
+		"tarantool-ee" + search.VersionCliSeparator + "master",
+	}
+
+	cmdCtx := cmdcontext.CmdCtx{Cli: cmdcontext.CliCtx{ConfigPath: cfgPath}}
+	result := GetList(&cmdCtx)
+
+	assert.ElementsMatch(result, expected)
+}


### PR DESCRIPTION
Enable keyword completion for:
tt search (static)
tt install (static)
tt uninstall (runtime)

Example:
$ tt uninstall tarantool=
tarantool=2.10.2  tarantool=2.10.3  tarantool=2.8.4   tarantool=master

$ tt search t
tarantool     tarantool-ee  tt