### PR TITLE
tt: disable ssl for lint and unit builds

### DIFF
--- a/golangci-lint.yml
+++ b/golangci-lint.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 3m
+  build-tags:
+    - go_tarantool_ssl_disable
 
 linters:
   disable-all: true

--- a/magefile.go
+++ b/magefile.go
@@ -210,10 +210,11 @@ func Unit() error {
 	mg.Deps(GenerateGoCode)
 
 	if mg.Verbose() {
-		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath))
+		return sh.RunV(goExecutableName, "test", "-v", "-tags", "go_tarantool_ssl_disable",
+			fmt.Sprintf("%s/...", packagePath))
 	}
 
-	return sh.RunV(goExecutableName, "test", fmt.Sprintf("%s/...", packagePath))
+	return sh.RunV(goExecutableName, "test", "-tags", "go_tarantool_ssl_disable", fmt.Sprintf("%s/...", packagePath))
 }
 
 // Run unit tests with a Tarantool instance integration.
@@ -224,11 +225,11 @@ func UnitFull() error {
 
 	if mg.Verbose() {
 		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath),
-			"-tags", "integration")
+			"-tags", "integration,go_tarantool_ssl_disable")
 	}
 
 	return sh.RunV(goExecutableName, "test", fmt.Sprintf("%s/...", packagePath),
-		"-tags", "integration")
+		"-tags", "integration,go_tarantool_ssl_disable")
 }
 
 // Run integration tests, excluding slow tests.


### PR DESCRIPTION
mage lint and mage unit fails without pkg-config tool. This tool is required to build go-openssl. tt is built with disabled ssl, so it must be disabled for lint and unit tests also.