### PR TITLE
connect: make user/pass environment variables constants and helper functions public

### DIFF
--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	usernameEnv = "TT_CLI_USERNAME"
-	passwordEnv = "TT_CLI_PASSWORD"
-	userpassRe  = `[^@:/]+:[^@:/]+`
+	// userPathRe is a regexp for a username:password pair.
+	userpassRe = `[^@:/]+:[^@:/]+`
 
 	// uriPathPrefixRe is a regexp for a path prefix in uri, such as `scheme://path``.
 	uriPathPrefixRe = `((~?/+)|((../+)*))?`
@@ -70,8 +69,8 @@ func NewConnectCmd() *cobra.Command {
 		Short: "Connect to the tarantool instance",
 		Long: "Connect to the tarantool instance.\n\n" +
 			"The command supports the following environment variables:\n\n" +
-			"* " + usernameEnv + " - specifies a username\n" +
-			"* " + passwordEnv + " - specifies a password\n" +
+			"* " + connect.TarantoolUsernameEnv + " - specifies a username\n" +
+			"* " + connect.TarantoolPasswordEnv + " - specifies a password\n" +
 			"\n" +
 			"You could pass command line arguments to the interpreted SCRIPT" +
 			" or COMMAND passed via -f flag:\n\n" +
@@ -272,10 +271,10 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 	} else if isBaseURI(args[0]) {
 		// Environment variables do not overwrite values.
 		if connectCtx.Username == "" {
-			connectCtx.Username = os.Getenv(usernameEnv)
+			connectCtx.Username = os.Getenv(connect.TarantoolUsernameEnv)
 		}
 		if connectCtx.Password == "" {
-			connectCtx.Password = os.Getenv(passwordEnv)
+			connectCtx.Password = os.Getenv(connect.TarantoolPasswordEnv)
 		}
 		network, address := parseBaseURI(args[0])
 		connOpts = makeConnOpts(network, address, *connectCtx)

--- a/cli/connect/const.go
+++ b/cli/connect/const.go
@@ -1,5 +1,13 @@
 package connect
 
+// TarantoolUsernameEnv is an environment variable with a username for
+// Tarantool.
+const TarantoolUsernameEnv = "TT_CLI_USERNAME"
+
+// TarantoolPasswordEnv is an environment variable with a password for
+// Tarantool.
+const TarantoolPasswordEnv = "TT_CLI_PASSWORD"
+
 // setLanguagePrefix is used to set a language in the Tarantool console.
 const setLanguagePrefix = "\\set language"
 

--- a/cli/connect/uri.go
+++ b/cli/connect/uri.go
@@ -1,0 +1,116 @@
+package connect
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/tarantool/tt/cli/connector"
+)
+
+const (
+	// userPathRe is a regexp for a username:password pair.
+	userpassRe = `[^@:/]+:[^@:/]+`
+
+	// uriPathPrefixRe is a regexp for a path prefix in uri, such as `scheme://path``.
+	uriPathPrefixRe = `((~?/+)|((../+)*))?`
+
+	// systemPathPrefixRe is a regexp for a path prefix to use without scheme.
+	systemPathPrefixRe = `(([\.~]?/+)|((../+)+))`
+)
+
+// IsBaseURI returns true if a string is a valid URI.
+func IsBaseURI(str string) bool {
+	// tcp://host:port
+	// host:port
+	tcpReStr := `(tcp://)?([\w\\.-]+:\d+)`
+	// unix://../path
+	// unix://~/path
+	// unix:///path
+	// unix://path
+	unixReStr := `unix://` + uriPathPrefixRe + `[^\./@]+[^@]*`
+	// ../path
+	// ~/path
+	// /path
+	// ./path
+	pathReStr := systemPathPrefixRe + `[^\./].*`
+
+	uriReStr := "^((" + tcpReStr + ")|(" + unixReStr + ")|(" + pathReStr + "))$"
+	uriRe := regexp.MustCompile(uriReStr)
+	return uriRe.MatchString(str)
+}
+
+// IsCredentialsURI returns true if a string is a valid credentials URI.
+func IsCredentialsURI(str string) bool {
+	// tcp://user:password@host:port
+	// user:password@host:port
+	tcpReStr := `(tcp://)?` + userpassRe + `@([\w\.-]+:\d+)`
+	// unix://user:password@../path
+	// unix://user:password@~/path
+	// unix://user:password@/path
+	// unix://user:password@path
+	unixReStr := `unix://` + userpassRe + `@` + uriPathPrefixRe + `[^\./@]+.*`
+	// user:password@../path
+	// user:password@~/path
+	// user:password@/path
+	// user:password@./path
+	pathReStr := userpassRe + `@` + systemPathPrefixRe + `[^\./].*`
+
+	uriReStr := "^((" + tcpReStr + ")|(" + unixReStr + ")|(" + pathReStr + "))$"
+	uriRe := regexp.MustCompile(uriReStr)
+	return uriRe.MatchString(str)
+}
+
+// ParseBaseURI parses an URI and returns:
+// (network, address)
+func ParseBaseURI(uri string) (string, string) {
+	var network, address string
+	uriLen := len(uri)
+
+	switch {
+	case uriLen > 0 && (uri[0] == '.' || uri[0] == '/' || uri[0] == '~'):
+		network = connector.UnixNetwork
+		address = uri
+	case uriLen >= 7 && uri[0:7] == "unix://":
+		network = connector.UnixNetwork
+		address = uri[7:]
+	case uriLen >= 6 && uri[0:6] == "tcp://":
+		network = connector.TCPNetwork
+		address = uri[6:]
+	default:
+		network = connector.TCPNetwork
+		address = uri
+	}
+
+	// In the case of a complex uri, shell expansion does not occur, so do it manually.
+	if network == connector.UnixNetwork &&
+		strings.HasPrefix(address, "~/") {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			address = filepath.Join(homeDir, address[2:])
+		}
+	}
+
+	return network, address
+}
+
+// ParseCredentialsURI parses a URI with credentials and returns:
+// (URI without credentials, user, password)
+func ParseCredentialsURI(str string) (string, string, string) {
+	if !IsCredentialsURI(str) {
+		return str, "", ""
+	}
+
+	re := regexp.MustCompile(userpassRe + `@`)
+	// Split the string into two parts by credentials to create a string
+	// without the credentials.
+	split := re.Split(str, 2)
+	newStr := split[0] + split[1]
+
+	// Parse credentials.
+	credentialsStr := re.FindString(str)
+	credentialsLen := len(credentialsStr) - 1 // We don't need a last '@'.
+	credentialsSlice := strings.Split(credentialsStr[:credentialsLen], ":")
+
+	return newStr, credentialsSlice[0], credentialsSlice[1]
+}

