### PR TITLE
build: hide building output if there are no errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+        
+### Changed
+- `tt build` now hides building output if `-V` is not provided.
 
 ## [1.1.0] - 2023-05-02
 

--- a/test/integration/ttbuild/test_build.py
+++ b/test/integration/ttbuild/test_build.py
@@ -124,6 +124,24 @@ def test_build_absolute_path(tt_cmd, tmpdir_with_cfg):
         assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
 
 
+def test_build_error_omit_stdout(tt_cmd, tmpdir_with_cfg):
+    build_cmd = [tt_cmd, "build"]
+    tt_process = subprocess.Popen(
+        build_cmd,
+        cwd=tmpdir_with_cfg,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stdin=subprocess.PIPE,
+        text=True
+    )
+    tt_process.stdin.close()
+    tt_process.wait()
+    assert tt_process.returncode == 1
+    tt_process.stderr.readline()  # Skip empty line.
+    assert tt_process.stderr.readline().find(
+        "please specify a rockspec to use on current directory") != -1
+
+
 def test_build_missing_rockspec(tt_cmd, tmpdir_with_cfg):
     buid_cmd = [tt_cmd, "build"]
     tt_process = subprocess.Popen(
@@ -139,6 +157,7 @@ def test_build_missing_rockspec(tt_cmd, tmpdir_with_cfg):
     assert tt_process.returncode == 1
 
     tt_process.stdout.readline()  # Skip empty line.
+    tt_process.stdout.readline()  # Skip log line.
     assert tt_process.stdout.readline().find(
         "please specify a rockspec to use on current directory") != -1
 


### PR DESCRIPTION
Hide building output if there are no errors.

tt build re-worked to redirect stdout to /dev/null in case of no -V.

Closes #450.