### PR TITLE
Fix systemd units generation in pack

### DIFF
--- a/cli/pack/systemd_dir.go
+++ b/cli/pack/systemd_dir.go
@@ -34,7 +34,7 @@ func initSystemdDir(packCtx *PackCtx, opts *config.CliOpts,
 		return err
 	}
 
-	systemdBaseDir := filepath.Join(baseDirPath, "etc", "systemd", "system")
+	systemdBaseDir := filepath.Join(baseDirPath, "usr", "lib", "systemd", "system")
 	err = os.MkdirAll(systemdBaseDir, dirPermissions)
 	if err != nil {
 		return err

--- a/cli/pack/systemd_dir.go
+++ b/cli/pack/systemd_dir.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/config"
-	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/util"
 	"gopkg.in/yaml.v2"
 )
@@ -70,12 +69,11 @@ func initSystemdDir(packCtx *PackCtx, opts *config.CliOpts,
 // returns its content. Otherwise, it returns the default params.
 func getUnitParams(packCtx *PackCtx, pathToEnv,
 	envName string) (map[string]interface{}, error) {
-	pathToEnvFile := filepath.Join(pathToEnv, configure.ConfigName)
 	ttBinary := getTTBinary(packCtx, pathToEnv)
 
 	referenceParams := map[string]interface{}{
 		"TT":         ttBinary,
-		"ConfigPath": pathToEnvFile,
+		"ConfigPath": pathToEnv,
 		"FdLimit":    defaultInstanceFdLimit,
 		"EnvName":    envName,
 	}

--- a/cli/pack/systemd_dir.go
+++ b/cli/pack/systemd_dir.go
@@ -56,7 +56,7 @@ func initSystemdDir(packCtx *PackCtx, opts *config.CliOpts,
 		return err
 	}
 
-	appInstUnitPath := fmt.Sprintf("%s%%.service", packageName)
+	appInstUnitPath := fmt.Sprintf("%s@.service", packageName)
 	appInstUnitPath = filepath.Join(systemdBaseDir, appInstUnitPath)
 	err = util.InstantiateFileFromTemplate(appInstUnitPath, appInstUnitTemplate, contentParams)
 	if err != nil {

--- a/cli/pack/systemd_dir_test.go
+++ b/cli/pack/systemd_dir_test.go
@@ -16,7 +16,7 @@ import (
 func Test_initSystemdDir(t *testing.T) {
 	baseTestDir := t.TempDir()
 
-	prefixToUnit := filepath.Join("etc", "systemd", "system")
+	prefixToUnit := filepath.Join("usr", "lib", "systemd", "system")
 	fakeCfgPath := "/path/to/cfg"
 
 	var (

--- a/cli/pack/templates/app-inst-unit-template.txt
+++ b/cli/pack/templates/app-inst-unit-template.txt
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 ExecStart={{ .TT }} -L {{ .ConfigPath }} start %i
+ExecStop={{ .TT }} -L {{ .ConfigPath }} stop %i
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/templates/app-unit-template.txt
+++ b/cli/pack/templates/app-unit-template.txt
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 ExecStart={{ .TT }} -L {{ .ConfigPath }} start
+ExecStop={{ .TT }} -L {{ .ConfigPath }} stop
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-1.txt
+++ b/cli/pack/testdata/expected-unit-content-1.txt
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg/tt.yaml start
+ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg start
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-1.txt
+++ b/cli/pack/testdata/expected-unit-content-1.txt
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg start
+ExecStop=/path/to/cfg/env/bin/tt -L /path/to/cfg stop
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-2.txt
+++ b/cli/pack/testdata/expected-unit-content-2.txt
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg/tt.yaml start
+ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg start
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-2.txt
+++ b/cli/pack/testdata/expected-unit-content-2.txt
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 ExecStart=/path/to/cfg/env/bin/tt -L /path/to/cfg start
+ExecStop=/path/to/cfg/env/bin/tt -L /path/to/cfg stop
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-3.txt
+++ b/cli/pack/testdata/expected-unit-content-3.txt
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 ExecStart=/usr/bin/tt -L /path/cfg start
+ExecStop=/usr/bin/tt -L /path/cfg stop
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/expected-unit-content-3.txt
+++ b/cli/pack/testdata/expected-unit-content-3.txt
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart=/usr/bin/tt -L /path/cfg/tt.yaml start
+ExecStart=/usr/bin/tt -L /path/cfg start
 Restart=on-failure
 RestartSec=2
 User=tarantool

--- a/cli/pack/testdata/fully-defined-params.yaml
+++ b/cli/pack/testdata/fully-defined-params.yaml
@@ -1,4 +1,4 @@
 TT: /usr/bin/tt
-ConfigPath: /path/cfg/tt.yaml
+ConfigPath: /path/cfg
 EnvName: customEnvName
 FdLimit: 2048

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -561,24 +561,25 @@ def test_pack_deb(tt_cmd, tmpdir):
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
                                              '{0}:/usr/src/'.format(base_dir),
                                              '-w', '/usr/src',
-                                             'ubuntu',
+                                             'jrei/systemd-ubuntu',
                                              '/bin/bash', '-c',
                                              '/bin/dpkg -i {0} && '
                                              'ls /usr/share/tarantool/bundle1 '
-                                             '&& ls /etc/systemd/system'
+                                             '&& systemctl list-unit-files | grep bundle1'
                                             .format(package_file_name)])
 
     assert re.search(r'Preparing to unpack {0}'.format(package_file_name), output)
     assert re.search(r'Unpacking bundle \(0\.1\.0\)', output)
     assert re.search(r'Setting up bundle \(0\.1\.0\)', output)
+
     installed_package_paths = ['app.lua', 'app2', 'env', 'instances_enabled',
                                config_name, 'var']
-    systemd_paths = ['bundle1%.service', 'bundle1.service']
+    systemd_units = ['bundle1@.service', 'bundle1.service']
 
     for path in installed_package_paths:
-        re.search(path, output)
-    for path in systemd_paths:
-        re.search(path, output)
+        assert re.search(path, output)
+    for unit in systemd_units:
+        assert re.search(unit, output)
     assert rc == 0
 
 
@@ -619,12 +620,12 @@ def test_pack_rpm(tt_cmd, tmpdir):
                                             .format(package_file_name)])
     installed_package_paths = ['app.lua', 'app2', 'env', 'instances_enabled',
                                config_name, 'var']
-    systemd_paths = ['bundle1%.service', 'bundle1.service']
+    systemd_paths = ['bundle1@.service', 'bundle1.service']
 
     for path in installed_package_paths:
-        re.search(path, output)
+        assert re.search(path, output)
     for path in systemd_paths:
-        re.search(path, output)
+        assert re.search(path, output)
 
     assert rc == 0
 

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -615,8 +615,9 @@ def test_pack_rpm(tt_cmd, tmpdir):
                                              '-w', '/usr/src',
                                              'centos:7',
                                              '/bin/bash', '-c',
-                                             'rpm -i {0} && ls /usr/share/tarantool/bundle1 '
-                                             '&& ls /etc/systemd/system'
+                                             'rpm -i --force {0} '
+                                             '&& ls /usr/share/tarantool/bundle1 '
+                                             '&& ls /usr/lib/systemd/system'
                                             .format(package_file_name)])
     installed_package_paths = ['app.lua', 'app2', 'env', 'instances_enabled',
                                config_name, 'var']
