### PR TITLE
restart: fix flaky restart integration test

### DIFF
--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 
-from utils import run_command_and_get_output, run_path, wait_file
+from utils import run_path, wait_file
 
 
 def app_cmd(tt_cmd, tmpdir_with_cfg, cmd, input):
@@ -28,37 +28,24 @@ def test_restart(tt_cmd, tmpdir_with_cfg):
     app_name = "test_app"
     start_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["start", app_name], [])
     assert "Starting an instance" in start_output[0]
-    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-    prev_pid = current_pid = 0
+    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
     try:
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            prev_pid = int(pid_file.readline())
-
         # Test confirmed restart.
         restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", app_name], ["y\n"])
         assert "Confirm restart of 'test_app' [y/n]" in restart_output[0]
         assert "has been terminated" in restart_output[0]
         assert "Starting an instance" in restart_output[1]
-        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            current_pid = int(pid_file.readline())
-            assert current_pid != prev_pid  # New pid after restart.
-            prev_pid = current_pid
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
         # Test cancelled restart.
         restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", app_name], ["n\n"])
         assert "Confirm restart of 'test_app' [y/n]" in restart_output[0]
         assert "Restart is cancelled" in restart_output[0]
-        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            assert int(pid_file.readline()) == prev_pid  # No restart, pid is the same.
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
-        stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], [])
 
 
 def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
@@ -66,35 +53,20 @@ def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
     app_name = "test_app"
     start_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["start", app_name], [])
     assert "Starting an instance" in start_output[0]
-    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-    prev_pid = current_pid = 0
+    wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
     try:
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            prev_pid = int(pid_file.readline())
-
         restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", "-y", app_name], [])
         assert "Confirm restart of 'test_app' [y/n]" not in restart_output[0]
         assert "has been terminated" in restart_output[0]
         assert "Starting an instance" in restart_output[1]
-        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            current_pid = int(pid_file.readline())
-            assert current_pid != prev_pid  # New pid after restart.
-            prev_pid = current_pid
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
         restart_output = app_cmd(tt_cmd, tmpdir_with_cfg, ["restart", "--yes", app_name], [])
         assert "Confirm restart of 'test_app' [y/n]" not in restart_output[0]
         assert "has been terminated" in restart_output[0]
         assert "Starting an instance" in restart_output[1]
-        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [])
-
-        with open(os.path.join(tmpdir_with_cfg, run_path, app_name, 'test_app.pid')) as pid_file:
-            current_pid = int(pid_file.readline())
-            assert current_pid != prev_pid  # New pid after restart.
-            prev_pid = current_pid
+        wait_file(os.path.join(tmpdir_with_cfg, run_path, app_name), 'test_app.pid', [], 5)
 
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
-        stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], [])


### PR DESCRIPTION
PID check cannot be used to test if restart is completed due to race condition between start and restart commands: #264 
Checks for PID changes are removed.