### PR TITLE
tt: refactor config loading code, minor fixes

### DIFF
--- a/cli/build/build.go
+++ b/cli/build/build.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/config"
 )
 
 // BuildCtx contains information for application building.
@@ -50,6 +51,6 @@ func FillCtx(buildCtx *BuildCtx, args []string) error {
 }
 
 // Run builds an application.
-func Run(cmdCtx *cmdcontext.CmdCtx, buildCtx *BuildCtx) error {
-	return buildLocal(cmdCtx, buildCtx)
+func Run(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, buildCtx *BuildCtx) error {
+	return buildLocal(cmdCtx, cliOpts, buildCtx)
 }

--- a/cli/build/local.go
+++ b/cli/build/local.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/rocks"
 	"github.com/tarantool/tt/cli/util"
 )
@@ -42,7 +43,7 @@ func runBuildHook(buildCtx *BuildCtx, hookNames []string) error {
 }
 
 // buildLocal builds an application locally.
-func buildLocal(cmdCtx *cmdcontext.CmdCtx, buildCtx *BuildCtx) error {
+func buildLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, buildCtx *BuildCtx) error {
 	cwd, err := util.Chdir(buildCtx.BuildDir)
 	if err != nil {
 		return err
@@ -59,7 +60,7 @@ func buildLocal(cmdCtx *cmdcontext.CmdCtx, buildCtx *BuildCtx) error {
 	if buildCtx.SpecFile != "" {
 		rocksMakeCmd = append(rocksMakeCmd, buildCtx.SpecFile)
 	}
-	if err := rocks.Exec(cmdCtx, rocksMakeCmd); err != nil {
+	if err := rocks.Exec(cmdCtx, cliOpts, rocksMakeCmd); err != nil {
 		return err
 	}
 

--- a/cli/build/local_test.go
+++ b/cli/build/local_test.go
@@ -53,7 +53,8 @@ func TestLocalBuild(t *testing.T) {
 	configure.Cli(&cmdCtx)
 	buildCtx := BuildCtx{BuildDir: workDir}
 
-	require.NoError(t, buildLocal(&cmdCtx, &buildCtx))
+	cliOpts := configure.GetDefaultCliOpts()
+	require.NoError(t, buildLocal(&cmdCtx, cliOpts, &buildCtx))
 	require.NoDirExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "metrics"))
 	require.DirExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "rocks"))
 	require.FileExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "checks.lua"))
@@ -69,7 +70,8 @@ func TestLocalBuildSpecFileSet(t *testing.T) {
 	configure.Cli(&cmdCtx)
 	buildCtx := BuildCtx{BuildDir: workDir, SpecFile: "app1-scm-1.rockspec"}
 
-	require.NoError(t, buildLocal(&cmdCtx, &buildCtx))
+	cliOpts := configure.GetDefaultCliOpts()
+	require.NoError(t, buildLocal(&cmdCtx, cliOpts, &buildCtx))
 	require.DirExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "rocks"))
 	require.DirExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "metrics"))
 	require.FileExists(t, filepath.Join(workDir, ".rocks", "share", "tarantool", "checks.lua"))

--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -39,5 +39,5 @@ func internalBuildModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	buildCtx.SpecFile = specFile
 
