### PR TITLE
connect: fix terminal after executing os.exit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - ``--dynamic`` option for `tt install tarantool` command to build non-static tarantool executable.
 
+### Fixed
+
+- ``tt connect`` command does not break a console after executing `os.exit()` command anymore.
+
 ## [1.0.2] - 2023-04-21
 
 ### Fixed


### PR DESCRIPTION
Fixed terminal brake after os.exit() in tt connect session. Have done it by adding workaround for the bug(c-bata/go-prompt#228) in case of executing os.exit().

Proof:

Terminal 1:
```
tarantool> better0fdead@better0fdead:~/.local/share/Trash$ tarantool
Tarantool 2.11.0-entrypoint-635-g5a38c5c90
type 'help' for interactive help
tarantool> box.cfg{listen=3305}
2023-04-27 12:44:48.029 [34240] main/103/interactive I> Tarantool 2.11.0-entrypoint-635-g5a38c5c90
2023-04-27 12:44:48.029 [34240] main/103/interactive I> log level 5
2023-04-27 12:44:48.030 [34240] main/103/interactive I> wal/engine cleanup is paused
2023-04-27 12:44:48.030 [34240] main/103/interactive I> mapping 268435456 bytes for memtx tuple arena...
2023-04-27 12:44:48.030 [34240] main/103/interactive I> Actual slab_alloc_factor calculated on the basis of desired slab_alloc_factor = 1.044274
2023-04-27 12:44:48.030 [34240] main/103/interactive I> mapping 134217728 bytes for vinyl tuple arena...
2023-04-27 12:44:48.034 [34240] main/103/interactive I> Recovering snapshot with schema version 2.11.0
2023-04-27 12:44:48.043 [34240] main/103/interactive I> update replication_synchro_quorum = 1
2023-04-27 12:44:48.043 [34240] main/103/interactive I> instance uuid 7a61e056-9b15-4c30-b6a1-f0110ea030aa
2023-04-27 12:44:48.044 [34240] main/103/interactive I> instance vclock {1: 5}
2023-04-27 12:44:48.044 [34240] main/103/interactive I> tx_binary: bound to 0.0.0.0:3305
2023-04-27 12:44:48.044 [34240] main/103/interactive I> recovery start
2023-04-27 12:44:48.044 [34240] main/103/interactive I> recovering from `./00000000000000000000.snap'
2023-04-27 12:44:48.057 [34240] main/103/interactive I> cluster uuid f0bd4cd7-d6df-42d0-8a9c-930cd9727f65
2023-04-27 12:44:48.065 [34240] main/103/interactive I> assigned id 1 to replica 7a61e056-9b15-4c30-b6a1-f0110ea030aa
2023-04-27 12:44:48.065 [34240] main/103/interactive I> update replication_synchro_quorum = 1
2023-04-27 12:44:48.065 [34240] main/103/interactive I> recover from `./00000000000000000000.xlog'
2023-04-27 12:44:48.065 [34240] main/103/interactive I> done `./00000000000000000000.xlog'
2023-04-27 12:44:48.065 [34240] main/103/interactive I> recover from `./00000000000000000005.xlog'
2023-04-27 12:44:48.065 [34240] main/103/interactive I> done `./00000000000000000005.xlog'
2023-04-27 12:44:48.066 [34240] main/103/interactive I> ready to accept requests
2023-04-27 12:44:48.066 [34240] main/103/interactive I> leaving orphan mode
2023-04-27 12:44:48.066 [34240] main/104/gc I> wal/engine cleanup is resumed
2023-04-27 12:44:48.066 [34240] main/103/interactive I> set 'listen' configuration option to 3305
2023-04-27 12:44:48.066 [34240] main/103/interactive I> set 'log_level' configuration option to 5
2023-04-27 12:44:48.066 [34240] main/103/interactive I> set 'log_format' configuration option to "plain"
---
...

2023-04-27 12:44:48.066 [34240] main/105/checkpoint_daemon I> scheduled next checkpoint for Thu Apr 27 14:20:21 2023
tarantool> box.schema.user.create("user", { password = "password", if_not_exists = true })
---
...

tarantool> box.schema.user.grant("user", "super", nil, nil, { if_not_exists = true })
---
...

2023-04-27 12:45:10.627 [34240] main/114/iproto.shutdown I> tx_binary: stopped
2023-04-27 12:45:13.619 [34240] main/102/on_shutdown fiber.c:642 E> TimedOut: timed out
2023-04-27 12:45:13.619 [34240] main/102/on_shutdown main.cc:157 E> on_shutdown triggers failed
2023-04-27 12:45:13.620 [34240] main/102/on_shutdown trigger.cc:251 E> TimedOut: timed out

```

Terminal 2:

```
better0fdead@better0fdead:~/tt$ ./tt connect 127.0.0.1:3305 -u user -p password
   • Connecting to the instance...
   • Connected to 127.0.0.1:3305

127.0.0.1:3305> os.exit()
   ⨯ Connection was closed. Probably instance process isn't running anymore
better0fdead@better0fdead:~/tt$ ps
    PID TTY          TIME CMD
  33829 pts/1    00:00:00 bash
  34276 pts/1    00:00:00 ps

```

Closes #425