### PR TITLE
revert "create: set `compat.fiber_slice_default` to `new` by default"

### DIFF
--- a/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
+++ b/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
@@ -27,11 +27,6 @@ else
     package.cpath = app_dir .. '/.rocks/lib/tarantool/?.dylib;' .. package.cpath
 end
 
-local has_compat, compat = pcall(require, 'compat')
-if has_compat then
-    compat.fiber_slice_default = 'new'
-end
-
 -- Configure cartridge.
 
 local cartridge = require('cartridge')


### PR DESCRIPTION
This reverts commit 6ff6c869c0420ccdeb8addfa3e547e8fff8db3bc, which was committed by mistake.