### PR TITLE
connect: add basic postgres like options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `tt install tarantool-dev`: ability to install tarantool from the local build directory.
 - `tt uninstall`: smart auto-completion. It shows installed versions of programs.
+- `tt connect`: expanded formatting modes.
 
 ### Fixed
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/connect"
 	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/formatter"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/running"
 	"github.com/tarantool/tt/cli/util"
@@ -38,6 +39,7 @@ var (
 	connectPassword    string
 	connectFile        string
 	connectLanguage    string
+	connectFormat      string
 	connectSslKeyFile  string
 	connectSslCertFile string
 	connectSslCaFile   string
@@ -94,6 +96,8 @@ func NewConnectCmd() *cobra.Command {
 		`file to read the script for evaluation. "-" - read the script from stdin`)
 	connectCmd.Flags().StringVarP(&connectLanguage, "language", "l",
 		connect.DefaultLanguage.String(), `language: lua or sql`)
+	connectCmd.Flags().StringVarP(&connectFormat, "outputformat", "x",
+		formatter.DefaultFormat.String(), `output format: yaml, lua, table or ttable`)
 	connectCmd.Flags().StringVarP(&connectSslKeyFile, "sslkeyfile", "",
 		connect.DefaultLanguage.String(), `path to a private SSL key file`)
 	connectCmd.Flags().StringVarP(&connectSslCertFile, "sslcertfile", "",
@@ -292,6 +296,9 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	var ok bool
 	if connectCtx.Language, ok = connect.ParseLanguage(connectLanguage); !ok {
 		return util.NewArgError(fmt.Sprintf("unsupported language: %s", connectLanguage))
+	}
+	if connectCtx.Format, ok = formatter.ParseFormat(connectFormat); !ok {
+		return util.NewArgError(fmt.Sprintf("unsupported output format: %s", connectFormat))
 	}
 
 	connOpts, newArgs, err := resolveConnectOpts(cmdCtx, cliOpts, connectCtx, args)

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -28,9 +28,10 @@ var luaCodeFiles = []generateLuaCodeOpts{
 		PackageName: "connect",
 		FileName:    "cli/connect/lua_code_gen.go",
 		VariablesMap: map[string]string{
-			"consoleEvalFuncBody":    "cli/connect/lua/console_eval_func_body.lua",
-			"evalFuncBody":           "cli/connect/lua/eval_func_body.lua",
-			"getSuggestionsFuncBody": "cli/connect/lua/get_suggestions_func_body.lua",
+			"consoleEvalFuncBody":        "cli/connect/lua/console_eval_func_body.lua",
+			"consoleEvalFuncBodyTblsFmt": "cli/connect/lua/console_eval_func_body_tbls_fmt.lua",
+			"evalFuncBody":               "cli/connect/lua/eval_func_body.lua",
+			"getSuggestionsFuncBody":     "cli/connect/lua/get_suggestions_func_body.lua",
 		},
 	},
 	{

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -32,6 +32,18 @@ var luaCodeFiles = []generateLuaCodeOpts{
 			"consoleEvalFuncBodyTblsFmt": "cli/connect/lua/console_eval_func_body_tbls_fmt.lua",
 			"evalFuncBody":               "cli/connect/lua/eval_func_body.lua",
 			"getSuggestionsFuncBody":     "cli/connect/lua/get_suggestions_func_body.lua",
+			"getFuncsListInteractOptBody": "cli/connect/lua/" +
+				"get_func_list_interactive_opt.lua",
+			"getSpaceIndexesListInteractOptBody": "cli/connect/lua/" +
+				"get_space_indexes_list_interactive_opt.lua",
+			"getSpaceIndexInfoInteractOptBody": "cli/connect/lua/" +
+				"get_space_index_info_interactive_opt.lua",
+			"getSpacesListInteractOptBody": "cli/connect/lua/" +
+				"get_spaces_list_interactive_opt.lua",
+			"getSpaceFormatInteractOptBody": "cli/connect/lua/" +
+				"get_space_format_interactive_opt.lua",
+			"getSpaceInfoInteractOptBody": "cli/connect/lua/" +
+				"get_space_info_interactive_opt.lua",
 		},
 	},
 	{

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/formatter"
 	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/yaml.v2"
 )
@@ -22,6 +23,8 @@ type ConnectCtx struct {
 	SrcFile string
 	// Language to use for execution.
 	Language Language
+	// Format to use as output format.
+	Format formatter.Format
 	// SslKeyFile is a path to a private SSL key file.
 	SslKeyFile string
 	// SslCertFile is a path to an SSL certificate file.
@@ -70,7 +73,7 @@ func getEvalCmd(connectCtx ConnectCtx) (string, error) {
 
 // Connect establishes a connection to the instance and starts the console.
 func Connect(connectCtx ConnectCtx, connOpts connector.ConnectOpts) error {
-	if err := runConsole(connOpts, "", connectCtx.Language); err != nil {
+	if err := runConsole(connOpts, "", connectCtx.Language, connectCtx.Format); err != nil {
 		return fmt.Errorf("failed to run interactive console: %s", err)
 	}
 	return nil
@@ -124,8 +127,9 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 }
 
 // runConsole run a new console.
-func runConsole(connOpts connector.ConnectOpts, title string, lang Language) error {
-	console, err := NewConsole(connOpts, title, lang)
+func runConsole(connOpts connector.ConnectOpts, title string,
+	lang Language, outputFormat formatter.Format) error {
+	console, err := NewConsole(connOpts, title, lang, outputFormat)
 	if err != nil {
 		return fmt.Errorf("failed to create new console: %s", err)
 	}

--- a/cli/connect/interactive.go
+++ b/cli/connect/interactive.go
@@ -1,0 +1,245 @@
+package connect
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/tarantool/tt/cli/formatter"
+)
+
+// setFormatPrefix is a prefix for a set output format interactive option.
+const setFormatPrefix = "\\set output "
+
+// setFormatShortPrefix is a short command for a set output format interactive option.
+const setFormatShortPrefix = "\\x"
+
+// setTableDialectPrefix is a short prefix for a set output table dialect interactive option.
+const setTableDialectPrefix = "\\set table_format "
+
+// setPseudoGraphicsEnable is an interactive option for pseudo graphics enabling of
+// table/ttalbe output formats.
+const setPseudoGraphicsEnable = "\\xG"
+
+// setPseudoGraphicsEnable is an interactive option for pseudo graphics disabling of
+// table/ttalbe output formats.
+const setPseudoGraphicsDisable = "\\xg"
+
+// setTableColWidthShortPrefix is a short prefix for table column width interactive option.
+const setTableColWidthShortPrefix = "\\xw "
+
+// setTableColWidthShortPrefix is a prefix for table column width interactive option.
+const setTableColWidthPrefix = "\\set table_column_width "
+
+// helpOptionHandler prints help of tt connect interactive option.
+func helpOptionHandler() {
+	var help string = `
+  To get help, see the Tarantool manual at https://tarantool.io/en/doc/
+  To start the interactive Tarantool tutorial, type 'tutorial()' here.
+
+  This help is expanded with additional backslash commands
+  because tt connect is using.
+
+  Available backslash commands:
+
+  \set language <language>        -- set language lua or sql
+  \set output <format>            -- set output format yaml, lua, table, ttable
+  \x[y,l,t,T]                     -- set output format yaml, lua, table, ttable
+  \x                              -- switches output format cyclically
+  \x[g,G]                         -- disables/enables pseudographics for tables
+  \set table_column_width <width> -- max column width for table/ttable
+  \xw                             -- max column width for table/ttable
+  \table_format <format>          -- tables format markdown, jira or default
+  \help                           -- show this screen
+  \quit                           -- quit interactive console
+  `
+	fmt.Println(help)
+}
+
+// handleLanguageOption handles language interactive option.
+func handleLanguageOption(trimmed string, console *Console) {
+	newLang := strings.TrimPrefix(trimmed, setLanguagePrefix)
+	if lang, ok := ParseLanguage(newLang); ok {
+		if err := ChangeLanguage(console.conn, lang); err != nil {
+			log.Warnf("Failed to change language: %s", err)
+		} else {
+			console.language = lang
+			log.Infof("Selected language: %s", console.language.String())
+		}
+	} else {
+		log.Warnf("Unsupported language: %s", newLang)
+	}
+}
+
+// handleWidthOption handles width interactive option for table/ttable output formats.
+func handleWidthOption(trimmed string, console *Console, formatterOpts *formatter.Opts) {
+	var maxWidthStr string
+	if strings.HasPrefix(trimmed, strings.TrimSpace(setTableColWidthShortPrefix)) {
+		maxWidthStr = strings.TrimPrefix(trimmed, setTableColWidthShortPrefix)
+	} else if strings.HasPrefix(trimmed, strings.TrimSpace(setTableColWidthPrefix)) {
+		maxWidthStr = strings.TrimPrefix(trimmed, setTableColWidthPrefix)
+	} else {
+		panic("there is no pattern cases for get width value")
+	}
+	valCasted, err := strconv.ParseInt(maxWidthStr, 10, 64)
+	if err == nil && valCasted >= 0 {
+		formatterOpts.ColWidthMax = int(valCasted)
+		if formatterOpts.ColWidthMax > 0 {
+			log.Infof("Selected max width: %v", formatterOpts.ColWidthMax)
+		} else {
+			log.Info("Selected max width: disabled")
+		}
+	} else {
+		log.Errorf("Max width must be non-negative number, but you gave: %v", maxWidthStr)
+	}
+}
+
+// handlePseudoGraphicsOption handles pseudo graphics enable/disable interactive option
+// for table/ttable output formats.
+func handlePseudoGraphicsOption(trimmed string, console *Console,
+	formatterOpts *formatter.Opts) {
+	if console.outputFormat == formatter.TableFormat ||
+		console.outputFormat == formatter.TTableFormat {
+		if trimmed == setPseudoGraphicsEnable {
+			formatterOpts.NoGraphics = false
+			log.Info("Pseudo graphics is enabled now")
+		} else if trimmed == setPseudoGraphicsDisable {
+			formatterOpts.NoGraphics = true
+			log.Info("Pseudo graphics is disabled now")
+		} else {
+			panic("there is no pattern cases for handling pseudo graphics enabling/disabling")
+		}
+	} else {
+		log.Error("Pseudo graphics enabling/disabling " +
+			"only allowed for table and ttable output formats")
+	}
+}
+
+// handleFormatOption handles output interactive option.
+func handleFormatOption(trimmed string, executorEval *string,
+	console *Console, formatterOpts *formatter.Opts) {
+	var newFormat string
+	if strings.HasPrefix(trimmed, setFormatPrefix) {
+		newFormat = strings.TrimPrefix(trimmed, setFormatPrefix)
+	}
+	if strings.HasPrefix(trimmed, setFormatShortPrefix) {
+		if trimmed == setFormatShortPrefix {
+			if console.outputFormat == formatter.DefaultFormat {
+				console.outputFormat = formatter.YamlFormat
+				formatterOpts.TransposeMode = formatter.IsTTableFormat(console.outputFormat)
+			}
+			console.outputFormat = 1 + (console.outputFormat % 4)
+			formatterOpts.TransposeMode = formatter.IsTTableFormat(console.outputFormat)
+			trimmed = console.outputFormat.String()
+		}
+		newFormat = strings.TrimPrefix(trimmed, setFormatShortPrefix)
+	}
+	if outputFormat, ok := formatter.ParseFormat(newFormat); ok {
+		if outputFormat == formatter.TableFormat || outputFormat == formatter.TTableFormat {
+			*executorEval = consoleEvalFuncBodyTblsFmt
+			console.outputFormat = outputFormat
+			formatterOpts.TransposeMode = formatter.IsTTableFormat(console.outputFormat)
+			log.Infof("Selected output format: %s", console.outputFormat.String())
+		} else {
+			*executorEval = consoleEvalFuncBody
+			console.outputFormat = outputFormat
+			formatterOpts.TransposeMode = formatter.IsTTableFormat(console.outputFormat)
+			log.Infof("Selected output format: %s", console.outputFormat.String())
+		}
+	} else {
+		log.Warnf("Unsupported output format: %s", newFormat)
+	}
+}
+
+// handleTableDialectOption handles table dialect interactive option
+// for table/ttable output formats.
+func handleTableDialectOption(trimmed string, formatterOpts *formatter.Opts) {
+	newTableDialect := strings.TrimPrefix(trimmed, setTableDialectPrefix)
+	if tableDialect, ok := formatter.ParseTableDialect(newTableDialect); ok {
+		formatterOpts.TableDialect = tableDialect
+		if formatterOpts.TableDialect != formatter.DefaultTableDialect &&
+			formatterOpts.ColWidthMax > 0 {
+			formatterOpts.ColWidthMax = 0
+			log.Info("Selected max width: disabled")
+		}
+		log.Infof("Selected table dialect: %s", formatterOpts.TableDialect.String())
+	} else {
+		log.Warnf("Unsupported table dialect: %s", newTableDialect)
+	}
+}
+
+// handleInteractiveOption handles slash options for interactive console and returns
+// true if slash options detected in user input.
+func handleInteractiveOption(in string, executorEval *string,
+	console *Console, formatterOpts *formatter.Opts) bool {
+	trimmed := strings.TrimSpace(in)
+
+	// Helper case handling.
+	if trimmed == "\\help" || in == "help" ||
+		trimmed == "\\" || trimmed == "\\?" {
+		helpOptionHandler()
+		return true
+	}
+
+	// Language case handling.
+	if strings.HasPrefix(trimmed, setLanguagePrefix) {
+		handleLanguageOption(trimmed, console)
+		return true
+	}
+
+	// Table width case handling.
+	if strings.HasPrefix(trimmed, strings.TrimSpace(setTableColWidthShortPrefix)) ||
+		strings.HasPrefix(trimmed, strings.TrimSpace(setTableColWidthPrefix)) {
+		if formatterOpts.TableDialect != formatter.DefaultTableDialect {
+			log.Error("Max width option only supports for default table dialect, " +
+				"not for jira or markdown.")
+			return true
+		}
+		if console.outputFormat != formatter.TableFormat &&
+			console.outputFormat != formatter.TTableFormat {
+			log.Error("Max width option only supports for table and ttable output formats.")
+			return true
+		}
+		handleWidthOption(trimmed, console, formatterOpts)
+		return true
+	}
+
+	// Table graphics enable/disable case handling.
+	if trimmed == setPseudoGraphicsDisable || trimmed == setPseudoGraphicsEnable {
+		if formatterOpts.TableDialect != formatter.DefaultTableDialect {
+			log.Error("Pseudo graphics enabling/disabling supports only for default table dialect")
+			return true
+		}
+		handlePseudoGraphicsOption(trimmed, console, formatterOpts)
+		return true
+	}
+
+	// Output format case handling.
+	if trimmed == strings.TrimSpace(setFormatPrefix) {
+		log.Error("Specify output format: yaml, lua, table or ttable.")
+		return true
+	}
+	if strings.HasPrefix(trimmed, setFormatPrefix) ||
+		strings.HasPrefix(trimmed, setFormatShortPrefix) {
+		handleFormatOption(trimmed, executorEval, console, formatterOpts)
+		return true
+	}
+
+	// Table dialect case handling.
+	if trimmed == strings.TrimSpace(setTableDialectPrefix) {
+		log.Error("Specify table dialect: default, markdown or jira")
+		return true
+	}
+	if strings.HasPrefix(trimmed, setTableDialectPrefix) {
+		if console.outputFormat != formatter.TableFormat &&
+			console.outputFormat != formatter.TTableFormat {
+			log.Error("Table dialects supports only for table and ttable output formats")
+			return true
+		}
+		handleTableDialectOption(trimmed, formatterOpts)
+		return true
+	}
+
+	return false
+}

--- a/cli/connect/lua/console_eval_func_body_tbls_fmt.lua
+++ b/cli/connect/lua/console_eval_func_body_tbls_fmt.lua
@@ -1,0 +1,59 @@
+local yaml = require('yaml')
+
+local function table_len(t)
+    local len = 0
+    for _ in pairs(t) do
+        len = len + 1
+    end
+
+    return len
+end
+
+local function metadata_mapping(res)
+    local mapped_res = {}
+    if table_len(res[1].rows) == 1 then
+        for k, v in ipairs(unpack(res[1].rows)) do
+            mapped_res[res[1].metadata[k].name] = v
+        end
+    elseif table_len(res[1].rows) > 1 then
+        for _, row in ipairs(res[1].rows) do
+            local row_mapped = {}
+            for row_col_num, row_col in ipairs(row) do
+                row_mapped[res[1].metadata[row_col_num].name] = row_col
+            end
+            table.insert(mapped_res, row_mapped)
+        end
+    end
+
+    if table_len(mapped_res) == 0 then
+        for _, v in ipairs(res[1].metadata) do
+            mapped_res[v.name] = ""
+        end
+    end
+
+    if table_len(res[1].rows) > 1 then
+        res = mapped_res
+    else
+        res = {mapped_res}
+    end
+
+    return res
+end
+
+local res = yaml.decode((require('console').eval(...)))
+
+if type(res[1]) == 'table' and type(res[1].metadata) == 'table'
+                           and type(res[1].rows) == 'table' then
+    res = metadata_mapping(res)
+end
+
+if not (type(res) == 'table' or box.tuple.is(res)) then
+    res = {res}
+end
+
+local ok, res_encoded = pcall(yaml.encode, res)
+if not ok then
+    return yaml.encode({{error = res_encoded}})
+end
+
+return res_encoded

--- a/cli/connect/lua/get_func_list_interactive_opt.lua
+++ b/cli/connect/lua/get_func_list_interactive_opt.lua
@@ -1,0 +1,30 @@
+local yaml = require('yaml')
+
+local function is_not_sys_func(name)
+    local sys_names = {
+        "box.schema.user.info",
+        "LUA",
+    }
+
+    if type(name) ~= 'string' then
+        return false
+    end
+
+    for _, v in pairs(sys_names) do
+        if v == name then
+            return false
+        end
+    end
+
+    return true
+end
+
+local func_list = unpack(yaml.decode(require('console').eval('box.func')))
+local res = {}
+for k, v in pairs(func_list) do
+    if is_not_sys_func(k) then
+        table.insert(res,{func_name = k, language = v.language})
+    end
+end
+
+return unpack(res)

--- a/cli/connect/lua/get_space_format_interactive_opt.lua
+++ b/cli/connect/lua/get_space_format_interactive_opt.lua
@@ -1,0 +1,9 @@
+local yaml = require('yaml')
+
+local space_name = ...
+
+if box.space[space_name] == nil then
+    return yaml.encode({{error="the specified space does not exist"}})
+end
+
+return yaml.encode(box.space[space_name]:format())

--- a/cli/connect/lua/get_space_index_info_interactive_opt.lua
+++ b/cli/connect/lua/get_space_index_info_interactive_opt.lua
@@ -1,0 +1,16 @@
+local yaml = require('yaml')
+
+local input = ...
+local space_name, index_name = input[1], input[2]
+
+if box.space[space_name] == nil then
+    return yaml.encode({{error="the specified space does not exist"}})
+end
+if box.space[space_name].index == nil then
+    return yaml.encode({{error="there is no indexes for specified space"}})
+end
+if box.space[space_name].index[index_name] == nil then
+    return yaml.encode({{error="the specified index does not exist"}})
+end
+
+return yaml.encode({box.space[space_name].index[index_name]})

--- a/cli/connect/lua/get_space_indexes_list_interactive_opt.lua
+++ b/cli/connect/lua/get_space_indexes_list_interactive_opt.lua
@@ -1,0 +1,31 @@
+local yaml = require('yaml')
+
+local function no_added_such_name(res, name)
+    for _,v in pairs(res) do
+        if v.name == name then
+            return false
+        end
+    end
+
+    return true
+end
+
+local space_name = ...
+if box.space[space_name] == nil then
+    return yaml.encode({{error="the specified space does not exist"}})
+end
+
+local indexes_list = box.space[space_name].index
+
+if indexes_list == nil then
+    return yaml.encode({{error="the specified space does not have indexes"}})
+end
+
+local res = {}
+for _, v in pairs(indexes_list) do
+    if no_added_such_name(res, v.name) then
+        table.insert(res, {type = v.type, name = v.name})
+    end
+end
+
+return yaml.encode(res)

--- a/cli/connect/lua/get_space_info_interactive_opt.lua
+++ b/cli/connect/lua/get_space_info_interactive_opt.lua
@@ -1,0 +1,19 @@
+local yaml = require('yaml')
+
+local space_name = ...
+
+if box.space[space_name] == nil then
+    return yaml.encode({{error="the specified space does not exist"}})
+end
+
+local space_info = yaml.decode(require('console').eval(
+    string.format("box.space.%s", space_name)
+))
+local res = {}
+for k, v in pairs(unpack(space_info)) do
+    if k ~= 'index' then
+        res[k] = v
+    end
+end
+
+return yaml.encode({res})

--- a/cli/connect/lua/get_spaces_list_interactive_opt.lua
+++ b/cli/connect/lua/get_spaces_list_interactive_opt.lua
@@ -1,0 +1,12 @@
+local yaml = require('yaml')
+
+local space_list = box.space
+
+local res = {}
+for k, v in pairs(space_list) do
+    if type(k) == 'string' and not k:match("^_") then
+        table.insert(res, {engine = v.engine, space_name = k})
+    end
+end
+
+return yaml.encode(res)

--- a/cli/formatter/format.go
+++ b/cli/formatter/format.go
@@ -1,0 +1,788 @@
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/apex/log"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"gopkg.in/yaml.v2"
+)
+
+// MakeOutput returns formatted output depending on specified output format and formatting options.
+func MakeOutput(data string, outputFormat Format, opts *Opts) string {
+	switch outputFormat {
+	case DefaultFormat, YamlFormat:
+		return fmt.Sprintf("%s\n", data)
+	case LuaFormat:
+		return fmt.Sprintf("%s\n", getRenderedLua(data))
+	case TableFormat, TTableFormat:
+		return fmt.Sprintf("%s", getRenderedTables(data, opts))
+	default:
+		panic("Unknown render case")
+	}
+}
+
+// IsTTableFormat returns true if outputFormat is TTableFormat.
+func IsTTableFormat(outputFormat Format) bool {
+	if outputFormat == TTableFormat {
+		return true
+	}
+
+	return false
+}
+
+// decodeYamlMap decodes yaml string as map[string]renderNode content.
+func decodeYamlMap(input string) (map[string]renderNode, error) {
+	var decodedRes map[string]renderNode
+	err := yaml.Unmarshal([]byte(input), &decodedRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedRes, nil
+}
+
+// decodeYamlArr decodes yaml string as []renderNode content.
+func decodeYamlArr(input string) ([]renderNode, error) {
+	var decodedRes []renderNode
+	err := yaml.Unmarshal([]byte(input), &decodedRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedRes, nil
+}
+
+// arrsOnlyInBatch detects whether batch consist only arrays and
+// whether there is only one array in it.
+func arrsOnlyInBatch(batch []renderNode) (bool, bool, error) {
+	var arrsOnly = true
+	for _, node := range batch {
+		if getRenderNodeType(node) != arrayRenderNodeType {
+			arrsOnly = false
+			break
+		}
+	}
+
+	var singleArrWithArrs = false
+	if len(batch) == 1 {
+		singleArrWithArrs = true
+		for _, node := range batch {
+			nodeBytes, err := yaml.Marshal(node)
+			if err != nil {
+				return false, false, err
+			}
+			iterableNode, err := decodeYamlArr(string(nodeBytes))
+			if err != nil {
+				return false, false, err
+			}
+			for _, nodeMember := range iterableNode {
+				if getRenderNodeType(nodeMember) != arrayRenderNodeType {
+					singleArrWithArrs = false
+				}
+			}
+		}
+	}
+
+	return arrsOnly, singleArrWithArrs, nil
+}
+
+// constructHeaderRowForArrs constructs header row for case with arrays.
+func constructHeaderRowForArrs(batch []renderNode) table.Row {
+	var headerLen = 1
+	for _, node := range batch {
+		nodeLen := len(node.([]interface{}))
+		if nodeLen > headerLen {
+			headerLen = nodeLen
+		}
+	}
+
+	var header table.Row
+	for i := 1; i <= headerLen; i++ {
+		header = append(header, "col"+strconv.Itoa(i))
+	}
+
+	return header
+}
+
+// isRenderMapsKeysEqual checks keys equal for maps[string]renderNodes.
+func isRenderMapsKeysEqual(x map[string]renderNode, y map[string]renderNode) bool {
+	var keysX, keysY []string
+
+	for k := range x {
+		keysX = append(keysX, k)
+	}
+	for k := range y {
+		keysY = append(keysY, k)
+	}
+	sort.Strings(keysX)
+	sort.Strings(keysY)
+
+	if len(keysX) != len(keysY) {
+		return false
+	}
+
+	for k, v := range keysX {
+		if keysY[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// convertMapIntrfToMapStr converts map[interface] to map[string].
+func convertMapIntrfToMapStr(v interface{}) interface{} {
+	switch x := v.(type) {
+	case map[interface{}]interface{}:
+		m := map[string]interface{}{}
+		for k, v2 := range x {
+			switch k2 := k.(type) {
+			case string:
+				m[k2] = convertMapIntrfToMapStr(v2)
+			default:
+				m[fmt.Sprint(k)] = convertMapIntrfToMapStr(v2)
+			}
+		}
+		v = m
+
+	case []interface{}:
+		for i, v2 := range x {
+			x[i] = convertMapIntrfToMapStr(v2)
+		}
+
+	case map[string]interface{}:
+		for k, v2 := range x {
+			x[k] = convertMapIntrfToMapStr(v2)
+		}
+	}
+
+	return v
+}
+
+// getRenderNodeType returns renderNode type.
+func getRenderNodeType(node renderNode) int {
+	switch node.(type) {
+	case map[interface{}]interface{}:
+		return mapRenderNodeType
+	case []interface{}:
+		return arrayRenderNodeType
+	default:
+		return scalarRenderNodeType
+	}
+}
+
+// isRenderNodesTypesEqual checks renderNode equal.
+func isRenderNodesTypesEqual(x renderNode, y renderNode) bool {
+	return getRenderNodeType(x) == getRenderNodeType(y)
+}
+
+// constructHeaderRowForMap constructs header row for case with map.
+func constructHeaderRowForMap(keys []string) table.Row {
+	var headerRow table.Row
+	var headerBuffer []string
+	for _, headerCalVal := range keys {
+		strVal := fmt.Sprintf("%v", headerCalVal)
+		_, err := strconv.ParseInt(strVal, 10, 64)
+		if err != nil {
+			headerBuffer = append(headerBuffer, strVal)
+		} else {
+			headerBuffer = append(headerBuffer, "col"+strVal)
+		}
+	}
+	for _, value := range headerBuffer {
+		headerRow = append(headerRow, value)
+	}
+
+	return headerRow
+}
+
+// transposeRows performs table rows transpose.
+func transposeRows(rowsRaw []table.Row) []table.Row {
+	var rowsRawTransposedCap = 0
+	for _, row := range rowsRaw {
+		if len(row) > rowsRawTransposedCap {
+			rowsRawTransposedCap = len(row)
+		}
+	}
+
+	for rowNum, row := range rowsRaw {
+		if len(row) < rowsRawTransposedCap {
+			for i := 0; i < rowsRawTransposedCap-len(row); i++ {
+				rowsRaw[rowNum] = append(rowsRaw[rowNum], "")
+			}
+		}
+	}
+
+	var rowsRawTransposed []table.Row
+
+	for i := 0; i < rowsRawTransposedCap; i++ {
+		var rowTransposed table.Row
+		for j := 0; j < len(rowsRaw); j++ {
+			rowTransposed = append(rowTransposed, rowsRaw[j][i])
+		}
+		rowsRawTransposed = append(rowsRawTransposed, rowTransposed)
+	}
+
+	return rowsRawTransposed
+}
+
+// renderMapsWithEqualKeys returns maps with equal keys as single table string.
+func renderMapsWithEqualKeys(maps []map[string]renderNode, opts *Opts) (string, error) {
+	var commonKeys []string
+	for mapKey := range maps[0] {
+		commonKeys = append(commonKeys, mapKey)
+	}
+
+	sort.Strings(commonKeys)
+
+	t := table.NewWriter()
+	var rows []table.Row
+	rows = append(rows, constructHeaderRowForMap(commonKeys))
+
+	for _, mapVal := range maps {
+		var rowVals table.Row
+		for _, commonKey := range commonKeys {
+			if getRenderNodeType(mapVal[commonKey]) == scalarRenderNodeType {
+				switch mapVal[commonKey].(type) {
+				case float64, float32:
+					rowVals = append(rowVals,
+						strconv.FormatFloat(mapVal[commonKey].(float64), 'f', -1, 64))
+				case nil:
+					rowVals = append(rowVals, "nil")
+				default:
+					rowVals = append(rowVals, fmt.Sprintf("%v", mapVal[commonKey]))
+				}
+			} else {
+				// Encoding as json value for map/array table cell cases.
+				jsonVal, err := json.Marshal(convertMapIntrfToMapStr(mapVal[commonKey]))
+				if err != nil {
+					return "", err
+				}
+				rowVals = append(rowVals, string(jsonVal))
+			}
+		}
+		rows = append(rows, rowVals)
+	}
+
+	t.Style().Options.SeparateRows = true
+	var rowsAmount = len(rows)
+	if opts.TransposeMode {
+		rows = transposeRows(rows)
+	}
+	t.AppendRows(rows)
+
+	if opts.NoGraphics {
+		t.SetStyle(table.Style{Box: StyleWithoutGraphics})
+	}
+	if opts.ColWidthMax > 0 {
+		colWidthTransformer := text.Transformer(func(val interface{}) string {
+			str := fmt.Sprintf("%v", val)
+			widthMax := opts.ColWidthMax
+			if utf8.RuneCountInString(str) > widthMax {
+				firstLine := string([]rune(str)[:widthMax])
+				remainingLines := string([]rune(str)[widthMax:])
+				firstLine = firstLine + "+"
+				remainingLines = text.InsertEveryN(remainingLines, '+', widthMax-1)
+				return firstLine + remainingLines
+			}
+			return fmt.Sprintf("%v", val)
+		})
+		var columnConfigs []table.ColumnConfig
+		for i := 1; i <= len(commonKeys); i++ {
+			columnConfigs = append(columnConfigs,
+				table.ColumnConfig{
+					Number:      i,
+					Transformer: colWidthTransformer,
+					WidthMax:    opts.ColWidthMax,
+				},
+			)
+		}
+		t.SetColumnConfigs(columnConfigs)
+	}
+
+	if opts.TableDialect == MarkdownTableDialect {
+		markdownTable := strings.Split(t.RenderMarkdown(), "\n")
+		if !opts.TransposeMode {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(len(commonKeys)))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(len(commonKeys)))
+		} else {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(rowsAmount))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(rowsAmount))
+		}
+		var res string
+		for _, v := range markdownTable {
+			res = res + v + "\n"
+		}
+		return res + "\n", nil
+	}
+	if opts.TableDialect == JiraTableDialect {
+		return t.RenderMarkdown() + "\n\n", nil
+	}
+
+	return t.Render() + "\n", nil
+}
+
+// mapsOnlyInBatch checks whether batch consist only maps.
+func mapsOnlyInBatch(batch []renderNode) bool {
+	var mapsOnly = true
+	for _, node := range batch {
+		if getRenderNodeType(node) != mapRenderNodeType {
+			mapsOnly = false
+			break
+		}
+	}
+
+	return mapsOnly
+}
+
+// scalarsOnlyInBatch checks whether batch consist only scalars.
+func scalarsOnlyInBatch(batch []renderNode) bool {
+	var scalarsOnly = true
+	for _, node := range batch {
+		if getRenderNodeType(node) != scalarRenderNodeType {
+			scalarsOnly = false
+			break
+		}
+	}
+
+	return scalarsOnly
+}
+
+// insertStrToStrSlice inserts string to string slice.
+func insertStrToStrSlice(slice []string, index int, value string) []string {
+	if len(slice) == index {
+		return append(slice, value)
+	}
+	slice = append(slice[:index+1], slice[index:]...)
+	slice[index] = value
+
+	return slice
+}
+
+// constructMarkdownHeaderSeparatorRow constructs separator row in markdown notation.
+func constructMarkdownHeaderSeparatorRow(totalRowAmount int) string {
+	var result = "|-"
+	for i := 1; i < totalRowAmount; i++ {
+		result = result + "|-"
+	}
+	result = result + "|"
+
+	return result
+}
+
+// constructMarkdownEmptyRow constructs empty row in markdown notation.
+func constructMarkdownEmptyRow(totalRowAmount int) string {
+	var result = "| "
+	for i := 1; i < totalRowAmount; i++ {
+		result = result + "| "
+	}
+	result = result + "|"
+
+	return result
+}
+
+// renderSingleColumnTable returns table with single column as string.
+func renderSingleColumnTable(renderBatch []renderNode, opts *Opts) string {
+	t := table.NewWriter()
+	var rows []table.Row
+	rows = append(rows, table.Row{"col1"})
+	for _, node := range renderBatch {
+		switch node.(type) {
+		case float64, float32:
+			rows = append(rows, []interface{}{strconv.FormatFloat(node.(float64), 'f', -1, 64)})
+		case nil:
+			rows = append(rows, []interface{}{"nil"})
+		default:
+			rows = append(rows, []interface{}{fmt.Sprintf("%v", node)})
+		}
+	}
+
+	var rowsAmount = len(rows)
+	if opts.TransposeMode {
+		rows = transposeRows(rows)
+	}
+	t.AppendRows(rows)
+	t.Style().Options.SeparateRows = true
+
+	if opts.NoGraphics {
+		t.SetStyle(table.Style{Box: StyleWithoutGraphics})
+	}
+	if opts.ColWidthMax > 0 {
+		colWidthTransformer := text.Transformer(func(val interface{}) string {
+			str := fmt.Sprintf("%v", val)
+			widthMax := opts.ColWidthMax
+			if utf8.RuneCountInString(str) > widthMax {
+				firstLine := string([]rune(str)[:widthMax])
+				remainingLines := string([]rune(str)[widthMax:])
+				firstLine = firstLine + "+"
+				remainingLines = text.InsertEveryN(remainingLines, '+', widthMax-1)
+				return firstLine + remainingLines
+			}
+			return fmt.Sprintf("%v", val)
+		})
+		var columnConfigs []table.ColumnConfig
+		for i := 1; i <= rowsAmount; i++ {
+			columnConfigs = append(columnConfigs,
+				table.ColumnConfig{
+					Number:      i,
+					Transformer: colWidthTransformer,
+					WidthMax:    opts.ColWidthMax,
+				},
+			)
+		}
+		t.SetColumnConfigs(columnConfigs)
+	}
+
+	if opts.TableDialect == MarkdownTableDialect {
+		markdownTable := strings.Split(t.RenderMarkdown(), "\n")
+		if !opts.TransposeMode {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(1))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(1))
+		} else {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(rowsAmount))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(rowsAmount))
+		}
+		var res string
+		for _, v := range markdownTable {
+			res = res + v + "\n"
+		}
+		return res + "\n"
+	}
+	if opts.TableDialect == JiraTableDialect {
+		return t.RenderMarkdown() + "\n\n"
+	}
+
+	return t.Render() + "\n"
+}
+
+// castRenderNodeToMap casts renderNode to map[string]renderNode.
+func castRenderNodeToMap(node renderNode) (map[string]renderNode, error) {
+	var castedRes map[string]renderNode
+	var err error
+	nodeYaml, err := yaml.Marshal(node)
+	if err != nil {
+		return nil, err
+	}
+	castedRes, err = decodeYamlMap(string(nodeYaml))
+	if err != nil {
+		return nil, err
+	}
+
+	return castedRes, nil
+}
+
+// renderArrs returns table as string for arrays case.
+func renderArrs(renderBatch []renderNode, opts *Opts) (string, error) {
+	t := table.NewWriter()
+
+	var rows []table.Row
+	rows = append(rows, constructHeaderRowForArrs(renderBatch))
+	for _, node := range renderBatch {
+		nodeBytes, err := yaml.Marshal(node)
+		if err != nil {
+			return "", err
+		}
+		nodeIterable, err := decodeYamlArr(string(nodeBytes))
+		if err != nil {
+			return "", err
+		}
+		var row []interface{}
+		for _, rowColVal := range nodeIterable {
+			if getRenderNodeType(rowColVal) == scalarRenderNodeType {
+				switch rowColVal.(type) {
+				case float64, float32:
+					row = append(row, strconv.FormatFloat(rowColVal.(float64), 'f', -1, 64))
+				case nil:
+					row = append(row, "nil")
+				default:
+					row = append(row, fmt.Sprintf("%v", rowColVal))
+				}
+			} else {
+				// Encoding as json value for map/array table cell cases.
+				jsonVal, err := json.Marshal(convertMapIntrfToMapStr(rowColVal))
+				if err != nil {
+					return "", err
+				}
+				row = append(row, string(jsonVal))
+			}
+		}
+		rows = append(rows, row)
+	}
+	t.Style().Options.SeparateRows = true
+	var rowsAmount = len(rows)
+	if opts.TransposeMode {
+		rows = transposeRows(rows)
+	}
+	t.AppendRows(rows)
+
+	if opts.NoGraphics {
+		t.SetStyle(table.Style{Box: StyleWithoutGraphics})
+	}
+	if opts.ColWidthMax > 0 {
+		colWidthTransformer := text.Transformer(func(val interface{}) string {
+			str := fmt.Sprintf("%v", val)
+			widthMax := opts.ColWidthMax
+			if utf8.RuneCountInString(str) > widthMax {
+				firstLine := string([]rune(str)[:widthMax])
+				remainingLines := string([]rune(str)[widthMax:])
+				firstLine = firstLine + "+"
+				remainingLines = text.InsertEveryN(remainingLines, '+', widthMax-1)
+				return firstLine + remainingLines
+			}
+			return fmt.Sprintf("%v", val)
+		})
+		var columnConfigs []table.ColumnConfig
+		for i := 1; i <= len(constructHeaderRowForArrs(renderBatch)); i++ {
+			columnConfigs = append(columnConfigs,
+				table.ColumnConfig{
+					Number:      i,
+					Transformer: colWidthTransformer,
+					WidthMax:    opts.ColWidthMax,
+				},
+			)
+		}
+		t.SetColumnConfigs(columnConfigs)
+	}
+
+	if opts.TableDialect == MarkdownTableDialect {
+		markdownTable := strings.Split(t.RenderMarkdown(), "\n")
+		if !opts.TransposeMode {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(len(constructHeaderRowForArrs(renderBatch))))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(len(constructHeaderRowForArrs(renderBatch))))
+		} else {
+			markdownTable = insertStrToStrSlice(markdownTable, 0,
+				constructMarkdownEmptyRow(rowsAmount))
+			markdownTable = insertStrToStrSlice(markdownTable, 1,
+				constructMarkdownHeaderSeparatorRow(rowsAmount))
+		}
+		var res string
+		for _, v := range markdownTable {
+			res = res + v + "\n"
+		}
+		return res + "\n", nil
+	}
+	if opts.TableDialect == JiraTableDialect {
+		return t.RenderMarkdown() + "\n\n", nil
+	}
+
+	return t.Render() + "\n", nil
+}
+
+// parseRenderBatch parses render batch and return tables as string for it.
+func parseRenderBatch(renderBatch []renderNode, opts *Opts) (string, error) {
+	if scalarsOnlyInBatch(renderBatch) {
+		return renderSingleColumnTable(renderBatch, opts), nil
+	}
+
+	if mapsOnlyInBatch(renderBatch) {
+		var renderNodeMaps []map[string]renderNode
+		for _, node := range renderBatch {
+			castedNode, err := castRenderNodeToMap(node)
+			if err != nil {
+				return "", err
+			}
+			renderNodeMaps = append(renderNodeMaps, castedNode)
+		}
+
+		var renderMapsBatchs = make([][]map[string]renderNode, len(renderNodeMaps))
+		var batchPointer = 0
+		renderMapsBatchs[batchPointer] = append(renderMapsBatchs[batchPointer], renderNodeMaps[0])
+
+		for i := 0; i < len(renderNodeMaps)-1; i++ {
+			if isRenderMapsKeysEqual(renderNodeMaps[i], renderNodeMaps[i+1]) {
+				renderMapsBatchs[batchPointer] = append(
+					renderMapsBatchs[batchPointer],
+					renderNodeMaps[i+1])
+			} else {
+				batchPointer = batchPointer + 1
+				renderMapsBatchs[batchPointer] = append(
+					renderMapsBatchs[batchPointer],
+					renderNodeMaps[i+1])
+			}
+		}
+
+		var res, batchRes string
+		var err error
+		for _, batch := range renderMapsBatchs {
+			if len(batch) != 0 {
+				batchRes, err = renderMapsWithEqualKeys(batch, opts)
+				if err != nil {
+					return "", err
+				}
+				if opts.NoGraphics {
+					batchRes = batchRes + "\n"
+				}
+				res = res + batchRes
+			}
+		}
+
+		return res, nil
+	}
+
+	onlyArrs, singleArrWithArrs, err := arrsOnlyInBatch(renderBatch)
+	if err != nil {
+		return "", err
+	}
+
+	if onlyArrs {
+		if !singleArrWithArrs {
+			result, err := renderArrs(renderBatch, opts)
+			if err != nil {
+				return "", err
+			}
+			return result, nil
+		} else {
+			// Unpack array with array(s).
+			var result string
+			for _, node := range renderBatch {
+				bytesNode, err := json.Marshal(convertMapIntrfToMapStr(node))
+				if err != nil {
+					return "", err
+				}
+				iterableNode, err := decodeYamlArr(string(bytesNode))
+				if err != nil {
+					return "", err
+				}
+				barchRes, err := renderArrs(iterableNode, opts)
+				if err != nil {
+					return "", err
+				}
+				result = result + barchRes
+			}
+			return result, nil
+		}
+	}
+
+	return "", fmt.Errorf("unknown parsing case with current render batch")
+}
+
+// getRenderedTables returns tables as string for table/ttable output formats.
+func getRenderedTables(inputYaml string, opts *Opts) string {
+	// Handle empty input from remote console.
+	if inputYaml == "---\n- \n...\n" || inputYaml == "---\n-\n...\n" {
+		inputYaml = "--- ['']\n...\n"
+	}
+	if renderNodes, err := decodeYamlArr(inputYaml); err != nil {
+		log.Errorf("unexpected server response: not yaml array, cannot render tables: %v", err)
+		return inputYaml
+	} else {
+		var renderBatchs = make([][]renderNode, len(renderNodes))
+		var batchPointer = 0
+		renderBatchs[batchPointer] = append(renderBatchs[batchPointer], renderNodes[0])
+
+		for i := 0; i < len(renderNodes)-1; i++ {
+			if isRenderNodesTypesEqual(renderNodes[i], renderNodes[i+1]) {
+				renderBatchs[batchPointer] = append(renderBatchs[batchPointer], renderNodes[i+1])
+			} else {
+				batchPointer = batchPointer + 1
+				renderBatchs[batchPointer] = append(renderBatchs[batchPointer], renderNodes[i+1])
+			}
+		}
+
+		var res, batchRes string
+		var err error
+		for _, batch := range renderBatchs {
+			if len(batch) != 0 {
+				batchRes, err = parseRenderBatch(batch, opts)
+				if err != nil {
+					log.Errorf("unexpected internal parser result, cannot render tables: %v", err)
+					return inputYaml
+				}
+				res = res + batchRes
+				if opts.NoGraphics {
+					res = res + "\n"
+				}
+			}
+		}
+
+		return res
+	}
+}
+
+// luaEncodeElement encodes element to lua string.
+func luaEncodeElement(elem interface{}) string {
+	switch elem.(type) {
+	case map[interface{}]interface{}:
+		res := "{"
+		for k, v := range elem.(map[interface{}]interface{}) {
+			if v != nil {
+				if reflect.TypeOf(v).String() == "string" {
+					v = "\"" + fmt.Sprintf("%v", v) + "\""
+				}
+			} else {
+				v = "nil"
+			}
+
+			if reflect.TypeOf(k).String() == "string" {
+				res = res + fmt.Sprintf("%v", k) + " = " + luaEncodeElement(v) + ","
+			} else {
+				res = res + "[" + fmt.Sprintf("%v", k) + "] = " + luaEncodeElement(v) + ","
+			}
+		}
+		return res + "}"
+	case []interface{}:
+		res := "{"
+		for k, v := range elem.([]interface{}) {
+			if v != nil {
+				if reflect.TypeOf(v).String() == "string" {
+					v = "\"" + fmt.Sprintf("%v", v) + "\""
+				}
+			} else {
+				v = "nil"
+			}
+			if k < len(elem.([]interface{}))-1 {
+				res = res + luaEncodeElement(v) + ", "
+			} else {
+				res = res + luaEncodeElement(v)
+			}
+		}
+		return res + "}"
+	default:
+		if elem == nil {
+			return "nil"
+		}
+		return fmt.Sprintf("%v", elem)
+	}
+}
+
+// getRenderedLua returns lua string by yaml string input.
+func getRenderedLua(inputYaml string) string {
+	// Handle empty input from remote console.
+	if inputYaml == "---\n...\n" {
+		inputYaml = "--- ['']\n...\n"
+	}
+	var decodedYaml interface{}
+	if err := yaml.Unmarshal([]byte(inputYaml), &decodedYaml); err == nil {
+		var res string
+		for i, unpackedVal := range decodedYaml.([]interface{}) {
+			if i < len(decodedYaml.([]interface{}))-1 {
+				res = res + luaEncodeElement(unpackedVal) + ", "
+			} else {
+				res = res + luaEncodeElement(unpackedVal)
+			}
+		}
+		res = res + ";"
+		return res
+	} else {
+		log.Errorf("unexpected server response: cannot render lua: %v", err)
+		return inputYaml
+	}
+}

