### PR TITLE
Ignore SIGURG at Start command

### DIFF
--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,6 @@ import (
 	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/ttlog"
 	"github.com/tarantool/tt/cli/util"
-	"golang.org/x/net/context"
 	"gopkg.in/yaml.v2"
 )
 
@@ -516,32 +514,21 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 
 // Start an Instance.
 func Start(cmdCtx *cmdcontext.CmdCtx, run *InstanceCtx) error {
-	// Register a context, related with a signal handler that
-	// removes a pid file if interrupt signals were sent before starting
-	// an instance and watchdog signal handlers.
-	sigCtx, stop := signal.NotifyContext(context.Background(),
-		syscall.SIGINT, syscall.SIGTERM)
-	if err := process_utils.CreatePIDFile(run.PIDFile); err != nil {
-		return err
+	logger := createLogger(run)
+	provider := providerImpl{cmdCtx: cmdCtx, instanceCtx: run}
+	preStartAction := func() error {
+		if err := process_utils.CreatePIDFile(run.PIDFile); err != nil {
+			return err
+		}
+		return nil
 	}
+	wd := NewWatchdog(run.Restartable, 5*time.Second, logger, &provider, preStartAction)
 
 	defer func() {
 		cleanup(run)
-		stop()
 	}()
 
-	logger := createLogger(run)
-	provider := providerImpl{cmdCtx: cmdCtx, instanceCtx: run}
-	wd := NewWatchdog(run.Restartable, 5*time.Second, logger, &provider)
-
-	// The Done() state of the context means that the process received
-	// an interrupt signal and there is a need to clean up the resources.
-	select {
-	case <-sigCtx.Done():
-		return nil
-	default:
-		wd.Start()
-	}
+	wd.Start()
 	return nil
 }
 

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -152,6 +152,13 @@ func (wd *Watchdog) startSignalHandling() {
 	signal.Reset()
 	signal.Notify(sigChan)
 
+	// This call is needed to ignore SIGURG signals which are part of
+	// preemptive multitasking implementation in go. See:
+	// https://go.googlesource.com/proposal/+/master/design/24543-non-cooperative-preemption.md.
+	// Also, there is no way to detect if a signal is related to the runtime or not:
+	// https://github.com/golang/go/issues/37942.
+	signal.Ignore(syscall.SIGURG)
+
 	// Set barrier to synchronize with the main loop when the Instance stops.
 	wd.doneBarrier.Add(1)
 

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -77,8 +77,8 @@ func createTestWatchdog(t *testing.T, restartable bool) *Watchdog {
 
 	provider := providerTestImpl{tarantool: tarantoolBin, appPath: appPath, logger: logger,
 		dataDir: dataDir, restartable: restartable}
-
-	wd := NewWatchdog(restartable, wdTestRestartTimeout, logger, &provider)
+	testPreAction := func() error { return nil }
+	wd := NewWatchdog(restartable, wdTestRestartTimeout, logger, &provider, testPreAction)
 
 	return wd
 }


### PR DESCRIPTION
This patch fixes the problem, which was occurring when the watchdog
process received a signal SIGURG from go runtime[1][2] and passed it
to the forked process before the exec call. Fixed by adding a call of
the Ignore function. Receiving this signal is unexpected, cause tt
doesn't work with sockets at all.

Also this patch fixes the signals handling strategy. Now there is only
one handling loop for all signals. Added two fields for controlling
a state of the instance being watched and a mutex for synchronizing
the goroutines changing them.

[1] - https://go.googlesource.com/proposal/+/master/design/24543-non-cooperative-preemption.md
[2] - https://github.com/golang/go/issues/37942

Closes https://github.com/tarantool/tt/issues/325