### PR TITLE
test: fix segmentation fault and races

### DIFF
--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -87,7 +87,7 @@ func NewInstance(tarantoolPath string, instanceCtx *InstanceCtx, env []string,
 
 // SendSignal sends a signal to the Instance.
 func (inst *Instance) SendSignal(sig os.Signal) error {
-	if inst.Cmd == nil {
+	if inst.Cmd == nil || inst.Cmd.Process == nil {
 		return fmt.Errorf("the instance hasn't started yet")
 	}
 	return inst.Cmd.Process.Signal(sig)

--- a/cli/running/instance_test.go
+++ b/cli/running/instance_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/ttlog"
 )
 
@@ -47,10 +48,14 @@ func startTestInstance(t *testing.T, app string, consoleSock string,
 		logger)
 	assert.Nilf(err, `Can't create an instance. Error: "%v".`, err)
 
+	binPath, err := os.Executable()
+	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
+	os.Setenv("started_flag_file", filepath.Join(filepath.Dir(binPath), app))
+	defer os.Remove(os.Getenv("started_flag_file"))
 	err = inst.Start()
 	assert.Nilf(err, `Can't start the instance. Error: "%v".`, err)
 
-	waitProcessStart()
+	require.NotZero(t, waitForFile(os.Getenv("started_flag_file")), "Instance is not started")
 	alive := inst.IsAlive()
 	assert.True(alive, "Can't start the instance.")
 

--- a/cli/running/running_test_helpers.go
+++ b/cli/running/running_test_helpers.go
@@ -1,10 +1,19 @@
 package running
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
-// waitProcessStart waits for the new process to set signal handlers.
-func waitProcessStart() {
-	// We need to wait for the new process (tarantool instance) to set handlers.
-	// It is necessary to update for more correct synchronization.
-	time.Sleep(1000 * time.Millisecond)
+// waitForFile waits for the file to appear.
+func waitForFile(filePath string) int {
+	retries := 10
+	for retries > 0 {
+		time.Sleep(500 * time.Millisecond)
+		if _, err := os.Stat(filePath); err == nil {
+			break
+		}
+		retries--
+	}
+	return retries
 }

--- a/cli/running/test_app/dumb_test_app.lua
+++ b/cli/running/test_app/dumb_test_app.lua
@@ -1,4 +1,7 @@
 local fiber = require('fiber')
+local fio = require('fio')
+
+fio.open(os.getenv('started_flag_file'), 'O_CREAT'):close()
 
 while true do
     fiber.sleep(5)

--- a/cli/running/test_app/dumb_test_run.lua
+++ b/cli/running/test_app/dumb_test_run.lua
@@ -1,1 +1,0 @@
-print('Instance started.')

--- a/cli/running/test_app/log_check_test_app.lua
+++ b/cli/running/test_app/log_check_test_app.lua
@@ -1,6 +1,9 @@
 local fiber = require('fiber')
+local fio = require('fio')
 
 print("Check Log.")
+
+fio.open(os.getenv('started_flag_file'), 'O_CREAT'):close()
 
 while true do
     fiber.sleep(5)


### PR DESCRIPTION
Watchdog tests rely on internal watchdog members to detect if an instance is started. But it's members can be uninitialized if watchdog did not start a process yet. The solution is to use external file for "instance is up" status check.