### PR TITLE
pack: add a flag to pass tarantool version for pack in docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ prompt line when using 'app:instance' target format.
 
 - `tt install tarantool/tt`: ability to install tarantool and tt from an arbitrary commit.
 The binary has the name tt/tarantool_ + seven-digit hash.
+- New `tt pack` flag `--tarantool-version` is added to specify tarantool 
+  version for pack in docker. It is supported only with `--use-docker` enabled.
 
 ### Fixed
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -36,6 +36,11 @@ The supported types are: tgz, deb, rpm`,
 				err = fmt.Errorf("cartridge-compat flag can only be used while packing tgz bundle")
 				log.Fatalf(err.Error())
 			}
+			if packCtx.TarantoolVersion != "" && !packCtx.UseDocker {
+				err = fmt.Errorf("tarantool-version argument can only be " +
+					"used while packing in docker")
+				log.Fatalf(err.Error())
+			}
 			cmdCtx.CommandName = cmd.Name()
 			err = modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo, internalPackModule, args)
 			handleCmdErr(cmd, err)
@@ -79,6 +84,9 @@ The supported types are: tgz, deb, rpm`,
 	packCmd.Flags().BoolVar(&packCtx.UseDocker, "use-docker",
 		packCtx.UseDocker,
 		"Use docker for building a package.")
+	packCmd.Flags().StringVar(&packCtx.TarantoolVersion, "tarantool-version",
+		packCtx.TarantoolVersion,
+		"Version of the tarantool for pack in docker (only with --use-docker flag).")
 
 	return packCmd
 }

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -30,6 +30,8 @@ type PackCtx struct {
 	UseDocker bool
 	// CartridgeCompat enables backward compatibility with cartridge cli.
 	CartridgeCompat bool
+	// TarantoolVersion specifies the version of the tarantool for pack in docker.
+	TarantoolVersion string
 }
 
 // ArchiveCtx contains flags specific for tgz type.


### PR DESCRIPTION
Add a new `tt pack` flag `--tarantool-version` to specify tarantool version for pack in docker. It is supported only with `--use-docker` enabled.
If `tt` can not parse given version, or this version does not exist, an error is thrown.

Closes #353