### PR TITLE
template: set `compat.fibert_slice_default` to `new` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Set `compat.fiber_slice_default` to `new` by default in cartridge application template.
+
 ### Added
 
 - `tt connect`: support for the `../` and `~/` at the beginning of the URI, when using unix sockets.

--- a/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
+++ b/cli/create/builtin_templates/templates/cartridge/init.lua.tt.template
@@ -27,6 +27,11 @@ else
     package.cpath = app_dir .. '/.rocks/lib/tarantool/?.dylib;' .. package.cpath
 end
 
+local has_compat, compat = pcall(require, 'compat')
+if has_compat then
+    compat.fiber_slice_default = 'new'
+end
+
 -- Configure cartridge.
 
 local cartridge = require('cartridge')


### PR DESCRIPTION
Closes #341