### PR TITLE
install: check include directory permission before it's mutation

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"path/filepath"
-
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/install"
@@ -107,7 +105,7 @@ func internalInstallModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	err = install.Install(cliOpts.App.BinDir, filepath.Join(cliOpts.App.IncludeDir, "include"),
+	err = install.Install(cliOpts.App.BinDir, cliOpts.App.IncludeDir,
 		installCtx, cliOpts.Repo.Install, cliOpts)
 	return err
 }

--- a/cli/install/install_test.go
+++ b/cli/install/install_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,44 @@ func Test_dirsAreWriteable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, dirsIsWriteable(tt.args.dir),
 				"dirIsWriteable(%v)", tt.args.dir)
+		})
+	}
+}
+
+func Test_subDirIsWritable(t *testing.T) {
+	tmpDirNonWriteableForAll := t.TempDir()
+	// dr-xr-xr-x mode.
+	permissions := 0555
+	require.NoError(t, os.Chmod(tmpDirNonWriteableForAll, os.FileMode(permissions)))
+
+	tmpDirNonWriteableExceptOwner := t.TempDir()
+	// drwxr-xr-x mode.
+	permissions = 0755
+	require.NoError(t, os.Chmod(tmpDirNonWriteableExceptOwner, os.FileMode(permissions)))
+
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Subdirectory is writeable",
+			args: args{dir: filepath.Join(tmpDirNonWriteableExceptOwner, "test", "test")},
+			want: true,
+		},
+		{
+			name: "Subdirectory is not writeable",
+			args: args{dir: filepath.Join(tmpDirNonWriteableForAll, "test", "test")},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, subDirIsWritable(tt.args.dir), "subDirIsWritable(%v)",
+				tt.args.dir)
 		})
 	}
 }


### PR DESCRIPTION
This patch fixes the behavior by permissions checking, now we ignore the directory check if it doesn't exist.

Follow up #413