### PR TITLE
util: check for instances file in app dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Set `compat.fiber_slice_default` to `new` by default in cartridge application template.
+- Treat the directory containing the instances file (instances.y[a]ml) as an application.
 
 ### Added
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -225,13 +225,17 @@ func findInstSeparator(inst string) int {
 func getInstancesFromYML(dirPath string, selectedInstName string) ([]InstanceCtx,
 	error) {
 	instances := []InstanceCtx{}
-	instCfgPath := path.Join(dirPath, "instances.yml")
+
 	defAppPath := path.Join(dirPath, "init.lua")
 	defAppExist := false
 	if _, err := os.Stat(defAppPath); err == nil {
 		defAppExist = true
 	}
 
+	instCfgPath, err := util.GetYamlFileName(path.Join(dirPath, "instances.yml"), true)
+	if err != nil {
+		return nil, err
+	}
 	ymlData, err := ioutil.ReadFile(instCfgPath)
 	if err != nil {
 		return nil, err
@@ -282,7 +286,6 @@ func getInstancesFromYML(dirPath string, selectedInstName string) ([]InstanceCtx
 
 // CollectInstances searches all instances available in application.
 func CollectInstances(appName string, appDir string) ([]InstanceCtx, error) {
-	var err error
 	var appPath string
 
 	// The user can select a specific instance from the application.
@@ -320,9 +323,8 @@ func CollectInstances(appName string, appDir string) ([]InstanceCtx, error) {
 		}
 		appPath = luaPath
 	} else if dirStatErr == nil && dirInfo.IsDir() {
-		// Search for instances.yml
-		instCfgPath := path.Join(dirPath, "instances.yml")
-		if _, err = os.Stat(instCfgPath); err == nil {
+		// Search for instances.yml.
+		if _, err := util.GetYamlFileName(path.Join(dirPath, "instances.yml"), true); err == nil {
 			return getInstancesFromYML(dirPath, selectedInstName)
 		} else {
 			appPath = path.Join(dirPath, "init.lua")

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -691,19 +691,22 @@ func IsApp(path string) bool {
 		return false
 	}
 
-	if !entry.IsDir() && filepath.Ext(entry.Name()) != ".lua" {
-		return false
-	} else if !entry.IsDir() && filepath.Ext(entry.Name()) == ".lua" {
-		return true
+	if entry.IsDir() {
+		// Check if the directory contains init.lua script or instances.yml file.
+		for _, fileTocheck := range [...]string{"init.lua", "instances.yml", "instances.yaml"} {
+			if fileInfo, err := os.Stat(filepath.Join(path, fileTocheck)); err == nil {
+				if !fileInfo.IsDir() {
+					return true
+				}
+			}
+		}
+	} else {
+		if filepath.Ext(entry.Name()) == ".lua" {
+			return true
+		}
 	}
 
-	if _, err = os.Stat(filepath.Join(path, "init.lua")); err == nil && entry.IsDir() {
-		return true
-	} else if entry.IsDir() {
-		return false
-	}
-
-	return true
+	return false
 }
 
 // CheckRequiredBinaries returns an error if some binaries not found in PATH

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -229,10 +229,36 @@ func TestIsApp(t *testing.T) {
 		isApp      bool
 	}{
 		{
-			testName: "Application is directory",
+			testName: "Application is a directory with init.lua",
 			createFunc: func() (string, error) {
 				baseDir := t.TempDir()
 				filePath := filepath.Join(baseDir, "init.lua")
+				_, err := os.Create(filePath)
+				if err != nil {
+					return "", err
+				}
+				return baseDir, nil
+			},
+			isApp: true,
+		},
+		{
+			testName: "Application is a directory, no init.lua, instances.yml exists",
+			createFunc: func() (string, error) {
+				baseDir := t.TempDir()
+				filePath := filepath.Join(baseDir, "instances.yml")
+				_, err := os.Create(filePath)
+				if err != nil {
+					return "", err
+				}
+				return baseDir, nil
+			},
+			isApp: true,
+		},
+		{
+			testName: "Application is a directory, no init.lua, instances.yaml exists",
+			createFunc: func() (string, error) {
+				baseDir := t.TempDir()
+				filePath := filepath.Join(baseDir, "instances.yaml")
 				_, err := os.Create(filePath)
 				if err != nil {
 					return "", err

--- a/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/instances.yml
+++ b/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/instances.yml
@@ -1,0 +1,4 @@
+router:                                                                                         
+                                                                                                
+storage:                                                                                         
+

--- a/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/router.init.lua
+++ b/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/router.init.lua
@@ -1,0 +1,12 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')                                          
+local app_name = os.getenv('TARANTOOL_APP_NAME')                                                
+                                                                                                
+while true do                                                                                   
+    print("custom init file...")                                                                
+    if app_name ~= nil and inst_name ~= nil then                                                
+        print(app_name .. ":" .. inst_name)                                                     
+    else                                                                                        
+        print("unknown instance")                                                               
+    end                                                                                         
+    require("fiber").sleep(1)                                                                   
+end

--- a/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/storage.init.lua
+++ b/test/integration/running/multi_inst_app_no_init/instances.enabled/mi_app/storage.init.lua
@@ -1,0 +1,11 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')                                          
+local app_name = os.getenv('TARANTOOL_APP_NAME')                                                
+                                                                                                
+while true do                                                                                   
+    if app_name ~= nil and inst_name ~= nil then                                                
+        print(app_name .. ":" .. inst_name)                                                     
+    else                                                                                        
+        print("unknown instance")                                                               
+    end                                                                                         
+    require("fiber").sleep(1)                                                                   
+end 

--- a/test/integration/running/multi_inst_app_no_init/tt.yaml
+++ b/test/integration/running/multi_inst_app_no_init/tt.yaml
@@ -1,0 +1,3 @@
+tt:
+  app:
+    instances_enabled: instances.enabled


### PR DESCRIPTION
It is possible to have an application without init.lua script. Script names can be specified using instances file. So if the directory contains instances file, it must be treated as a multi-instance application.