### PR TITLE
Fix restart test race

### DIFF
--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -286,13 +286,14 @@ local function start_instance()
         -- So the socket will be closed automatically on termination and
         -- deleted from "running.go".
         if box.ctl.on_shutdown ~= nil then
-            local close_sock_tr = box.ctl.on_shutdown(function()
+            local function close_sock_tr()
                 box.ctl.on_shutdown(nil, close_sock_tr)
                 local res, err = pcall(cons_listen_sock.close, cons_listen_sock)
                 if not res then
                     log.error('Failed to close console socket %s: %s', console_sock, err)
                 end
-            end)
+            end
+            box.ctl.on_shutdown(close_sock_tr)
         end
 
     end

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -129,6 +129,7 @@ func (wd *Watchdog) Start() error {
 		} else {
 			wd.logger = logger
 		}
+		wd.logger.Printf(`Watchdog(INFO): waiting for restart timeout %s.`, wd.restartTimeout)
 		time.Sleep(wd.restartTimeout)
 
 		wd.shouldStop = false

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -472,6 +472,12 @@ def test_running_reread_config(tt_cmd, tmpdir):
     instance_process_rc = instance_process.wait(1)
     assert instance_process_rc == 0
 
+    status_cmd = [tt_cmd, "status", inst_name]
+    status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc == 0
+    status_out = extract_status(status_out)
+    assert status_out[inst_name]["STATUS"] == "NOT RUNNING"
+
 
 def test_no_args_usage(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_app")

--- a/test/utils.py
+++ b/test/utils.py
@@ -113,7 +113,7 @@ def kill_procs(procs):
     return len(procs)
 
 
-def wait_instance_start(log_path, timeout_sec=5):
+def wait_instance_start(log_path, timeout_sec=10):
     started = False
     iter_timeout_sec = 0.05
 


### PR DESCRIPTION
Sometimes instance restart test fails on the system with a loaded CPU.
This failure is due to timeout waiting for the instance to restart.
Wait time is 5 second. Watchdog already has 5 seconds timeout before
restarting the instance. so the whole start time becomes 5s watchdog
timeout + instance start time. So test's 5 seconds is not enough.
Increased wait time. Added log message about waiting for restart.
Added check for app status in test.