### PR TITLE
connect: change default prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use CLI arg connect string for the prompt line and the title to avoid too long
+prompt line when using 'app:instance' target format.
+
 ### Added
 
 - `tt install tarantool/tt`: ability to install tarantool and tt from an arbitrary commit.

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -33,6 +33,8 @@ type ConnectCtx struct {
 	SslCiphers string
 	// Interactive mode is used.
 	Interactive bool
+	// ConnectTarget contains connection target string: URI or instance name.
+	ConnectTarget string
 }
 
 const (
@@ -70,7 +72,7 @@ func getEvalCmd(connectCtx ConnectCtx) (string, error) {
 
 // Connect establishes a connection to the instance and starts the console.
 func Connect(connectCtx ConnectCtx, connOpts connector.ConnectOpts) error {
-	if err := runConsole(connOpts, "", connectCtx.Language); err != nil {
+	if err := runConsole(connOpts, connectCtx, ""); err != nil {
 		return fmt.Errorf("failed to run interactive console: %s", err)
 	}
 	return nil
@@ -124,8 +126,8 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 }
 
 // runConsole run a new console.
-func runConsole(connOpts connector.ConnectOpts, title string, lang Language) error {
-	console, err := NewConsole(connOpts, title, lang)
+func runConsole(connOpts connector.ConnectOpts, connectCtx ConnectCtx, title string) error {
+	console, err := NewConsole(connOpts, connectCtx, title)
 	if err != nil {
 		return fmt.Errorf("failed to create new console: %s", err)
 	}


### PR DESCRIPTION
Use connect target for interactive command prompt. Examples:

```
tt connect app1:router
   • Connecting to the instance...
   • Connected to app1:router

app1:router>

tt connect localhost:3301
   • Connecting to the instance...
   • Connected to localhost:3301

localhost:3301>

tt connect ./var/run/app1/router/router.control
   • Connecting to the instance...
   • Connected to ./var/run/app1/router/router.control

./var/run/app1/router/router.control>
```

Closes #573