### PR TITLE
running: add check for tarantool executable

### DIFF
--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -503,6 +503,12 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 		}
 	}
 
+	if cmdCtx.CommandName != "connect" {
+		if cmdCtx.Cli.TarantoolExecutable == "" {
+			return fmt.Errorf("tarantool binary not found")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added check if tarantool executable is present in system

Old behavior:
```
hppro:~/work/tmp/env$ tarantool
Command 'tarantool' not found, but can be installed with:
sudo snap install tarantool  # version 1.9~git, or
sudo apt  install tarantool  # version 2.6.0-1ubuntu3
See 'snap info tarantool' for additional versions.

hppro:~/work/tmp/env$ ../../tt/tt start app1:router
   • Starting an instance [router]...

hppro:~/work/tmp/env$ cat var/log/app1/router/router.log 
2022/11/08 21:00:47 Watchdog(ERROR): "exec: "": executable file not found in $PATH".
```

New behavior:
```
f.terekhin@f-terekhin tt221 % tarantool
zsh: command not found: tarantool

f.terekhin@f-terekhin tt221 % ./tt start test_app
   ⨯ tarantool binary not found
```

Closes #218