### PR TITLE
connect: fix nil pointer dereference

### DIFF
--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -159,7 +159,8 @@ func (console *Console) Close() {
 	}
 }
 
-func getExecutor(console *Console) prompt.Executor {
+// getExecutor returns command executor.
+func getExecutor(console *Console) func(string) {
 	executor := func(in string) {
 		if console.input == "" {
 			trimmed := strings.TrimSpace(in)
@@ -193,8 +194,11 @@ func getExecutor(console *Console) prompt.Executor {
 				log.Debug(err.Error())
 			}
 		}
-		if err := console.prompt.PushToHistory(trimmedInput); err != nil {
-			log.Debug(err.Error())
+
+		if console.prompt != nil {
+			if err := console.prompt.PushToHistory(trimmedInput); err != nil {
+				log.Debug(err.Error())
+			}
 		}
 
 		var results []string

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -178,6 +178,12 @@ def test_connect_to_localhost_app(tt_cmd, tmpdir_with_cfg):
         assert ret
         assert output == "---\n- Hello\n- World\n...\n\n"
 
+        # Execute stdout without args.
+        ret, output = try_execute_on_instance(tt_cmd, tmpdir, uri,
+                                              stdin="2+2")
+        assert ret
+        assert output == "---\n- 4\n...\n\n"
+
     # Stop the Instance.
     stop_app(tt_cmd, tmpdir, "test_app")
 


### PR DESCRIPTION
`console.prompt` can be nill in the case of calling the executor without a prompt, so a check has been added.

Also, the return type of `getExecutor` has been changed to to make it clearer, that the executor can be used not only with a prompt.