### PR TITLE
rocks: added admin commands tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The binary has the name tt/tarantool_ + seven-digit hash.
   commands.
 - `tt connect`: added command `\quit` to quit from the console.
 - `tt connect`: expanded formatting modes for the interactive console.
+- `tt rocks`: added `admin` commands tree.
+  `tt rocks admin` implements `luarocks-admin` commands tree.
 
 ### Fixed
 

--- a/cli/rocks/extra/wrapper.lua
+++ b/cli/rocks/extra/wrapper.lua
@@ -2,11 +2,36 @@ local function exec(bin, ...)
     local cfg = require("luarocks.core.cfg")
     local util = require("luarocks.util")
 
+    local arg = ...
+
     -- Tweak help messages.
-    util.this_program = function(default) -- luacheck: no unused args
-        return bin .. " rocks"
+    if arg == "admin" then
+        util.this_program = function(default) -- luacheck: no unused args
+            return bin .. " rocks admin"
+        end
+    else
+        util.this_program = function(default) -- luacheck: no unused args
+            return bin .. " rocks"
+        end
     end
     local cmd = require("luarocks.cmd")
+
+    if arg == "admin" then
+        local description = "LuaRocks repository administration interface"
+        local admin_args = {...}
+
+        table.remove(admin_args, 1)
+
+        local commands = {
+           make_manifest = "luarocks.admin.cmd.make_manifest",
+           add = "luarocks.admin.cmd.add",
+           remove = "luarocks.admin.cmd.remove",
+           refresh_cache = "luarocks.admin.cmd.refresh_cache",
+        }
+
+        cmd.run_command(description, commands, "luarocks.admin.cmd.external", unpack(admin_args))
+        return
+    end
 
     --[[ Disabled: path, upload,
     -- init: luarocks init command generates a project, including local

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/tarantool/go-prompt v1.0.0
 	github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d
 	github.com/vmihailenco/msgpack/v5 v5.3.5
-	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
+	github.com/yuin/gopher-lua v1.1.1-0.20230219103905-71163b697a8f
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9
 	go.etcd.io/etcd/client/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -921,6 +921,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 h1:5mLPGnFdSsevFRFc9q3yYbBkB6tsm4aCwwQV/j1JQAQ=
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+github.com/yuin/gopher-lua v1.1.1-0.20230219103905-71163b697a8f h1:kpWD5Gyh4AM22d9UrIkTuPPJaSpTigJoeDuYL8yFGNI=
+github.com/yuin/gopher-lua v1.1.1-0.20230219103905-71163b697a8f/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -77,6 +77,32 @@ def test_rocks_module(tt_cmd, tmpdir):
     assert "testapp scm-1 is now installed" in output
 
 
+def test_rocks_admin_module(tt_cmd, tmpdir):
+    repo_path = os.path.join(tmpdir, "rocks_repo")
+    os.mkdir(repo_path)
+
+    rc, output = run_command_and_get_output(
+            [tt_cmd, "rocks", "admin", "make_manifest", repo_path],
+            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert os.path.isfile(f'{tmpdir}/rocks_repo/index.html')
+    assert os.path.isfile(f'{tmpdir}/rocks_repo/manifest')
+
+    test_app_path = os.path.join(os.path.dirname(__file__), "files", "testapp-scm-1.rockspec")
+    shutil.copy(test_app_path, tmpdir)
+    rc, output = run_command_and_get_output(
+            [tt_cmd, "rocks", "admin", "add", "testapp-scm-1.rockspec", "--server", repo_path],
+            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert os.path.isfile(f'{tmpdir}/rocks_repo/testapp-scm-1.rockspec')
+
+    rc, output = run_command_and_get_output(
+            [tt_cmd, "rocks", "admin", "remove", "testapp-scm-1.rockspec", "--server", repo_path],
+            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert not os.path.exists(f'{tmpdir}/rocks_repo/testapp-scm-1.rockspec')
+
+
 def test_rocks_install_remote(tt_cmd, tmpdir):
     with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''tt:


### PR DESCRIPTION
tt rocks admin implements luarocks-admin commands tree.
    
Gopher-lua is bumped to 71163b697a8f07f32b7f6d2898726b198f25ba20:
https://github.com/yuin/gopher-lua/commit/71163b697a8f07f32b7f6d2898726b198f25ba20
    
Before this fix, gopher-lua could corrupt files (affected on tt admin
remove).
    
A pull request was also made to the upstream to support the 'remove'
command with the 'file' protocol:
https://github.com/luarocks/luarocks/pull/1536
    
Closes #563