### PR TITLE
install: check if MAKEFLAGS is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - tt config is renamed to tt.yaml.
+- Do not use `make` command options for `tarantool` build if `MAKEFLAGS` environment variable
+is set.
 
 ### Fixed
 

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -588,7 +588,12 @@ func buildTarantool(srcPath string, tarVersion string,
 		}
 	}
 
-	maxThreads := fmt.Sprint(runtime.NumCPU())
+	makeOpts := []string{}
+	if _, isMakeFlagsSet := os.LookupEnv("MAKEFLAGS"); !isMakeFlagsSet {
+		maxThreads := fmt.Sprint(runtime.NumCPU())
+		makeOpts = append(makeOpts, "-j", maxThreads)
+	}
+
 	err = util.ExecuteCommand("cmake", installCtx.verbose, logFile, buildPath,
 		"..", `-DCMAKE_TARANTOOL_ARGS="-DCMAKE_BUILD_TYPE=RelWithDebInfo;`+
 			`-DENABLE_WERROR=OFF;-DENABLE_BACKTRACE=`+btFlag,
@@ -597,9 +602,7 @@ func buildTarantool(srcPath string, tarVersion string,
 		return err
 	}
 
-	err = util.ExecuteCommand("make", installCtx.verbose, logFile, buildPath,
-		"-j"+maxThreads)
-	return err
+	return util.ExecuteCommand("make", installCtx.verbose, logFile, buildPath, makeOpts...)
 }
 
 // copyLocalTarantool finds and copies local tarantool folder to tmp folder.


### PR DESCRIPTION
A user can specify make flags for tarantool building by using MAKEFLAGS environment variable. Do not append any make options if MAKEFLAGS is set.
Manual tests:
```
$ MAKEFLAGS="-j1" tt -V install tarantool
[  2%] Creating directories for 'openssl'
[  4%] Performing download step (download, verify and extract) for 'openssl'
-- Downloading...
```
```
$ MAKEFLAGS="-j4" tt -V install tarantool
[  8%] Creating directories for 'zlib'
[  8%] Creating directories for 'openssl'
[  8%] Creating directories for 'icu'
[  8%] Creating directories for 'ncurses'
[ 16%] Performing download step (download, verify and extract) for 'zlib'
[ 16%] Performing download step (download, verify and extract) for 'icu'
[ 16%] Performing download step (download, verify and extract) for 'ncurses'
[ 16%] Performing download step (download, verify and extract) for 'openssl'
```
```
$ tt -V install tarantool
   • Run: /usr/bin/make -j 8
 
[  2%] Creating directories for 'openssl'
[  4%] Creating directories for 'readline'
[  6%] Creating directories for 'ncurses'
[  8%] Creating directories for 'zlib'
[ 12%] Creating directories for 'icu'
[ 12%] Generating iconv-prefix/include/iconv.h
[ 14%] Performing download step (download, verify and extract) for 'zlib'
[ 16%] Performing download step (download, verify and extract) for 'readline'
[ 18%] Performing download step (download, verify and extract) for 'openssl'
[ 20%] Performing download step (download, verify and extract) for 'ncurses'
[ 20%] Built target iconv
[ 22%] Performing download step (download, verify and extract) for 'icu'
```