@@ -661,7 +662,7 @@ def test_pack_rpm_use_docker(tt_cmd, tmpdir):
                                              'centos:7',
                                              '/bin/bash', '-c',
                                              'rpm -i {0} && ls /usr/share/tarantool/bundle1 '
-                                             '&& ls /etc/systemd/system'
+                                             '&& ls /usr/lib/systemd/system'
                                             .format(package_file_name)])
     installed_package_paths = ['app.lua', 'app2', 'env', 'instances_enabled',
                                config_name, 'var']
@@ -707,7 +708,7 @@ def test_pack_deb_use_docker(tt_cmd, tmpdir):
                                              '/bin/bash', '-c',
                                              '/bin/dpkg -i {0} && '
                                              'ls /usr/share/tarantool/bundle1 '
-                                             '&& ls /etc/systemd/system'
+                                             '&& ls /usr/lib/systemd/system'
                                             .format(package_file_name)])
     installed_package_paths = ['app.lua', 'app2', 'env', 'instances_enabled',
                                config_name, 'var']


### PR DESCRIPTION
With this patch:
- added tests for checking that systemd units are visible for systemd after installation.
- replaced the path to tt.yaml in ExecStart script with the path to the directory where this file is located. It is needed to use tt with -L option.
- added a stop script section to systemd unit file by packing

Closes #330 
Closes #332