### PR TITLE
pack: fix packing in docker

### DIFF
--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -42,6 +42,7 @@ var (
 
 	packageBinPath     = ""
 	packageModulesPath = ""
+	packageIncludePath = ""
 
 	packageInstancesEnabledPath = ""
 
@@ -217,6 +218,7 @@ func createPackageStructure(destPath string, cartridgeCompat bool) error {
 			packageVarDataPath,
 			packageBinPath,
 			packageModulesPath,
+			packageIncludePath,
 			packageInstancesEnabledPath,
 			packageVarVinylPath,
 			packageVarWalPath,
@@ -454,6 +456,7 @@ func prepareDefaultPackagePaths(opts *config.CliOpts, packagePath string) {
 
 	packageBinPath = filepath.Join(packagePath, configure.BinPath)
 	packageModulesPath = filepath.Join(packagePath, configure.ModulesPath)
+	packageIncludePath = filepath.Join(packagePath, configure.IncludePath)
 
 	packageInstancesEnabledPath = filepath.Join(packagePath, configure.InstancesEnabledDirName)
 }

--- a/cli/pack/docker.go
+++ b/cli/pack/docker.go
@@ -99,9 +99,11 @@ func PackInDocker(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 
 	// If bin_dir is not empty, we need to pack binaries built in container.
 	relEnvBinPath := configure.BinPath
-	ttPackCommandLine = append([]string{"/bin/bash", "-c",
-		fmt.Sprintf("cp $(which tarantool) %s && cp $(which tt) %s && %s",
-			relEnvBinPath, relEnvBinPath, strings.Join(ttPackCommandLine, " "))})
+	ttPackCommandLine = []string{"/bin/bash", "-c",
+		fmt.Sprintf(`cp $(which tarantool) %s && \
+	cp $(which tt) %s && \
+	cp -r /usr/local/include ./include/ && \
+	%s`, relEnvBinPath, relEnvBinPath, strings.Join(ttPackCommandLine, " "))}
 
 	// Get a pack context for preparing a bundle without binaries.
 	// All binary files will be taken from the docker image.

--- a/cli/pack/templates/Dockerfile.pack.build
+++ b/cli/pack/templates/Dockerfile.pack.build
@@ -31,7 +31,10 @@ FROM --platform=linux/amd64 ubuntu:20.04
 COPY --from=tt-builder /usr/bin/tt /usr/bin
 
 COPY --from=tarantool-builder /usr/bin/tarantool /usr/bin
+COPY --from=tarantool-builder /usr/src/tarantool/include /usr/local/
 
 WORKDIR /usr/src/{{ .env_dir }}
 
-RUN apt update && apt install -y cpio binutils
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt update && apt install -y git build-essential cmake make cpio binutils curl unzip


### PR DESCRIPTION
Copy tarantool include files from tarantool build image. Install required dependencies for building rocks.