### PR TITLE
binaries: change error message

### DIFF
--- a/cli/list/list.go
+++ b/cli/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -109,12 +110,11 @@ func parseBinaries(fileList []fs.DirEntry, programName string,
 func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) (err error) {
 	binDir := cliOpts.App.BinDir
 	binDirFilesList, err := os.ReadDir(binDir)
-	if err != nil {
-		return fmt.Errorf("error reading directory %q: %s", binDir, err)
-	}
 
-	if len(binDirFilesList) == 0 {
-		return fmt.Errorf("there are no installed binaries")
+	if len(binDirFilesList) == 0 || errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("there are no binaries installed in this environment of 'tt'")
+	} else if err != nil {
+		return fmt.Errorf("error reading directory %q: %s", binDir, err)
 	}
 
 	programs := [...]string{search.ProgramTt, search.ProgramCe}

--- a/test/integration/binaries/test_binaries.py
+++ b/test/integration/binaries/test_binaries.py
@@ -54,7 +54,7 @@ def test_binaries_no_directory(tt_cmd, tmpdir):
     binaries_process.wait()
     output = binaries_process.stdout.read()
 
-    assert "error reading directory" in output
+    assert "there are no binaries installed in this environment of 'tt'" in output
 
 
 def test_binaries_empty_directory(tt_cmd, tmpdir):
@@ -77,4 +77,4 @@ def test_binaries_empty_directory(tt_cmd, tmpdir):
     binaries_process.wait()
     output = binaries_process.stdout.read()
 
-    assert "there are no installed binaries" in output
+    assert "there are no binaries installed in this environment of 'tt'" in output


### PR DESCRIPTION
Changed error message, so it is more understandable for user

Previously:

```
f.terekhin@f-terekhin tt % ./tt binaries
   ⨯ error reading directory "/opt/tarantool/bin": open /opt/tarantool/bin: no such file or directory
```

Now:

```
f.terekhin@f-terekhin tt % ./tt binaries
   ⨯ there are no binaries installed in this environment of 'tt'
```