### PR TITLE
pack: add flag `without-modules` to `tt pack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt connect`: support for multi-line commands in the history.
 - New `tt pack` flag `--cartridge-compat` is added to maintain backward compatibility 
 with the cartridge-cli. It is supported only by `tgz` type packing.
+- `tt pack`: added option `--without-modules` allowing not to take external 
+  modules into the pack bundle.
 
 ### Fixed
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -57,6 +57,8 @@ The supported types are: tgz, deb, rpm`,
 		"Include tarantool and tt binaries to the result package")
 	packCmd.Flags().BoolVar(&packCtx.CartridgeCompat, "cartridge-compat", false,
 		"Pack cartridge cli compatible archive (only for tgz type)")
+	packCmd.Flags().BoolVar(&packCtx.WithoutModules, "without-modules",
+		packCtx.WithoutModules, "Don't include external modules to the result package")
 
 	// TarGZ flags.
 	packCmd.Flags().BoolVar(&packCtx.Archive.All, "all", packCtx.Archive.All,

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -101,7 +101,8 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	}
 
 	// Copy modules step.
-	if !packCtx.CartridgeCompat && cliOpts.Modules != nil && cliOpts.Modules.Directory != "" {
+	if !packCtx.CartridgeCompat && cliOpts.Modules != nil && cliOpts.Modules.Directory != "" &&
+		!packCtx.WithoutModules {
 		err = copy.Copy(cliOpts.Modules.Directory, packageModulesPath)
 		if err != nil {
 			log.Warnf("Failed to copy modules from %s: %s", cliOpts.Modules.Directory, err)

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -16,6 +16,8 @@ type PackCtx struct {
 	WithBinaries bool
 	// WithoutBinaries ignores binaries regardless if tarantool is system or not.
 	WithoutBinaries bool
+	// WithoutModules ignores external modules.
+	WithoutModules bool
 	// TarantoolExecutable is a path to tarantool executable path
 	TarantoolExecutable string
 	// TarantoolIsSystem shows if tarantool is system.

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -152,6 +152,22 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "bundle_src": "bundle1",
             "cmd": tt_cmd,
             "pack_type": "tgz",
+            "args": ["--without-modules"],
+            "res_file": "bundle1-0.1.0.0." + get_arch() + ".tar.gz",
+            "check_exist": [
+                os.path.join("app2", "init.lua"),
+                os.path.join("app2", ".rocks"),
+                os.path.join("app.lua"),
+                os.path.join("bin", "tarantool*"),
+                os.path.join("bin", "tt"),
+            ],
+            "check_not_exist": [],
+            "artifacts_in_separated_dir": False,
+        },
+        {
+            "bundle_src": "bundle1",
+            "cmd": tt_cmd,
+            "pack_type": "tgz",
             "args": ["--without-binaries"],
             "res_file": "bundle1-0.1.0.0." + get_arch() + ".tar.gz",
             "check_exist": [
@@ -461,6 +477,9 @@ def test_pack_tgz_table(tt_cmd, tmpdir):
         else:
             assert_bundle_structure(extract_path)
             assert_env(extract_path, test_case["artifacts_in_separated_dir"], "instances.enabled")
+
+        if "--without-modules" in test_case["args"]:
+            assert not os.listdir(os.path.join(extract_path, "modules"))
 
         for file_path in test_case["check_exist"]:
             assert glob.glob(os.path.join(extract_path, file_path))


### PR DESCRIPTION
Add flag `--without-modules` to `tt pack` which allows not to take external modules into the bundle.

Closes #289