### PR TITLE
status: make the output of the command as a table

### DIFF
--- a/cli/cmd/daemon.go
+++ b/cli/cmd/daemon.go
@@ -138,7 +138,7 @@ func internalDaemonStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error 
 	}
 
 	daemonCtx := daemon.NewDaemonCtx(opts)
-	log.Info(process_utils.ProcessStatus(daemonCtx.PIDFile).Text)
+	log.Info(process_utils.ProcessStatus(daemonCtx.PIDFile).String())
 
 	return nil
 }

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
+	"github.com/tarantool/tt/cli/status"
 )
 
 // NewStatusCmd creates status command.
@@ -35,11 +35,6 @@ func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	for _, run := range runningCtx.Instances {
-		fullInstanceName := running.GetAppInstanceName(run)
-		procStatus := running.Status(&run)
-		log.Infof("%s: %s", procStatus.ColorSprint(fullInstanceName), procStatus.Text)
-	}
-
-	return nil
+	err := status.Status(runningCtx)
+	return err
 }

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -23,7 +23,8 @@ const defaultDirPerms = 0770
 type ProcessState struct {
 	Code        int
 	ColorSprint func(a ...interface{}) string
-	Text        string
+	Status      string
+	PID         int
 }
 
 const (
@@ -34,16 +35,26 @@ const (
 
 var (
 	ProcStateRunning = ProcessState{
-		ProcessRunningCode,
-		color.New(color.FgGreen).SprintFunc(),
-		"RUNNING. PID: %v."}
-	ProcStateStopped = ProcessState{ProcessStoppedCode,
-		color.New(color.FgYellow).SprintFunc(),
-		"NOT RUNNING"}
-	ProcStateDead = ProcessState{ProcessDeadCode,
-		color.New(color.FgRed).SprintFunc(),
-		"ERROR. The process is dead"}
+		Code:        ProcessRunningCode,
+		ColorSprint: color.New(color.FgGreen).SprintFunc(),
+		Status:      "RUNNING"}
+	ProcStateStopped = ProcessState{
+		Code:        ProcessStoppedCode,
+		ColorSprint: color.New(color.FgYellow).SprintFunc(),
+		Status:      "NOT RUNNING"}
+	ProcStateDead = ProcessState{
+		Code:        ProcessDeadCode,
+		ColorSprint: color.New(color.FgRed).SprintFunc(),
+		Status:      "ERROR. The process is dead"}
 )
+
+// String makes a string from ProcessState.
+func (procState ProcessState) String() string {
+	if procState.Code == ProcessRunningCode {
+		return fmt.Sprintf("%s. PID: %d.", procState.Status, procState.PID)
+	}
+	return procState.Status
+}
 
 // GetPIDFromFile returns PID from the PIDFile.
 func GetPIDFromFile(pidFileName string) (int, error) {
@@ -167,7 +178,7 @@ func ProcessStatus(pidFile string) ProcessState {
 	}
 
 	procState := ProcStateRunning
-	procState.Text = fmt.Sprintf(procState.Text, pid)
+	procState.PID = pid
 	return procState
 }
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -516,12 +516,12 @@ func Status(run *InstanceCtx) process_utils.ProcessState {
 func Logrotate(run *InstanceCtx) (string, error) {
 	pid, err := process_utils.GetPIDFromFile(run.PIDFile)
 	if err != nil {
-		return "", fmt.Errorf(instStateStopped.Text)
+		return "", fmt.Errorf(instStateStopped.String())
 	}
 
 	alive, err := process_utils.IsProcessAlive(pid)
 	if !alive {
-		return "", fmt.Errorf(instStateDead.Text)
+		return "", fmt.Errorf(instStateDead.String())
 	}
 
 	if err := syscall.Kill(pid, syscall.Signal(syscall.SIGHUP)); err != nil {

--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -1,0 +1,65 @@
+package status
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/fatih/color"
+	"github.com/tarantool/tt/cli/process_utils"
+	"github.com/tarantool/tt/cli/running"
+)
+
+const (
+	// colorBytesNumber is the number of bytes added to the colorized string.
+	colorBytesNumber = 9
+
+	// padding is the padding between two columns of the table.
+	padding = 5
+)
+
+var header = []string{"INSTANCE", "STATUS", "PID"}
+
+// Status writes the status as a table.
+func Status(runningCtx running.RunningCtx) error {
+	instColWidth := 0
+	sb := strings.Builder{}
+	tw := tabwriter.NewWriter(&sb, 0, 1, padding, ' ', 0)
+
+	fmt.Fprintln(tw, strings.Join(header, "\t"))
+	for _, run := range runningCtx.Instances {
+		fullInstanceName := running.GetAppInstanceName(run)
+		procStatus := running.Status(&run)
+		if len(fullInstanceName) > instColWidth {
+			instColWidth = len(fullInstanceName)
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t", fullInstanceName,
+			procStatus.ColorSprint(procStatus.Status))
+		if procStatus.Code == process_utils.ProcessRunningCode {
+			fmt.Fprintf(tw, "%d", procStatus.PID)
+		}
+		fmt.Fprintf(tw, "\n")
+	}
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	rawOutput := sb.String()
+	rawHeader, rest, _ := strings.Cut(rawOutput, "\n")
+
+	// Calculating the position of the `status` end in the header.
+	statusOffset := instColWidth + padding + len(header[1])
+	fmt.Print(rawHeader[:statusOffset])
+
+	var toSkip int
+	if len(runningCtx.Instances) > 0 && !color.NoColor {
+		// We need to skip the spaces that appear
+		// as a result of using color bytes, if any.
+		toSkip = colorBytesNumber
+	}
+	fmt.Println(rawHeader[statusOffset+toSkip:])
+	fmt.Print(rest)
+	return nil
+}

--- a/test/integration/daemon/test_daemon.py
+++ b/test/integration/daemon/test_daemon.py
@@ -214,7 +214,8 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
     body = {"command_name": "status", "params": ["test_app"]}
     response = requests.post(default_url, json=body)
     assert response.status_code == 200
-    assert re.search(r"RUNNING. PID: \d+.", response.json()["res"])
+    status_info = utils.extract_status(response.json()["res"])
+    assert status_info["test_app"]["STATUS"] == "RUNNING"
 
     body = {"command_name": "stop", "params": ["test_app"]}
     response = requests.post(default_url, json=body)
@@ -286,8 +287,8 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
     body = {"command_name": "status", "params": ["test_app"]}
     response = requests.post(url, json=body)
     assert response.status_code == 200
-    assert re.search(r"RUNNING. PID: \d+.", response.json()["res"])
-
+    status_info = utils.extract_status(response.json()["res"])
+    assert status_info["test_app"]["STATUS"] == "RUNNING"
     body = {"command_name": "stop", "params": ["test_app"]}
     response = requests.post(url, json=body)
     assert response.status_code == 200

--- a/test/utils.py
+++ b/test/utils.py
@@ -322,3 +322,20 @@ def find_port(port=8000):
             return find_port(port=port + 1)
         else:
             return port
+
+
+def extract_status(status_output):
+    result = {}
+    statuses = status_output.split("\n")
+    for i in range(1, len(statuses)-1):
+        summary = statuses[i]
+        fields = summary.split()
+        instance = fields[0]
+        info = {}
+        if fields[1] == "RUNNING":
+            info["STATUS"] = fields[1]
+            info["PID"] = int(fields[2])
+        else:
+            info["STATUS"] = " ".join(fields[1:])
+        result[instance] = info
+    return result


### PR DESCRIPTION
Made the output of the status command as a table.
Have done it using tabwriter from the standard library. Since tabwriter does not support ANSI escape codes, I need to remove extra spaces from the table header to use colored text in the second column of the table.

Closes #197