--- a/cli/formatter/format_test.go
+++ b/cli/formatter/format_test.go
@@ -1,0 +1,112 @@
+package formatter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/tt/cli/formatter"
+)
+
+func TestFormatter_ParseFormat(t *testing.T) {
+	cases := []struct {
+		str      string
+		expected formatter.Format
+		ok       bool
+	}{
+		{"", formatter.DefaultFormat, true},
+		{"yaml", formatter.YamlFormat, true},
+		{"y", formatter.YamlFormat, true},
+		{"lua", formatter.LuaFormat, true},
+		{"lua", formatter.LuaFormat, true},
+		{"table", formatter.TableFormat, true},
+		{"t", formatter.TableFormat, true},
+		{"ttable", formatter.TTableFormat, true},
+		{"T", formatter.TTableFormat, true},
+		{".", formatter.DefaultFormat, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.str, func(t *testing.T) {
+			format, ok := formatter.ParseFormat(c.str)
+			assert.Equal(t, c.ok, ok, "Unexpected result")
+			if ok {
+				assert.Equal(t, c.expected, format, "Unexpected output format")
+			}
+		})
+	}
+}
+
+func TestFormatter_Format_String(t *testing.T) {
+	cases := []struct {
+		format   formatter.Format
+		expected string
+		panic    bool
+	}{
+		{formatter.DefaultFormat, "", false},
+		{formatter.YamlFormat, "yaml", false},
+		{formatter.LuaFormat, "lua", false},
+		{formatter.TableFormat, "table", false},
+		{formatter.TTableFormat, "ttable", false},
+		{formatter.Format(2023), "Unknown output format", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expected, func(t *testing.T) {
+			if c.panic {
+				f := func() { _ = c.format.String() }
+				assert.PanicsWithValue(t, "Unknown output format", f)
+			} else {
+				result := c.format.String()
+				assert.Equal(t, c.expected, result, "Unexpected result")
+			}
+		})
+	}
+}
+
+func TestFormatter_ParseTableDialect(t *testing.T) {
+	cases := []struct {
+		str      string
+		expected formatter.TableDialect
+		ok       bool
+	}{
+		{"default", formatter.DefaultTableDialect, true},
+		{"markdown", formatter.MarkdownTableDialect, true},
+		{"jira", formatter.JiraTableDialect, true},
+		{".", formatter.DefaultTableDialect, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.str, func(t *testing.T) {
+			format, ok := formatter.ParseTableDialect(c.str)
+			assert.Equal(t, c.ok, ok, "Unexpected result")
+			if ok {
+				assert.Equal(t, c.expected, format, "Unexpected table dialect")
+			}
+		})
+	}
+}
+
+func TestFormatter_TableDialect_String(t *testing.T) {
+	cases := []struct {
+		tableDialect formatter.TableDialect
+		expected     string
+		panic        bool
+	}{
+		{formatter.DefaultTableDialect, "default", false},
+		{formatter.MarkdownTableDialect, "markdown", false},
+		{formatter.JiraTableDialect, "jira", false},
+		{formatter.TableDialect(2023), "Unknown table dialect", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expected, func(t *testing.T) {
+			if c.panic {
+				f := func() { _ = c.tableDialect.String() }
+				assert.PanicsWithValue(t, "Unknown table dialect", f)
+			} else {
+				result := c.tableDialect.String()
+				assert.Equal(t, c.expected, result, "Unexpected result")
+			}
+		})
+	}
+}

