### PR TITLE
run: minor fixes in tt run

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -2,17 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -81,42 +78,9 @@ func internalRunModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 				return fmt.Errorf("there was some problem locating script: %s", err)
 			}
 			startIndex = 1
-		} else {
-			return fmt.Errorf("specify script : %s", args[0])
 		}
 	}
-	if len(args) > 0 {
-		// If '-' flag is specified, then read stdin.
-		if args[0] == "-" {
-			// Code below reads input when run is called
-			// with input through pipe e.g "test.lua | ./tt run -".
-			if !terminal.IsTerminal(syscall.Stdin) {
-				cmdByte, err := ioutil.ReadAll(os.Stdin)
-				if err != nil {
-					return err
-				}
-				runStdin = string(cmdByte)
-				if len(args) > 1 {
-					for i := 1; i < len(args); i++ {
-						runArgs = append(runArgs, args[i])
-					}
-				}
-			} else {
-				runStdin = ""
-				for i := 1; i < len(args); i++ {
-					runStdin += args[i]
-				}
-			}
-		} else {
-			if len(args) > 0 {
-				for i := startIndex; i < len(args); i++ {
-					runArgs = append(runArgs, args[i])
-				}
-				runOpts.RunFlags.RunArgs = runArgs
-			}
-		}
-	}
-
+	runOpts.RunFlags.RunArgs = args[startIndex:]
 	if err := running.Run(runOpts, scriptPath); err != nil {
 		return err
 	}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -44,11 +44,12 @@ func newRunOpts(cmdCtx cmdcontext.CmdCtx) *running.RunOpts {
 // NewRunCmd creates run command.
 func NewRunCmd() *cobra.Command {
 	var runCmd = &cobra.Command{
-		Use:   "run [APPLICATION_NAME]",
-		Short: "Run tarantool instance",
-		Long: "Run tarantool instance\n" +
-			"Flags processed within the application\n" +
-			"are passed after: '--'",
+		Use:   "run [SCRIPT.lua [flags] [-- ARGS]]",
+		Short: "Run Tarantool instance",
+		Long: `Run Tarantool instance.
+All command line arguments are passed to the interpreted SCRIPT. Options to process in the SCRIPT
+are passed after '--'.
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.Name(), &modulesInfo, internalRunModule, args)
@@ -56,7 +57,38 @@ func NewRunCmd() *cobra.Command {
 				log.Fatalf(err.Error())
 			}
 		},
+		Example: `
+# Print current environment Tarantool version:
+
+    $ tt run --version
+    Tarantool 2.11.0-entrypoint-724-gd2d7f4de3
+    . . .
+
+# Run a script (which print passed arguments) with 3 arguments and 2 options:
+
+    $ run script.lua a b c -- -a -b
+    a	b	c	-a	-b
+
+# Run a script, pass '-i' argument to it, and enter interactive mode after script execution:
+
+    $ tt run -i script.lua -- -i
+    -i
+    Tarantool 2.11.0-entrypoint-724-gd2d7f4de3
+    type 'help' for interactive help
+    tarantool>
+
+First '-i' option is parsed by 'tt run' and means 'enter interactive mode'. The second '-i'
+is after '--', so passed to script.lua as is.
+
+# Execute stdin:
+
+    $ echo 'print(42)' | tt run -
+    42
+
+`,
+		DisableFlagsInUseLine: true,
 	}
+
 	runCmd.Flags().StringVarP(&runEval, "evaluate", "e", "", "execute string 'EXPR'")
 	runCmd.Flags().StringVarP(&runLib, "library", "l", "", "require library 'NAME'")
 	runCmd.Flags().BoolVarP(&runInteractive, "interactive", "i", false,

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -21,8 +21,7 @@ var luaCodeFiles = []generateLuaCodeOpts{
 		PackageName: "running",
 		FileName:    "cli/running/lua_code_gen.go",
 		VariablesMap: map[string]string{
-			"instanceLauncher": "cli/running/lua/launcher.lua",
-			"checkSyntax":      "cli/running/lua/check.lua",
+			"checkSyntax": "cli/running/lua/check.lua",
 		},
 	},
 	{

--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -1,6 +1,7 @@
 package running
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,6 +51,9 @@ type Instance struct {
 	// done represent whether the instance was stopped.
 	done bool
 }
+
+//go:embed lua/launcher.lua
+var instanceLauncher []byte
 
 // NewInstance creates an Instance.
 func NewInstance(tarantoolPath string, appPath string, appName string, instName string,

--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -27,7 +27,7 @@ local function split_version(version_string)
     return version_table
 end
 
---- Returns true if version of tarantool is greater then expected
+--- Returns true if version of tarantool is greater than expected
 --- else false.
 local function check_version(expected)
     local version = _TARANTOOL

--- a/test/integration/run/test_run.py
+++ b/test/integration/run/test_run.py
@@ -93,4 +93,38 @@ def test_running_multi_instance(tt_cmd, tmpdir):
         text=True
     )
     run_output = instance_process.stdout.readline()
-    assert re.search(r"specify script", run_output)
+    assert re.search(r"Can't open script foo/bar/: No such file or directory", run_output)
+
+
+def test_run_from_input(tt_cmd, tmpdir):
+    process = subprocess.Popen(f"echo 'print(42)'| {tt_cmd} run -",
+                               shell=True,
+                               cwd=tmpdir,
+                               stderr=subprocess.STDOUT,
+                               stdout=subprocess.PIPE,
+                               text=True
+                               )
+    run_output = process.stdout.readline()
+    assert "42\n" == run_output
+
+    process = subprocess.Popen(f"echo 'print(...) print(unpack(arg))' | {tt_cmd} run -- - a b c",
+                               shell=True,
+                               cwd=tmpdir,
+                               stderr=subprocess.STDOUT,
+                               stdout=subprocess.PIPE,
+                               text=True
+                               )
+    run_output = process.stdout.readlines()
+    assert re.search(r"a\s+b\s+c", run_output[0])
+    assert re.search(r"a\s+b\s+c", run_output[0])
+
+    process = subprocess.Popen(f"echo 'print(...) print(unpack(arg))' | {tt_cmd} run - a b c",
+                               shell=True,
+                               cwd=tmpdir,
+                               stderr=subprocess.STDOUT,
+                               stdout=subprocess.PIPE,
+                               text=True
+                               )
+    run_output = process.stdout.readlines()
+    assert re.search(r"a\s+b\s+c", run_output[0])
+    assert re.search(r"a\s+b\s+c", run_output[0])


### PR DESCRIPTION
* `tt run` uses exec instead of child Tarantool process.This change fixes some issues like:
```
echo 'print(42)' | ../../tt/tt run -
   ⨯ specify script : 
```
and
```
echo 'print(...) print(unpack(arg))' | ../../tt/tt run -- - a b c
   ⨯ specify script : -
```

* `tt run` help is updated.