### PR TITLE
init: fix tarantoolctl config loading

### DIFF
--- a/cli/init/init.go
+++ b/cli/init/init.go
@@ -112,12 +112,14 @@ func loadTarantoolctlConfig(initCtx *InitCtx, configPath string) (appDirInfo, er
 			log.Warnf("Failed to parse output of tarantoolctl : %s", dirDefinition)
 		}
 		switch varName {
-		case "wal_dir":
+		case "data_dir":
 			appDirInfo.dataDir = dirPath
-		case "logger":
+		case "log_dir":
 			appDirInfo.logDir = dirPath
 		case "pid_file":
 			appDirInfo.runDir = dirPath
+		case "instance_dir":
+			appDirInfo.instancesEnabled = dirPath
 		default:
 			log.Warnf("Unknown var: %s", varName)
 		}
@@ -147,10 +149,6 @@ func generateTtEnv(configPath string, appDirInfo appDirInfo) error {
 
 	if err := util.WriteYaml(configPath, cfg); err != nil {
 		return err
-	}
-
-	if appDirInfo.instancesEnabled != "" {
-		cfg.CliConfig.App.InstancesEnabled = appDirInfo.instancesEnabled
 	}
 
 	directoriesToCreate := []string{
@@ -243,7 +241,7 @@ func Run(initCtx *InitCtx) error {
 			}
 		}
 	}
-	if !util.IsApp(".") {
+	if !util.IsApp(".") && appDirInfo.instancesEnabled == "" {
 		// Current directory is not app dir, instances enabled dir will be used.
 		appDirInfo.instancesEnabled = configure.InstancesEnabledDirName
 	}

--- a/cli/init/print_tarantoolctl_cfg.lua
+++ b/cli/init/print_tarantoolctl_cfg.lua
@@ -1,24 +1,32 @@
 if #arg ~= 1 then
+    io.stderr:write("One argument is expected\n")
     os.exit(1)
 end
 
 dofile(arg[1])
 
 if default_cfg == nil then
-    io.stderr:write("tarantoolctl config does not initialize default_cfg")
+    io.stderr:write("tarantoolctl config does not initialize default_cfg\n")
     os.exit(1)
 end
 
--- Check data directories are the same.
-if default_cfg.wal_dir ~= default_cfg.snap_dir then
-    io.stderr:write("ambiguous data directory")
-    os.exit(1)
-end
-if default_cfg.vinyl_dir ~= default_cfg.snap_dir then
-    io.stderr:write("ambiguous data directory")
-    os.exit(1)
+-- Data/lib dir discovery.
+local lib_dir = default_cfg.wal_dir
+for _, data_dir in pairs({default_cfg.memtx_dir, default_cfg.vinyl_dir, default_cfg.snap_dir}) do
+    if lib_dir == nil then
+        if data_dir ~= nil then
+            lib_dir = data_dir
+        end
+    else
+        if data_dir ~= nil and lib_dir ~= data_dir then
+            io.stderr:write("Unable to identify data directory from taractoolctl config. " ..
+            "There is uncertainty between " .. lib_dir .. " and " .. data_dir .. "\n")
+            os.exit(1)
+        end
+    end
 end
 
-print("wal_dir=" .. (default_cfg.wal_dir or ""))
-print("logger=" .. (default_cfg.logger or ""))
+print("data_dir=" .. (lib_dir or ""))
+print("log_dir=" .. (default_cfg.log or default_cfg.logger or ""))
 print("pid_file=" .. (default_cfg.pid_file or ""))
+print("instance_dir=" .. (instance_dir or ""))

--- a/cli/init/testdata/tarantoolctl_no_snap_dir.lua
+++ b/cli/init/testdata/tarantoolctl_no_snap_dir.lua
@@ -1,0 +1,7 @@
+default_cfg = {
+    pid_file   = "./run",
+    wal_dir    = "./lib",
+    vinyl_dir  = "./lib",
+    log        = "./log",
+}
+instance_dir = "./instances"

--- a/test/integration/init/configs/default_ttctl_cfg_from_doc.lua
+++ b/test/integration/init/configs/default_ttctl_cfg_from_doc.lua
@@ -1,0 +1,9 @@
+default_cfg = {
+    pid_file  = "./run/tarantool",
+    wal_dir   = "./lib/tarantool",
+    memtx_dir = "./lib/tarantool",
+    vinyl_dir = "./lib/tarantool",
+    log       = "./log/tarantool",
+    language  = "Lua",
+}
+instance_dir = "./instances"


### PR DESCRIPTION
Skip missing values (nil) comparison in default_cfg. Handle instance_dir from tarantoolctl config. Add tests for these fixes.