### PR TITLE
tt: print usage for arg errors for some commands

### DIFF
--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/build"
 	"github.com/tarantool/tt/cli/cmdcontext"
@@ -21,9 +20,7 @@ func NewBuildCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalBuildModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		Args: cobra.MaximumNArgs(1),
 	}

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -34,10 +34,9 @@ func NewCatCmd() *cobra.Command {
 		Short: "Print into stdout the contents of .snap/.xlog files",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
-			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalCatModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
+				internalCatModule, args)
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -18,9 +18,7 @@ func NewCheckCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalCheckModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -22,11 +22,9 @@ func NewCleanCmd() *cobra.Command {
 		Use:   "clean [INSTANCE_NAME]",
 		Short: "Clean instance(s) files",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
-				internalCleanModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalCleanModule,
+				args)
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// handleCmdErr handles an error returned by command implementation.
+// If received error is of an ArgError type, usage help is printed.
+func handleCmdErr(cmd *cobra.Command, err error) {
+	if err != nil {
+		var argError *util.ArgError
+		if errors.As(err, &argError) {
+			log.Error(argError.Error())
+			cmd.Usage()
+			os.Exit(1)
+		}
+		log.Fatalf(err.Error())
+	}
+}

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
@@ -21,10 +20,9 @@ func NewCompletionCmd() *cobra.Command {
 			args = modules.GetDefaultCmdArgs(cmd.Name())
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalCompletionCmd, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
+		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	}
 
 	return cmd
@@ -50,10 +48,6 @@ func RootShellCompletionCommands(cmd *cobra.Command, args []string,
 
 // internalCompletionCmd is a default (internal) completion module function.
 func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("it is required to specify shell type")
-	}
-
 	switch shell := args[0]; shell {
 	case "bash":
 		if err := rootCmd.GenBashCompletionV2(os.Stdout, true); err != nil {

--- a/cli/cmd/coredump.go
+++ b/cli/cmd/coredump.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/coredump"
 )
@@ -17,39 +16,33 @@ func NewCoredumpCmd() *cobra.Command {
 		Use:   "pack <COREDUMP>",
 		Short: "pack tarantool coredump into tar.gz archive",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify <COREDUMP> arg.")
-			}
 			if err := runCoredumpCommand(coredump.Pack, args[0]); err != nil {
-				log.Fatalf(err.Error())
+				handleCmdErr(cmd, err)
 			}
 		},
+		Args: cobra.ExactArgs(1),
 	}
 
 	var unpackCmd = &cobra.Command{
 		Use:   "unpack <ARCHIVE>",
 		Short: "unpack tarantool coredump tar.gz archive",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify <ARCHIVE> arg.")
-			}
 			if err := runCoredumpCommand(coredump.Unpack, args[0]); err != nil {
-				log.Fatalf(err.Error())
+				handleCmdErr(cmd, err)
 			}
 		},
+		Args: cobra.ExactArgs(1),
 	}
 
 	var inspectCmd = &cobra.Command{
 		Use:   "inspect <FOLDER>",
 		Short: "inspect tarantool coredump folder",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 1 {
-				log.Fatalf("Wrong number of arguments, please specify <FOLDER> arg.")
-			}
 			if err := runCoredumpCommand(coredump.Inspect, args[0]); err != nil {
-				log.Fatalf(err.Error())
+				handleCmdErr(cmd, err)
 			}
 		},
