### PR TITLE
Replace flake and isort with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length=100

--- a/.github/actions/static-code-check/action.yml
+++ b/.github/actions/static-code-check/action.yml
@@ -39,6 +39,5 @@ runs:
           skip-cache: true
 
       - name: Python Linter
-        run: python3 -m flake8 test
+        run: python3 -m ruff .
         shell: bash
-

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-known_local_folder=utils

--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,7 @@ To run tests:
 
 * `Python3 <https://www.python.org/downloads/>`_
 * `pytest <https://docs.pytest.org/en/7.2.x/getting-started.html#get-started>`_
-* `flake8 <https://pypi.org/project/flake8/>`_
-* `flake8-isort <https://pypi.org/project/flake8-isort/>`_
-* `flake8-unused-arguments <https://pypi.org/project/flake8-unused-arguments/>`_
+* `ruff <https://beta.ruff.rs>`_
 * `golangci-lint <https://golangci-lint.run/usage/install/#local-installation>`_
 * `lichen <https://github.com/uw-labs/lichen#install>`_
 * `docker <https://docs.docker.com/engine/install/>`_

--- a/magefile.go
+++ b/magefile.go
@@ -228,9 +228,9 @@ func Lint() error {
 		return err
 	}
 
-	fmt.Println("Running flake8...")
+	fmt.Println("Running ruff...")
 
-	if err := sh.RunV(pythonExecutableName, "-m", "flake8", "test"); err != nil {
+	if err := sh.RunV(pythonExecutableName, "-m", "ruff", "."); err != nil {
 		return err
 	}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[tool.ruff]
+select = [
+    "A",
+    "ARG",
+    "B",
+    "C4",
+    "C9",
+    "DTZ",
+    "E",
+    "EM",
+    "EXE",
+    "F",
+    "G",
+    "I",
+    "ICN",
+    "PGH",
+    "PIE",
+    "PL",
+    "RSE",
+    "SIM",
+    "SLF",
+    "TCH",
+    "TID",
+    "W",
+]
+exclude = ["bin/www/olsystem.py"]
+ignore = ["PLC1901", "PLR2004"]
+line-length = 100
+target-version = "py37"
+
+[tool.ruff.isort]
+known-local-folder = ["utils"]
+
+[tool.ruff.mccabe]
+max-complexity = 10
+
+[tool.ruff.pylint]
+max-args = 8
+max-branches = 12
+max-returns = 6
+max-statements = 52
+
+[tool.ruff.per-file-ignores]
+"test/integration/init/test_init.py" = ["A002"]
+"test/integration/restart/test_restart.py" = ["A002"]
+"test/integration/running/test_running.py" = ["B007"]
+"test/utils.py" = ["B008", "EM"]

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -5,8 +5,7 @@ import tempfile
 import pytest
 import yaml
 
-from utils import (config_name, create_external_module, create_tt_config,
-                   run_command_and_get_output)
+from utils import config_name, create_external_module, create_tt_config, run_command_and_get_output
 
 # Some of the tests below should check the behavior
 # of modules that have an internal implementation.

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -1,7 +1,6 @@
 import pytest
 
-from utils import (create_external_module, create_tt_config,
-                   run_command_and_get_output)
+from utils import create_external_module, create_tt_config, run_command_and_get_output
 
 
 # ##### #
@@ -51,13 +50,13 @@ def test_internal_help_with_external_module(tt_cmd, tmpdir):
     # In this case, the external module version should be called with the --help flag.
     rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmpdir)
     assert rc == 0
-    assert "Help for external version module\nList of passed args: --help\n" == output
+    assert output == "Help for external version module\nList of passed args: --help\n"
 
     create_external_module("abc", tmpdir)
     # External modules without internal implementation.
     rc, output = run_command_and_get_output([tt_cmd, "help", "abc"], cwd=tmpdir)
     assert rc == 0
-    assert "Help for external abc module\nList of passed args: --help\n" == output
+    assert output == "Help for external abc module\nList of passed args: --help\n"
 
     # If the external module help and version exist at the same time,
     # then the external module help should be called with the <version>

--- a/test/integration/play/test_play.py
+++ b/test/integration/play/test_play.py
@@ -4,8 +4,7 @@ import shutil
 
 import pytest
 
-from utils import (TarantoolTestInstance, kill_child_process,
-                   run_command_and_get_output)
+from utils import TarantoolTestInstance, kill_child_process, run_command_and_get_output
 
 # The name of instance config file within this integration tests.
 # This file should be in /test/integration/play/test_file/.

--- a/test/integration/run/test_run.py
+++ b/test/integration/run/test_run.py
@@ -105,7 +105,7 @@ def test_run_from_input(tt_cmd, tmpdir):
                                text=True
                                )
     run_output = process.stdout.readline()
-    assert "42\n" == run_output
+    assert run_output == "42\n"
 
     process = subprocess.Popen(f"echo 'print(...) print(unpack(arg))' | {tt_cmd} run -- - a b c",
                                shell=True,

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -6,9 +6,16 @@ import tempfile
 
 import yaml
 
-from utils import (config_name, kill_child_process, log_path,
-                   run_command_and_get_output, run_path, wait_file,
-                   wait_instance_start, wait_instance_stop)
+from utils import (
+    config_name,
+    kill_child_process,
+    log_path,
+    run_command_and_get_output,
+    run_path,
+    wait_file,
+    wait_instance_start,
+    wait_instance_stop,
+)
 
 
 def test_running_base_functionality(tt_cmd, tmpdir_with_cfg):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,10 +1,8 @@
-pytest==6.2.5
-tarantool==0.7.1
-requests==2.26.0
-flake8==3.8.1
-flake8-unused-arguments==0.0.6
-flake8-isort==4.0.0
-psutil==5.7.0
-pyyaml==5.4
 codespell==2.2.1
 netifaces==0.11.0
+psutil==5.7.0
+pytest==6.2.5
+pyyaml==5.4
+requests==2.26.0
+ruff==0.0.259
+tarantool==0.7.1


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.