### PR TITLE
tt: fix race in running package unit test

### DIFF
--- a/cli/running/testdata/signal_handling.py
+++ b/cli/running/testdata/signal_handling.py
@@ -1,0 +1,15 @@
+import signal, sys
+
+def handler(signum, frame):
+    print("sigusr1", flush=True)
+def int_handler(signum, frame):
+    print("interrupted", flush=True)
+    sys.exit(10)
+
+signal.signal(signal.SIGUSR1, handler)
+signal.signal(signal.SIGINT, int_handler)
+signal.signal(signal.SIGTERM, int_handler)
+
+print("started", flush=True)
+while True:
+    signal.pause()


### PR DESCRIPTION
Child process exits after stdin descriptor is closed, because `read` is used as interruptible sleep. Sometimes the unit-test sends SIGINT to already stopped process, which causes test failure. The solution is to create a separate script to test signal handling whithout sleep using bash read call.