### PR TITLE
connect: update go-prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `tt pack` now skips all `.git` files in packed environment, not only in main directory.
+- `tt connect`: the reverse search function to work consistently with tarantool.
+
 ### Added
 
 - `tt install tarantool-dev`: ability to install tarantool from the local build directory.
@@ -17,11 +19,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt uninstall`: when removing symlinks and an existing installed version, the
   symlink will be switched to the latest installed version, so that `tt` can
   continue working with the program.
+- `tt connect`: support for multi-line commands in the history.
 
 ### Fixed
 
 - `tt install tarantool`: symlink to the directory with tarantool headers is now updated 
 when installing an existing version.
+- `tt connect`: terminal failure after throwing an error.
 
 ## [1.1.2] - 2023-06-16
 

--- a/cli/connect/input.go
+++ b/cli/connect/input.go
@@ -95,9 +95,7 @@ func AddStmtPart(stmt, part string, validator Validator) (string, bool) {
 			stmt = part
 		}
 	} else {
-		// We can't detect multiline strings. That's why we can't skip an
-		// empty lines.
-		stmt += " " + part
+		stmt += "\n" + part
 	}
 
 	return stmt, validator.Validate(stmt)

--- a/cli/connect/input_test.go
+++ b/cli/connect/input_test.go
@@ -140,7 +140,7 @@ func TestAddStmtPart(t *testing.T) {
 	validator := &ValidatorMock{}
 	const stmt = "1part"
 	const part = "2part"
-	const expected = "1part 2part"
+	const expected = "1part\n2part"
 
 	for _, c := range []bool{false, true} {
 		name := "false"
@@ -168,11 +168,11 @@ func TestAddStmtPart_luaValidator(t *testing.T) {
 	}{
 		{"   ", "", true},
 		{"for i = 1,10 do", "for i = 1,10 do", false},
-		{"    print(x)", "for i = 1,10 do     print(x)", false},
-		{"    local j = 5", "for i = 1,10 do     print(x)     local j = 5", false},
-		{"", "for i = 1,10 do     print(x)     local j = 5 ", false},
-		{" ", "for i = 1,10 do     print(x)     local j = 5   ", false},
-		{"end", "for i = 1,10 do     print(x)     local j = 5    end", true},
+		{"    print(x)", "for i = 1,10 do\n    print(x)", false},
+		{"    local j = 5", "for i = 1,10 do\n    print(x)\n    local j = 5", false},
+		{"", "for i = 1,10 do\n    print(x)\n    local j = 5\n", false},
+		{" ", "for i = 1,10 do\n    print(x)\n    local j = 5\n\n ", false},
+		{"end", "for i = 1,10 do\n    print(x)\n    local j = 5\n\n \nend", true},
 	}
 
 	stmt := ""

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/alecthomas/participle/v2 v2.0.0-alpha4
 	github.com/apex/log v1.9.0
 	github.com/briandowns/spinner v1.11.1
-	github.com/c-bata/go-prompt v0.2.6
 	github.com/dave/jennifer v1.5.0
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/fatih/color v1.13.0
@@ -21,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.1
 	github.com/tarantool/cartridge-cli v0.0.0-20220605082730-53e6a5be9a61
+	github.com/tarantool/go-prompt v1.0.0
 	github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
@@ -39,6 +39,7 @@ require (
 	github.com/Microsoft/hcsshim v0.9.6 // indirect
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	github.com/c-bata/go-prompt v0.2.6 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
 	github.com/containerd/containerd v1.6.18 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -858,6 +858,8 @@ github.com/tarantool/go-openssl v0.0.8-0.20230307065445-720eeb389195 h1:/AN3eUPs
 github.com/tarantool/go-openssl v0.0.8-0.20230307065445-720eeb389195/go.mod h1:M7H4xYSbzqpW/ZRBMyH0eyqQBsnhAMfsYk5mv0yid7A=
 github.com/tarantool/go-prompt v0.2.6-tarantool h1:/dYMRBuM5nE3mleka/mqJWPf8SrJ151U+OqDlTzvES0=
 github.com/tarantool/go-prompt v0.2.6-tarantool/go.mod h1:8enZKIgoGFEQu2XPBK79TguJG2XF3SR4QU2iYI28NSo=
+github.com/tarantool/go-prompt v1.0.0 h1:7lDXh+SBCf4/S3xmDPNOxTA4yfWugD+t82AZOkQviAE=
+github.com/tarantool/go-prompt v1.0.0/go.mod h1:9Vuvi60Bk+3yaXqgYaXNTpLbwPPaaEOeaUgpFW1jqTU=
 github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d h1:qkKjWaxX8GPdHSP2WETv096vm/MH2iBPOZa6hnJ780s=
 github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d/go.mod h1:oMCTx0UAjEkHjdVdgnh3DjwUxs0xgyvIcaOBV8i4CF4=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=


### PR DESCRIPTION
Since a new version of the `tarantool/go-prompt` was released, it's usage has been updated in the `tt`.

- The module has been renamed. See https://github.com/tarantool/go-prompt/commit/8289fd9b72d9749cc6ec6e94728ca48492ccacfb

- The terminal failure after exit was fixed, so `stty sane` has been removed. See https://github.com/tarantool/go-prompt/commit/85a5ca7c72f75d94e6b5bcd237a9a2ac3d41b142

- Manual pushes to the prompt history have been added to handle multi-line commands correctly. See https://github.com/tarantool/go-prompt/commit/d4fc71bf3bfe9fda0edf6e7ec4cbdc45a9a4f958

- Functions 'prompt.GoLeftWord' and 'prompt.GoRightWord' are now used for word navigation. See https://github.com/tarantool/go-prompt/commit/cd83a88dd4a9d47f45c085029282fd62a16d9563

- `prompt.OptionReverseSearch` has been added. See https://github.com/tarantool/go-prompt/commit/9a5cf0976f0dfc3e35e91aa587e8c73aab7f83f3

- The command line delimeter has been changed to `\n` since support for multiline commands was added to `go-prompt`.
See https://github.com/tarantool/go-prompt/commit/dc30449900e5645c57341e143b838512148ba5b6

Closes #507