### PR TITLE
uninstall: remove unused flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Panic in tarantool 1.10.15 static build by `tt`.
+- Removed `--use-docker` flag from `tt uninstall tarantool` since it was added by mistake.
 
 ## [1.1.1] - 2023-06-08
 

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -44,9 +44,6 @@ func newUninstallTarantoolCmd() *cobra.Command {
 		},
 	}
 
-	tntCmd.Flags().BoolVarP(&installCtx.BuildInDocker, "use-docker", "", false,
-		"build tarantool in Ubuntu 18.04 docker container")
-
 	return tntCmd
 }
 


### PR DESCRIPTION
Removed '--use-docker' flag from 'tt uninstall tarantool' since it was added by mistake.

Closes #501