### PR TITLE
rocks: consider environment for some paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - smart auto-completion for `tt start`, `tt stop`, `tt restart`, `tt connect`, `tt build`, `tt clean`, `tt logrotate`, `tt status`.   
 It shows suitable apps, in case of the pattern doesn't contain delimiter `:`, and suitable instances otherwise.
+- support tt environment directories overriding using environment variables:
+  * TT_CLI_REPO_ROCKS environment variable value is used as rocks repository path if it is set and
+there is no tt.repo.rocks in tt configuration file or tt.repo.rocks directory does not include
+repository manifest file.
+  * TT_CLI_TARANTOOL_PREFIX environment variable value is used for as tarantool installation prefix
+directory for rocks commands if it is set and tarantool executable is found in PATH.
 
 ## [1.1.0] - 2023-05-02
 

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -30,10 +30,6 @@ type CliCtx struct {
 	TarantoolExecutable string
 	// Tarantool version.
 	TarantoolVersion string
-	// Tarantool install prefix path.
-	TarantoolInstallPrefix string
-	// Path to header files supplied with tarantool.
-	TarantoolIncludeDir string
 	// The flag determines if the tarantool binary is from the internal tt repository.
 	IsTarantoolBinFromRepo bool
 	// Verbose logging flag. Enables debug log output.

--- a/cli/rocks/rocks_test.go
+++ b/cli/rocks/rocks_test.go
@@ -1,9 +1,14 @@
 package rocks
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
 )
 
@@ -80,5 +85,138 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 			}
 			require.EqualValues(t, got, tt.want)
 		})
+	}
+}
+
+func TestGetRocksRepoPath(t *testing.T) {
+	assert.EqualValues(t, "./testdata/repo", getRocksRepoPath("./testdata/repo"))
+	assert.EqualValues(t, "./testdata/emptyrepo", getRocksRepoPath("./testdata/emptyrepo"))
+
+	os.Setenv(repoRocksPathEnvVarName, "./other_repo")
+	// If env var is set, return it if manifets is missing in passed repo.
+	assert.EqualValues(t, "./other_repo", getRocksRepoPath("./testdata/emptyrepo"))
+	// Return passed repo path, since manifest exists. Env var is ignored.
+	assert.EqualValues(t, "./testdata/repo", getRocksRepoPath("./testdata/repo"))
+	os.Unsetenv(repoRocksPathEnvVarName)
+}
+
+func TestSetupTarantoolPrefix(t *testing.T) {
+	type prefixInput struct {
+		cli          cmdcontext.CliCtx
+		cliOpts      *config.CliOpts
+		data         *[]byte
+		tntPrefixEnv string
+	}
+
+	type prefixOutput struct {
+		prefix string
+		err    error
+	}
+
+	assert := assert.New(t)
+	testDir, err := ioutil.TempDir("/tmp", "tt-unit")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(testDir)
+
+	err = os.Mkdir(testDir+"/bin", os.ModePerm)
+	require.NoError(t, err)
+
+	tntBinPath := testDir + "/bin/tarantool"
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	testCases := make(map[prefixInput]prefixOutput)
+
+	tntOkData := []byte("#!/bin/sh\n" +
+		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
+		"Target: Linux-x86_64-RelWithDebInfo\n" +
+		"Build options: cmake . -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_BACKTRACE=yes'")
+
+	testCases[prefixInput{cli: cmdcontext.CliCtx{
+		IsTarantoolBinFromRepo: false,
+		TarantoolExecutable:    tntBinPath,
+	}, data: &tntOkData}] =
+		prefixOutput{
+			prefix: "/usr",
+			err:    nil,
+		}
+
+	testCases[prefixInput{cli: cmdcontext.CliCtx{
+		IsTarantoolBinFromRepo: false,
+		TarantoolExecutable:    tntBinPath,
+	},
+		data:         &tntOkData,
+		tntPrefixEnv: "/tnt/prefix"}] =
+		prefixOutput{
+			prefix: "/tnt/prefix",
+			err:    nil,
+		}
+
+	tntBadData0 := []byte("#!/bin/sh\n" +
+		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
+		"Target: Linux-x86_64-RelWithDebInfo\n" +
+		"Build options: cmake . -D_FAIL_HERE_=/usr -DENABLE_BACKTRACE=yes'")
+
+	testCases[prefixInput{cli: cmdcontext.CliCtx{
+		IsTarantoolBinFromRepo: false,
+		TarantoolExecutable:    tntBinPath,
+	}, data: &tntBadData0}] =
+		prefixOutput{
+			err: fmt.Errorf("failed to get prefix path: regexp does not match"),
+		}
+
+	tntBadData1 := []byte("#!/bin/sh\n" +
+		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
+		"Target: Linux-x86_64-RelWithDebInfo\n'")
+
+	testCases[prefixInput{cli: cmdcontext.CliCtx{
+		IsTarantoolBinFromRepo: false,
+		TarantoolExecutable:    tntBinPath,
+	}, data: &tntBadData1}] =
+		prefixOutput{
+			err: fmt.Errorf("failed to get prefix path: expected more data"),
+		}
+
+	appOpts := config.AppOpts{IncludeDir: "hdr"}
+	cliOpts := config.CliOpts{App: &appOpts}
+
+	testCases[prefixInput{cli: cmdcontext.CliCtx{
+		IsTarantoolBinFromRepo: true,
+		TarantoolExecutable:    tntBinPath,
+	},
+		cliOpts:      &cliOpts,
+		data:         &tntOkData,
+		tntPrefixEnv: "/tnt/prefix"}] =
+		prefixOutput{
+			prefix: cwd + "/hdr",
+			err:    nil,
+		}
+
+	for input, output := range testCases {
+		tntFile, err := os.Create(tntBinPath)
+		require.NoError(t, err)
+
+		_, err = tntFile.Write(*input.data)
+		require.NoError(t, err)
+		tntFile.Close()
+
+		err = os.Chmod(tntFile.Name(), 0755)
+		require.NoError(t, err)
+
+		if input.tntPrefixEnv != "" {
+			os.Setenv(tarantoolPrefixEnvVarName, input.tntPrefixEnv)
+		}
+		tarantoolPrefix, err := GetTarantoolPrefix(&input.cli, input.cliOpts)
+		os.Unsetenv(tarantoolPrefixEnvVarName)
+		if err == nil {
+			assert.Nil(err)
+			assert.Equal(output.prefix, tarantoolPrefix)
+		} else {
+			assert.Equal(output.err, err)
+		}
+
+		os.Remove(tntBinPath)
 	}
 }

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -24,7 +24,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/config"
 	"gopkg.in/yaml.v2"
 )
 
