### PR TITLE
uninstall: don't ask version if only one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Packing symlinks into RPM package.
 
+### Changed
+
+- ``tt uninstall`` does not ask version if only one version of a program is installed.
+
 ## [1.0.0] - 2023-03-23
 
 ### Added

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/uninstall"
-	"github.com/tarantool/tt/cli/version"
 )
 
 // NewUninstallCmd creates uninstall command.
@@ -44,9 +40,6 @@ func NewUninstallCmd() *cobra.Command {
 
 // InternalUninstallModule is a default uninstall module.
 func InternalUninstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	if !strings.Contains(args[0], version.CliSeparator) {
-		return fmt.Errorf("incorrect usage.\n   e.g program%sversion", version.CliSeparator)
-	}
 	err := uninstall.UninstallProgram(args[0], cliOpts.App.BinDir,
 		cliOpts.App.IncludeDir+"/include", cmdCtx)
 	return err

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -251,9 +251,9 @@ func programDependenciesInstalled(program string) bool {
 	programs := []Package{}
 	packages := []string{}
 	osName, _ := detectOsName()
-	if program == "tt" {
+	if program == search.ProgramTt {
 		programs = []Package{{"mage", "mage"}, {"git", "git"}}
-	} else if program == "tarantool" {
+	} else if program == search.ProgramCe {
 		if osName == "darwin" {
 			programs = []Package{{"cmake", "cmake"}, {"git", "git"},
 				{"make", "make"}, {"clang", "clang"}, {"openssl", "openssl"}}
@@ -430,12 +430,12 @@ func installTt(versionStr string, binDir string, installCtx InstallCtx, distfile
 	// Check tt dependencies.
 	if !installCtx.Force {
 		log.Infof("Checking dependencies...")
-		if !programDependenciesInstalled("tt") {
+		if !programDependenciesInstalled(search.ProgramTt) {
 			return nil
 		}
 	}
 
-	versionStr = "tt" + version.FsSeparator + ttVersion
+	versionStr = search.ProgramTt + version.FsSeparator + ttVersion
 	// Check if that version is already installed.
 	log.Infof("Checking existing...")
 	if checkExisting(versionStr, binDir) && !installCtx.Reinstall {
@@ -713,7 +713,7 @@ func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx Inst
 		tntInstallCommandLine = append(tntInstallCommandLine, "-V")
 	}
 	tntInstallCommandLine = append(tntInstallCommandLine, "install",
-		"tarantool"+version.CliSeparator+tntVersion, "-f")
+		search.ProgramCe+version.CliSeparator+tntVersion, "-f")
 	if installCtx.Reinstall {
 		tntInstallCommandLine = append(tntInstallCommandLine, "--reinstall")
 	}
@@ -783,7 +783,7 @@ func installTarantool(versionStr string, binDir string, incDir string,
 		}
 	}
 
-	versionStr = "tarantool" + version.FsSeparator + tarVersion
+	versionStr = search.ProgramCe + version.FsSeparator + tarVersion
 	// Check if program is already installed.
 	if !installCtx.Reinstall {
 		log.Infof("Checking existing...")
@@ -809,7 +809,7 @@ func installTarantool(versionStr string, binDir string, incDir string,
 	// Check dependencies.
 	if !installCtx.Force {
 		log.Infof("Checking dependencies...")
-		if !programDependenciesInstalled("tarantool") {
+		if !programDependenciesInstalled(search.ProgramCe) {
 			return nil
 		}
 	}
@@ -945,7 +945,7 @@ func installTarantoolEE(versionStr string, binDir string, includeDir string, ins
 	// Check dependencies.
 	if !installCtx.Force {
 		log.Infof("Checking dependencies...")
-		if !programDependenciesInstalled("tarantool") {
+		if !programDependenciesInstalled(search.ProgramCe) {
 			return nil
 		}
 	}
@@ -956,7 +956,7 @@ func installTarantoolEE(versionStr string, binDir string, includeDir string, ins
 	bundleName := ver.Version.Tarball
 	bundleSource := ver.Prefix
 
-	versionStr = "tarantool-ee" + version.FsSeparator + tarVersion
+	versionStr = search.ProgramEe + version.FsSeparator + tarVersion
 	if !installCtx.Reinstall {
 		log.Infof("Checking existing...")
 		versionExists, err := checkExistingTarantool(versionStr,
@@ -1060,11 +1060,11 @@ func Install(args []string, binDir string, includeDir string, installCtx Install
 	var err error
 
 	switch installCtx.programName {
-	case "tt":
+	case search.ProgramTt:
 		err = installTt(args[0], binDir, installCtx, local)
-	case "tarantool":
+	case search.ProgramCe:
 		err = installTarantool(args[0], binDir, includeDir, installCtx, local)
-	case "tarantool-ee":
+	case search.ProgramEe:
 		err = installTarantoolEE(args[0], binDir, includeDir, installCtx, local, cliOpts)
 	default:
 		return fmt.Errorf("unknown application: %s", installCtx.programName)
@@ -1089,7 +1089,7 @@ func FillCtx(cmdCtx *cmdcontext.CmdCtx, installCtx *InstallCtx, args []string) e
 	}
 	installCtx.programName = matches["prog"]
 
-	if installCtx.BuildInDocker && installCtx.programName != "tarantool" {
+	if installCtx.BuildInDocker && installCtx.programName != search.ProgramCe {
 		return fmt.Errorf("--use-docker can be used only for 'tarantool' program")
 	}
 

--- a/cli/list/list.go
+++ b/cli/list/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/running"
+	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 )
@@ -116,7 +117,7 @@ func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) (err error
 		return fmt.Errorf("there are no installed binaries")
 	}
 
-	programs := [...]string{"tt", "tarantool"}
+	programs := [...]string{search.ProgramTt, search.ProgramCe}
 	fmt.Println("List of installed binaries:")
 	for _, programName := range programs {
 		binaryVersions, err := parseBinaries(binDirFilesList, programName, binDir)

--- a/cli/search/const.go
+++ b/cli/search/const.go
@@ -1,0 +1,7 @@
+package search
+
+const (
+	ProgramCe = "tarantool"
+	ProgramEe = "tarantool-ee"
+	ProgramTt = "tt"
+)

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -147,7 +147,7 @@ func printVersion(bindir string, program string, versionStr string) {
 	if _, err := os.Stat(filepath.Join(bindir,
 		program+version.FsSeparator+versionStr)); err == nil {
 		target := ""
-		if program == "tarantool-ee" {
+		if program == ProgramEe {
 			target, _ = util.ResolveSymlink(filepath.Join(bindir, "tarantool"))
 		} else {
 			target, _ = util.ResolveSymlink(filepath.Join(bindir, program))
@@ -169,19 +169,19 @@ func SearchVersions(cmdCtx *cmdcontext.CmdCtx, searchCtx SearchCtx,
 	var repo string
 	versions := []version.Version{}
 
-	if program == "tarantool" {
+	if program == ProgramCe {
 		repo = GitRepoTarantool
 		if searchCtx.Dev || searchCtx.Dbg {
 			log.Warnf("--dbg and --dev options can be used only for" +
 				" tarantool-ee packages searching.")
 		}
-	} else if program == "tt" {
+	} else if program == ProgramTt {
 		repo = GitRepoTT
 		if searchCtx.Dev || searchCtx.Dbg {
 			log.Warnf("--dbg and --dev options can be used only for" +
 				" tarantool-ee packages searching.")
 		}
-	} else if program == "tarantool-ee" {
+	} else if program == ProgramEe {
 		// Do nothing. Needs for bypass arguments check.
 	} else {
 		return fmt.Errorf("search supports only tarantool/tarantool-ee/tt")
@@ -189,7 +189,7 @@ func SearchVersions(cmdCtx *cmdcontext.CmdCtx, searchCtx SearchCtx,
 
 	var err error
 	log.Infof("Available versions of " + program + ":")
-	if program == "tarantool-ee" {
+	if program == ProgramEe {
 		bundles, err := FetchBundlesInfo(searchCtx, cliOpts)
 		if err != nil {
 			log.Fatalf(err.Error())
@@ -243,7 +243,7 @@ func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, pro
 		return err
 	}
 
-	if program == "tarantool" {
+	if program == ProgramCe {
 		if _, err = os.Stat(localDir + "/tarantool"); !os.IsNotExist(err) {
 			log.Infof("Available versions of " + program + ":")
 			versions, err := GetVersionsFromGitLocal(localDir + "/tarantool")
@@ -256,7 +256,7 @@ func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, pro
 			}
 			printVersion(cliOpts.App.BinDir, program, "master")
 		}
-	} else if program == "tt" {
+	} else if program == ProgramTt {
 		if _, err = os.Stat(localDir + "/tt"); !os.IsNotExist(err) {
 			log.Infof("Available versions of " + program + ":")
 			versions, err := GetVersionsFromGitLocal(localDir + "/tt")
@@ -269,7 +269,7 @@ func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, pro
 			}
 			printVersion(cliOpts.App.BinDir, program, "master")
 		}
-	} else if program == "tarantool-ee" {
+	} else if program == ProgramEe {
 		files := []string{}
 		for _, v := range localFiles {
 			if strings.Contains(v.Name(), "tarantool-enterprise-bundle") && !v.IsDir() {

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 )
@@ -28,7 +29,7 @@ func remove(program string, directory string, cmdCtx *cmdcontext.CmdCtx) error {
 		return fmt.Errorf("unknown program: %s", program)
 	}
 
-	if matches["prog"] == "tarantool" || matches["prog"] == "tarantool-ee" {
+	if matches["prog"] == search.ProgramCe || matches["prog"] == search.ProgramEe {
 		linkPath, err = util.JoinAbspath(directory, "tarantool")
 	} else {
 		linkPath, err = util.JoinAbspath(directory, matches["prog"])

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -11,19 +11,59 @@ def test_uninstall_tt(tt_cmd, tmpdir):
     with open(configPath, 'w') as f:
         f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
 
-    # Do not test uninstall through installing tt. Because installed tt will be invoked by current
-    # tt. As a result the test will run for the installed tt and not the current. Creating fake
-    # tarantool instead.
+    for prog in ["tarantool", "tarantool=master"]:
+        # Do not test uninstall through installing tt. Because installed tt will be invoked by
+        # current tt. As a result the test will run for the installed tt and not the current.
+        # Creating fake tarantool instead.
+        os.mkdir(os.path.join(tmpdir, "bin"))
+        with open(os.path.join(tmpdir, "bin", "tarantool_master"), 'w') as f:
+            f.write('''#!/bin/sh
+                    echo "hello"''')
+        os.chmod(os.path.join(tmpdir, "bin", "tarantool_master"), 0o775)
+        os.symlink("./tarantool_master", os.path.join(tmpdir, "bin", "tarantool"))
+        os.makedirs(os.path.join(tmpdir, "include", "include", "tarantool_master"))
+        os.symlink("./tarantool_master", os.path.join(tmpdir, "include", "include", "tarantool"))
+
+        uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", prog]
+        uninstall_process = subprocess.Popen(
+            uninstall_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        uninstall_process.wait()
+        uninstall_output = uninstall_process.stdout.readlines()
+        assert "Removing binary..." in uninstall_output[0]
+        assert "Removing headers..." in uninstall_output[1]
+        assert "tarantool=master is uninstalled" in uninstall_output[2]
+
+        assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool_master"))
+        assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool"))
+        assert not os.path.exists(os.path.join(tmpdir, "include", "include", "tarantool_master"))
+        os.rmdir(os.path.join(tmpdir, "bin"))
+
+
+def test_uninstall_default_many(tt_cmd, tmpdir):
+    configPath = os.path.join(tmpdir, config_name)
+    # Create test config.
+    with open(configPath, 'w') as f:
+        f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
+
+    # Do not test uninstall through installing tt. Because installed tt will be invoked by
+    # current tt. As a result the test will run for the installed tt and not the current.
+    # Creating fake tarantool instead.
     os.mkdir(os.path.join(tmpdir, "bin"))
     with open(os.path.join(tmpdir, "bin", "tarantool_master"), 'w') as f:
         f.write('''#!/bin/sh
                 echo "hello"''')
+    with open(os.path.join(tmpdir, "bin", "tarantool_123"), 'w') as f:
+        f.write('''#!/bin/sh
+                echo "hello"''')
     os.chmod(os.path.join(tmpdir, "bin", "tarantool_master"), 0o775)
     os.symlink("./tarantool_master", os.path.join(tmpdir, "bin", "tarantool"))
-    os.makedirs(os.path.join(tmpdir, "include", "include", "tarantool_master"))
-    os.symlink("./tarantool_master", os.path.join(tmpdir, "include", "include", "tarantool"))
 
-    uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", "tarantool=master"]
+    uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", "tarantool"]
     uninstall_process = subprocess.Popen(
         uninstall_cmd,
         cwd=tmpdir,
@@ -34,12 +74,9 @@ def test_uninstall_tt(tt_cmd, tmpdir):
     uninstall_process.wait()
     uninstall_output = uninstall_process.stdout.readlines()
     assert "Removing binary..." in uninstall_output[0]
-    assert "Removing headers..." in uninstall_output[1]
-    assert "tarantool=master is uninstalled" in uninstall_output[2]
-
-    assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool_master"))
-    assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool"))
-    assert not os.path.exists(os.path.join(tmpdir, "include", "include", "tarantool_master"))
+    expected = "tarantool has more than one installed version, " \
+               + "please specify the version to uninstall"
+    assert expected in uninstall_output[1]
 
 
 def test_uninstall_missing(tt_cmd, tmpdir):
@@ -68,16 +105,17 @@ def test_uninstall_missing(tt_cmd, tmpdir):
 
 def test_uninstall_foreign_program(tt_cmd, tmpdir):
     # Remove bash.
-    uninstall_cmd = [tt_cmd, "uninstall", "bash=123"]
-    uninstall_process = subprocess.Popen(
-        uninstall_cmd,
-        cwd=tmpdir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True
-    )
-    uninstall_process.wait()
-    uninstall_output = uninstall_process.stdout.readline()
-    assert re.search(r"Removing binary...", uninstall_output)
-    uninstall_output = uninstall_process.stdout.readline()
-    assert re.search(r"unknown program:", uninstall_output)
+    for prog in ["bash", "bash=123"]:
+        uninstall_cmd = [tt_cmd, "uninstall", prog]
+        uninstall_process = subprocess.Popen(
+            uninstall_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        uninstall_process.wait()
+        uninstall_output = uninstall_process.stdout.readline()
+        assert re.search(r"Removing binary...", uninstall_output)
+        uninstall_output = uninstall_process.stdout.readline()
+        assert re.search(r"unknown program:", uninstall_output)


### PR DESCRIPTION
After the patch `tt uninstall` does not ask version if only one version of a program is installed.

Closes #222