### PR TITLE
ci: switch macOS tests fully to selfhosted

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -117,7 +117,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.action == 'synchronize' &&
         contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: [self-hosted, macOS-12-self-hosted, x86_64, regular]
+    runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
     steps:
       - uses: actions/checkout@master
         with:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Integration tests
         run: mage integrationfull
 
-  full-ci-macOS-no-docker:
+  full-ci-macOS:
     if: |
       (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
@@ -149,55 +149,14 @@ jobs:
           echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
       - name: Run unit tests
-        run: mage unitfullnodocker
+        run: mage unitfull
 
       - name: Set env for integration tests
         run: |
           echo "TT_CLI_TARANTOOL_PREFIX=${GITHUB_WORKSPACE}/include/" >> $GITHUB_ENV
 
       - name: Integration tests
-        run: mage integrationfullnodocker
-
-  full-ci-macOS-docker:
-    if: |
-      (github.event_name == 'push') ||
-      (github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'full-ci') ||
-      (github.event_name == 'pull_request' &&
-        github.event.action == 'synchronize' &&
-        contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Install dependencies
-        run: |
-          brew install --overwrite go mage wget
-          pip3 install pytest requests psutil pyyaml netifaces tarantool
-
-      - name: Setup Docker
-        uses: tarantool/actions-setup-docker@main
-
-      - name: Build tt
-        env:
-          TT_CLI_BUILD_SSL: 'static'
-        run: mage build
-
-      - name: Install tarantool
-        run: |
-          brew install tarantool
-
-      - name: Integration tests with docker
-        run: mage integrationdocker
+        run: mage integrationfull
 
   # ee suffix means that the job runs ee integration tests.
   full-ci-macOS-ee:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.owner.login != 'tarantool' &&
         !contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: [self-hosted, macOS-12-self-hosted, x86_64, regular]
+    runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
 
     steps:
       - uses: actions/checkout@master

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -157,7 +157,7 @@ func TestRunContainerInvalidDockerfile(t *testing.T) {
 		Command:     []string{"touch", "/work/file_from_container"},
 		Binds:       []string{fmt.Sprintf("%s:/work", tmpDir)},
 	}, os.Stdout)
-	require.True(t, strings.Contains(err.Error(), "dockerfile parse error line"))
+	require.True(t, strings.Contains(err.Error(), "dockerfile parse error"))
 	assert.NoFileExists(t, filepath.Join(tmpDir, "file_from_container"))
 }
 

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -1,4 +1,4 @@
-//go:build docker
+//go:build integration
 
 package docker
 

--- a/cli/running/running_test_helpers.go
+++ b/cli/running/running_test_helpers.go
@@ -6,5 +6,5 @@ import "time"
 func waitProcessStart() {
 	// We need to wait for the new process (tarantool instance) to set handlers.
 	// It is necessary to update for more correct synchronization.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 }

--- a/magefile.go
+++ b/magefile.go
@@ -260,21 +260,6 @@ func UnitFull() error {
 
 	if mg.Verbose() {
 		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath),
-			"-tags", "integration", "docker")
-	}
-
-	return sh.RunV(goExecutableName, "test", fmt.Sprintf("%s/...", packagePath),
-		"-tags", "integration", "docker")
-}
-
-// Run unit tests with a Tarantool instance integration without docker.
-func UnitFullNoDocker() error {
-	fmt.Println("Running full unit tests without docker...")
-
-	mg.Deps(GenerateGoCode)
-
-	if mg.Verbose() {
-		return sh.RunV(goExecutableName, "test", "-v", fmt.Sprintf("%s/...", packagePath),
 			"-tags", "integration")
 	}
 
@@ -295,22 +280,6 @@ func IntegrationFull() error {
 	fmt.Println("Running all integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool",
-		"test/integration")
-}
-
-// Run integration tests without docker.
-func IntegrationFullNoDocker() error {
-	fmt.Println("Running integration tests without docker...")
-
-	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool and not docker",
-		"test/integration")
-}
-
-// Run integration tests with docker.
-func IntegrationDocker() error {
-	fmt.Println("Running integration tests with docker...")
-
-	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "docker",
 		"test/integration")
 }
 

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -87,7 +87,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
     tmpdir_without_config = tempfile.mkdtemp()
 
     # Install latest tarantool.
