### PR TITLE
ci: switch to own fork of action-setup-docker

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -40,7 +40,7 @@ jobs:
           tarantool-version: '${{ matrix.tarantool-version }}'
 
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: better0fdead/actions-setup-docker@master
 
       - name: Static code check
         uses: ./.github/actions/static-code-check
@@ -93,7 +93,7 @@ jobs:
           sdk-download-token: '${{ secrets.SDK_DOWNLOAD_TOKEN }}'
 
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: better0fdead/actions-setup-docker@master
 
       - name: Static code check
         uses: ./.github/actions/static-code-check
@@ -131,7 +131,7 @@ jobs:
           pip3 install pytest tarantool requests psutil pyyaml netifaces
 
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: better0fdead/actions-setup-docker@master
 
       - name: Build tt
         env:


### PR DESCRIPTION
Switched to own [fork](https://github.com/better0fdead/actions-setup-docker) of action because it contains increase of timeout for docker to start. This fix issues when docker don't start in time on github runners.