### PR TITLE
rocks: replace $PWD with getwd call

### DIFF
--- a/cli/rocks/extra/hardcoded.lua
+++ b/cli/rocks/extra/hardcoded.lua
@@ -1,10 +1,5 @@
 -- This file contains LuaRocks hardcoded settings.
 
-local function get_cwd()
-    local cwd = os.getenv("PWD") or io.popen("cd"):read()
-    return cwd
-end
-
 local function get_tarantool_path()
     local path = os.getenv('TT_CLI_TARANTOOL_PATH')
     if path ~= nil then
@@ -32,6 +27,8 @@ local function get_tarantool_prefix_path()
     return "/usr"
 end
 
+local cwd = tt_getwd()
+
 return {
     PREFIX = get_tarantool_prefix_path(),
     LUA_BINDIR = get_tarantool_path(),
@@ -43,7 +40,7 @@ return {
     ROCKS_SERVERS = {
         [[http://rocks.tarantool.org/]],
     },
-    LOCALDIR = get_cwd(),
+    LOCALDIR = cwd,
 
     HOME_TREE_SUBDIR = [[/.rocks]],
     EXTERNAL_DEPS_SUBDIRS = {

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -95,6 +95,13 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 	return prefixDir, nil
 }
 
+// getwdWrapperForLua is getwd call wrapper.
+func getwdWrapperForLua(L *lua.LState) int {
+	dir, _ := os.Getwd()
+	L.Push(lua.LString(dir))
+	return 1
+}
+
 // Execute LuaRocks command. All args will be processed by LuaRocks.
 func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) error {
 	var cmd string
@@ -240,6 +247,7 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) err
 
 	L := lua.NewState()
 	defer L.Close()
+	L.SetGlobal("tt_getwd", L.NewFunction(getwdWrapperForLua))
 	preload := L.GetField(L.GetField(L.Get(lua.EnvironIndex), "package"), "preload")
 
 	for modname, path := range rocks_preload {


### PR DESCRIPTION
Relying on PWD var means that tt invocation from  other code require setting of the PWD variable, making chdir is not enogh. Call getwd instead of using getring PWD. getwd call internally also checks PWD environment variable.