### PR TITLE
tt: support tarantoolctl app files layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Follow-up message support for application templates.
+- tarantool_layout config option to enable compatibility mode with tarantoolctl artifacts layout.
+  If this option is set to `true`, `tt` will not create sub-directories for runtime artifacts such
+  as control socket, pid file and log file. This option affects only single instance applications.
 
 ### Changed
 

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,7 @@ file format:
         log_maxage: num (Days)
         log_maxbackups: num
         restart_on_failure: bool
+        tarantoolctl_layout: bool
       repo:
         rocks: path/to/rocks
         distfiles: path/to/install
@@ -143,6 +144,9 @@ file format:
   The default is to retain all old log files (though log_maxage may still cause
   them to get deleted.)
 * ``restart_on_failure`` (bool) - should it restart on failure.
+* ``tarantoolctl_layout`` (bool) - enable/disable tarantoolctl layout compatible mode for
+  artifact files: control socket, pid, log files. Data files (wal, vinyl, snapshots) and
+  multi-instance applications are not affected by this option.
 
 **repo**
 

--- a/cli/cfg/dump_test.go
+++ b/cli/cfg/dump_test.go
@@ -81,6 +81,7 @@ tt:
     bin_dir: %[1]s/bin
     inc_dir: %[1]s/test_inc
     instances_enabled: .
+    tarantoolctl_layout: false
   ee:
     credential_path: ""
   templates: []

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 //     restart_on_failure: bool
 //     bin_dir: path
 //     inc_dir: path
+//     tarantoolctl_layout: false
 //   repo:
 //     rocks: path
 //     distfiles: path
@@ -76,6 +77,10 @@ type AppOpts struct {
 	IncludeDir string `mapstructure:"inc_dir" yaml:"inc_dir"`
 	// InstancesEnabled is the directory where all enabled applications are stored.
 	InstancesEnabled string `mapstructure:"instances_enabled" yaml:"instances_enabled"`
+	// TarantoolctlLayout enables artifact files layout compatibility with tarantoolctl:
+	// application sub-directories are not created for runtime artifacts like
+	// control socket, pid files and logs.
+	TarantoolctlLayout bool `mapstructure:"tarantoolctl_layout" yaml:"tarantoolctl_layout"`
 }
 
 // TemplateOpts contains configuration for applications templates.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -65,16 +65,17 @@ var (
 // getDefaultAppOpts generates default app config.
 func getDefaultAppOpts() *config.AppOpts {
 	return &config.AppOpts{
-		InstancesEnabled: ".",
-		RunDir:           varRunPath,
-		LogDir:           varLogPath,
-		LogMaxSize:       logMaxSize,
-		LogMaxAge:        logMaxAge,
-		LogMaxBackups:    logMaxBackups,
-		Restartable:      false,
-		DataDir:          varDataPath,
-		BinDir:           binPath,
-		IncludeDir:       includePath,
+		InstancesEnabled:   ".",
+		RunDir:             varRunPath,
+		LogDir:             varLogPath,
+		LogMaxSize:         logMaxSize,
+		LogMaxAge:          logMaxAge,
+		LogMaxBackups:      logMaxBackups,
+		Restartable:        false,
+		DataDir:            varDataPath,
+		BinDir:             binPath,
+		IncludeDir:         includePath,
+		TarantoolctlLayout: false,
 	}
 }
 

