### PR TITLE
cmd: add config check for almost all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - tt config is renamed to tt.yaml.
 - Do not use `make` command options for `tarantool` build if `MAKEFLAGS` environment variable
 is set.
+- `binaries`, `build`, `check`, `clean`, `create`, `install`, `instances`, `logrotate`, `pack`,
+  `restart`, `run`, `start`, `status`, `stop`, `uninstall` require environment configuration file.
 
 ### Fixed
 

--- a/cli/cmd/binaries.go
+++ b/cli/cmd/binaries.go
@@ -24,5 +24,9 @@ func NewBinariesCmd() *cobra.Command {
 
 // internalBinariesModule is a default binaries module.
 func internalBinariesModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	return list.ListBinaries(cmdCtx, cliOpts)
 }

--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -32,6 +32,10 @@ func NewBuildCmd() *cobra.Command {
 
 // internalBuildModule is a default build module.
 func internalBuildModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var buildCtx build.BuildCtx
 	if err := build.FillCtx(&buildCtx, cliOpts, args); err != nil {
 		return err

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -26,6 +26,10 @@ func NewCheckCmd() *cobra.Command {
 
 // internalCheckModule is a default check module.
 func internalCheckModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -97,6 +97,10 @@ func clean(run *running.InstanceCtx) error {
 
 // internalCleanModule is a default clean module.
 func internalCleanModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/util"
 )
 
@@ -21,4 +23,14 @@ func handleCmdErr(cmd *cobra.Command, err error) {
 		}
 		log.Fatalf(err.Error())
 	}
+}
+
+// errNoConfig is returned if environment config file tt.yaml not found.
+var errNoConfig = errors.New(configure.ConfigName +
+	" not found, you need to create tt environment config with 'tt init'" +
+	" or provide exact config location with --cfg option")
+
+// isConfigExist returns `true` if environment config file tt.yaml exist.
+func isConfigExist(cmdCtx *cmdcontext.CmdCtx) bool {
+	return cmdCtx.Cli.ConfigPath != ""
 }

--- a/cli/cmd/common_test.go
+++ b/cli/cmd/common_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/configure"
+)
+
+func TestCheckConfig(t *testing.T) {
+	const expected = configure.ConfigName +
+		" not found, you need to create tt environment config with 'tt init'" +
+		" or provide exact config location with --cfg option"
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"binaries", internalBinariesModule(&cmdcontext.CmdCtx{}, nil)},
+		{"build", internalBuildModule(&cmdcontext.CmdCtx{}, nil)},
+		{"check", internalCheckModule(&cmdcontext.CmdCtx{}, nil)},
+		{"clean", internalCleanModule(&cmdcontext.CmdCtx{}, nil)},
+		{"create", internalCreateModule(&cmdcontext.CmdCtx{}, nil)},
+		{"install", internalInstallModule(&cmdcontext.CmdCtx{}, nil)},
+		{"instances", internalInstancesModule(&cmdcontext.CmdCtx{}, nil)},
+		{"logrotate", internalLogrotateModule(&cmdcontext.CmdCtx{}, nil)},
+		{"pack", internalPackModule(&cmdcontext.CmdCtx{}, nil)},
+		{"restart", internalRestartModule(&cmdcontext.CmdCtx{}, nil)},
+		{"run", internalRunModule(&cmdcontext.CmdCtx{}, nil)},
+		{"start", internalStartModule(&cmdcontext.CmdCtx{}, nil)},
+		{"status", internalStatusModule(&cmdcontext.CmdCtx{}, nil)},
+		{"stop", internalStopModule(&cmdcontext.CmdCtx{}, nil)},
+		{"uninstall", InternalUninstallModule(&cmdcontext.CmdCtx{}, nil)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ErrorContains(t, tc.err, expected)
+		})
+	}
+}

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -69,6 +69,10 @@ Built-in templates:
 
 // internalCreateModule is a default create module.
 func internalCreateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	createCtx := create_ctx.CreateCtx{
 		AppName:        appName,
 		ForceMode:      forceMode,

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -57,6 +57,10 @@ func NewInstallCmd() *cobra.Command {
 
 // internalInstallModule is a default install module.
 func internalInstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	installCtx := install.InstallCtx{
 		Force:         force,
 		Noclean:       noclean,

--- a/cli/cmd/instances.go
+++ b/cli/cmd/instances.go
@@ -26,6 +26,9 @@ func NewInstancesCmd() *cobra.Command {
 
 // internalInstancesModule is a default instances module.
 func internalInstancesModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
 
 	err := list.ListInstances(cmdCtx, cliOpts)
 

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -26,6 +26,10 @@ func NewLogrotateCmd() *cobra.Command {
 
 // internalLogrotateModule is a default logrotate module.
 func internalLogrotateModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -77,6 +77,10 @@ The supported types are: tgz, deb, rpm`,
 
 // internalPackModule is a default pack module.
 func internalPackModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	err := pack.FillCtx(cmdCtx, packCtx, args)
 	if err != nil {
 		return err

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -37,6 +37,10 @@ func NewRestartCmd() *cobra.Command {
 
 // internalRestartModule is a default restart module.
 func internalRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	if !autoYes {
 		instancesToConfirm := ""
 		if len(args) == 0 {

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -97,6 +97,10 @@ is after '--', so passed to script.lua as is.
 
 // internalRunModule is a default run module.
 func internalRunModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	runOpts := newRunOpts(*cmdCtx)
 	scriptPath := ""
 	startIndex := 0

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -39,6 +39,10 @@ func NewStartCmd() *cobra.Command {
 
 // internalStartModule is a default start module.
 func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -26,6 +26,10 @@ func NewStatusCmd() *cobra.Command {
 
 // internalStatusModule is a default status module.
 func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {
 		return err

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -26,6 +26,10 @@ func NewStopCmd() *cobra.Command {
 
 // internalStopModule is a default stop module.
 func internalStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	var runningCtx running.RunningCtx
 	var err error
 	if err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args); err != nil {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -40,6 +40,10 @@ func NewUninstallCmd() *cobra.Command {
 
 // InternalUninstallModule is a default uninstall module.
 func InternalUninstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if !isConfigExist(cmdCtx) {
+		return errNoConfig
+	}
+
 	err := uninstall.UninstallProgram(args[0], cliOpts.App.BinDir,
 		cliOpts.App.IncludeDir+"/include", cmdCtx)
 	return err

--- a/test/integration/check/test_check.py
+++ b/test/integration/check/test_check.py
@@ -5,10 +5,10 @@ import shutil
 from utils import run_command_and_get_output
 
 
-def test_check_too_many_args(tt_cmd, tmpdir):
+def test_check_too_many_args(tt_cmd, tmpdir_with_cfg):
     # Testing with more than one specified files.
     cmd = [tt_cmd, "check", "file1", "file2"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmpdir_with_cfg)
     assert rc == 1
     assert re.search(r"currently, you can specify only one instance at a time", output)
 

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -228,14 +228,23 @@ def test_launch_local_tarantool_missing_in_bin_dir(tt_cmd, tmpdir):
 
     os.mkdir(os.path.join(tmpdir, "binaries"))
 
-    commands = [
+    commands_intmp = [
         [tt_cmd, "run", "--version"],
+    ]
+
+    commands_external = [
         [tt_cmd, "-L", tmpdir, "run", "--version"],
         [tt_cmd, "--cfg", config_path, "run", "--version"]
     ]
 
+    for cmd in commands_intmp:
+        rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+        # Missing binaries is not a error. Default Tarantool is used.
+        assert rc == 0
+        assert "Tarantool" in output
+
     with tempfile.TemporaryDirectory() as tmp_working_dir:
-        for cmd in commands:
+        for cmd in commands_external:
             rc, output = run_command_and_get_output(cmd, cwd=tmp_working_dir)
             # Missing binaries is not a error. Default Tarantool is used.
             assert rc == 0

--- a/test/integration/instances/test_instances.py
+++ b/test/integration/instances/test_instances.py
@@ -14,6 +14,10 @@ def test_instances_enabled_apps(tt_cmd):
         test_app_path = os.path.join(tmpdir, "multi_app")
         shutil.copytree(test_app_path_src, test_app_path)
 
+        config_path = os.path.join(test_app_path, "tt.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump({"tt": {"app": {"instances_enabled": "."}}}, f)
+
         # List all instances.
         start_cmd = [tt_cmd, "instances"]
         instance_process = subprocess.Popen(
@@ -34,6 +38,10 @@ def test_instances_enabled_apps(tt_cmd):
 def test_instances_no_apps(tt_cmd):
     with tempfile.TemporaryDirectory() as tmpdir:
         test_app_path = os.path.join(tmpdir)
+
+        config_path = os.path.join(test_app_path, "tt.yaml")
+        with open(config_path, "w") as f:
+            yaml.dump({"tt": {"app": {"instances_enabled": "."}}}, f)
 
         # List all instances.
         start_cmd = [tt_cmd, "instances"]

--- a/test/integration/run/test_run.py
+++ b/test/integration/run/test_run.py
@@ -4,16 +4,16 @@ import shutil
 import subprocess
 
 
-def test_run_base_functionality(tt_cmd, tmpdir):
+def test_run_base_functionality(tt_cmd, tmpdir_with_cfg):
     # Copy the test application to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmpdir_with_cfg)
 
     # Run an instance.
     start_cmd = [tt_cmd, "run", "test_app.lua"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -22,12 +22,12 @@ def test_run_base_functionality(tt_cmd, tmpdir):
     assert re.search(r"Instance running!", run_output)
 
 
-def test_running_flag_version(tt_cmd, tmpdir):
+def test_running_flag_version(tt_cmd, tmpdir_with_cfg):
     # Run an instance.
     start_cmd = [tt_cmd, "run", "-v"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -36,12 +36,12 @@ def test_running_flag_version(tt_cmd, tmpdir):
     assert re.search(r"Tarantool", run_output)
 
 
-def test_running_flag_eval(tt_cmd, tmpdir):
+def test_running_flag_eval(tt_cmd, tmpdir_with_cfg):
     # Run an instance.
     start_cmd = [tt_cmd, "run", "-e", "print('123')"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -50,16 +50,16 @@ def test_running_flag_eval(tt_cmd, tmpdir):
     assert re.search(r"123", run_output)
 
 
-def test_running_arg(tt_cmd, tmpdir):
+def test_running_arg(tt_cmd, tmpdir_with_cfg):
     # Copy the test application to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app_arg.lua")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmpdir_with_cfg)
 
     # Run an instance.
     start_cmd = [tt_cmd, "run", "test_app_arg.lua", "123"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -68,12 +68,12 @@ def test_running_arg(tt_cmd, tmpdir):
     assert re.search(r"123", run_output)
 
 
-def test_running_missing_script(tt_cmd, tmpdir):
+def test_running_missing_script(tt_cmd, tmpdir_with_cfg):
     # Run an instance.
     start_cmd = [tt_cmd, "run", "test_foo_bar.lua", "123"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -82,12 +82,12 @@ def test_running_missing_script(tt_cmd, tmpdir):
     assert re.search(r"was some problem locating script", run_output)
 
 
-def test_running_multi_instance(tt_cmd, tmpdir):
+def test_running_multi_instance(tt_cmd, tmpdir_with_cfg):
     # Run an instance.
     start_cmd = [tt_cmd, "run", "foo/bar/", "123"]
     instance_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -96,10 +96,10 @@ def test_running_multi_instance(tt_cmd, tmpdir):
     assert re.search(r"Can't open script foo/bar/: No such file or directory", run_output)
 
 
-def test_run_from_input(tt_cmd, tmpdir):
+def test_run_from_input(tt_cmd, tmpdir_with_cfg):
     process = subprocess.Popen(f"echo 'print(42)'| {tt_cmd} run -",
                                shell=True,
-                               cwd=tmpdir,
+                               cwd=tmpdir_with_cfg,
                                stderr=subprocess.STDOUT,
                                stdout=subprocess.PIPE,
                                text=True
@@ -109,7 +109,7 @@ def test_run_from_input(tt_cmd, tmpdir):
 
     process = subprocess.Popen(f"echo 'print(...) print(unpack(arg))' | {tt_cmd} run -- - a b c",
                                shell=True,
-                               cwd=tmpdir,
+                               cwd=tmpdir_with_cfg,
                                stderr=subprocess.STDOUT,
                                stdout=subprocess.PIPE,
                                text=True
@@ -120,7 +120,7 @@ def test_run_from_input(tt_cmd, tmpdir):
 
     process = subprocess.Popen(f"echo 'print(...) print(unpack(arg))' | {tt_cmd} run - a b c",
                                shell=True,
-                               cwd=tmpdir,
+                               cwd=tmpdir_with_cfg,
                                stderr=subprocess.STDOUT,
                                stdout=subprocess.PIPE,
                                text=True

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -103,13 +103,13 @@ def test_uninstall_missing(tt_cmd, tmpdir):
     assert re.search(r"there is no", uninstall_output)
 
 
-def test_uninstall_foreign_program(tt_cmd, tmpdir):
+def test_uninstall_foreign_program(tt_cmd, tmpdir_with_cfg):
     # Remove bash.
     for prog in ["bash", "bash=123"]:
         uninstall_cmd = [tt_cmd, "uninstall", prog]
         uninstall_process = subprocess.Popen(
             uninstall_cmd,
-            cwd=tmpdir,
+            cwd=tmpdir_with_cfg,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             text=True


### PR DESCRIPTION
The check has been added for:

- binaries
- build
- check
- clean
- create
- install
- instances
- logrotate
- pack
- restart
- run
- start
- status
- stop
- uninstall

Closes #371

The patch does not affect:

-  cartridge
-  cat
-  cfg
-  completion
-  connect
-  coredump
-  daemon
-  help
-  init
-  play
-  rocks 
-  search
-  version

I'm not sure about the command list. I suggest to add commands in a review.