### PR TITLE
cli: fix flag parsing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Print log messages to stderr.
+- Global flags are required to be positioned only before child
+commands. Example: ``tt --cfg tt.yaml install tt``.
 
 ## [1.3.0] - 2023-09-28
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -111,8 +111,8 @@ func NewCmdRoot() *cobra.Command {
 		Use:   "tt",
 		Short: "Tarantool CLI",
 		Long:  "Utility for managing Tarantool packages and Tarantool-based applications",
-		Example: `$ tt version -L /path/to/local/dir
-  $ tt help -S -I
+		Example: `$ tt -L /path/to/local/dir version
+  $ tt -S -I help
   $ tt completion`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
@@ -131,6 +131,8 @@ func NewCmdRoot() *cobra.Command {
 		"", "Path to configuration file")
 	rootCmd.Flags().BoolVarP(&cmdCtx.Cli.Verbose, "verbose", "V",
 		false, "Verbose output")
+
+	rootCmd.Flags().SetInterspersed(false)
 
 	rootCmd.AddCommand(
 		NewVersionCmd(),
@@ -191,7 +193,7 @@ func Execute() {
 // modules and configure `help` module.
 func InitRoot() {
 	rootCmd = NewCmdRoot()
-	rootCmd.ParseFlags(os.Args)
+	rootCmd.ParseFlags(os.Args[1:])
 
 	if err := configure.ValidateCliOpts(&cmdCtx.Cli); err != nil {
 		log.Fatal(err.Error())

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootFlags(t *testing.T) {
+	rootCmd = NewCmdRoot()
+	rootCmd.ParseFlags([]string{"--cfg", "one.yaml", "rocks", "--cfg", "second.yaml"})
+	assert.Equal(t, cmdCtx.Cli.ConfigPath, "one.yaml")
+}

--- a/test/integration/cli/test_launch.py
+++ b/test/integration/cli/test_launch.py
@@ -18,7 +18,7 @@ from utils import (config_name, create_external_module, create_tt_config,
 # ##### #
 def test_local_launch(tt_cmd, tmpdir):
     module = "version"
-    cmd = [tt_cmd, module, "-L", tmpdir]
+    cmd = [tt_cmd, "-L", tmpdir, module]
 
     # No configuration file specified.
     assert subprocess.run(cmd).returncode == 1
@@ -37,7 +37,7 @@ def test_local_launch_find_cfg(tt_cmd, tmpdir):
 
     # Find tt.yaml at cwd parent.
     tmpdir_without_config = tempfile.mkdtemp(dir=tmpdir)
-    cmd = [tt_cmd, module, "-L", tmpdir_without_config]
+    cmd = [tt_cmd, "-L", tmpdir_without_config, module]
 
     create_tt_config(tmpdir, tmpdir)
     module_message = create_external_module(module, tmpdir)
@@ -66,7 +66,7 @@ def test_local_launch_find_cfg_modules_relative_path(tt_cmd, tmpdir):
 
 def test_local_launch_non_existent_dir(tt_cmd, tmpdir):
     module = "version"
-    cmd = [tt_cmd, module, "-L", "non-exists-dir"]
+    cmd = [tt_cmd, "-L", "non-exists-dir", module]
     rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
 
     assert rc == 1
@@ -481,7 +481,7 @@ def test_launch_external_cmd_with_flags(tt_cmd, tmpdir, module):
 
 def test_std_err_stream_local_launch_non_existent_dir(tt_cmd, tmpdir):
     module = "version"
-    cmd = [tt_cmd, module, "-L", "non-exists-dir"]
+    cmd = [tt_cmd, "-L", "non-exists-dir", module]
     tt_process = subprocess.Popen(
         cmd,
         cwd=tmpdir,

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -14,6 +14,20 @@ def test_help_without_external_modules(tt_cmd, help_cmd):
     assert "EXTERNAL COMMANDS" not in output
 
 
+def test_help_internal_module(tt_cmd, tmpdir):
+    module = "version"
+    commands = [
+        [tt_cmd, "help", module],
+        [tt_cmd, module, "--help"],
+        [tt_cmd, module, "-h"],
+    ]
+
+    for cmd in commands:
+        rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+        assert rc == 0
+        assert "Show Tarantool CLI version information" in output
+
+
 def test_external_help_module(tt_cmd, tmpdir):
     create_tt_config(tmpdir, tmpdir)
     module_message = create_external_module("help", tmpdir)
@@ -28,7 +42,7 @@ def test_external_help_module(tt_cmd, tmpdir):
     commands = [
         [tt_cmd, "-h"],
         [tt_cmd, "--help"],
-        [tt_cmd, "help", "-I"],
+        [tt_cmd, "-I", "help"],
         [tt_cmd],
     ]
 


### PR DESCRIPTION
This patch fixes incorrect behavior of parsing global flags of the tt
command.
    
E.g: `tt --cfg some_file install tarantool --cfg other_file`
    
In this case, the result of the second cfg option was taken and the
error was thrown that there was no such option in install.
This behavior is incorrect and has been fixed. The value of the overridden
option will now be ignored.
    
Now global flags are required to be positioned only before child
commands:
    
OK:
`tt --cfg tt.yaml install ...`
    
Not OK:
`tt install ... --cfg tt.yaml`
    
Closes #521