### PR TITLE
Fix install test hang

### DIFF
--- a/cli/install/Dockerfile.tnt.build
+++ b/cli/install/Dockerfile.tnt.build
@@ -1,7 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 WORKDIR /work
 RUN apt-get update && apt-get install -y git cmake make build-essential zlib1g-dev \
-libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev
+libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev autoconf libtool
 RUN chown {{.uid}} /work
 COPY ./ ./

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -656,7 +656,7 @@ func copyBuildedTarantool(binPath, incPath, binDir, includeDir, version string,
 //go:embed Dockerfile.tnt.build
 var tarantoolBuildDockerfile []byte
 
-func installTarantoolInDocker(binDir string, incDir string, installCtx InstallCtx,
+func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx InstallCtx,
 	distfiles string) error {
 	tmpDir, err := ioutil.TempDir("", "docker_build_ctx")
 	if err != nil {
@@ -707,7 +707,8 @@ func installTarantoolInDocker(binDir string, incDir string, installCtx InstallCt
 	if installCtx.verbose {
 		tntInstallCommandLine = append(tntInstallCommandLine, "-V")
 	}
-	tntInstallCommandLine = append(tntInstallCommandLine, "install", "tarantool", "-f")
+	tntInstallCommandLine = append(tntInstallCommandLine, "install",
+		"tarantool"+search.VersionCliSeparator+tntVersion, "-f")
 	if installCtx.Reinstall {
 		tntInstallCommandLine = append(tntInstallCommandLine, "--reinstall")
 	}
@@ -789,7 +790,7 @@ func installTarantool(version string, binDir string, incDir string,
 	}
 
 	if installCtx.BuildInDocker {
-		return installTarantoolInDocker(binDir, incDir, installCtx, distfiles)
+		return installTarantoolInDocker(tarVersion, binDir, incDir, installCtx, distfiles)
 	}
 
 	logFile, err := ioutil.TempFile("", "tarantool_install")

--- a/cli/pack/templates/Dockerfile.pack.build
+++ b/cli/pack/templates/Dockerfile.pack.build
@@ -8,7 +8,7 @@ RUN curl -L https://tarantool.io/release/2/installer.sh | bash
 RUN apt-get update && apt-get install -y tt
 
 # Install Tarantool
-FROM ubuntu:16.04 as tarantool-builder
+FROM ubuntu:18.04 as tarantool-builder
 
 COPY --from=tt-builder /usr/bin/tt /usr/bin
 
@@ -18,7 +18,7 @@ RUN apt update
 
 RUN apt install -y git build-essential cmake make zlib1g-dev \
   libreadline-dev libncurses5-dev libssl-dev libunwind-dev libicu-dev \
-  python3 python3-yaml python3-six python3-gevent
+  python3 python3-yaml python3-six python3-gevent autoconf libtool
 
 RUN tt init
 

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -122,7 +122,7 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     # Check tarantool glibc version.
     out = subprocess.getoutput("objdump -T " + os.path.join(tmpdir, "bin", "tarantool") +
                                " | grep -o -E 'GLIBC_[.0-9]+' | sort -V | tail -n1")
-    assert out == "GLIBC_2.18"
+    assert out == "GLIBC_2.27"
 
     assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
 

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -98,7 +98,10 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
         install_cmd,
         cwd=tmpdir_without_config,
         stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
+        # Do not use pipe for stdout, if you are not going to read from it.
+        # In case of build failure, docker logs are printed to stdout. It fills pipe buffer and
+        # blocks all subsequent stdout write calls in tt, because there is no pipe reader in test.
+        stdout=subprocess.DEVNULL,
         text=True
     )
 


### PR DESCRIPTION
- Use devnull instead of pipe for stdout.
- Update Ubuntu docker image version to avoid build errors related for no-pic libgomp.a.
- Update cmake and install additional dependencies for building the latest tarantool version.