--- a/cli/formatter/style.go
+++ b/cli/formatter/style.go
@@ -1,0 +1,34 @@
+package formatter
+
+import (
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// StyleWithoutGraphics defines a style without graphics like below:
+// col1  col2  col3       col4
+// 1     477   Elizabeth  12
+// 3     2804  David      33
+// 4     1161  William    81
+// 5     1172  Jack       35
+// 6     1064  William    25
+var StyleWithoutGraphics = table.BoxStyle{
+	BottomLeft:       " ",
+	BottomRight:      " ",
+	BottomSeparator:  " ",
+	EmptySeparator:   text.RepeatAndTrim(" ", text.RuneWidthWithoutEscSequences(" ")),
+	Left:             " ",
+	LeftSeparator:    " ",
+	MiddleHorizontal: " ",
+	MiddleSeparator:  " ",
+	MiddleVertical:   " ",
+	PaddingLeft:      " ",
+	PaddingRight:     " ",
+	PageSeparator:    "\n",
+	Right:            " ",
+	RightSeparator:   " ",
+	TopLeft:          " ",
+	TopRight:         " ",
+	TopSeparator:     " ",
+	UnfinishedRow:    "  ",
+}

--- a/cli/formatter/types.go
+++ b/cli/formatter/types.go
@@ -1,0 +1,120 @@
+package formatter
+
+// renderNode represents content for rendering.
+type renderNode interface{}
+
+const (
+	scalarRenderNodeType = iota
+	arrayRenderNodeType
+	mapRenderNodeType
+)
+
+// Opts contains formatting options.
+type Opts struct {
+	TransposeMode bool
+	NoGraphics    bool
+	ColWidthMax   int
+	TableDialect  TableDialect
+}
+
+const (
+	defaultFormatStr     = ""
+	yamlFormatStr        = "yaml"
+	yamlFormatShortStr   = "y"
+	luaFormatStr         = "lua"
+	luaFormatShortStr    = "l"
+	tableFormatStr       = "table"
+	tableFormatShortStr  = "t"
+	ttableFormatStr      = "ttable"
+	ttableFormatShortStr = "T"
+)
+
+// Format defines a set of supported output format.
+type Format int
+
+const (
+	DefaultFormat Format = iota
+	YamlFormat
+	LuaFormat
+	TableFormat
+	TTableFormat
+)
+
+// ParseFormat parses a output format string representation. It supports
+// mixed case letters.
+func ParseFormat(str string) (Format, bool) {
+	switch str {
+	case defaultFormatStr:
+		return DefaultFormat, true
+	case yamlFormatStr, yamlFormatShortStr:
+		return YamlFormat, true
+	case luaFormatStr, luaFormatShortStr:
+		return LuaFormat, true
+	case tableFormatStr, tableFormatShortStr:
+		return TableFormat, true
+	case ttableFormatStr, ttableFormatShortStr:
+		return TTableFormat, true
+	}
+	return DefaultFormat, false
+}
+
+// String returns a string representation of the output format.
+func (l Format) String() string {
+	switch l {
+	case DefaultFormat:
+		return defaultFormatStr
+	case YamlFormat:
+		return yamlFormatStr
+	case LuaFormat:
+		return luaFormatStr
+	case TableFormat:
+		return tableFormatStr
+	case TTableFormat:
+		return ttableFormatStr
+	default:
+		panic("Unknown output format")
+	}
+}
+
+// TableDialect defines a set of supported table dialect.
+type TableDialect int
+
+const (
+	DefaultTableDialect TableDialect = iota
+	MarkdownTableDialect
+	JiraTableDialect
+)
+
+const (
+	defaultTableDialectStr  = "default"
+	markdownTableDialectStr = "markdown"
+	jiraTableDialectStr     = "jira"
+)
+
+// ParseTableDialect parses a table dialect string representation. It supports
+// mixed case letters.
+func ParseTableDialect(str string) (TableDialect, bool) {
+	switch str {
+	case defaultTableDialectStr:
+		return DefaultTableDialect, true
+	case markdownTableDialectStr:
+		return MarkdownTableDialect, true
+	case jiraTableDialectStr:
+		return JiraTableDialect, true
+	}
+	return DefaultTableDialect, false
+}
+
+// String returns a string representation of the table dialect.
+func (f TableDialect) String() string {
+	switch f {
+	case DefaultTableDialect:
+		return defaultTableDialectStr
+	case MarkdownTableDialect:
+		return markdownTableDialectStr
+	case JiraTableDialect:
+		return jiraTableDialectStr
+	default:
+		panic("Unknown table dialect")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c
 	github.com/otiai10/copy v1.7.1
 	github.com/spf13/cobra v1.3.0
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.8.4
 	github.com/tarantool/cartridge-cli v0.0.0-20220605082730-53e6a5be9a61
 	github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d
 	github.com/vmihailenco/msgpack/v5 v5.3.5
@@ -52,9 +52,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.4.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/moby/sys/mount v0.3.3 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e // indirect
 	github.com/shirou/gopsutil v3.21.2+incompatible // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1Rjl9Jw=
+github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -620,6 +622,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-tty v0.0.3 h1:5OfyWorkyO7xP52Mq7tB36ajHDG5OHrmBGIS/DtakQI=
@@ -735,6 +739,7 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
@@ -774,6 +779,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e h1:3/9k/etUfgykjM3Rx8X0echJzo7gNNeND/ubPkqYw1k=
 github.com/robfig/config v0.0.0-20141207224736-0f78529c8c7e/go.mod h1:Zerq1qYbCKtIIU9QgPydffGlpYfZ8KI/si49wuTLY/Q=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -841,6 +848,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -850,6 +858,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1185,6 +1196,7 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/test/integration/connect/test_output_format_app/test_app.lua
+++ b/test/integration/connect/test_output_format_app/test_app.lua
@@ -1,0 +1,43 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+box.cfg({listen = 'localhost:3013'})
+
+box.schema.user.create('test', { password = 'password' , if_not_exists = true })
+box.schema.user.grant('guest','read,write,execute,create,drop','universe')
+box.schema.user.grant('test','read,write,execute,create,drop','universe')
+
+box.schema.create_space('customers', {
+    format = {
+        {name = 'id', type = 'unsigned'},
+        {name = 'name', type = 'string'},
+        {name = 'age', type = 'number'},
+    }
+})
+box.space.customers:create_index('primary_index', {
+    parts = {
+        {field = 1, type = 'unsigned'},
+    },
+})
+
+box.space.customers:insert({1, 'Elizabeth', 12})
+box.space.customers:insert({2, 'Mary', 46})
+box.space.customers:insert({3, 'David', 33})
+box.space.customers:insert({4, 'William', 81})
+box.space.customers:insert({5, 'Jack', 35})
+box.space.customers:insert({6, 'William', 25})
+box.space.customers:insert({7, 'Elizabeth', 18})
+
+if box.execute ~= nil then
+    box.execute([[CREATE TABLE table1 (column1 INT PRIMARY key, column2 VARCHAR(10));]])
+    box.execute([[INSERT INTO table1 VALUES (10,'Hello SQL world!');]])
+    box.execute([[INSERT INTO table1 VALUES (20,'Hello LUA world!');]])
+    box.execute([[INSERT INTO table1 VALUES (30,'Hello YAML world!');]])
+end
+
+fh = fio.open('ready', {'O_WRONLY', 'O_CREAT'}, tonumber('644',8))
+fh:close()
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/connect/test_output_format_app/test_app.lua
+++ b/test/integration/connect/test_output_format_app/test_app.lua
@@ -33,6 +33,7 @@ if box.execute ~= nil then
     box.execute([[INSERT INTO table1 VALUES (10,'Hello SQL world!');]])
     box.execute([[INSERT INTO table1 VALUES (20,'Hello LUA world!');]])
     box.execute([[INSERT INTO table1 VALUES (30,'Hello YAML world!');]])
+    box.schema.func.create('sum', {body = [[function(a, b) return a + b end]]})
 end
 
 fh = fio.open('ready', {'O_WRONLY', 'O_CREAT'}, tonumber('644',8))


### PR DESCRIPTION
```
localhost:3333> \?

  To get help, see the Tarantool manual at https://tarantool.io/en/doc/
  To start the interactive Tarantool tutorial, type 'tutorial()' here.

  This help is expanded with additional backslash commands
  because tt connect is using.

  Available backslash commands:
... ... ...
  \df                             -- show list of functions
  \df <func_name>                 -- show info about function by its name
  \d | \df                        -- show list of spaces
  \d <space_name>                 -- show space format by space name
  \dt <space_name>                -- show info about space by its name
  \di <space_name>                -- show info about indexes by space name
  \di <space_name> <index_name>   -- show info about certain index
... ... ...

localhost:3333> \d customers
+-----------+----------+
| name      | type     |
+-----------+----------+
| id        | unsigned |
+-----------+----------+
| bucket_id | unsigned |
+-----------+----------+
| name      | string   |
+-----------+----------+
| age       | number   |
+-----------+----------+

localhost:3333> \di developers
+---------------+------+
| name          | type |
+---------------+------+
| primary_index | TREE |
+---------------+------+
| bucket_id     | TREE |
+---------------+------+
| age_index     | TREE |
+---------------+------+
| full_name     | TREE |
+---------------+------+
```

Closes #502