+		Args: cobra.ExactArgs(1),
 	}
 
 	replicasetsSubCommands := []*cobra.Command{

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/configure"
@@ -29,9 +28,7 @@ func NewCreateCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalCreateModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {

--- a/cli/cmd/daemon.go
+++ b/cli/cmd/daemon.go
@@ -27,9 +27,7 @@ func NewDaemonCmd() *cobra.Command {
 
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalDaemonStartModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 
@@ -43,9 +41,7 @@ func NewDaemonCmd() *cobra.Command {
 
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalDaemonStopModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 
@@ -59,9 +55,7 @@ func NewDaemonCmd() *cobra.Command {
 
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalDaemonStatusModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 
@@ -75,9 +69,7 @@ func NewDaemonCmd() *cobra.Command {
 
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalDaemonRestartModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/configure"
@@ -23,9 +22,7 @@ func NewInitCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalInitModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"path/filepath"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/configure"
@@ -34,9 +33,7 @@ func NewInstallCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalInstallModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		ValidArgs: []string{"tt", "tarantool", "tarantool-ee"},
 	}

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -18,9 +18,7 @@ func NewLogrotateCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalLogrotateModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -34,9 +34,7 @@ The supported types are: tgz, deb, rpm`,
 			}
 			cmdCtx.CommandName = cmd.Name()
 			err = modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalPackModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -35,9 +35,7 @@ func NewPlayCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalPlayModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -24,9 +24,7 @@ func NewRestartCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalRestartModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		Args: cobra.RangeArgs(0, 1),
 	}

--- a/cli/cmd/rocks.go
+++ b/cli/cmd/rocks.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
@@ -20,9 +19,7 @@ func NewRocksCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalRocksModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
@@ -53,9 +52,7 @@ are passed after '--'.
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalRunModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		Example: `
 # Print current environment Tarantool version:

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/search"
+	"github.com/tarantool/tt/cli/util"
 )
 
 var (
@@ -27,9 +25,7 @@ func NewSearchCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalSearchModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		ValidArgs: []string{"tt", "tarantool", "tarantool-ee"},
 	}
@@ -42,14 +38,13 @@ func NewSearchCmd() *cobra.Command {
 func internalSearchModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	var err error
 	if len(args) == 0 {
-		log.Warnf("Available programs: \n" +
+		return util.NewArgError("missing program name\n\nAvailable programs:\n" +
 			"tt - tarantool CLI Community Edition\n" +
 			"tarantool - tarantool Community Edition\n" +
-			"tarantool-ee - tarantool Enterprise Edition")
-		return nil
+			"tarantool-ee - tarantool Enterprise Edition\n")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("incorrect arguments")
+		return util.NewArgError("incorrect arguments")
 	}
 	if local {
 		err = search.SearchVersionsLocal(cmdCtx, args[0])

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -28,9 +28,7 @@ func NewStartCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStartModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -18,9 +18,7 @@ func NewStatusCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStatusModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -18,9 +18,7 @@ func NewStopCmd() *cobra.Command {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStopModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/configure"
@@ -27,9 +26,7 @@ func NewUninstallCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				InternalUninstallModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string,
 			toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
@@ -25,9 +24,7 @@ func NewVersionCmd() *cobra.Command {
 			args = modules.GetDefaultCmdArgs(cmd.Name())
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalVersionModule, args)
-			if err != nil {
-				log.Fatalf(err.Error())
-			}
+			handleCmdErr(cmd, err)
 		},
 	}
 

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -21,7 +21,7 @@ type ConnectCtx struct {
 	// SrcFile describes the source of code for the evaluation.
 	SrcFile string
 	// Language to use for execution.
-	Language string
+	Language Language
 	// Interactive mode is used.
 	Interactive bool
 }
@@ -71,15 +71,10 @@ func Connect(connectCtx ConnectCtx, args []string) error {
 		return fmt.Errorf("should be specified one connection string")
 	}
 
-	lang, ok := ParseLanguage(connectCtx.Language)
-	if !ok {
-		return fmt.Errorf("unsupported language: %s", connectCtx.Language)
-	}
-
 	connString := args[0]
 	connOpts := getConnOpts(connString, connectCtx)
 
-	if err := runConsole(connOpts, "", lang); err != nil {
+	if err := runConsole(connOpts, "", connectCtx.Language); err != nil {
 		return fmt.Errorf("failed to run interactive console: %s", err)
 	}
 
@@ -88,11 +83,6 @@ func Connect(connectCtx ConnectCtx, args []string) error {
 
 // Eval executes the command on the remote instance (according to args).
 func Eval(connectCtx ConnectCtx, args []string) ([]byte, error) {
-	lang, ok := ParseLanguage(connectCtx.Language)
-	if !ok {
-		return nil, fmt.Errorf("unsupported language: %s", connectCtx.Language)
-	}
-
 	// Parse the arguments.
 	connString := args[0]
 	connOpts := getConnOpts(connString, connectCtx)
@@ -109,8 +99,8 @@ func Eval(connectCtx ConnectCtx, args []string) ([]byte, error) {
 	defer conn.Close()
 
 	// Change a language.
-	if lang != DefaultLanguage {
-		if err := ChangeLanguage(conn, lang); err != nil {
+	if connectCtx.Language != DefaultLanguage {
+		if err := ChangeLanguage(conn, connectCtx.Language); err != nil {
 			return nil, fmt.Errorf("unable to change a language: %s", err)
 		}
 	}

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -431,7 +431,7 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 	var err error
 
 	if len(args) > 1 && cmdCtx.CommandName != "run" {
-		return fmt.Errorf("currently, you can specify only one instance at a time")
+		return util.NewArgError("currently, you can specify only one instance at a time")
 	}
 
 	// All relative paths are built from the path of the tarantool.yaml file.

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -38,6 +38,21 @@ const (
 	OsUnknown
 )
 
+// ArgError represents command line arguments error.
+type ArgError struct {
+	msg string
+}
+
+// Error returns error message.
+func (e ArgError) Error() string {
+	return e.msg
+}
+
+// NewArgError creates and returns new argument error.
+func NewArgError(text string) error {
+	return &ArgError{text}
+}
+
 // VersionFunc is a type of function that return
 // string with current Tarantool CLI version.
 type VersionFunc func(bool, bool) string

--- a/test/integration/search/test_search.py
+++ b/test/integration/search/test_search.py
@@ -22,8 +22,8 @@ def test_version_cmd(tt_cmd, tmpdir):
 
     cmd = [tt_cmd, "search"]
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
-    assert rc == 0
-    assert re.search(r"Available programs: ", output)
+    assert rc == 1
+    assert re.search(r"missing program name", output)
 
 
 def test_version_cmd_local(tt_cmd, tmpdir):
@@ -61,5 +61,5 @@ def test_version_cmd_local(tt_cmd, tmpdir):
 
     cmd = [tt_cmd, "search", "--local-repo"]
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
-    assert rc == 0
-    assert re.search(r"Available programs: ", output)
+    assert rc == 1
+    assert re.search(r"missing program name", output)


### PR DESCRIPTION
Added new error type ArgError. returning this
error from command implementation causes
printing command usage help.

Closes #246