### PR TITLE
version: add commits since tag info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Global flags are required to be positioned only before child
 commands. Example: ``tt --cfg tt.yaml install tt``.
 - tt config format: separate tt environment options from application options.
+- tt version: additional version information for non-release builds.
 
 ### Fixed
 - ``tt rocks``: broken ``--verbose`` option.

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -17,9 +17,10 @@ const (
 // Get the value of this variables at build time.
 // See magefile for more details.
 var (
-	gitTag       string
-	gitCommit    string
-	versionLabel string
+	gitTag            string
+	gitCommit         string
+	gitCommitSinceTag string
+	versionLabel      string
 )
 
 // GetVersion return string with Tarantool CLI version info.
@@ -51,6 +52,13 @@ func GetVersion(showShort bool, needCommit bool) string {
 		}
 
 		return version
+	}
+
+	if gitCommitSinceTag != "" && gitCommitSinceTag != "0" && gitTag != "" {
+		return fmt.Sprintf(
+			"%s version %s, %s/%s. commit: %s (%s)",
+			cliVersionTitle, version, runtime.GOOS, runtime.GOARCH, gitCommit, gitTag,
+		)
 	}
 
 	return fmt.Sprintf(

--- a/magefile.go
+++ b/magefile.go
@@ -36,6 +36,7 @@ var (
 		"-s", "-w",
 		"-X ${PACKAGE}/version.gitTag=${GIT_TAG}",
 		"-X ${PACKAGE}/version.gitCommit=${GIT_COMMIT}",
+		"-X ${PACKAGE}/version.gitCommitSinceTag=${GIT_COMMIT_SINCE_TAG}",
 		"-X ${PACKAGE}/version.versionLabel=${VERSION_LABEL}",
 		"-X ${PACKAGE}/configure.defaultConfigPath=${CONFIG_PATH}",
 	}
@@ -366,7 +367,9 @@ func getBuildEnvironment() map[string]string {
 
 	var currentDir string
 	var gitTag string
+	var gitTagShort string
 	var gitCommit string
+	var gitCommitSinceTag string
 
 	if currentDir, err = os.Getwd(); err != nil {
 		log.Warnf("Failed to get current directory: %s", err)
@@ -374,16 +377,19 @@ func getBuildEnvironment() map[string]string {
 
 	if _, err := exec.LookPath("git"); err == nil {
 		gitTag, _ = sh.Output("git", "describe", "--tags")
+		gitTagShort, _ = sh.Output("git", "describe", "--tags", "--abbrev=0")
 		gitCommit, _ = sh.Output("git", "rev-parse", "--short", "HEAD")
+		gitCommitSinceTag, _ = sh.Output("git", "rev-list", gitTagShort+"..", "--count")
 	}
 
 	return map[string]string{
-		"PACKAGE":       goPackageName,
-		"GIT_TAG":       gitTag,
-		"GIT_COMMIT":    gitCommit,
-		"VERSION_LABEL": os.Getenv("VERSION_LABEL"),
-		"PWD":           currentDir,
-		"CONFIG_PATH":   getDefaultConfigPath(),
-		"CGO_ENABLED":   "1",
+		"PACKAGE":              goPackageName,
+		"GIT_TAG":              gitTag,
+		"GIT_COMMIT":           gitCommit,
+		"GIT_COMMIT_SINCE_TAG": gitCommitSinceTag,
+		"VERSION_LABEL":        os.Getenv("VERSION_LABEL"),
+		"PWD":                  currentDir,
+		"CONFIG_PATH":          getDefaultConfigPath(),
+		"CGO_ENABLED":          "1",
 	}
 }


### PR DESCRIPTION
If there were commits after the tag, this information will be shown. Otherwise it will be the usual format.

Example:
$  git tag v5.6.7
$  mage build
Building tt...
Apply cartridge-cli patches...
$  ./tt version
Tarantool CLI version 5.6.7, linux/amd64. commit: b69e586 
$  git tag -d v5.6.7
Deleted tag 'v5.6.7' (was b69e586)
$  mage build
Building tt...
Apply cartridge-cli patches...
$  ./tt version
Tarantool CLI version 1.3.0, linux/amd64. commit: b69e586 (v1.3.0-9-b69e586)