### PR TITLE
connect: change console title and prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ paths. Default names are changed for PID-files, control sockets and log files.
 - Enable logging to file by default for `tarantool` cluster instances.
 Default log file name for an instance is `tarantool.log`. `tarantool`'s
 stdout/stderr and `tt` logs go to `tt.log` file.
+- Remove URI with creds from console title and prompt.
 
 ### Added
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -268,6 +268,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 		connectCtx.Username = user
 		connectCtx.Password = pass
 		connOpts = makeConnOpts(network, address, *connectCtx)
+		connectCtx.ConnectTarget = newURI
 	} else if isBaseURI(args[0]) {
 		// Environment variables do not overwrite values.
 		if connectCtx.Username == "" {
@@ -282,7 +283,9 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 		err = fillErr
 		return
 	}
-	connectCtx.ConnectTarget = args[0]
+	if connectCtx.ConnectTarget == "" {
+		connectCtx.ConnectTarget = args[0]
+	}
 	return
 }
 


### PR DESCRIPTION
If a user specifies creds in connect string, use
cleaned up URI for console title and prompt.
```
$ tt connect admin:admin@localhost:3301
   • Connecting to the instance...
   • Connected to localhost:3301

localhost:3301>

$ tt connect localhost:3301
   • Connecting to the instance...
   • Connected to localhost:3301

localhost:3301>
```