### PR TITLE
doc: fix packing environments section

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -193,12 +193,13 @@ Instantiated ``init.lua`` content:
     require("fiber").sleep(1)
 
 Packing environments
-----------------------------------
+--------------------
 
 For example, we want to pack a single application. Here is the content of the sample application::
-      single_environment/
-      ├── tarantool.yaml
-      └── init.lua
+
+    single_environment/
+    ├── tarantool.yaml
+    └── init.lua
 
 ``tarantool.yaml``:
 


### PR DESCRIPTION
Before this PR directory tree was displayed
incorrect in `Packing environments` section:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/63649739/208081546-d1dfdb95-e381-437b-9fb5-b52224639606.png">
