### PR TITLE
connect: fix crash on `\q`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - ``tt start`` now does not start an instance if it is already running.
 - ``tt rocks`` uses rocks repo path relative to tt environment config location.
+- ``tt connect`` now does not crash on `\q` input.
 
 ### Added
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -254,6 +254,10 @@ func getExecutor(console *Console) prompt.Executor {
 			} else {
 				log.Fatalf("Failed to execute command: %s", err)
 			}
+		} else if len(results) == 0 {
+			console.Close()
+			log.Infof("Connection closed")
+			os.Exit(0)
 		} else {
 			data = results[0]
 		}


### PR DESCRIPTION
Fixed crash on `\q` input in `tt connect`.
In this case, instance returns an empty response,
add a check for this.

Closes #476 