-    install_cmd = [tt_cmd, "--cfg", config_path, "install", "-f", "tarantool", "2.10.4"]
+    install_cmd = [tt_cmd, "--cfg", config_path, "install", "-f", "tarantool", "2.10.7"]
     instance_process = subprocess.Popen(
         install_cmd,
         cwd=tmpdir_without_config,
@@ -111,7 +111,7 @@ def test_install_tarantool(tt_cmd, tmpdir):
     run_output = installed_program_process.stdout.readline()
     assert re.search(r"Tarantool", run_output)
     assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
-    assert os.path.exists(os.path.join(tmpdir, "bin", "tarantool_2.10.4"))
+    assert os.path.exists(os.path.join(tmpdir, "bin", "tarantool_2.10.7"))
 
 
 @pytest.mark.slow

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -115,7 +115,6 @@ def test_install_tarantool(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -344,7 +344,6 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_pack_tgz_table(tt_cmd, tmpdir):
     test_cases = prepare_tgz_test_cases(tt_cmd)
 
@@ -607,7 +606,6 @@ def test_pack_nonexistent_modules_directory(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_pack_deb(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -660,7 +658,6 @@ def test_pack_deb(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_pack_rpm(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -709,7 +706,6 @@ def test_pack_rpm(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_pack_rpm_use_docker(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
@@ -755,7 +751,6 @@ def test_pack_rpm_use_docker(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-@pytest.mark.docker
 def test_pack_deb_use_docker(tt_cmd, tmpdir):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import re
 import shutil
@@ -63,7 +64,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "check_exist": [
                 os.path.join("app2", "init.lua"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -79,7 +80,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "check_exist": [
                 os.path.join("app2", "init.lua"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -96,7 +97,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -113,7 +114,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -130,7 +131,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -150,7 +151,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("modules", "test_module.txt"),
             ],
             "check_not_exist": [
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
             ],
             "artifacts_in_separated_dir": False,
@@ -165,7 +166,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
                 os.path.join("var", "lib", "app1", "test.snap"),
@@ -191,7 +192,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
                 os.path.join("var", "snap", "app1", "test.snap"),
@@ -223,7 +224,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
                 os.path.join("app1.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -246,7 +247,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("app2", "init.lua"),
                 os.path.join("app2", ".rocks"),
 
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("modules", "test_module.txt"),
             ],
@@ -263,7 +264,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "res_file": "cartridge_app-v2." + get_arch() + ".tar.gz",
             "check_exist": [
                 os.path.join("cartridge_app"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("cartridge_app", "app", "roles", "custom.lua"),
                 os.path.join("cartridge_app", "app", "admin.lua"),
@@ -287,7 +288,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "res_file": "cartridge_app-v2." + get_arch() + ".tar.gz",
             "check_exist": [
                 os.path.join("cartridge_app"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("cartridge_app", "app", "roles", "custom.lua"),
                 os.path.join("cartridge_app", "app", "admin.lua"),
@@ -311,7 +312,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "res_file": "bundle6-v1." + get_arch() + ".tar.gz",
             "check_exist": [
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("instances.enabled", "app.lua"),
                 os.path.join("var", "wal", "app", "artifact_wal"),
@@ -329,7 +330,7 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "res_file": "bundle7-v1." + get_arch() + ".tar.gz",
             "check_exist": [
                 os.path.join("app.lua"),
-                os.path.join("bin", "tarantool"),
+                os.path.join("bin", "tarantool*"),
                 os.path.join("bin", "tt"),
                 os.path.join("instances.enabled", "app.lua"),
                 os.path.join("var", "wal", "app", "artifact_wal"),
@@ -382,10 +383,10 @@ def test_pack_tgz_table(tt_cmd, tmpdir):
         assert_env(extract_path, test_case["artifacts_in_separated_dir"])
 
         for file_path in test_case["check_exist"]:
-            assert os.path.exists(os.path.join(extract_path, file_path))
+            assert glob.glob(os.path.join(extract_path, file_path))
 
         for file_path in test_case["check_not_exist"]:
-            assert not os.path.exists(os.path.join(extract_path, file_path))
+            assert not glob.glob(os.path.join(extract_path, file_path))
 
         shutil.rmtree(extract_path)
         os.remove(package_file)

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -3,4 +3,3 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     slow_ee: marks ee tests as slow (deselect with '-m "not slow_ee"')
     notarantool: marks tests that must be invoked without pre-installed tarantool (deselect with '-m "not notarantool"')
-    docker: marks tests that use docker (deselect with '-m "not docker"')


### PR DESCRIPTION
Since docker daemon is now running on selfhosted
there is no need to use github runners anymore.
Switched full-ci macOS to selfhosted.
Closes #517 