--- a/cli/running/path_builder.go
+++ b/cli/running/path_builder.go
@@ -1,0 +1,90 @@
+package running
+
+import "path/filepath"
+
+// artifactsPathBuilder is a builder pattern implementation for app artifacts paths generation.
+type artifactsPathBuilder struct {
+	// baseDir is base directory. Relative path is related to this dir.
+	baseDir string
+	// path is a path for using in conjunction with baseDir.
+	path string
+	// appName is an application name.
+	appName string
+	// instanceName is an instanceName.
+	instanceName string
+	// tarantoolctlLayout enables/disables tarantoolctl compatible path generation.
+	tarantoolctlLayout bool
+}
+
+// WithPath sets path in builder.
+func (builder *artifactsPathBuilder) WithPath(path string) *artifactsPathBuilder {
+	builder.path = path
+	return builder
+}
+
+// ForInstance sets instance name in builder.
+func (builder *artifactsPathBuilder) ForInstance(instanceName string) *artifactsPathBuilder {
+	builder.instanceName = instanceName
+	return builder
+}
+
+// WithTarantoolctlLayout enables/disables tarantoolctl layout flag in builder.
+func (builder *artifactsPathBuilder) WithTarantoolctlLayout(ctlLayout bool) *artifactsPathBuilder {
+	builder.tarantoolctlLayout = ctlLayout
+	return builder
+}
+
+// makePath make application path with rules:
+// * if path is not set:
+//   - if single instance application: baseBath + application name.
+//   - else : baseBath + application name + instance name.
+//
+// * if path is set and it is absolute:
+//   - if single instance application: path + application name
+//   - else: path + application name + instance name.
+//
+// * if path is set and it is relative:
+//   - if single instance application: basePath + path + application name.
+//   - else: basePath + path + application name + instance name.
+//
+// * if tarantoolctlLayout flag is set, application subdirectory is not created for single
+// instance applications for runtime aftifacts.
+func (builder *artifactsPathBuilder) Make() string {
+	if builder.path == "" {
+		if builder.instanceName == "" {
+			if builder.tarantoolctlLayout {
+				return builder.baseDir
+			}
+			return filepath.Join(builder.baseDir, builder.appName)
+		} else {
+			return filepath.Join(builder.baseDir, builder.appName, builder.instanceName)
+		}
+	}
+
+	if filepath.IsAbs(builder.path) {
+		if builder.instanceName == "" {
+			if builder.tarantoolctlLayout {
+				return builder.path
+			}
+			return filepath.Join(builder.path, builder.appName)
+		} else {
+			return filepath.Join(builder.path, builder.appName, builder.instanceName)
+		}
+	}
+
+	if builder.instanceName == "" {
+		if builder.tarantoolctlLayout {
+			return filepath.Join(builder.baseDir, builder.path)
+		}
+		return filepath.Join(builder.baseDir, builder.path, builder.appName)
+	}
+	return filepath.Join(builder.baseDir, builder.path, builder.appName, builder.instanceName)
+}
+
+// NewArtifactsPathBuilder creates new builder for paths generation.
+func NewArtifactsPathBuilder(baseDir, appName string) *artifactsPathBuilder {
+	return &artifactsPathBuilder{
+		baseDir: baseDir,
+		appName: appName,
+	}
+}

--- a/cli/running/path_builder_test.go
+++ b/cli/running/path_builder_test.go
@@ -1,0 +1,31 @@
+package running
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathBuilder(t *testing.T) {
+	builder := NewArtifactsPathBuilder("/var", "app1")
+	assert.Equal(t, "/var/app1", builder.Make())
+
+	builder = builder.WithPath("rundir")
+	assert.Equal(t, "/var/rundir/app1", builder.Make())
+
+	builder = builder.WithPath("/rundir")
+	assert.Equal(t, "/rundir/app1", builder.Make())
+
+	builder = builder.WithTarantoolctlLayout(true)
+	assert.Equal(t, "/rundir", builder.Make())
+
+	builder = builder.WithPath("rundir")
+	assert.Equal(t, "/var/rundir", builder.Make())
+
+	// For multi instance app, application sub-dir is always used.
+	builder = builder.WithPath("rundir").ForInstance("router")
+	assert.Equal(t, "/var/rundir/app1/router", builder.Make())
+
+	builder = builder.WithTarantoolctlLayout(false)
+	assert.Equal(t, "/var/rundir/app1/router", builder.Make())
+}

--- a/tt.yaml.default
+++ b/tt.yaml.default
@@ -36,6 +36,11 @@ tt:
     # The directory can also contain symbolic links to applications.
     instances_enabled: /etc/tarantool/instances.enabled
 
+    # Tarantoolctl artifacts layout compatibility: if set to true tt will not create application
+    # sub-directories for control socket, pid files, log files, etc.. Data files (wal, vinyl, 
+    # snap) and multi-instance applications are not affected by this option.
+    tarantoolctl_layout: true
+
   ee: null
     # Path to file with credentials for downloading Tarantool Enterprise Edition.
     # credential_path: /path/to/file


### PR DESCRIPTION
Added tarantoolctl_layout config option to enable compatibility mode with tarantoolctl artifacts layout. If this option is set to `true`, `tt` will not create sub-directories for runtime artifacts such as control socket, pid file and log file. This option affects only single instance applications.

Here is manual testing of tt & tarantoolctl:
```
~# tarantoolctl start app1
Starting instance app1...
Forwarding to 'systemctl start tarantool@app1'

~# tarantoolctl status app1
Forwarding to 'systemctl status tarantool@app1'
● tarantool@app1.service - Tarantool Database Server
     Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2023-02-08 15:20:11 MSK; 4s ago

~# tt status app1
   • app1: RUNNING. PID: 142492.

~# tt connect app1
   • Connecting to the instance...
   • Connected to /var/run/tarantool/app1.control

/var/run/tarantool/app1.control> 

~# tt stop app1
   • The Instance app1 (PID = 142492) has been terminated.
   
~# tarantoolctl status app1
Forwarding to 'systemctl status tarantool@app1'
○ tarantool@app1.service - Tarantool Database Server
     Loaded: loaded (/lib/systemd/system/tarantool@.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Wed 2023-02-08 15:20:37 MSK; 1min 1s ago

```
Closes #334