### PR TITLE
connect: add ability to pass arguments to a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - An ability to set different directories for WAL, vinyl and snapshots artifacts.
 - ``tt instances`` command to print a list of enabled applications.
 - SSL options for ``tt connect`` command.
+- An ability to pass arguments to a connect command.
 
 ### Changed
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -40,20 +40,27 @@ var (
 func NewConnectCmd() *cobra.Command {
 	var connectCmd = &cobra.Command{
 		Use: "connect (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)" +
-			" [<FILE> | <COMMAND>] [flags]\n" +
-			"  COMMAND | tt connect (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>) [flags]",
+			" [flags] [-f <FILE>] [-- ARGS]\n" +
+			"  COMMAND | tt connect (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)" +
+			" [flags]\n" +
+			"  COMMAND | tt connect (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)" +
+			" [flags] [-f-] [-- ARGS]",
 		Short: "Connect to the tarantool instance",
 		Long: "Connect to the tarantool instance.\n\n" +
 			"The command supports the following environment variables:\n\n" +
 			"* " + usernameEnv + " - specifies a username\n" +
-			"* " + passwordEnv + " - specifies a password\n",
+			"* " + passwordEnv + " - specifies a password\n" +
+			"\n" +
+			"You could pass command line arguments to the interpreted SCRIPT" +
+			" or COMMAND passed via -f flag:\n\n" +
+			`echo "print(...)" | tt connect user@pass:localhost:3013 -f- 1, 2, 3`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalConnectModule, args)
 			handleCmdErr(cmd, err)
 		},
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MinimumNArgs(1),
 	}
 
 	connectCmd.Flags().StringVarP(&connectUser, "username", "u", "", "username")

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -28,6 +28,7 @@ var luaCodeFiles = []generateLuaCodeOpts{
 		PackageName: "connect",
 		FileName:    "cli/connect/lua_code_gen.go",
 		VariablesMap: map[string]string{
+			"consoleEvalFuncBody":    "cli/connect/lua/console_eval_func_body.lua",
 			"evalFuncBody":           "cli/connect/lua/eval_func_body.lua",
 			"getSuggestionsFuncBody": "cli/connect/lua/get_suggestions_func_body.lua",
 		},

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -245,7 +245,7 @@ func getExecutor(console *Console) prompt.Executor {
 		}
 
 		var data string
-		if _, err := console.conn.Eval(evalFuncBody, args, opts); err != nil {
+		if _, err := console.conn.Eval(consoleEvalFuncBody, args, opts); err != nil {
 			if err == io.EOF {
 				log.Fatalf("Connection was closed. Probably instance process isn't running anymore")
 			} else {

--- a/cli/connect/language.go
+++ b/cli/connect/language.go
@@ -63,7 +63,7 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 	}
 
 	languageCmd := setLanguagePrefix + lang.String()
-	response, err := evaler.Eval(evalFuncBody,
+	response, err := evaler.Eval(consoleEvalFuncBody,
 		[]interface{}{languageCmd},
 		connector.RequestOpts{},
 	)

--- a/cli/connect/lua/console_eval_func_body.lua
+++ b/cli/connect/lua/console_eval_func_body.lua
@@ -1,0 +1,1 @@
+return require('console').eval(...)

--- a/cli/connect/lua/eval_func_body.lua
+++ b/cli/connect/lua/eval_func_body.lua
@@ -1,1 +1,28 @@
-return require('console').eval(...)
+local yaml = require('yaml')
+local args = {...}
+local cmd = table.remove(args, 1)
+local fun, errmsg = loadstring("return "..cmd)
+if not fun then
+    fun, errmsg = loadstring(cmd)
+end
+if not fun then
+    return yaml.encode({box.NULL})
+end
+
+local function table_pack(...)
+    return {n = select('#', ...), ...}
+end
+
+local ret = table_pack(pcall(fun, unpack(args)))
+if not ret[1] then
+    return yaml.encode({box.NULL})
+end
+if ret.n == 1 then
+    return "---\n...\n"
+end
+for i=2,ret.n do
+    if ret[i] == nil then
+        ret[i] = box.NULL
+    end
+end
+return yaml.encode({unpack(ret, 2, ret.n)})

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -366,7 +366,7 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 	runningCtx *RunningCtx, args []string) error {
 	var err error
 
-	if len(args) > 1 && cmdCtx.CommandName != "run" {
+	if len(args) > 1 && cmdCtx.CommandName != "run" && cmdCtx.CommandName != "connect" {
 		return util.NewArgError("currently, you can specify only one instance at a time")
 	}
 


### PR DESCRIPTION
A usage examples:

```bash
$ tt connect URI -f print.lua 1 2 3
$ echo "print(...)" | tt connect URI -f- 1 2 3
$ echo "print(...)" | tt connect URI -f- -- -flag 1 2 3 $ echo "print(...)" | tt connect URI -f- 1 2 -- -flag
```

Closes #256