### PR TITLE
Add app template follow up message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Follow-up message support for application templates.
+
 ## [0.4.0] - 2022-12-31
 
 ### Added

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -76,6 +76,7 @@ func internalCreateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		VarsFromCli:    *varsFromCli,
 		VarsFile:       varsFile,
 		DestinationDir: dstPath,
+		CliOpts:        cliOpts,
 	}
 
 	if err := create.FillCtx(cliOpts, &createCtx, args); err != nil {

--- a/cli/create/builtin_templates/templates/cartridge/MANIFEST.yaml
+++ b/cli/create/builtin_templates/templates/cartridge/MANIFEST.yaml
@@ -1,1 +1,9 @@
 description: Cartridge template
+follow-up-message: |
+  What's next?
+  Build and start '{{ .name }}' application:
+      $ tt build {{.name}}
+      $ tt start {{.name}}
+
+  To bootstrap vshard run the following command:
+      $ tt cartridge replicasets setup --bootstrap-vshard --name {{ .name }} --run-dir {{ cwdRelative .rundir }}/{{ .name }}

--- a/cli/create/context/create_ctx.go
+++ b/cli/create/context/create_ctx.go
@@ -1,5 +1,7 @@
 package create_ctx
 
+import "github.com/tarantool/tt/cli/config"
+
 // CreateCtx contains information for creating applications from templates.
 type CreateCtx struct {
 	// AppName is application name to create.
@@ -21,4 +23,6 @@ type CreateCtx struct {
 	SilentMode bool
 	// VarsFile is a file with variables definitions.
 	VarsFile string
+	// CliOpts is loaded tt environment config.
+	CliOpts *config.CliOpts
 }

--- a/cli/create/context/create_ctx.go
+++ b/cli/create/context/create_ctx.go
@@ -14,7 +14,7 @@ type CreateCtx struct {
 	TemplateSearchPaths []string
 	// TemplateName is a template to use for application creation.
 	TemplateName string
-	// VarsFromCli base directory for instances available.
+	// VarsFromCli template variables definitions provided in command line.
 	VarsFromCli []string
 	// ForceMode - if flag is set, remove application existing application directory.
 	ForceMode bool

--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -66,6 +66,7 @@ func Run(cliOpts *config.CliOpts, createCtx *create_ctx.CreateCtx) error {
 		steps.CreateDockerfile{},
 		steps.MoveAppDirectory{},
 		steps.CreateAppSymlink{SymlinkDir: cliOpts.App.InstancesEnabled},
+		steps.PrintFollowUpMessage{Writer: os.Stdout},
 	}
 
 	templateCtx := app_template.NewTemplateContext()

--- a/cli/create/internal/app_template/manifest.go
+++ b/cli/create/internal/app_template/manifest.go
@@ -37,7 +37,7 @@ type TemplateManifest struct {
 	// PostHook is a path to the executable to run after template instantiation.
 	// Application path is passed as a first parameter.
 	PostHook string `mapstructure:"post-hook"`
-	// Include contains a list of files to keep after template instantiaion.
+	// Include contains a list of files to keep after template instantiation.
 	Include []string
 	// FollowUpMessage is a message to print to console after application creation.
 	FollowUpMessage string `mapstructure:"follow-up-message"`

--- a/cli/create/internal/app_template/manifest.go
+++ b/cli/create/internal/app_template/manifest.go
@@ -39,6 +39,8 @@ type TemplateManifest struct {
 	PostHook string `mapstructure:"post-hook"`
 	// Include contains a list of files to keep after template instantiaion.
 	Include []string
+	// FollowUpMessage is a message to print to console after application creation.
+	FollowUpMessage string `mapstructure:"follow-up-message"`
 }
 
 func validateManifest(manifest *TemplateManifest) error {

--- a/cli/create/internal/steps/print_follow_up_msg.go
+++ b/cli/create/internal/steps/print_follow_up_msg.go
@@ -1,0 +1,32 @@
+package steps
+
+import (
+	"io"
+
+	create_ctx "github.com/tarantool/tt/cli/create/context"
+	"github.com/tarantool/tt/cli/create/internal/app_template"
+	"github.com/tarantool/tt/cli/templates"
+)
+
+type PrintFollowUpMessage struct {
+	// Writer is used to write follow-up message.
+	Writer io.Writer
+}
+
+// Run prints application template follow-up message.
+func (printFollowUpMsgStep PrintFollowUpMessage) Run(createCtx *create_ctx.CreateCtx,
+	templateCtx *app_template.TemplateCtx) error {
+	if templateCtx.IsManifestPresent && templateCtx.Manifest.FollowUpMessage != "" &&
+		!createCtx.SilentMode {
+		templateEngine := templates.NewDefaultEngine()
+		followUpText, err := templateEngine.RenderText(templateCtx.Manifest.FollowUpMessage,
+			templateCtx.Vars)
+		if err != nil {
+			return err
+		}
+
+		printFollowUpMsgStep.Writer.Write([]byte(followUpText + "\n"))
+	}
+
+	return nil
+}

--- a/cli/create/internal/steps/print_follow_up_msg_test.go
+++ b/cli/create/internal/steps/print_follow_up_msg_test.go
@@ -1,0 +1,50 @@
+package steps
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/config"
+	create_ctx "github.com/tarantool/tt/cli/create/context"
+	"github.com/tarantool/tt/cli/create/internal/app_template"
+)
+
+func TestPrintFollowUpMessage(t *testing.T) {
+	var buffer bytes.Buffer
+	printFollowUpMsgStep := PrintFollowUpMessage{
+		Writer: &buffer,
+	}
+	err := printFollowUpMsgStep.Run(&create_ctx.CreateCtx{
+		CliOpts: &config.CliOpts{},
+	}, &app_template.TemplateCtx{
+		Vars: map[string]string{
+			"name": "app1",
+		},
+		Manifest: app_template.TemplateManifest{
+			FollowUpMessage: "App name is {{.name}}",
+		},
+		IsManifestPresent: true,
+	})
+	require.NoError(t, err)
+	msg, err := buffer.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "App name is app1\n", msg)
+}
+
+func TestPrintFollowUpMessageError(t *testing.T) {
+	var buffer bytes.Buffer
+	printFollowUpMsgStep := PrintFollowUpMessage{
+		Writer: &buffer,
+	}
+	err := printFollowUpMsgStep.Run(&create_ctx.CreateCtx{
+		CliOpts: &config.CliOpts{},
+	}, &app_template.TemplateCtx{
+		Vars: map[string]string{},
+		Manifest: app_template.TemplateManifest{
+			FollowUpMessage: "App name is {{.name}}",
+		},
+		IsManifestPresent: true,
+	})
+	require.Error(t, err)
+}

--- a/cli/create/internal/steps/set_predefined_variables.go
+++ b/cli/create/internal/steps/set_predefined_variables.go
@@ -13,5 +13,8 @@ type SetPredefinedVariables struct {
 func (SetPredefinedVariables) Run(createCtx *create_ctx.CreateCtx,
 	templateCtx *app_template.TemplateCtx) error {
 	templateCtx.Vars["name"] = createCtx.AppName
+	if createCtx.CliOpts != nil && createCtx.CliOpts.App != nil {
+		templateCtx.Vars["rundir"] = createCtx.CliOpts.App.RunDir
+	}
 	return nil
 }

--- a/cli/templates/internal/engines/go_text_engine_test.go
+++ b/cli/templates/internal/engines/go_text_engine_test.go
@@ -91,3 +91,19 @@ func TestTextRendering(t *testing.T) {
 	require.EqualError(t, err, "template execution failed: template: file:1:2: "+
 		"executing \"file\" at <.hello>: map has no entry for key \"hello\"")
 }
+
+func TestTextRenderingRelPath(t *testing.T) {
+	templateText := `{{ cwdRelative .fullpath }}`
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	parentDir, err := filepath.Abs(filepath.Dir(cwd))
+	require.NoError(t, err)
+
+	expectedText := `../var/run`
+	data := map[string]string{"fullpath": filepath.Join(parentDir, "var", "run")}
+	engine := GoTextEngine{}
+	actualText, err := engine.RenderText(templateText, data)
+	require.NoError(t, err)
+	assert.Equal(t, expectedText, actualText)
+}

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -602,7 +602,7 @@ def test_create_app_from_builtin_cartridge_template(tt_cmd, tmpdir):
     with open(os.path.join(tmpdir, "tarantool.yaml"), "w") as tnt_env_file:
         tnt_env_file.write(tt_config_text.format(tmpdir))
 
-    create_cmd = [tt_cmd, "create", "cartridge", "--non-interactive", "--name", "app1"]
+    create_cmd = [tt_cmd, "create", "cartridge", "--name", "app1"]
     tt_process = subprocess.Popen(
         create_cmd,
         cwd=tmpdir,
@@ -614,6 +614,11 @@ def test_create_app_from_builtin_cartridge_template(tt_cmd, tmpdir):
     tt_process.stdin.close()
     tt_process.wait()
     assert tt_process.returncode == 0
+
+    output = tt_process.stdout.read()
+    assert output.find("Build and start 'app1' application") != -1
+    assert output.find("./app1") != -1
+    assert output.find("tt cartridge replicasets setup --bootstrap-vshard") != -1
 
     app_path = os.path.join(tmpdir, "app1")
     assert os.path.exists(os.path.join(app_path, "init.lua"))


### PR DESCRIPTION
Added support of follow-up messages to make it simpler to start to work with recently created app.
```
$ ../tt create cartridge --name app1 -f
   • Creating application in /tmp/test/app1
   • Using built-in 'cartridge' template.
   • Application 'app1' created successfully
What's next?
Build and start 'app1' application:
    $ tt build app1
    $ tt start app1

To bootstrap vshard run the following command:
    $ tt cartridge replicasets setup --bootstrap-vshard --name app1 --run-dir var/run/app1
```