### PR TITLE
help: fix output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - tt config is renamed to tt.yaml.
 
+### Fixed
+
+- Output of the ``help`` with all commands.
+
 ## [0.4.0] - 2022-12-31
 
 ### Added

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -114,15 +114,12 @@ func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
 	}
 
 	if str != "" {
-		return str[:len(str)-1]
+		str = util.Bold("\nEXTERNAL COMMANDS\n") + str
+		return strings.Trim(str, "\n")
 	}
 
-	return fmt.Sprintf("  %s", noAvailableExternalCmdMsg)
+	return ""
 }
-
-const (
-	noAvailableExternalCmdMsg = `No available external commands`
-)
 
 var (
 	errorUsageTemplate = `%s
@@ -141,6 +138,12 @@ Usage: {{ .Cmd }}
   {{.CommandPath}} [flags] <command> [command flags]
 {{end -}}
 
+{{if not .HasAvailableSubCommands}}
+{{- if .Runnable}}
+  {{.UseLine}}
+{{end -}}
+{{end}}
+
 {{- if gt (len .Aliases) 0}}` + util.Bold("\nALIASES") + `
   {{.NameAndAliases}}
 {{end -}}
@@ -155,8 +158,7 @@ Usage: {{ .Cmd }}
 {{end}}
 {{end -}}
 
-{{- if not .HasAvailableInheritedFlags}}` + util.Bold("\nEXTERNAL COMMANDS") + `
-%s
+{{- if not .HasAvailableInheritedFlags}} %s
 {{end -}}
 
 {{- if .HasAvailableLocalFlags}}` + util.Bold("\nFLAGS") + `

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -11,7 +11,7 @@ from utils import (create_external_module, create_tt_config,
 def test_help_without_external_modules(tt_cmd, help_cmd):
     rc, output = run_command_and_get_output([tt_cmd, help_cmd])
     assert rc == 0
-    assert "No available external commands" in output
+    assert "EXTERNAL COMMANDS" not in output
 
 
 def test_external_help_module(tt_cmd, tmpdir):


### PR DESCRIPTION
Usage is now shown for all commands.
External commands is now not shown for commands without it.

Example with external command: 
```  
Utility for managing Tarantool packages and Tarantool-based applications

USAGE
  tt [flags] <command> [command flags]

COMMANDS
  build       Build an application in specified PATH (default ".")
...
  version     Show Tarantool CLI version information
 
EXTERNAL COMMANDS
  help	Description for external module help
List of passed args: --description

FLAGS
  -c, --cfg string     Path to configuration file
...
  -V, --verbose        Verbose output

EXAMPLES
  $ tt version -L /path/to/local/dir
  $ tt help -S -I
  $ tt completion

Use "tt <command> --help" for more information about a command.
``` 

Example without external command: 
``` 
Utility for managing Tarantool packages and Tarantool-based applications

USAGE
  tt [flags] <command> [command flags]

COMMANDS
  build       Build an application in specified PATH (default ".")
...
  version     Show Tarantool CLI version information
 
FLAGS
  -c, --cfg string     Path to configuration file
...
  -V, --verbose        Verbose output

EXAMPLES
  $ tt version -L /path/to/local/dir
  $ tt help -S -I
  $ tt completion

Use "tt <command> --help" for more information about a command.
``` 

Closes #320