### PR TITLE
tt: enable shell completion scripts after installation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,13 @@ jobs:
           ./Configure --prefix=${GITHUB_WORKSPACE}/openssl no-shared
           make && make install
 
+      # These scripts will be picked up while building packages with goreleaser.
+      - name: Generate ZSH and Bash completion scripts
+        run: |
+          mage build
+          ./tt completion bash > tt-completion.bash
+          ./tt completion zsh > tt-completion.zsh
+
       - name: Setup GoReleaser
         run: |
           curl -O -L https://github.com/goreleaser/goreleaser/releases/download/v1.12.3/goreleaser_1.12.3_amd64.deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,16 @@ nfpms:
       - src: "tt.yaml.default"
         dst: "/etc/tarantool/tt.yaml"
         type: config
+      # ZSH and Bash autocompletion scripts get placed in appropriate directories
+      # and get activated automatically with restarting corresponding shell after
+      # the package installation.
+      # Sources:
+      # https://github.com/scop/bash-completion/blob/master/README.md#faq
+      # https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#intro
+      - src: "tt-completion.bash"
+        dst: "/usr/share/bash-completion/completions/tt"
+      - src: "tt-completion.zsh"
+        dst: "/usr/share/zsh/vendor-completions/_tt"
 
     overrides:
       rpm:


### PR DESCRIPTION
This patch adds a step for autocompletion scripts generating in CI before package publishing jobs. 
Those scripts get packed into tt packages for further distribution.

Closes #399