### PR TITLE
tt: stdout/stderr for different log levels

### DIFF
--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -299,7 +299,7 @@ func programDependenciesInstalled(program string) bool {
 	}
 
 	if len(missing_pack) != 0 || len(missing_pack_src) != 0 {
-		log.Infof("The operation requires some dependencies.")
+		log.Error("The operation requires some dependencies.")
 		fmt.Println("Missing packages: " + strings.Join(missing_pack, " ") + " " +
 			strings.Join(missing_pack_src, " "))
 		if osName == "darwin" {

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -468,3 +468,21 @@ def test_launch_external_cmd_with_flags(tt_cmd, tmpdir, module):
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
     assert module_message in output
+
+
+def test_std_err_stream_local_launch_non_existent_dir(tt_cmd, tmpdir):
+    module = "version"
+    cmd = [tt_cmd, module, "-L", "non-exists-dir"]
+    tt_process = subprocess.Popen(
+        cmd,
+        cwd=tmpdir,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True
+    )
+    tt_process.stdin.close()
+    tt_process.wait()
+    assert tt_process.returncode == 1
+    assert "failed to change working directory" not in tt_process.stdout.readline()
+    assert "failed to change working directory" in tt_process.stderr.readline()


### PR DESCRIPTION
Error, warning and fatal log messages will be written to stderr stream. Other messages will be written to stdout.

The test from the issue:
```
$ tt status app1 2>/dev/null
   • app1:s1-replica: RUNNING. PID: 36692.
   • app1:s2-master: RUNNING. PID: 36693.
   • app1:s2-replica: RUNNING. PID: 36694.
   • app1:stateboard: RUNNING. PID: 36695.
   • app1:router: RUNNING. PID: 36696.
   • app1:s1-master: RUNNING. PID: 36704.
```

Closes #157