### PR TITLE
create: replace app symlink in force mode

### DIFF
--- a/cli/create/internal/steps/enable_instance.go
+++ b/cli/create/internal/steps/enable_instance.go
@@ -30,7 +30,7 @@ func (createSymlinkStep CreateAppSymlink) Run(createCtx *create_ctx.CreateCtx,
 	}
 	if err = util.CreateSymlink(relativeAppPath,
 		filepath.Join(createSymlinkStep.SymlinkDir, createCtx.AppName),
-		false); err != nil {
+		createCtx.ForceMode); err != nil {
 		log.Warnf("Failed to enable %s application: %s", createCtx.AppName, err)
 	}
 


### PR DESCRIPTION
If force mode is enabled, tt create must replace existing application symlink in instances enabled. No warning message in force mode if application symlink already exists.