### PR TITLE
install: get latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- ``tt install tarantool`` without version specification now installs the latest release.
+
 ### Added
 
 - ``--dynamic`` option for `tt install tarantool` command to build non-static tarantool executable.

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -782,6 +782,19 @@ func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx Inst
 	return nil
 }
 
+func getLatestRelease(versions []version.Version) string {
+	latestRelease := ""
+
+	for n := len(versions) - 1; n >= 0; n-- {
+		if versions[n].Release.Type == version.TypeRelease {
+			latestRelease = versions[n].Str
+			break
+		}
+	}
+
+	return latestRelease
+}
+
 // installTarantool installs selected version of tarantool.
 func installTarantool(binDir string, incDir string, installCtx InstallCtx,
 	distfiles string) error {
@@ -801,12 +814,12 @@ func installTarantool(binDir string, incDir string, installCtx InstallCtx,
 	// Get latest version if it was not specified.
 	tarVersion := installCtx.version
 	if tarVersion == "" {
-		log.Infof("Getting latest tarantool version..")
-		if len(versions) == 0 {
+		log.Infof("Getting latest tarantool version...")
+
+		tarVersion = getLatestRelease(versions)
+		if tarVersion == "" {
 			return fmt.Errorf("no version found")
 		}
-
-		tarVersion = versions[len(versions)-1].Str
 	}
 
 	// Check that the version exists.

--- a/cli/install/install_test.go
+++ b/cli/install/install_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/version"
 )
 
 func Test_dirsAreWriteable(t *testing.T) {
@@ -83,4 +84,30 @@ func Test_subDirIsWritable(t *testing.T) {
 				tt.args.dir)
 		})
 	}
+}
+
+func Test_getLatestRelease(t *testing.T) {
+	getFirst := func(verStr string) version.Version {
+		ver, _ := version.Parse(verStr)
+		return ver
+	}
+
+	versions := []version.Version{
+		getFirst("2.10.6"),
+		getFirst("2.10.7-entrypoint"),
+		getFirst("2.11.0-entrypoint"),
+		getFirst("2.11.0-rc1"),
+		getFirst("2.11.0-rc2"),
+		getFirst("3.0.0-entrypoint"),
+	}
+
+	latestRelease := getLatestRelease(versions)
+	require.Equal(t, "2.10.6", latestRelease)
+
+	versions = append(versions, getFirst("3.0.0"))
+	latestRelease = getLatestRelease(versions)
+	require.Equal(t, "3.0.0", latestRelease)
+
+	latestRelease = getLatestRelease(versions[1:6])
+	require.Equal(t, "", latestRelease)
 }


### PR DESCRIPTION
`tt install tarantool` without version specification now installs the latest release.