### PR TITLE
tt: fix CLI arguments/flags processing and help printing

### DIFF
--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -40,8 +40,6 @@ func configureHelpCommand(cmdCtx *cmdcontext.CmdCtx, rootCmd *cobra.Command) err
 		}
 	})
 
-	rootCmd.SetFlagErrorFunc(helpFlagError)
-
 	// Add valid arguments for completion.
 	helpCmd := util.GetHelpCommand(rootCmd)
 	for name := range modulesInfo {
@@ -80,23 +78,6 @@ func getInternalHelpFunc(cmd *cobra.Command, help DefaultHelpFunc) modules.Inter
 	}
 }
 
-// helpFlagError prints some help information if the user entered an invalid flag.
-func helpFlagError(cmd *cobra.Command, errMsg error) error {
-	templatedStr, err := util.GetHTMLTemplatedStr(&errorUsageTemplate, map[string]interface{}{
-		"ErrorMsg":  errMsg,
-		"Cmd":       cmd.CommandPath(),
-		"HasFlags":  cmd.HasAvailableFlags(),
-		"HasSubCmd": cmd.HasAvailableSubCommands(),
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to get templated string: %s", err)
-	}
-
-	cmd.Printf(templatedStr, errMsg)
-	return nil
-}
-
 // getExternalCommandString returns a pretty string
 // of descriptions for external modules.
 func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
@@ -122,13 +103,6 @@ func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
 }
 
 var (
-	errorUsageTemplate = `%s
-
-Usage: {{ .Cmd }}
-{{- if .HasFlags}} [flags] {{end}}
-{{- if .HasSubCmd -}} <command> [command flags] {{end}}
-`
-
 	usageTemplate = util.Bold("USAGE") + `
 {{- if (and .Runnable .HasAvailableInheritedFlags)}}
   {{.UseLine}}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"github.com/tarantool/tt/cli/util"
 	"os"
 	"path/filepath"
 
@@ -172,9 +174,15 @@ func NewCmdRoot() *cobra.Command {
 }
 
 // Execute root command.
+// If received error is of an ArgError type, usage help is printed.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatalf(err.Error())
+		var argError *util.ArgError
+		if errors.As(err, &argError) {
+			log.Error(argError.Error())
+			rootCmd.Usage()
+		}
+		os.Exit(1)
 	}
 }
 

--- a/cli/util/templates.go
+++ b/cli/util/templates.go
@@ -2,25 +2,9 @@ package util
 
 import (
 	"bytes"
-	htmlTemplate "html/template"
 	"strings"
 	textTemplate "text/template"
 )
-
-// GetHTMLTemplatedStr returns the processed string html template.
-func GetHTMLTemplatedStr(text *string, obj interface{}) (string, error) {
-	tmpl, err := htmlTemplate.New("s").Parse(*text)
-	if err != nil {
-		return "", err
-	}
-
-	buf := new(bytes.Buffer)
-	if err = tmpl.Execute(buf, obj); err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
-}
 
 // GetTextTemplatedStr returns the processed string text template.
 func GetTextTemplatedStr(text *string, obj interface{}) (string, error) {


### PR DESCRIPTION
Fix some issues with CLI.
Usage and allowed flags are now printed when invalid flags are entered, and exit code in this case is 1.

Screenshot for more info:

![Screenshot from 2023-07-06 15-54-23](https://github.com/tarantool/tt/assets/38702085/e0beb0d8-cfb7-4040-8079-c1c5b52f87e5)

Closes #274