--- a/cli/connect/uri_test.go
+++ b/cli/connect/uri_test.go
@@ -1,10 +1,11 @@
-package cmd
+package connect_test
 
 import (
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/tt/cli/connect"
 	"github.com/tarantool/tt/cli/connector"
 )
 
@@ -93,7 +94,7 @@ var invalidCredentialsUris = []string{
 func TestIsBaseURIValid(t *testing.T) {
 	for _, uri := range validBaseUris {
 		t.Run(uri, func(t *testing.T) {
-			assert.True(t, isBaseURI(uri), "URI must be valid")
+			assert.True(t, connect.IsBaseURI(uri), "URI must be valid")
 		})
 	}
 }
@@ -106,7 +107,7 @@ func TestIsBaseURIInvalid(t *testing.T) {
 
 	for _, uri := range invalid {
 		t.Run(uri, func(t *testing.T) {
-			assert.False(t, isBaseURI(uri), "URI must be invalid")
+			assert.False(t, connect.IsBaseURI(uri), "URI must be invalid")
 		})
 	}
 }
@@ -114,7 +115,7 @@ func TestIsBaseURIInvalid(t *testing.T) {
 func TestIsCredentialsURIValid(t *testing.T) {
 	for _, uri := range validCredentialsUris {
 		t.Run(uri, func(t *testing.T) {
-			assert.True(t, isCredentialsURI(uri), "URI must be valid")
+			assert.True(t, connect.IsCredentialsURI(uri), "URI must be valid")
 		})
 	}
 }
@@ -127,7 +128,7 @@ func TestIsCredentialsURIInvalid(t *testing.T) {
 
 	for _, uri := range invalid {
 		t.Run(uri, func(t *testing.T) {
-			assert.False(t, isCredentialsURI(uri), "URI must be invalid")
+			assert.False(t, connect.IsCredentialsURI(uri), "URI must be invalid")
 		})
 	}
 }
@@ -151,7 +152,7 @@ func TestParseCredentialsURI(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.srcUri, func(t *testing.T) {
-			newUri, user, pass := parseCredentialsURI(c.srcUri)
+			newUri, user, pass := connect.ParseCredentialsURI(c.srcUri)
 			assert.Equal(t, c.newUri, newUri, "a unexpected new URI")
 			assert.Equal(t, testUser, user, "a unexpected username")
 			assert.Equal(t, testPass, pass, "a unexpected password")
@@ -162,7 +163,7 @@ func TestParseCredentialsURI(t *testing.T) {
 func TestParseCredentialsURI_parseValid(t *testing.T) {
 	for _, uri := range validCredentialsUris {
 		t.Run(uri, func(t *testing.T) {
-			newUri, user, pass := parseCredentialsURI(uri)
+			newUri, user, pass := connect.ParseCredentialsURI(uri)
 			assert.NotEqual(t, uri, newUri, "URI must change")
 			assert.NotEqual(t, "", user, "username must not be empty")
 			assert.NotEqual(t, "", pass, "password must not be empty")
@@ -178,7 +179,7 @@ func TestParseCredentialsURI_notParseInvalid(t *testing.T) {
 
 	for _, uri := range invalid {
 		t.Run(uri, func(t *testing.T) {
-			newUri, user, pass := parseCredentialsURI(uri)
+			newUri, user, pass := connect.ParseCredentialsURI(uri)
 			assert.Equal(t, uri, newUri, "URI must no change")
 			assert.Equal(t, "", user, "username must be empty")
 			assert.Equal(t, "", pass, "password must be empty")
@@ -204,7 +205,7 @@ func TestParseBaseURI(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.URI, func(t *testing.T) {
-			network, address := parseBaseURI(tc.URI)
+			network, address := connect.ParseBaseURI(tc.URI)
 			assert.Equal(t, network, tc.network)
 			assert.Equal(t, address, tc.address)
 		})
@@ -212,11 +213,11 @@ func TestParseBaseURI(t *testing.T) {
 
 	t.Run("starts from ~", func(t *testing.T) {
 		homeDir, _ := os.UserHomeDir()
-		network, address := parseBaseURI("unix://~/a/b")
+		network, address := connect.ParseBaseURI("unix://~/a/b")
 		assert.Equal(t, connector.UnixNetwork, network)
 		assert.Equal(t, homeDir+"/a/b", address)
 
-		network, address = parseBaseURI("~/a/b")
+		network, address = connect.ParseBaseURI("~/a/b")
 		assert.Equal(t, connector.UnixNetwork, network)
 		assert.Equal(t, homeDir+"/a/b", address)
 	})


### PR DESCRIPTION
We need this environment variables and functions for `tt-ee` modules to unify the behavior across modules.

Part of https://github.com/tarantool/roadmap-internal/issues/281