### PR TITLE
tt: fix version parsing with GC suffix

### DIFF
--- a/cli/version/version_tools.go
+++ b/cli/version/version_tools.go
@@ -51,12 +51,13 @@ func Parse(verStr string) (Version, error) {
 	// Part 4 (optional) -> release type and number (e.g: rc2),
 	// Part 5 (optional) -> additional commits,
 	// Part 6 (optional) -> commit hash and revision.
+	// GC suffix is not saved, since it is not part of version.
 	re := regexp.MustCompile(
 		`^((?P<buildname>.+)-)?` +
 			`v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)` +
 			`(?:-(?P<release>entrypoint|rc|alpha|beta)(?P<releaseNum>\d+)?)?` +
 			`(?:-(?P<additional>\d+))?` +
-			`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?$`)
+			`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?(-gc64|-nogc64)?$`)
 
 	matches := util.FindNamedMatches(re, verStr)
 	if len(matches) == 0 {

--- a/cli/version/version_tools_test.go
+++ b/cli/version/version_tools_test.go
@@ -45,6 +45,34 @@ func TestParseVersion(t *testing.T) {
 		nil,
 	}
 
+	testCases["2.11.0-0-gc9673ebb7-r575-nogc64"] = returnValueParseVersion{
+		Version{
+			Major:      2,
+			Minor:      11,
+			Patch:      0,
+			Release:    Release{Type: TypeRelease},
+			Additional: 0,
+			Hash:       "gc9673ebb7",
+			Revision:   575,
+			Str:        "2.11.0-0-gc9673ebb7-r575-nogc64",
+		},
+		nil,
+	}
+
+	testCases["2.11.0-0-gc9673ebb7-r575-gc64"] = returnValueParseVersion{
+		Version{
+			Major:      2,
+			Minor:      11,
+			Patch:      0,
+			Release:    Release{Type: TypeRelease},
+			Additional: 0,
+			Hash:       "gc9673ebb7",
+			Revision:   575,
+			Str:        "2.11.0-0-gc9673ebb7-r575-gc64",
+		},
+		nil,
+	}
+
 	testCases["1.10.123-rc1-100-g2ba6c0"] = returnValueParseVersion{
 		Version{
 			Major:      1,
@@ -170,6 +198,12 @@ func TestParseVersion(t *testing.T) {
 	testCases["42"] = returnValueParseVersion{
 		Version{},
 		fmt.Errorf("failed to parse version \"42\": format is not valid"),
+	}
+
+	testCases["2.11.0-0-gc9673ebb7-r575-gc32"] = returnValueParseVersion{
+		Version{},
+		fmt.Errorf("failed to parse version \"2.11.0-0-gc9673ebb7-r575-gc32\": " +
+			"format is not valid"),
 	}
 
 	for input, output := range testCases {


### PR DESCRIPTION
Tarantool Enterprise version includes gc suffix in version string. Version parse fails to parse such versions. Fix it by adding supported suffixes in regexp.