### PR TITLE
ci: change full-ci-macos

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -108,7 +108,57 @@ jobs:
       - name: Integration tests
         run: mage integrationfull
 
-  full-ci-macOS:
+  full-ci-macOS-no-docker:
+    if: |
+      (github.event_name == 'push') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'full-ci') ||
+      (github.event_name == 'pull_request' &&
+        github.event.action == 'synchronize' &&
+        contains(github.event.pull_request.labels.*.name, 'full-ci'))
+    runs-on: [self-hosted, macOS-12-self-hosted, x86_64, regular]
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          brew install --overwrite go mage wget
+          pip3 install pytest requests psutil pyyaml netifaces tarantool
+
+      - name: Build tt
+        env:
+          TT_CLI_BUILD_SSL: 'static'
+        run: mage build
+
+      - name: Install tarantool
+        run: |
+          ./tt init
+          ./tt install tarantool 2.10.7
+
+      - name: Add Tarantool to Path
+        run: |
+          echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
+
+      - name: Run unit tests
+        run: mage unitfullnodocker
+
+      - name: Set env for integration tests
+        run: |
+          echo "TT_CLI_TARANTOOL_PREFIX=${GITHUB_WORKSPACE}/include/" >> $GITHUB_ENV
+
+      - name: Integration tests
+        run: mage integrationfullnodocker
+
+  full-ci-macOS-docker:
     if: |
       (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
@@ -124,14 +174,18 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install dependencies
         run: |
-          brew install --overwrite go mage
-          brew install python3
-          pip3 install pytest tarantool requests psutil pyyaml netifaces
+          brew install --overwrite go mage wget
+          pip3 install pytest requests psutil pyyaml netifaces tarantool
 
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: tarantool/actions-setup-docker@main
 
       - name: Build tt
         env:
@@ -139,13 +193,11 @@ jobs:
         run: mage build
 
       - name: Install tarantool
-        run: brew install tarantool
+        run: |
+          brew install tarantool
 
-      - name: Run unit tests
-        run: mage unitfull
-
-      - name: Integration tests
-        run: mage integrationfull
+      - name: Integration tests with docker
+        run: mage integrationdocker
 
   # ee suffix means that the job runs ee integration tests.
   full-ci-macOS-ee:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.owner.login != 'tarantool' &&
         !contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: macos-12
+    runs-on: [self-hosted, macOS-12-self-hosted, x86_64, regular]
 
     steps:
       - uses: actions/checkout@master
@@ -117,10 +117,14 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install dependencies
         run: |
           brew install --overwrite go mage
-          brew install python3
           pip3 install pytest tarantool requests psutil pyyaml netifaces
 
       - name: Build tt
@@ -129,10 +133,20 @@ jobs:
         run: mage build
 
       - name: Install tarantool
-        run: brew install tarantool
+        run: |
+          ./tt init
+          ./tt -V install tarantool 2.10.7
 
-      - name: Run unit tests
+      - name: Add Tarantool to Path
+        run: |
+          echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
+
+      - name: Unit tests
         run: mage unit
+
+      - name: Set env for integration tests
+        run: |
+          echo "TT_CLI_TARANTOOL_PREFIX=${GITHUB_WORKSPACE}/include/" >> $GITHUB_ENV
 
       - name: Run integration tests
         run: mage integration

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build docker
 
 package docker
 

--- a/magefile.go
+++ b/magefile.go
@@ -260,6 +260,21 @@ func UnitFull() error {
 
 	if mg.Verbose() {
 		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath),
+			"-tags", "integration", "docker")
+	}
+
+	return sh.RunV(goExecutableName, "test", fmt.Sprintf("%s/...", packagePath),
+		"-tags", "integration", "docker")
+}
+
+// Run unit tests with a Tarantool instance integration without docker.
+func UnitFullNoDocker() error {
+	fmt.Println("Running full unit tests without docker...")
+
+	mg.Deps(GenerateGoCode)
+
+	if mg.Verbose() {
+		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath),
 			"-tags", "integration")
 	}
 
@@ -280,6 +295,22 @@ func IntegrationFull() error {
 	fmt.Println("Running all integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool",
+		"test/integration")
+}
+
+// Run integration tests without docker.
+func IntegrationFullNoDocker() error {
+	fmt.Println("Running integration tests without docker...")
+
+	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool and not docker",
+		"test/integration")
+}
+
+// Run integration tests with docker.
+func IntegrationDocker() error {
+	fmt.Println("Running integration tests with docker...")
+
+	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "docker",
 		"test/integration")
 }
 

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -116,6 +116,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -320,6 +320,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_pack_tgz_table(tt_cmd, tmpdir):
     test_cases = prepare_tgz_test_cases(tt_cmd)
 
@@ -582,6 +583,7 @@ def test_pack_nonexistent_modules_directory(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_pack_deb(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -634,6 +636,7 @@ def test_pack_deb(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_pack_rpm(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -682,6 +685,7 @@ def test_pack_rpm(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_pack_rpm_use_docker(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -727,6 +731,7 @@ def test_pack_rpm_use_docker(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
+@pytest.mark.docker
 def test_pack_deb_use_docker(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -54,7 +54,13 @@ def test_rocks_module(tt_cmd, tmpdir):
             [tt_cmd, "rocks", "unpack", rock_file],
             cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
     assert rc == 0
-    rock_dir = rock_file.split('.', 1)[0]
+
+    rock_dir = ""
+    rock_dir_items = rock_file.split('.')
+    for i in range((len(rock_dir_items) - 2)):
+        rock_dir += rock_dir_items[i] + "."
+    rock_dir = rock_dir[:-1]
+
     assert os.path.isdir(rock_dir)
 
     rc, output = run_command_and_get_output(

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -3,3 +3,4 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     slow_ee: marks ee tests as slow (deselect with '-m "not slow_ee"')
     notarantool: marks tests that must be invoked without pre-installed tarantool (deselect with '-m "not notarantool"')
+    docker: marks tests that use docker (deselect with '-m "not docker"')


### PR DESCRIPTION
Switched testing on macOS to selfhosted runners.
Tests should no more be 'flaky'.
'full-ci 'is now 18 minutes faster.