### PR TITLE
ci: fix publish workflow error on mac

### DIFF
--- a/.gen_tarballs.sh
+++ b/.gen_tarballs.sh
@@ -46,6 +46,7 @@ fi
 
 TAG_ORIG=${TAG}
 TAG=${TAG//v}
+TAG=${TAG##*/} # Remove everything before the last / to avoid using / in file names.
 TMPDIR="/tmp/gentoo_tarballs"
 TT_DIR="${TMPDIR}/tt-${TAG}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,10 +182,19 @@ jobs:
           rm ./packages-macos/tt*checksums.txt
           mv checksums.txt ./packages-macos/
 
+      - name: Set GoReleaser flags
+        id: set-goreleaser-flags
+        run: |
+          if ${{ startsWith(github.ref, 'refs/tags') }} ; then
+            echo "GORELEASER_FLAGS=--skip-validate" >> $GITHUB_OUTPUT
+          else
+            echo "GORELEASER_FLAGS=--snapshot" >> $GITHUB_OUTPUT
+          fi
+
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: release --config ./goreleaser/.goreleaser_publish.yml --skip-validate
+          args: release ${{ steps.set-goreleaser-flags.outputs.GORELEASER_FLAGS }} --config ./goreleaser/.goreleaser_publish.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,9 @@ jobs:
 
       - name: Setup Mage
         run: |
-          brew install mage
+          git clone https://github.com/magefile/mage
+          cd mage
+          go run bootstrap.go
 
       - name: Build OpenSSL 3.0
         run: |


### PR DESCRIPTION
Install mage from source as on Linux and on Mac for test workflows. It prevents from installing dependencies, which are not required.