@@ -299,51 +298,6 @@ func GetTarantoolVersion(cli *cmdcontext.CliCtx) (string, error) {
 	cli.TarantoolVersion = version[len(version)-1]
 
 	return cli.TarantoolVersion, nil
-}
-
-// SetupTarantoolPrefix defines the installation prefix and the path to the tarantool header files.
-func SetupTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) error {
-	if cli.TarantoolIncludeDir != "" && cli.TarantoolInstallPrefix != "" {
-		return nil
-	}
-
-	if cli.IsTarantoolBinFromRepo {
-		includeDir, err := JoinAbspath(cliOpts.App.IncludeDir, "include/tarantool")
-		if err != nil {
-			return err
-		}
-
-		prefix, err := JoinAbspath(cliOpts.App.IncludeDir)
-		if err != nil {
-			return err
-		}
-
-		cli.TarantoolIncludeDir = includeDir
-		cli.TarantoolInstallPrefix = prefix
-
-		return nil
-	}
-
-	output, err := exec.Command(cli.TarantoolExecutable, "--version").Output()
-	if err != nil {
-		return fmt.Errorf("failed to get tarantool version: %s", err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(lines) < 3 {
-		return fmt.Errorf("failed to get prefix path: expected more data")
-	}
-
-	re := regexp.MustCompile(`^.*\s-DCMAKE_INSTALL_PREFIX=(?P<prefix>\/.*)\s.*$`)
-	matches := FindNamedMatches(re, lines[2])
-	if len(matches) == 0 {
-		return fmt.Errorf("failed to get prefix path: regexp does not match")
-	}
-
-	cli.TarantoolInstallPrefix = matches["prefix"]
-	cli.TarantoolIncludeDir = cli.TarantoolInstallPrefix + "/include/tarantool"
-
-	return nil
 }
 
 // ReadEmbedFile reads content of embed file in string mode.

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/pack/test_helpers"
 )
 
@@ -89,112 +87,6 @@ func TestIsRegularFile(t *testing.T) {
 
 	assert.False(IsRegularFile(workDir))
 	assert.False(IsRegularFile("./non-existing-file"))
-}
-
-type prefixInput struct {
-	cli     cmdcontext.CliCtx
-	cliOpts *config.CliOpts
-	data    *[]byte
-}
-
-type prefixOutput struct {
-	prefix  string
-	include string
-	err     error
-}
-
-func TestSetupTarantoolPrefix(t *testing.T) {
-	assert := assert.New(t)
-	testDir, err := ioutil.TempDir("/tmp", "tt-unit")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(testDir)
-
-	err = os.Mkdir(testDir+"/bin", os.ModePerm)
-	require.NoError(t, err)
-
-	tntBinPath := testDir + "/bin/tarantool"
-
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
-	testCases := make(map[prefixInput]prefixOutput)
-
-	tntOkData := []byte("#!/bin/sh\n" +
-		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
-		"Target: Linux-x86_64-RelWithDebInfo\n" +
-		"Build options: cmake . -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_BACKTRACE=yes'")
-
-	testCases[prefixInput{cli: cmdcontext.CliCtx{
-		IsTarantoolBinFromRepo: false,
-		TarantoolExecutable:    tntBinPath,
-	}, data: &tntOkData}] =
-		prefixOutput{
-			prefix:  "/usr",
-			include: "/usr/include/tarantool",
-			err:     nil,
-		}
-
-	tntBadData0 := []byte("#!/bin/sh\n" +
-		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
-		"Target: Linux-x86_64-RelWithDebInfo\n" +
-		"Build options: cmake . -D_FAIL_HERE_=/usr -DENABLE_BACKTRACE=yes'")
-
-	testCases[prefixInput{cli: cmdcontext.CliCtx{
-		IsTarantoolBinFromRepo: false,
-		TarantoolExecutable:    tntBinPath,
-	}, data: &tntBadData0}] =
-		prefixOutput{
-			err: fmt.Errorf("failed to get prefix path: regexp does not match"),
-		}
-
-	tntBadData1 := []byte("#!/bin/sh\n" +
-		"echo 'Tarantool 2.10.2-0-gb924f0b\n" +
-		"Target: Linux-x86_64-RelWithDebInfo\n'")
-
-	testCases[prefixInput{cli: cmdcontext.CliCtx{
-		IsTarantoolBinFromRepo: false,
-		TarantoolExecutable:    tntBinPath,
-	}, data: &tntBadData1}] =
-		prefixOutput{
-			err: fmt.Errorf("failed to get prefix path: expected more data"),
-		}
-
-	appOpts := config.AppOpts{IncludeDir: "hdr"}
-	cliOpts := config.CliOpts{App: &appOpts}
-
-	testCases[prefixInput{cli: cmdcontext.CliCtx{
-		IsTarantoolBinFromRepo: true,
-		TarantoolExecutable:    tntBinPath,
-	}, cliOpts: &cliOpts, data: &tntOkData}] =
-		prefixOutput{
-			prefix:  cwd + "/hdr",
-			include: cwd + "/hdr/include/tarantool",
-			err:     nil,
-		}
-
-	for input, output := range testCases {
-		tntFile, err := os.Create(tntBinPath)
-		require.NoError(t, err)
-
-		_, err = tntFile.Write(*input.data)
-		require.NoError(t, err)
-		tntFile.Close()
-
-		err = os.Chmod(tntFile.Name(), 0755)
-		require.NoError(t, err)
-
-		err = SetupTarantoolPrefix(&input.cli, input.cliOpts)
-		if err == nil {
-			assert.Nil(err)
-			assert.Equal(output.prefix, input.cli.TarantoolInstallPrefix)
-			assert.Equal(output.include, input.cli.TarantoolIncludeDir)
-		} else {
-			assert.Equal(output.err, err)
-		}
-
-		os.Remove(tntBinPath)
-	}
 }
 
 func TestCreateDirectory(t *testing.T) {


### PR DESCRIPTION
Rocks local repository path and tarantool installation prefix path can be specified using environment variables. TT_CLI_REPO_ROCKS variable is used if it is set and there is no repo.rocks in tt config or repo.rocks directory does not include repository manifest.
TT_CLI_TARANTOOL_PREFIX variable is used for build, rocks commands if it is set and tarantool executable is found in PATH.

Closes #471