### PR TITLE
ee: add ee integration tests

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Integration tests
         run: mage integrationfull
 
-  full-ci-ee:
+  full-ci-sdk:
     # Tests will run only when the pull request is labeled with `full-ci`. To
     # avoid security problems, the label must be reset manually for every run.
     #
@@ -144,5 +144,125 @@ jobs:
       - name: Run unit tests
         run: mage unitfull
 
-      - name: Run integration tests
+      - name: Integration tests
         run: mage integrationfull
+
+  # ee suffix means that the job runs ee integration tests.
+  full-ci-macOS-ee:
+    if: |
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'full-ci') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'synchronize' &&
+        contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew install --overwrite go mage
+          brew install python3
+          pip3 install pytest tarantool requests psutil pyyaml netifaces
+
+      - name: Build tt
+        env:
+          TT_CLI_BUILD_SSL: 'static'
+        run: mage build
+
+      - name: Integration tests
+        env:
+          TT_EE_USERNAME: '${{ secrets.TT_EE_USERNAME }}'
+          TT_EE_PASSWORD: '${{ secrets.TT_EE_PASSWORD }}'
+        run: mage integrationee
+
+  # sdk suffix means the tests will be run on tarantool from EE SDK package.
+  # ee suffix means that the job runs EE integration tests.
+  full-ci-sdk-ee:
+    # Tests will run only when the pull request is labeled with `full-ci`. To
+    # avoid security problems, the label must be reset manually for every run.
+    #
+    # We need to use `pull_request_target` because it has access to base
+    # repository secrets unlike `pull_request`.
+    if: (github.event_name == 'push') ||
+      (github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'full-ci')
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        sdk-version: [ "2.10.2-0-gf4228cb7d-r508-linux-x86_64" ]
+      fail-fast: false
+    steps:
+      # `ref` as merge request is needed for pull_request_target because this
+      # target runs in the context of the base commit of the pull request.
+      - uses: actions/checkout@master
+        if: github.event_name == 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: actions/checkout@master
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Prepare EE env
+        uses: ./.github/actions/prepare-ee-test-env
+        with:
+          sdk-version: '${{ matrix.sdk-version }}'
+          sdk-download-token: '${{ secrets.SDK_DOWNLOAD_TOKEN }}'
+
+      - name: Install dependencies
+        run: |
+          pip3 install pytest tarantool requests psutil pyyaml netifaces
+
+      - name: Integration tests
+        env:
+          TT_EE_USERNAME: '${{ secrets.TT_EE_USERNAME }}'
+          TT_EE_PASSWORD: '${{ secrets.TT_EE_PASSWORD }}'
+        run: mage integrationee
+
+  # ce suffix means that the job will be run on CE tarantool.
+  # ee suffix means that the job runs EE integration tests.
+  full-ci-ce-ee:
+    if: |
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'full-ci') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'synchronize' &&
+        contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        tarantool-version: ["1.10", "2.10"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Prepare CE env
+        uses: ./.github/actions/prepare-ce-test-env
+        with:
+          tarantool-version: '${{ matrix.tarantool-version }}'
+
+      - name: Install dependencies
+        run: |
+          pip3 install pytest tarantool requests psutil pyyaml netifaces
+
+      - name: Integration tests
+        env:
+          TT_EE_USERNAME: '${{ secrets.TT_EE_USERNAME }}'
+          TT_EE_PASSWORD: '${{ secrets.TT_EE_PASSWORD }}'
+        run: mage integrationee

--- a/magefile.go
+++ b/magefile.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	buildTypeEnv = "TT_CLI_BUILD_SSL"
+	buildTypeEnv  = "TT_CLI_BUILD_SSL"
 	goPackageName = "github.com/tarantool/tt/cli"
 
 	asmflags = "all=-trimpath=${PWD}"
@@ -270,14 +270,23 @@ func UnitFull() error {
 func Integration() error {
 	fmt.Println("Running integration tests...")
 
-	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow", "test/integration")
+	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow", "-m", "not slow_ee",
+		"test/integration")
 }
 
 // Run full set of integration tests.
 func IntegrationFull() error {
 	fmt.Println("Running all integration tests...")
 
-	return sh.RunV(pythonExecutableName, "-m", "pytest", "test/integration")
+	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee",
+		"test/integration")
+}
+
+// Run set of ee integration tests.
+func IntegrationEE() error {
+	fmt.Println("Running all EE integration tests...")
+
+	return sh.RunV(pythonExecutableName, "-m", "pytest", "test/integration/ee")
 }
 
 // Run codespell checks.

--- a/test/integration/ee/test_ee_install.py
+++ b/test/integration/ee/test_ee_install.py
@@ -1,0 +1,37 @@
+import os
+import re
+
+import pytest
+
+from utils import run_command_and_get_output
+
+# ##### #
+# Tests #
+# ##### #
+
+
+@pytest.mark.slow_ee
+def test_install_ee(tt_cmd, tmpdir):
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "init"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "search", "tarantool-ee"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+
+    version = output.split('\n')[1]
+    assert re.search(r"(\d+.\d+.\d+|<unknown>)",
+                     version)
+
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "install", "tarantool-ee="+version],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+
+    assert rc == 0
+    assert re.search("Installing tarantool-ee="+version, output)
+    assert re.search("Downloading tarantool-ee...", output)
+    assert re.search("Done.", output)
+    assert os.path.exists(os.path.join(tmpdir, 'bin', 'tarantool'))
+    assert os.path.exists(os.path.join(tmpdir, 'include', 'include', 'tarantool'))

--- a/test/integration/ee/test_ee_search.py
+++ b/test/integration/ee/test_ee_search.py
@@ -1,0 +1,24 @@
+import os
+import re
+
+import pytest
+
+from utils import run_command_and_get_output
+
+# ##### #
+# Tests #
+# ##### #
+
+
+@pytest.mark.slow_ee
+def test_search_ee(tt_cmd, tmpdir):
+    cmds = [
+        [tt_cmd, "search", "tarantool-ee"],
+        [tt_cmd, "search", "tarantool-ee", "--dev"],
+    ]
+    for cmd in cmds:
+        rc, output = run_command_and_get_output(
+            cmd, cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        assert re.search(r"(\d+.\d+.\d+)",
+                         output)
+        assert rc == 0

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    slow_ee: marks ee tests as slow (deselect with '-m "not slow_ee"')


### PR DESCRIPTION
With this patch:
- added integration tests for search/install tarantool-ee
- added a new pytest tag for ee tests
- included ee tests in full-ci target

Closes #357