### PR TITLE
connect: make console history consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ repository manifest file.
 directory for rocks commands if it is set and tarantool executable is found in PATH.
 - smart auto-completion for `tt create`. It shows a list of built-in templates and
 templates from the config.
+- `tt connect`: support for the timestamp format in the history file.
 
 ## [1.1.0] - 2023-05-02
 

--- a/cli/connect/history.go
+++ b/cli/connect/history.go
@@ -1,0 +1,119 @@
+package connect
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tarantool/tt/cli/util"
+)
+
+// commandHistory stores console command history.
+type commandHistory struct {
+	filepath    string
+	commands    []string
+	timestamps  []int64
+	maxCommands int
+}
+
+// parseHistoryCells extracts timestamps and commands from history lines.
+// If format doesn't contain timestamps, it sets the current timestamp
+// for each command.
+func parseHistoryCells(
+	lines []string) (commands []string, timestamps []int64) {
+	timestampRegex := regexp.MustCompile(`^#\d+$`)
+
+	// startPos is the first position of a timestamp.
+	startPos := -1
+	for i, line := range lines {
+		if timestampRegex.MatchString(line) {
+			startPos = i
+			break
+		}
+	}
+	timestamps = make([]int64, 0)
+	if startPos == -1 {
+		// Read one line per command.
+		// Set the current timestamp for each command.
+		commands = lines
+		timestamp := time.Now().Unix()
+		for range lines {
+			timestamps = append(timestamps, timestamp)
+		}
+		return
+	}
+
+	commands = make([]string, 0)
+	for startPos < len(lines) {
+		j := startPos + 1
+
+		// Move pointer to the next timestamp.
+		for j < len(lines) && !timestampRegex.MatchString(lines[j]) {
+			j++
+		}
+
+		// Extract the current timestamp.
+		timestamp, err := strconv.ParseInt(lines[startPos][1:], 10, 0)
+
+		if j != startPos+1 && err == nil {
+			timestamps = append(timestamps, timestamp)
+			commands = append(commands, strings.Join(lines[startPos+1:j], "\n"))
+		}
+		startPos = j
+	}
+
+	return
+}
+
+// load loads console history from the history file.
+func (history *commandHistory) load() error {
+	rawLines, err := util.GetLastNLines(history.filepath, history.maxCommands)
+	if err != nil {
+		return err
+	}
+
+	history.commands, history.timestamps = parseHistoryCells(rawLines)
+	return nil
+}
+
+// appendCommand appends new command to the history.
+func (history *commandHistory) appendCommand(command string) {
+	history.commands = append(history.commands, command)
+	history.timestamps = append(history.timestamps, time.Now().Unix())
+	if len(history.commands) > history.maxCommands {
+		history.commands = history.commands[1:]
+		history.timestamps = history.timestamps[1:]
+	}
+}
+
+// writeToFile writes console history to the file.
+func (history *commandHistory) writeToFile() error {
+	historyContent := bytes.Buffer{}
+	for i, command := range history.commands {
+		historyContent.WriteString(fmt.Sprintf("#%d\n%s\n", history.timestamps[i], command))
+	}
+	if err := os.WriteFile(history.filepath, historyContent.Bytes(), 0640); err != nil {
+		return fmt.Errorf("failed to write to history file: %s", err)
+	}
+
+	return nil
+}
+
+// newCommandHistory returns new commandHistory instance.
+func newCommandHistory(historyFileName string, maxCommands int) (*commandHistory, error) {
+	homeDir, err := util.GetHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %s", err)
+	}
+
+	history := commandHistory{
+		filepath:    filepath.Join(homeDir, historyFileName),
+		maxCommands: maxCommands,
+	}
+	return &history, nil
+}

--- a/cli/connect/history_test.go
+++ b/cli/connect/history_test.go
@@ -1,0 +1,78 @@
+package connect
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHistoryCells(t *testing.T) {
+	t.Run("actual", func(t *testing.T) {
+		lines := []string{
+			"#1685979611",
+			"print(1)",
+			"#1685979622",
+			"print(2",
+			")",
+			"#1685979630",
+			"#1685979645",
+			"box.cfg{}",
+		}
+		commands, timestamps := parseHistoryCells(lines)
+		assert.Equal(t, []string{"print(1)", "print(2\n)", "box.cfg{}"}, commands)
+		assert.Equal(t, []int64{1685979611, 1685979622, 1685979645}, timestamps)
+	})
+
+	t.Run("# in command", func(t *testing.T) {
+		lines := []string{
+			"#1111111111",
+			"a={1,2,",
+			"3}",
+			"#2222222222",
+			"#3333333333",
+			"for i=0,",
+			"#a",
+			",1 do",
+			"print(i)",
+			"end",
+			"#4444444444",
+			"os.exit()",
+		}
+		commands, timestamps := parseHistoryCells(lines)
+		assert.Equal(t,
+			[]string{"a={1,2,\n3}", "for i=0,\n#a\n,1 do\nprint(i)\nend", "os.exit()"},
+			commands)
+		assert.Equal(t, []int64{1111111111, 3333333333, 4444444444}, timestamps)
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		lines := []string{
+			"a=3",
+			"b=4",
+			"print(a+b)",
+			"box.cfg{}",
+		}
+		commands, timestamps := parseHistoryCells(lines)
+		assert.Equal(t, []string{"a=3", "b=4", "print(a+b)", "box.cfg{}"}, commands)
+		assert.Equal(t, 4, len(timestamps))
+	})
+}
+
+func TestHistoryAppend(t *testing.T) {
+	limit := 20
+
+	h, _ := newCommandHistory("", limit)
+	for i := 0; i < limit; i++ {
+		h.appendCommand(fmt.Sprintf("command%d", i))
+		assert.Equal(t, len(h.commands), i+1)
+		assert.Equal(t, len(h.timestamps), i+1)
+	}
+
+	for i := limit; i < 2*limit; i++ {
+		h.appendCommand(fmt.Sprintf("command%d", i))
+		assert.Equal(t, len(h.commands), limit)
+		assert.Equal(t, len(h.timestamps), limit)
+		assert.Equal(t, fmt.Sprintf("command%d", i+1-limit), h.commands[0])
+	}
+}


### PR DESCRIPTION
Reworked operations with console history in `tt connect`
to be consistently with tarantool console history.
i.e.:
1) When a new command appears, it completely
rewrites the history file.
2) When writes history, it uses format with
timestamps.
3) Added parsing of timestamps history format.
Parsing mode (with timestamps or not) switches
in dependency of the history file content.

Closes https://github.com/tarantool/tt/issues/478, https://github.com/tarantool/tt/issues/426