### PR TITLE
ci: remove stopping 1.10 service

### DIFF
--- a/.github/actions/prepare-ce-test-env/action.yml
+++ b/.github/actions/prepare-ce-test-env/action.yml
@@ -41,14 +41,6 @@ runs:
       with:
         tarantool-version: '${{ inputs.tarantool-version }}'
 
-    - name: Stop and disable Taranool 1.10 example service
-      if: matrix.tarantool-version == '1.10'
-      run: |
-        sudo systemctl stop tarantool@example || true
-        sudo systemctl disable tarantool@example || true
-        sudo rm -rf /lib/systemd/system/tarantool@.service
-      shell: bash
-
     - name: Build tt
       run: mage build
       shell: bash


### PR DESCRIPTION
Current 1.10 tarantool package does not start systemd service after installation. So stopping is not required.