### PR TITLE
install: support of tarantool non-static build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ``--dynamic`` option for `tt install tarantool` command to build non-static tarantool executable.
+
 ## [1.0.2] - 2023-04-21
 
 ### Fixed

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -42,6 +42,8 @@ func newInstallTarantoolCmd() *cobra.Command {
 
 	tntCmd.Flags().BoolVarP(&installCtx.BuildInDocker, "use-docker", "", false,
 		"build tarantool in Ubuntu 18.04 docker container")
+	tntCmd.Flags().BoolVarP(&installCtx.Dynamic, "dynamic", "", false,
+		"use dynamic linking for building tarantool")
 
 	return tntCmd
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -68,7 +68,7 @@ def tmpdir_with_tarantool(tt_cmd, request):
     tt_process.wait()
     assert tt_process.returncode == 0
 
-    init_cmd = [tt_cmd, "install", "tarantool"]
+    init_cmd = [tt_cmd, "install", "tarantool", "--dynamic"]
     tt_process = subprocess.Popen(
         init_cmd,
         cwd=tmpdir,


### PR DESCRIPTION
Added new option --dynamic for tt install tarantool command. This options enables dynamic linking for building tarantool executable.