### PR TITLE
tt: smart autocomplete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
         
 ### Changed
+
 - `tt build` now hides building output if `-V` is not provided.
 
 ### Fixed
 
 - ``tt start`` now does not start an instance if it is already running.
+
+### Added
+
+- smart auto-completion for `tt start`, `tt stop`, `tt restart`, `tt connect`, `tt build`, `tt clean`, `tt logrotate`, `tt status`.   
+It shows suitable apps, in case of the pattern doesn't contain delimiter `:`, and suitable instances otherwise.
 
 ## [1.1.0] - 2023-05-02
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,11 @@ You can generate autocompletion for `bash` or `zsh` shell:
 ```
 
 Enter `tt`, press tab and you will see a list of available modules with
-descriptions. Also, autocomplete supports external modules.
+descriptions. Also, autocomplete supports external modules.  
+   
+For commands, which argument is app or instance, autocompletion
+will show suitable apps, in case of the pattern doesn't contain
+delimiter `:`, and suitable instances otherwise.    
 
 ## TT usage
 

--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -5,6 +5,7 @@ import (
 	"github.com/tarantool/tt/cli/build"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var (
@@ -23,6 +24,17 @@ func NewBuildCmd() *cobra.Command {
 			handleCmdErr(cmd, err)
 		},
 		Args: cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			var runningCtx running.RunningCtx
+			if err := running.FillCtx(cliOpts, &cmdCtx, &runningCtx, []string{}); err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return running.ExtractAppNames(runningCtx.Instances),
+				cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	buildCmd.Flags().StringVarP(&specFile, "spec", "", "", "Rockspec file to use for building")

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/process_utils"
@@ -25,6 +26,15 @@ func NewCleanCmd() *cobra.Command {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalCleanModule,
 				args)
 			handleCmdErr(cmd, err)
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractAppNames,
+				running.ExtractInstanceNames)
 		},
 	}
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/connect"
@@ -61,6 +62,18 @@ func NewConnectCmd() *cobra.Command {
 			handleCmdErr(cmd, err)
 		},
 		Args: cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractActiveAppNames,
+				running.ExtractActiveInstanceNames)
+		},
 	}
 
 	connectCmd.Flags().StringVarP(&connectUser, "username", "u", "", "username")

--- a/cli/cmd/internal/completion.go
+++ b/cli/cmd/internal/completion.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/running"
+)
+
+// InstPicker is function that takes a list of instances and returns
+// some instance names.
+type InstPicker func([]running.InstanceCtx) []string
+
+// ValidArgsFunction is the function used for dynamic auto-completion.
+// In case of app's completion, it uses appPicker, instPicker otherwise.
+func ValidArgsFunction(
+	cliOpts *config.CliOpts,
+	cmdCtx *cmdcontext.CmdCtx,
+	cmd *cobra.Command,
+	toComplete string,
+	appPicker InstPicker,
+	instPicker InstPicker,
+) (args []string, directive cobra.ShellCompDirective) {
+	directive = cobra.ShellCompDirectiveNoFileComp
+
+	var runningCtx running.RunningCtx
+	if err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, []string{}); err != nil {
+		return
+	}
+
+	if strings.ContainsRune(toComplete, running.InstanceDelimiter) {
+		args = instPicker(runningCtx.Instances)
+		return
+	}
+
+	args = appPicker(runningCtx.Instances)
+	return
+}

--- a/cli/cmd/logrotate.go
+++ b/cli/cmd/logrotate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
@@ -18,6 +19,15 @@ func NewLogrotateCmd() *cobra.Command {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalLogrotateModule, args)
 			handleCmdErr(cmd, err)
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractAppNames,
+				running.ExtractInstanceNames)
 		},
 	}
 

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/running"
 	"github.com/tarantool/tt/cli/util"
 )
 
@@ -27,6 +29,15 @@ func NewRestartCmd() *cobra.Command {
 			handleCmdErr(cmd, err)
 		},
 		Args: cobra.RangeArgs(0, 1),
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractActiveAppNames,
+				running.ExtractActiveInstanceNames)
+		},
 	}
 
 	restartCmd.Flags().BoolVarP(&autoYes, "yes", "y", false,

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/process_utils"
@@ -29,6 +30,15 @@ func NewStartCmd() *cobra.Command {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStartModule, args)
 			handleCmdErr(cmd, err)
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractInactiveAppNames,
+				running.ExtractInactiveInstanceNames)
 		},
 	}
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
@@ -18,6 +19,15 @@ func NewStatusCmd() *cobra.Command {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStatusModule, args)
 			handleCmdErr(cmd, err)
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractAppNames,
+				running.ExtractInstanceNames)
 		},
 	}
 

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
@@ -18,6 +19,15 @@ func NewStopCmd() *cobra.Command {
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalStopModule, args)
 			handleCmdErr(cmd, err)
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string) ([]string, cobra.ShellCompDirective) {
+			return internal.ValidArgsFunction(
+				cliOpts, &cmdCtx, cmd, toComplete,
+				running.ExtractActiveAppNames,
+				running.ExtractActiveInstanceNames)
 		},
 	}
 

--- a/cli/running/instance_filter.go
+++ b/cli/running/instance_filter.go
@@ -1,0 +1,86 @@
+package running
+
+import (
+	"github.com/tarantool/tt/cli/process_utils"
+)
+
+// InstanceDelimiter is the delimiter of the app and instance name.
+const InstanceDelimiter = ':'
+
+var getStatus = Status
+
+// extractInstanceNames returns the names of instances, that satisfy the filter.
+func extractInstanceNames(instances []InstanceCtx,
+	filter func(*InstanceCtx) bool) []string {
+	validNames := make([]string, 0)
+	for _, instance := range instances {
+		if filter(&instance) {
+			validNames = append(validNames, GetAppInstanceName(instance))
+		}
+	}
+	return validNames
+}
+
+// extractAppNames returns the names of applications, that
+// have an instance, that satisfy the filter.
+func extractAppNames(instances []InstanceCtx,
+	filter func(*InstanceCtx) bool) []string {
+	validAppNames := make([]string, 0)
+	isAnyValid := false
+	for i, instance := range instances {
+		isAnyValid = isAnyValid || filter(&instance)
+		if i+1 == len(instances) || instance.AppName != instances[i+1].AppName {
+			if isAnyValid {
+				validAppNames = append(validAppNames, instance.AppName)
+			}
+			isAnyValid = false
+		}
+	}
+	return validAppNames
+}
+
+// IsInstanceActive returns true if the instance have running status.
+func IsInstanceActive(instance *InstanceCtx) bool {
+	return getStatus(instance).Code == process_utils.ProcessRunningCode
+}
+
+// IsInstanceInactive return true if the instance have not running status.
+func IsInstanceInactive(instance *InstanceCtx) bool {
+	return !IsInstanceActive(instance)
+}
+
+// ExtractActiveInstanceNames returns the names of running instances.
+func ExtractActiveInstanceNames(instances []InstanceCtx) []string {
+	return extractInstanceNames(instances, IsInstanceActive)
+}
+
+// ExtractInactiveInstanceNames returns the names of not running instances.
+func ExtractInactiveInstanceNames(instances []InstanceCtx) []string {
+	return extractInstanceNames(instances, IsInstanceInactive)
+}
+
+// ExtractActiveAppNames returns the names of applications,
+// that have a running instance.
+func ExtractActiveAppNames(instances []InstanceCtx) []string {
+	return extractAppNames(instances, IsInstanceActive)
+}
+
+// ExtractInactiveAppNames returns the names of applications,
+// that have a not running instance.
+func ExtractInactiveAppNames(instances []InstanceCtx) []string {
+	return extractAppNames(instances, IsInstanceInactive)
+}
+
+// ExtractInstanceNames returns the names of instances.
+func ExtractInstanceNames(instances []InstanceCtx) []string {
+	return extractInstanceNames(instances, func(_ *InstanceCtx) bool {
+		return true
+	})
+}
+
+// ExtractAppNames returns the names of apps.
+func ExtractAppNames(instances []InstanceCtx) []string {
+	return extractAppNames(instances, func(_ *InstanceCtx) bool {
+		return true
+	})
+}

--- a/cli/running/instance_filter_test.go
+++ b/cli/running/instance_filter_test.go
@@ -1,0 +1,95 @@
+package running
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/tt/cli/process_utils"
+)
+
+func TestCompletionHelpers(t *testing.T) {
+	savedGetStatus := getStatus
+	defer func() {
+		getStatus = savedGetStatus
+	}()
+
+	instances := []InstanceCtx{
+		{AppName: "single_run", SingleApp: true},
+
+		{AppName: "app1", InstName: "master"},
+		{AppName: "app1", InstName: "replica"},
+
+		{AppName: "single_stopped", SingleApp: true},
+
+		{AppName: "app2", InstName: "master"},
+		{AppName: "app2", InstName: "replica1"},
+		{AppName: "app2", InstName: "replica2"},
+
+		{AppName: "app3", InstName: "master"},
+		{AppName: "app3", InstName: "replica1"},
+		{AppName: "app3", InstName: "stateboard"},
+	}
+
+	statuses := map[string]process_utils.ProcessState{
+		"single_run": process_utils.ProcStateRunning,
+
+		"app1:master":  process_utils.ProcStateRunning,
+		"app1:replica": process_utils.ProcStateRunning,
+
+		"single_stopped": process_utils.ProcStateStopped,
+
+		"app2:master":   process_utils.ProcStateDead,
+		"app2:replica1": process_utils.ProcStateStopped,
+		"app2:replica2": process_utils.ProcStateStopped,
+
+		"app3:master":     process_utils.ProcStateDead,
+		"app3:replica1":   process_utils.ProcStateStopped,
+		"app3:stateboard": process_utils.ProcStateRunning,
+	}
+
+	getStatus = func(instCtx *InstanceCtx) process_utils.ProcessState {
+		return statuses[GetAppInstanceName(*instCtx)]
+	}
+
+	cases := []struct {
+		name     string
+		tf       func([]InstanceCtx) []string
+		expected []string
+	}{
+		{
+			name: "active instances",
+			tf:   ExtractActiveInstanceNames,
+			expected: []string{"single_run",
+				"app1:master", "app1:replica", "app3:stateboard"},
+		},
+		{
+			name: "inactive instances",
+			tf:   ExtractInactiveInstanceNames,
+			expected: []string{
+				"single_stopped",
+				"app2:master", "app2:replica1", "app2:replica2",
+				"app3:master", "app3:replica1"},
+		},
+		{
+			name:     "active apps",
+			tf:       ExtractActiveAppNames,
+			expected: []string{"single_run", "app1", "app3"},
+		},
+		{
+			name:     "inactive apps",
+			tf:       ExtractInactiveAppNames,
+			expected: []string{"single_stopped", "app2", "app3"},
+		},
+		{
+			name:     "all apps",
+			tf:       ExtractAppNames,
+			expected: []string{"single_run", "app1", "single_stopped", "app2", "app3"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.tf(instances))
+		})
+	}
+}

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -122,7 +122,8 @@ func (provider *providerImpl) updateCtx() error {
 	if provider.instanceCtx.SingleApp {
 		args = []string{provider.instanceCtx.AppName}
 	} else {
-		args = []string{provider.instanceCtx.AppName + ":" + provider.instanceCtx.InstName}
+		args = []string{provider.instanceCtx.AppName + string(InstanceDelimiter) +
+			provider.instanceCtx.InstName}
 	}
 
 	var runningCtx RunningCtx
@@ -287,7 +288,7 @@ func CollectInstances(appName string, appDir string) ([]InstanceCtx, error) {
 	// The user can select a specific instance from the application.
 	// Example: `tt status application:server`.
 	selectedInstName := ""
-	colonIds := strings.Index(appName, ":")
+	colonIds := strings.Index(appName, string(InstanceDelimiter))
 	if colonIds != -1 {
 		appNameTmp := appName
 		appName = appNameTmp[:colonIds]
@@ -555,7 +556,7 @@ func GetAppInstanceName(instance InstanceCtx) string {
 	if instance.SingleApp {
 		fullInstanceName = instance.AppName
 	} else {
-		fullInstanceName = instance.AppName + ":" + instance.InstName
+		fullInstanceName = instance.AppName + string(InstanceDelimiter) + instance.InstName
 	}
 	return fullInstanceName
 }


### PR DESCRIPTION
Make autocomplete smart.
For commands, which argument is APP|INSTANCE,
smart auto-complete basically shows:
1) Suitable apps, in case of the pattern doesn't contain delimiter `:`.
2) Suitable instances, otherwise.

Suitable means:
1) `tt start`: inactive apps (which has any no running instance) / inactive instances.
2) `tt stop`: active apps (which has any running instance) / active instances.
3) `tt restart`: same as `tt stop`.
4) `tt connect`: same as `tt stop`.
5) `tt build`: apps.
6) `tt clean`: apps / instances.
7) `tt logrotate`: same as `tt clean`.
8) `tt status`: same as `tt clean`.

Closes https://github.com/tarantool/tt/issues/467.