-	return build.Run(cmdCtx, &buildCtx)
+	return build.Run(cmdCtx, cliOpts, &buildCtx)
 }

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -4,7 +4,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -27,13 +26,8 @@ func NewCheckCmd() *cobra.Command {
 
 // internalCheckModule is a default check module.
 func internalCheckModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
-	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -8,7 +8,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/running"
@@ -100,13 +99,8 @@ func clean(run *running.InstanceCtx) error {
 
 // internalCleanModule is a default clean module.
 func internalCleanModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
-	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}
 
@@ -115,7 +109,7 @@ func internalCleanModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if status.Code == process_utils.ProcessStoppedCode {
 			var statusMsg string
 
-			err = clean(&run)
+			err := clean(&run)
 			if err != nil {
 				statusMsg = "[ERR] " + err.Error()
 			} else {

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/connect"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
@@ -166,11 +165,6 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 
 // internalConnectModule is a default connect module.
 func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	connectCtx := connect.ConnectCtx{
 		Username:    connectUser,
 		Password:    connectPassword,

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/create"
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/modules"
@@ -70,11 +69,6 @@ Built-in templates:
 
 // internalCreateModule is a default create module.
 func internalCreateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	createCtx := create_ctx.CreateCtx{
 		AppName:        appName,
 		ForceMode:      forceMode,
@@ -84,7 +78,7 @@ func internalCreateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		DestinationDir: dstPath,
 	}
 
-	if err = create.FillCtx(cliOpts, &createCtx, args); err != nil {
+	if err := create.FillCtx(cliOpts, &createCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/install"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/search"
@@ -50,11 +49,6 @@ func NewInstallCmd() *cobra.Command {
 
 // internalInstallModule is a default install module.
 func internalInstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	installCtx := install.InstallCtx{
 		Force:         force,
 		Noclean:       noclean,
@@ -63,6 +57,7 @@ func internalInstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		BuildInDocker: buildInDocker,
 	}
 
+	var err error
 	if err = install.FillCtx(cmdCtx, &installCtx, args); err != nil {
 		return err
 	}

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -4,7 +4,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -27,13 +26,8 @@ func NewLogrotateCmd() *cobra.Command {
 
 // internalLogrotateModule is a default logrotate module.
 func internalLogrotateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
-	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -6,7 +6,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/pack"
 )
@@ -74,14 +73,7 @@ The supported types are: tgz, deb, rpm`,
 
 // internalPackModule is a default pack module.
 func internalPackModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	log.Debugf("Config path is located here: %s", cmdCtx.Cli.ConfigPath)
-
-	opts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
-	err = pack.FillCtx(cmdCtx, packCtx, args)
+	err := pack.FillCtx(cmdCtx, packCtx, args)
 	if err != nil {
 		return err
 	}
@@ -93,7 +85,7 @@ func internalPackModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return fmt.Errorf("incorrect type of package. Available types: rpm, deb, tgz")
 	}
 
-	err = packer.Run(cmdCtx, packCtx, opts)
+	err = packer.Run(cmdCtx, packCtx, cliOpts)
 	if err != nil {
 		return fmt.Errorf("failed to pack: %v", err)
 	}

--- a/cli/cmd/rocks.go
+++ b/cli/cmd/rocks.go
@@ -28,5 +28,5 @@ func NewRocksCmd() *cobra.Command {
 
 // internalRocksModule is a default rocks module.
 func internalRocksModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	return rocks.Exec(cmdCtx, args)
+	return rocks.Exec(cmdCtx, cliOpts, args)
 }

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -47,9 +47,9 @@ func internalSearchModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return util.NewArgError("incorrect arguments")
 	}
 	if local {
-		err = search.SearchVersionsLocal(cmdCtx, args[0])
+		err = search.SearchVersionsLocal(cmdCtx, cliOpts, args[0])
 	} else {
-		err = search.SearchVersions(cmdCtx, args[0])
+		err = search.SearchVersions(cmdCtx, cliOpts, args[0])
 	}
 	return err
 }

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -7,7 +7,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -40,13 +39,8 @@ func NewStartCmd() *cobra.Command {
 
 // internalStartModule is a default start module.
 func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
-	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -4,7 +4,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -27,13 +26,8 @@ func NewStatusCmd() *cobra.Command {
 
 // internalStatusModule is a default status module.
 func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
-	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}
 

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -4,7 +4,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 )
@@ -27,12 +26,8 @@ func NewStopCmd() *cobra.Command {
 
 // internalStopModule is a default stop module.
 func internalStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
 	var runningCtx running.RunningCtx
+	var err error
 	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err
 	}

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/uninstall"
@@ -33,7 +32,7 @@ func NewUninstallCmd() *cobra.Command {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			return uninstall.GetList(&cmdCtx), cobra.ShellCompDirectiveNoFileComp
+			return uninstall.GetList(cliOpts), cobra.ShellCompDirectiveNoFileComp
 		},
 		Example: `
 # To uninstall Tarantool:
@@ -45,14 +44,10 @@ func NewUninstallCmd() *cobra.Command {
 
 // InternalUninstallModule is a default uninstall module.
 func InternalUninstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
 	if !strings.Contains(args[0], search.VersionCliSeparator) {
 		return fmt.Errorf("incorrect usage.\n   e.g program%sversion", search.VersionCliSeparator)
 	}
-	err = uninstall.UninstallProgram(args[0], cliOpts.App.BinDir,
+	err := uninstall.UninstallProgram(args[0], cliOpts.App.BinDir,
 		cliOpts.App.IncludeDir+"/include", cmdCtx)
 	return err
 }

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -21,6 +21,9 @@ type CliCtx struct {
 	LocalLaunchDir string
 	// Path to Tarantool CLI (tarantool.yaml) config.
 	ConfigPath string
+	// ConfigDir is tt configuration file directory.
+	// And current working directory, if there is no config.
+	ConfigDir string
 	// Path to tt daemon (tt_daemon.yaml) config.
 	DaemonCfgPath string
 	// Path to Tarantool executable (detected if CLI launch is local).

--- a/cli/pack/opts.go
+++ b/cli/pack/opts.go
@@ -17,7 +17,6 @@ const (
 func FillCtx(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	args []string) error {
 
-	packCtx.ConfigPath = cmdCtx.Cli.ConfigPath
 	packCtx.TarantoolIsSystem = cmdCtx.Cli.IsSystem
 	packCtx.TarantoolExecutable = cmdCtx.Cli.TarantoolExecutable
 	packCtx.Type = args[0]

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -20,8 +20,6 @@ type PackCtx struct {
 	TarantoolExecutable string
 	// TarantoolIsSystem shows if tarantool is system.
 	TarantoolIsSystem bool
-	// ConfigPath is a full path to tarantool.yaml file.
-	ConfigPath string
 	// ArchiveCtx contains flags specific for tgz type.
 	Archive ArchiveCtx
 	// RpmDeb contains all information about rpm and deb type of packing.

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/util"
 	lua "github.com/yuin/gopher-lua"
 )
@@ -36,7 +35,7 @@ func addLuarocksRepoOpts(cliOpts *config.CliOpts, args []string) ([]string, erro
 }
 
 // Execute LuaRocks command. All args will be processed by LuaRocks.
-func Exec(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) error {
 	var cmd string
 
 	// Print rocks help if no arguments given.
@@ -44,11 +43,7 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		cmd = "help"
 	}
 
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
+	var err error
 	if args, err = addLuarocksRepoOpts(cliOpts, args); err != nil {
 		return err
 	}

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -11,7 +11,6 @@ import (
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/install_ee"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
@@ -161,7 +160,7 @@ func printVersion(bindir string, program string, version string) {
 }
 
 // SearchVersions outputs available versions of program.
-func SearchVersions(cmdCtx *cmdcontext.CmdCtx, program string) error {
+func SearchVersions(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, program string) error {
 	var repo string
 	versions := []version.Version{}
 
@@ -175,11 +174,7 @@ func SearchVersions(cmdCtx *cmdcontext.CmdCtx, program string) error {
 		return fmt.Errorf("search supports only tarantool/tarantool-ee/tt")
 	}
 
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
-
+	var err error
 	log.Infof("Available versions of " + program + ":")
 	if program == "tarantool-ee" {
 		versions, err = install_ee.FetchVersions(cliOpts)
@@ -219,12 +214,8 @@ func RunCommandAndGetOutputInDir(program string, dir string, args ...string) (st
 }
 
 // SearchVersionsLocal outputs available versions of program from distfiles directory.
-func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, program string) error {
+func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, program string) error {
 	var err error
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return err
-	}
 	if cliOpts.Repo == nil {
 		cliOpts.Repo = &config.RepoOpts{Install: "", Rocks: ""}
 	}

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/configure"
+	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
 )
@@ -85,18 +85,13 @@ func UninstallProgram(program string, binDst string, headerDst string,
 }
 
 // GetList generates a list of options to uninstall.
-func GetList(cmdCtx *cmdcontext.CmdCtx) []string {
+func GetList(cliOpts *config.CliOpts) []string {
 	list := []string{}
 	re := regexp.MustCompile(
 		"^(?P<prog>(?:tarantool)|(?:tarantool-ee)|(?:tt))" +
 			search.VersionFsSeparator +
 			"(?P<ver>.*)$",
 	)
-
-	cliOpts, err := configure.GetCliOpts(cmdCtx.Cli.ConfigPath)
-	if err != nil {
-		return nil
-	}
 
 	if cliOpts.App.BinDir == "" {
 		return nil

--- a/cli/uninstall/uninstall_test.go
+++ b/cli/uninstall/uninstall_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/search"
 )
 
@@ -47,8 +47,9 @@ func TestGetList(t *testing.T) {
 		"tarantool-ee" + search.VersionCliSeparator + "master",
 	}
 
-	cmdCtx := cmdcontext.CmdCtx{Cli: cmdcontext.CliCtx{ConfigPath: cfgPath}}
-	result := GetList(&cmdCtx)
+	cliOpts, _, err := configure.GetCliOpts(cfgPath)
+	require.NoError(t, err)
+	result := GetList(cliOpts)
 
 	assert.ElementsMatch(result, expected)
 }

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -522,13 +522,13 @@ func TestCollectAppList(t *testing.T) {
 	err = test_helpers.CreateFiles(testDir, filesToCreate)
 	require.NoErrorf(t, err, "failed to initialize a directory structure: %v", err)
 
-	collected, err := CollectAppList(testDir)
+	collected, err := CollectAppList("", testDir)
 	assert.Nilf(t, err, "failed to collect an app list: %v", err)
 
 	require.Equalf(t, len(apps), len(collected), "wrong count applications collected,"+
 		" expected: %d, got %d", len(apps), len(collected))
 
 	for _, item := range collected {
-		require.Truef(t, apps[item], "wrong item got collected in app list: %s", item)
+		require.Truef(t, apps[item.Name], "wrong item got collected in app list: %s", item)
 	}
 }

--- a/test/integration/check/test_check.py
+++ b/test/integration/check/test_check.py
@@ -13,10 +13,10 @@ def test_check_too_many_args(tt_cmd, tmpdir):
     assert re.search(r"currently, you can specify only one instance at a time", output)
 
 
-def test_check_non_existent_file(tt_cmd, tmpdir):
+def test_check_non_existent_file(tt_cmd, tmpdir_with_cfg):
     # Testing with non-existent application file.
     cmd = [tt_cmd, "check", "path-to-non-existent-file"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir_with_cfg)
     assert rc == 1
     assert re.search(r"no such file or directory", output)
 

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -187,7 +187,7 @@ def test_launch_local_tt_missing_executable(tt_cmd, tmpdir):
     commands = [
         [tt_cmd, "version"],
         [tt_cmd, "-L", tmpdir, "version"],
-        [tt_cmd, "version", "--cfg", config_path]
+        [tt_cmd, "--cfg", config_path, "version"]
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -210,8 +210,8 @@ def test_launch_local_tarantool(tt_cmd, tmpdir):
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
     commands = [
-        [tt_cmd, "run", "-L", tmpdir, "--version"],
-        [tt_cmd, "run", "--cfg", config_path, "--version"]
+        [tt_cmd, "-L", tmpdir, "run", "--version"],
+        [tt_cmd, "--cfg", config_path, "run", "--version"]
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -230,8 +230,8 @@ def test_launch_local_tarantool_missing_in_bin_dir(tt_cmd, tmpdir):
 
     commands = [
         [tt_cmd, "run", "--version"],
-        [tt_cmd, "run", "-L", tmpdir, "--version"],
-        [tt_cmd, "run", "--cfg", config_path, "--version"]
+        [tt_cmd, "-L", tmpdir, "run", "--version"],
+        [tt_cmd, "--cfg", config_path, "run", "--version"]
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -255,7 +255,7 @@ def test_launch_local_launch_tarantool_with_config_in_parent_dir(tt_cmd, tmpdir)
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
     commands = [
-        [tt_cmd, "run", "-L", tmpdir_without_config, "--version"],
+        [tt_cmd, "-L", tmpdir_without_config, "run", "--version"],
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -279,7 +279,7 @@ def test_launch_local_launch_tarantool_with_yml_config_in_parent_dir(tt_cmd, tmp
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
     commands = [
-        [tt_cmd, "run", "-L", tmpdir_without_config, "--version"],
+        [tt_cmd, "-L", tmpdir_without_config, "run", "--version"],
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -302,7 +302,7 @@ def test_launch_system_tarantool(tt_cmd, tmpdir):
         f.write(f"#!/bin/sh\necho \"{tarantool_message}\"")
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
-    command = [tt_cmd, "run", "-S"]
+    command = [tt_cmd, "-S", "run"]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
         with open(os.path.join(tmp_working_dir, "tarantool.yaml"), "w") as f:
@@ -327,7 +327,7 @@ def test_launch_system_tarantool_yml_system_config(tt_cmd, tmpdir):
         f.write(f"#!/bin/sh\necho \"{tarantool_message}\"")
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
-    command = [tt_cmd, "run", "-S"]
+    command = [tt_cmd, "-S", "run"]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
         with open(os.path.join(tmp_working_dir, "tarantool.yml"), "w") as f:
@@ -346,7 +346,7 @@ def test_launch_system_tarantool_missing_executable(tt_cmd, tmpdir):
         yaml.dump({"tt": {"modules": {"directory": f"{tmpdir}"},
                    "app": {"bin_dir": "./binaries"}}}, f)
 
-    command = [tt_cmd, "run", "-S", "--version"]
+    command = [tt_cmd, "-S", "run", "--version"]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
         my_env = os.environ.copy()
@@ -368,7 +368,7 @@ def test_launch_system_config_not_loaded_if_local_enabled(tt_cmd, tmpdir):
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
-        command = [tt_cmd, "run", "-L", tmp_working_dir, "--version"]
+        command = [tt_cmd, "-L", tmp_working_dir, "run", "--version"]
         my_env = os.environ.copy()
         my_env["TT_SYSTEM_CONFIG_DIR"] = tmpdir
         rc, output = run_command_and_get_output(command, cwd=tmp_working_dir, env=my_env)
@@ -388,7 +388,7 @@ def test_launch_system_config_not_loaded_if_cfg_specified_is_missing(tt_cmd, tmp
     os.chmod(os.path.join(tmpdir, "binaries/tarantool"), 0o777)
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
-        command = [tt_cmd, "run", "-c", os.path.join(tmp_working_dir, "tarantool.yaml"),
+        command = [tt_cmd, "-c", os.path.join(tmp_working_dir, "tarantool.yaml"), "run",
                    "--version"]
         my_env = os.environ.copy()
         my_env["TT_SYSTEM_CONFIG_DIR"] = tmpdir
@@ -405,9 +405,9 @@ def test_launch_ambiguous_config_opts(tt_cmd, tmpdir):
     os.mkdir(os.path.join(tmpdir, "binaries"))
 
     commands = [
-        [tt_cmd, "run", "--cfg", config_path, "-L", tmpdir, "--version"],
-        [tt_cmd, "run", "--cfg", config_path, "-S", "--version"],
-        [tt_cmd, "run", "-S", "-L", tmpdir, "--version"],
+        [tt_cmd, "--cfg", config_path, "-L", tmpdir, "run", "--version"],
+        [tt_cmd, "--cfg", config_path, "-S", "run", "--version"],
+        [tt_cmd, "-S", "-L", tmpdir, "run", "--version"],
     ]
 
     with tempfile.TemporaryDirectory() as tmp_working_dir:
@@ -432,7 +432,7 @@ def test_external_module_without_internal_implementation(tt_cmd, tmpdir):
     # Trying to start external module with -I flag.
     # In this case, tt should ignore this flag and just
     # start module.
-    cmd = [tt_cmd, module, "-I"]
+    cmd = [tt_cmd, "-I", module]
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
     assert module_message in output
@@ -443,7 +443,7 @@ def test_launch_with_cfg_flag(tt_cmd, tmpdir):
 
     # Send non existent config path.
     non_exist_cfg_tmpdir = tempfile.mkdtemp(dir=tmpdir)
-    cmd = [tt_cmd, module, "--cfg", "non-exists-path"]
+    cmd = [tt_cmd, "--cfg", "non-exists-path", module]
     rc, output = run_command_and_get_output(cmd, cwd=non_exist_cfg_tmpdir)
     assert rc == 1
     assert "specified path to the configuration file is invalid" in output
@@ -453,7 +453,7 @@ def test_launch_with_cfg_flag(tt_cmd, tmpdir):
     module_message = create_external_module(module, exists_cfg_tmpdir)
     config_path = create_tt_config(exists_cfg_tmpdir, exists_cfg_tmpdir)
 
-    cmd = [tt_cmd, module, "--cfg", config_path]
+    cmd = [tt_cmd, "--cfg", config_path, module]
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
     assert module_message in output

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -16,7 +16,7 @@ def test_install_tt(tt_cmd, tmpdir):
         f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
 
     # Install latest tt.
-    install_cmd = [tt_cmd, "install", "tt=0.1.0", "--cfg", configPath]
+    install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt=0.1.0"]
     instance_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir,
@@ -51,7 +51,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
     tmpdir_without_config = tempfile.mkdtemp()
 
     # Install latest tarantool.
-    install_cmd = [tt_cmd, "install", "tarantool", "-f", "--cfg", config_path]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tarantool", "-f"]
     instance_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,
@@ -87,7 +87,7 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     tmpdir_without_config = tempfile.mkdtemp()
 
     # Install latest tarantool.
-    install_cmd = [tt_cmd, "install", "tarantool", "-f", "--cfg", config_path, "--use-docker"]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tarantool", "-f", "--use-docker"]
     tt_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,
@@ -125,7 +125,7 @@ def test_install_tt_in_docker(tt_cmd, tmpdir):
 
     tmpdir_without_config = tempfile.mkdtemp()
 
-    install_cmd = [tt_cmd, "install", "tt", "--cfg", config_path, "--use-docker"]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tt", "--use-docker"]
     tt_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -289,6 +289,8 @@ def test_pack_tgz_table(tt_cmd, tmpdir):
 
         assert rc == 0
         package_file = os.path.join(base_dir, test_case["res_file"])
+        print("PACKAGE FILE " + package_file)
+        os.system("ls -l "+package_file)
         assert os.path.isfile(package_file)
 
         # if the bundle was packed with option --filename,

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -21,7 +21,7 @@ def test_uninstall_tt(tt_cmd, tmpdir):
     os.makedirs(os.path.join(tmpdir, "include", "include", "tarantool_master"))
     os.symlink("./tarantool_master", os.path.join(tmpdir, "include", "include", "tarantool"))
 
-    uninstall_cmd = [tt_cmd, "uninstall", "tarantool=master", "--cfg", configPath]
+    uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", "tarantool=master"]
     uninstall_process = subprocess.Popen(
         uninstall_cmd,
         cwd=tmpdir,


### PR DESCRIPTION
- Load tt config only once.
- Fix start/stop/status without app name if instance enabled is '.'.
- Fix pack: if tt pack is invoked from sub-directory and higher level config has '.' a instanced enabled.
- Make root command flags local. Sub-commands will not support them.
Fixed issues:
### start/stop/status in application dir without app name and instance_enabled = .:
```
tt start
   • Skipping bin: the source is not an application.
   • Skipping distfiles: the source is not an application.
   • Skipping include: the source is not an application.
   • Skipping instances.enabled: the source is not an application.
   • Skipping modules: the source is not an application.
   • Skipping tarantool.yaml: the source is not an application.
   • Skipping templates: the source is not an application.
   • Skipping var: the source is not an application.
   • Starting an instance [app:s1-master]...
   • Starting an instance [app:s1-replica]...
   • Starting an instance [app:s2-master]...
   • Starting an instance [app:s2-replica]...
   • Starting an instance [app:stateboard]...
   • Starting an instance [app:router]...
   • Starting an instance [init]...
```
After the fix:
```
tt start
   • Starting an instance [test_start]...
```

### Pack in sub-directory, if tt config is in parent dir and having instances_enabled = '.'. Pack must pack application local to tarantool.yaml config and not current dir app.
Here is the fs tree:
```
.
├── init.lua
├── subdir
│   └── init.lua
└── tarantool.yaml
```
Invokation of tt pack in subdir:
```
tt pack tgz 
   • Apps to pack: subdir
```
Fixed to:
```
tt pack tgz 
   • Apps to pack: app
```
### Config option handling is confusing:
```
$ tt install tarantool --cfg ../test_install/tarantool.yaml 
   • Getting latest tarantool version..
   • Checking existing...

$ tt install tarantool -f --cfg ../test_install/tarantool.yaml 
   ⨯ Failed to configure Tarantool CLI: found tt binary in local directory "/tmp/uuuuuu" isn't executable: exec: "/tmp/uuuuuu/my_bin/tt": permission denied

$ tt install tarantool --cfg ../test_install/tarantool.yaml -f
   • Getting latest tarantool version..
   • Checking existing...

$ tt --cfg ../test_install/tarantool.yaml install tarantool -f --cfg ../test_install/tarantool.yaml 
   • Getting latest tarantool version..
   • Checking existing...
```
After:
```
$ tt --cfg ../test_install/tarantool.yaml install tarantool -f --cfg ../test_install/tarantool.yaml 
unknown flag: --cfg

$ tt --cfg ../test_install/tarantool.yaml install tarantool -f
```