### PR TITLE
running: avoid starting an already running instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- ``tt start`` now does not start an instance if it is already running.
+
 ## [1.1.0] - 2023-05-02
 
 ### Changed

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/running"
 )
 
@@ -55,6 +56,15 @@ func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		}
 		for _, run := range runningCtx.Instances {
 			appName := running.GetAppInstanceName(run)
+			// If an instance is already running don't try to start it again.
+			// For restarting an instance use tt restart command.
+			procStatus := process_utils.ProcessStatus(run.PIDFile)
+			if procStatus.Code ==
+				process_utils.ProcStateRunning.Code {
+				log.Infof("The instance %s (PID = %d) is already running.",
+					appName, procStatus.PID)
+				continue
+			}
 
 			log.Infof("Starting an instance [%s]...", appName)
 


### PR DESCRIPTION
Before this patch, starting an already running instance did not stop the existing process. 
As a result, the PID file of the existing process was being overwritten by the new start command. 
This led to the situation where it was impossible to control the old process, as the new one was already started. 
Additionally, if the old instance had allocated a port, the new process was unable to allocate it again and failed without the possibility of reallocation without manual killing of the existing process.

Closes #451