### PR TITLE
status: fix truncated column name

### DIFF
--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -22,7 +22,7 @@ var header = []string{"INSTANCE", "STATUS", "PID"}
 
 // Status writes the status as a table.
 func Status(runningCtx running.RunningCtx) error {
-	instColWidth := 0
+	instColWidth := len(header[0])
 	sb := strings.Builder{}
 	tw := tabwriter.NewWriter(&sb, 0, 1, padding, ' ', 0)
 


### PR DESCRIPTION
Fixed the following issue with short app names:
```
../../tt/tt status app2
INSTANCE     ST              PID
app2         NOT RUNNING 
```
After the fix:
```
$ ../../tt/tt status
INSTANCE            STATUS          PID
app1:s1-master      RUNNING         50733
app1:s1-replica     RUNNING         50734
app1:s2-master      RUNNING         50735
app1:s2-replica     RUNNING         50738
app1:stateboard     RUNNING         50749
app1:router         NOT RUNNING     
app2                NOT RUNNING     

$ ../../tt/tt status app2
INSTANCE     STATUS          PID
app2         NOT RUNNING
```