### PR TITLE
rocks: fix --verbose option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 commands. Example: ``tt --cfg tt.yaml install tt``.
 - tt config format: separate tt environment options from application options.
 
+### Fixed
+- ``tt rocks``: broken ``--verbose`` option.
+
 ## [1.3.0] - 2023-09-28
 
 ### Changed

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -76,6 +76,12 @@ def test_rocks_module(tt_cmd, tmpdir):
     assert rc == 0
     assert "testapp scm-1 is now installed" in output
 
+    rc, output = run_command_and_get_output(
+            [tt_cmd, "rocks", "--verbose", "list"],
+            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+    assert "fs.current_dir()\n" in output
+
 
 def test_rocks_admin_module(tt_cmd, tmpdir):
     repo_path = os.path.join(tmpdir, "rocks_repo")


### PR DESCRIPTION
The behavior of io.popen() is different in lua and gopher-lua. See: https://github.com/yuin/gopher-lua/issues/459

The fix uses a temporary fix in our luarocks fork.

Closes #612