### PR TITLE
test: fix test segfault if net dial fails

### DIFF
--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -38,11 +38,11 @@ func textConnectWithValidation(t *testing.T) *TextConnector {
 	t.Helper()
 
 	conn, err := net.Dial("unix", console)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	protocol, err := GetProtocol(conn)
-	assert.NoError(t, err)
-	assert.Equal(t, TextProtocol, protocol)
+	require.NoError(t, err)
+	require.Equal(t, TextProtocol, protocol)
 
 	return NewTextConnector(conn)
 }


### PR DESCRIPTION
Sometimes `connector` unit test fails with segfault due to `assert`, which does not stop a test in case of failure:
```
--- FAIL: TestConnect_Eval (0.00s)
    integration_test.go:62: 
        	Error Trace:	integration_test.go:41
        	            				integration_test.go:62
        	            				integration_test.go:68
        	Error:      	Received unexpected error:
        	            	dial unix work_dir/console.control: connect: no such file or directory
        	Test:       	TestConnect_Eval
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10035f220]
```
Use the `require` to check the result of `net.Dial` and get protocol.