### PR TITLE
Minor changes in docs and tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ To run tests:
 * `flake8-unused-arguments <https://pypi.org/project/flake8-unused-arguments/>`_
 * `golangci-lint <https://golangci-lint.run/usage/install/#local-installation>`_
 * `lichen <https://github.com/uw-labs/lichen#install>`_
+* `docker <https://docs.docker.com/engine/install/>`_
 
 ~~~~~
 Build
@@ -56,9 +57,17 @@ Dependencies
 Run tests
 ~~~~~~~~~
 
-.. code-block:: bash
+To run default set of tests (excluding slow tests):
+
+.. code-block::
 
    mage test
+
+To run full set of tests:
+
+.. code-block::
+
+   mage testfull
 
 Configuration
 -------------

--- a/magefile.go
+++ b/magefile.go
@@ -252,9 +252,14 @@ func Codespell() error {
 	return sh.RunV("codespell", packagePath, "test", "README.rst", "doc")
 }
 
-// Run all tests together.
+// Run all tests together, excluding slow and unit integration tests.
 func Test() {
 	mg.SerialDeps(Lint, CheckLicenses, Unit, Integration)
+}
+
+// Run all tests together.
+func TestFull() {
+	mg.SerialDeps(Lint, CheckLicenses, UnitFull, IntegrationFull)
 }
 
 // Cleanup directory.

--- a/test/integration/search/test_search.py
+++ b/test/integration/search/test_search.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+import pytest
+
 from utils import run_command_and_get_output
 
 
@@ -26,6 +28,7 @@ def test_version_cmd(tt_cmd, tmpdir):
     assert re.search(r"Available programs: ", output)
 
 
+@pytest.mark.slow
 def test_version_cmd_local(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, "tarantool.yaml")
     # Create test config


### PR DESCRIPTION
- Update readme testing info.
- Add new mage command to run full test.
- Mark one of search tests as slow. `mage integration`: 01:51 - before, 49.15s - after.