### PR TITLE
install: make sub-commands from program names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - ``tt cartridge`` command takes into account run dir path from the `tt` environment. So most
   of the `tt cartridge` sub-commands are able to work without specifying `--run-dir` option.
 
+### Changed
+  - ``tt install`` command line interface is updated. Program names have become sub-commands with
+  their own options.
+
 ## [1.0.1] - 2023-04-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of the `tt cartridge` sub-commands are able to work without specifying `--run-dir` option.
 
 ### Changed
-  - ``tt install`` command line interface is updated. Program names have become sub-commands with
-  their own options.
+  - ``tt install/uninstall`` command line interface is updated. Program names have become
+  sub-commands with their own options.
 
 ## [1.0.1] - 2023-04-04
 

--- a/test/integration/ee/test_ee_install.py
+++ b/test/integration/ee/test_ee_install.py
@@ -26,7 +26,7 @@ def test_install_ee(tt_cmd, tmpdir):
                      version)
 
     rc, output = run_command_and_get_output(
-        [tt_cmd, "install", "tarantool-ee="+version],
+        [tt_cmd, "install", "tarantool-ee", version],
         cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
 
     assert rc == 0

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -19,7 +19,7 @@ def test_install_tt(tt_cmd, tmpdir):
         f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
 
     # Install latest tt.
-    install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt=0.1.0"]
+    install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt"]
     instance_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir,
@@ -41,7 +41,41 @@ def test_install_tt(tt_cmd, tmpdir):
         text=True
     )
     start_output = installed_program_process.stdout.readline()
-    assert re.search(r"commit: ccd9c0c", start_output)
+    assert re.search(r"Tarantool CLI version \d+.\d+.\d+", start_output)
+
+
+@pytest.mark.slow
+def test_install_tt_specific_version(tt_cmd, tmpdir):
+
+    configPath = os.path.join(tmpdir, config_name)
+    # Create test config
+    with open(configPath, 'w') as f:
+        f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
+
+    # Install latest tt.
+    install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt", "1.0.0"]
+    instance_process = subprocess.Popen(
+        install_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+
+    # Check that the process shutdowned correctly.
+    instance_process_rc = instance_process.wait()
+    assert instance_process_rc == 0
+
+    installed_cmd = [tmpdir + "/bin/tt", "version"]
+    installed_program_process = subprocess.Popen(
+        installed_cmd,
+        cwd=tmpdir + "/bin",
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = installed_program_process.stdout.readline()
+    assert re.search(r"Tarantool CLI version 1.0.0", start_output)
 
 
 @pytest.mark.slow
@@ -54,7 +88,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
     tmpdir_without_config = tempfile.mkdtemp()
 
     # Install latest tarantool.
-    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tarantool=2.10.4", "-f"]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "-f", "tarantool", "2.10.4"]
     instance_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,
@@ -78,6 +112,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
     run_output = installed_program_process.stdout.readline()
     assert re.search(r"Tarantool", run_output)
     assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
+    assert os.path.exists(os.path.join(tmpdir, "bin", "tarantool_2.10.4"))
 
 
 @pytest.mark.slow
@@ -93,7 +128,7 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     tmpdir_without_config = tempfile.mkdtemp()
 
     # Install latest tarantool.
-    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tarantool", "-f", "--use-docker"]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "-f", "tarantool", "--use-docker"]
     tt_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,
@@ -125,28 +160,3 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     assert out == "GLIBC_2.27"
 
     assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
-
-
-def test_install_tt_in_docker(tt_cmd, tmpdir):
-    if platform.system() == "Darwin":
-        pytest.skip("/set platform is unsupported")
-
-    config_path = os.path.join(tmpdir, config_name)
-    with open(config_path, "w") as f:
-        yaml.dump({"tt": {"app": {"bin_dir": "", "inc_dir": "./my_inc"}}}, f)
-
-    tmpdir_without_config = tempfile.mkdtemp()
-
-    install_cmd = [tt_cmd, "--cfg", config_path, "install", "tt", "--use-docker"]
-    tt_process = subprocess.Popen(
-        install_cmd,
-        cwd=tmpdir_without_config,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True
-    )
-
-    tt_process_rc = tt_process.wait()
-    assert tt_process_rc == 1
-    output = tt_process.stdout.readline()
-    assert re.search(r"--use-docker can be used only for 'tarantool' program", output)

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -11,7 +11,7 @@ def test_uninstall_tt(tt_cmd, tmpdir):
     with open(configPath, 'w') as f:
         f.write('tt:\n  app:\n    bin_dir:\n    inc_dir:\n')
 
-    for prog in ["tarantool", "tarantool=master"]:
+    for prog in [["tarantool"], ["tarantool", "master"]]:
         # Do not test uninstall through installing tt. Because installed tt will be invoked by
         # current tt. As a result the test will run for the installed tt and not the current.
         # Creating fake tarantool instead.
@@ -24,7 +24,7 @@ def test_uninstall_tt(tt_cmd, tmpdir):
         os.makedirs(os.path.join(tmpdir, "include", "include", "tarantool_master"))
         os.symlink("./tarantool_master", os.path.join(tmpdir, "include", "include", "tarantool"))
 
-        uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", prog]
+        uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", *prog]
         uninstall_process = subprocess.Popen(
             uninstall_cmd,
             cwd=tmpdir,
@@ -88,7 +88,7 @@ def test_uninstall_missing(tt_cmd, tmpdir):
     os.mkdir(os.path.join(tmpdir, "bin"))
     os.mkdir(os.path.join(tmpdir, "include"))
     # Remove not installed program.
-    uninstall_cmd = [tt_cmd, "uninstall", "tt=1.2.3"]
+    uninstall_cmd = [tt_cmd, "uninstall", "tt", "1.2.3"]
     uninstall_process = subprocess.Popen(
         uninstall_cmd,
         cwd=tmpdir,
@@ -105,8 +105,8 @@ def test_uninstall_missing(tt_cmd, tmpdir):
 
 def test_uninstall_foreign_program(tt_cmd, tmpdir_with_cfg):
     # Remove bash.
-    for prog in ["bash", "bash=123"]:
-        uninstall_cmd = [tt_cmd, "uninstall", prog]
+    for prog in [["bash"], ["bash", "123"]]:
+        uninstall_cmd = [tt_cmd, "uninstall", *prog]
         uninstall_process = subprocess.Popen(
             uninstall_cmd,
             cwd=tmpdir_with_cfg,
@@ -116,6 +116,4 @@ def test_uninstall_foreign_program(tt_cmd, tmpdir_with_cfg):
         )
         uninstall_process.wait()
         uninstall_output = uninstall_process.stdout.readline()
-        assert re.search(r"Removing binary...", uninstall_output)
-        uninstall_output = uninstall_process.stdout.readline()
-        assert re.search(r"unknown program:", uninstall_output)
+        assert re.search(r"Uninstalls a program", uninstall_output)


### PR DESCRIPTION
tt install uses first cli arguments as a program name to install. This leads to difficulties with cli options separation by program name. Transform program names to sub-commands of tt install to make CLI more convenient.