### PR TITLE
create: add variable cluster_cookie for cartridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- A configurable variable `cluster_cookie` for `tt create cartridge` teamplate.
+
 ## [1.0.0] - 2023-03-23
 
 ### Added

--- a/cli/create/builtin_templates/templates/cartridge/MANIFEST.yaml
+++ b/cli/create/builtin_templates/templates/cartridge/MANIFEST.yaml
@@ -7,3 +7,8 @@ follow-up-message: |
 
   To bootstrap vshard run the following command:
       $ tt cartridge replicasets setup --bootstrap-vshard --name {{ .name }} --run-dir {{ cwdRelative .rundir }}/{{ .name }}
+vars:
+  - prompt: Cluster cookie
+    name: cluster_cookie
+    default: secret-cluster-cookie
+    re: ^[\w-]+$

--- a/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
+++ b/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
@@ -38,6 +38,7 @@ local ok, err = cartridge.cfg({
         'cartridge.roles.metrics',
         'app.roles.custom',
     },
+    cluster_cookie = '{{.cluster_cookie}}',
 })
 
 assert(ok, tostring(err))


### PR DESCRIPTION
The patch adds a configurable variable `cluster_cookie` for the cartridge template.

Closes #244

`secret-cluster-cookie` is a default value:

https://github.com/tarantool/cartridge/blob/892e25198d73204433ddb857ddafa116afafcd52/cartridge.lua#L57