### PR TITLE
rocks: support only-server opt different formats

### DIFF
--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
@@ -21,7 +22,7 @@ var luarocks embed.FS
 func addLuarocksRepoOpts(cliOpts *config.CliOpts, args []string) ([]string, error) {
 	// Make sure there is no --only-server option is specified.
 	for _, opt := range args {
-		if opt == "--only-server" {
+		if opt == "--only-server" || strings.HasPrefix(opt, "--only-server=") {
 			return args, nil // If --only-server is specified, no need to add --server option.
 		}
 	}

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -102,6 +102,26 @@ def test_rocks_install_local(tt_cmd, tmpdir):
     assert "Installing repo/stat-0.3.2-1.all.rock" in output
 
 
+def test_rocks_install_local_if_network_is_up(tt_cmd, tmpdir):
+    if platform.system() == "Darwin":
+        pytest.skip("/set platform is unsupported")
+
+    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+        tnt_env_file.write('''tt:
+  repo:
+    rocks: "repo"''')
+
+    shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
+                    os.path.join(tmpdir, "repo"))
+
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "rocks", "--only-server=repo", "install", "stat"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert "Installing repo/stat-0.3.2-1.all.rock" in output
+    assert "stat 0.3.2-1 is now installed in " + os.path.join(tmpdir, ".rocks") in output
+
+
 def test_rocks_install_local_specific_version(tt_cmd, tmpdir):
     with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''tt:


### PR DESCRIPTION
--only-server rocks option can be provided using two formats: --only-server <server> and --only-server=<server>. Need to support both.