### PR TITLE
cluster: add missed credentials pass methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ stdout/stderr and `tt` logs go to `tt.log` file.
 - tarantool-ee: search and install development builds.
 - ``tt play``: ability to pass username and password via flags and environment
   variables.
+- tt cluster: credentials could be passed via environment variables and command
+flags.
 
 ### Fixed
 - ``tt rocks``: broken ``--verbose`` option.

--- a/cli/cluster/cmd/publish.go
+++ b/cli/cluster/cmd/publish.go
@@ -10,6 +10,10 @@ import (
 // PublishCtx contains information abould cluster publish command execution
 // context.
 type PublishCtx struct {
+	// Username defines an etcd username.
+	Username string
+	// Password defines an etcd password.
+	Password string
 	// Force defines whether the publish should be forced and a validation step
 	// is omitted.
 	Force bool
@@ -24,6 +28,10 @@ func PublishEtcd(publishCtx PublishCtx, uri *url.URL) error {
 	etcdOpts, err := cluster.MakeEtcdOptsFromUrl(uri)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", uri, err)
+	}
+	if etcdOpts.Username == "" && etcdOpts.Password == "" {
+		etcdOpts.Username = publishCtx.Username
+		etcdOpts.Password = publishCtx.Password
 	}
 
 	instance := uri.Query().Get("name")

--- a/cli/cluster/cmd/show.go
+++ b/cli/cluster/cmd/show.go
@@ -9,6 +9,10 @@ import (
 
 // ShowCtx contains information about cluster show command execution context.
 type ShowCtx struct {
+	// Username defines an etcd username.
+	Username string
+	// Password defines an etcd password.
+	Password string
 	// Validate defines whether the command will check the showed
 	// configuration.
 	Validate bool
@@ -19,6 +23,10 @@ func ShowEtcd(showCtx ShowCtx, uri *url.URL) error {
 	etcdOpts, err := cluster.MakeEtcdOptsFromUrl(uri)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", uri, err)
+	}
+	if etcdOpts.Username == "" && etcdOpts.Password == "" {
+		etcdOpts.Username = showCtx.Username
+		etcdOpts.Password = showCtx.Password
 	}
 
 	etcdcli, err := cluster.ConnectEtcd(etcdOpts)

--- a/cli/connect/const.go
+++ b/cli/connect/const.go
@@ -8,6 +8,12 @@ const TarantoolUsernameEnv = "TT_CLI_USERNAME"
 // Tarantool.
 const TarantoolPasswordEnv = "TT_CLI_PASSWORD"
 
+// EtcdUsernameEnv is an environment variable with a username for etcd.
+const EtcdUsernameEnv = "TT_CLI_ETCD_USERNAME"
+
+// EtcdPasswordEnv is an environment variable with a password for etcd.
+const EtcdPasswordEnv = "TT_CLI_ETCD_PASSWORD"
+
 // setLanguagePrefix is used to set a language in the Tarantool console.
 const setLanguagePrefix = "\\set language"
 

--- a/test/integration/cluster/test_cluster.py
+++ b/test/integration/cluster/test_cluster.py
@@ -58,6 +58,10 @@ iproto:
   listen: 127.0.0.1:3303
 """
 
+# The root user requires the least amount of steps to work.
+etcd_username = "root"
+etcd_password = "password"
+
 
 def copy_app(tmpdir, app_name):
     app_path = os.path.join(tmpdir, app_name)
@@ -81,17 +85,37 @@ def etcd_start(host, tmpdir):
     except Exception:
         pass
 
-    if not popen.poll():
-        return popen
+    if popen.poll():
+        return None
 
-    print(popen.stdout.read())
+    return popen
 
-    return None
+
+# etcdv3 client have a bug that prevents to establish a connection with
+# authentication enabled in latest python versions. So we need a separate steps
+# to upload/fetch data to/from etcd via the client.
+def etcd_enable_auth(popen, host):
+    try:
+        subprocess.run(["etcdctl", "user", "add", etcd_username,
+                        f"--new-user-password={etcd_password}",
+                        f"--endpoints={host}"])
+        subprocess.run(["etcdctl", "auth", "enable",
+                        f"--user={etcd_username}:{etcd_password}",
+                        f"--endpoints={host}"])
+    except Exception as ex:
+        etcd_stop(popen)
+        raise ex
+
+
+def etcd_disable_auth(host):
+    subprocess.run(["etcdctl", "auth", "disable",
+                    f"--user={etcd_username}:{etcd_password}",
+                    f"--endpoints={host}"])
 
 
 def etcd_stop(popen):
     if popen:
-        popen.kill()
+        popen.terminate()
         popen.wait()
 
 
@@ -291,29 +315,16 @@ def test_cluster_show_config_etcd_no_prefix(tt_cmd, tmpdir_with_cfg):
     assert expected in show_output
 
 
-def test_cluster_show_config_etcd_cluster(tt_cmd, tmpdir_with_cfg):
+def test_cluster_show_config_etcd_no_auth(tt_cmd, tmpdir_with_cfg):
     tmpdir = tmpdir_with_cfg
-    host = "localhost"
-    port = 12388
-    endpoint = f"http://{host}:{port}"
-    popen = etcd_start(endpoint, tmpdir)
+    host = "http://localhost:12388"
+    popen = etcd_start(host, tmpdir)
     assert popen
+    etcd_enable_auth(popen, host)
 
     try:
-        etcd = etcd3.client(host=host, port=port)
-        etcd.put('/prefix/config/', r"""groups:
-  group-001:
-    replicasets:
-      replicaset-001:
-        instances:
-          master:
-            database:
-              mode: rw
-            iproto:
-              listen: 127.0.0.1:3301
-""")
         show_cmd = [tt_cmd, "cluster", "show",
-                    f"{endpoint}/prefix?timeout=5"]
+                    f"{host}/prefix?timeout=5"]
         instance_process = subprocess.Popen(
             show_cmd,
             cwd=tmpdir,
@@ -325,7 +336,44 @@ def test_cluster_show_config_etcd_cluster(tt_cmd, tmpdir_with_cfg):
     finally:
         etcd_stop(popen)
 
-    assert r"""groups:
+    expected = (r"   ⨯ failed to collect a configuration from etcd: " +
+                "failed to fetch data from etcd: etcdserver: user name is empty")
+    assert expected in show_output
+
+
+def test_cluster_show_config_etcd_bad_auth(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    host = "localhost:12388"
+    popen = etcd_start(f"http://{host}", tmpdir)
+    assert popen
+    etcd_enable_auth(popen, f"http://{host}")
+
+    try:
+        show_cmd = [tt_cmd, "cluster", "show",
+                    f"http://invalid_user:invalid_pass@{host}/prefix?timeout=5"]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        show_output = instance_process.stdout.read()
+    finally:
+        etcd_stop(popen)
+
+    expected = (r"   ⨯ failed to connect to etcd: " +
+                "etcdserver: authentication failed, invalid user ID or password")
+    assert expected in show_output
+
+
+@pytest.mark.parametrize('auth', [False, "url", "flag", "env"])
+def test_cluster_show_config_etcd_cluster(tt_cmd, tmpdir_with_cfg, auth):
+    tmpdir = tmpdir_with_cfg
+    host = "localhost"
+    port = 12388
+    endpoint = f"http://{host}:{port}"
+    config = r"""groups:
   group-001:
     replicasets:
       replicaset-001:
@@ -335,7 +383,47 @@ def test_cluster_show_config_etcd_cluster(tt_cmd, tmpdir_with_cfg):
               mode: rw
             iproto:
               listen: 127.0.0.1:3301
-""" in show_output
+"""
+    popen = etcd_start(endpoint, tmpdir)
+    assert popen
+
+    try:
+        etcd = etcd3.client(host=host, port=port)
+        etcd.put('/prefix/config/', config)
+
+        if auth:
+            etcd_enable_auth(popen, endpoint)
+
+        if not auth:
+            env = None
+            url = f"{endpoint}/prefix?timeout=5"
+            show_cmd = [tt_cmd, "cluster", "show", url]
+        elif auth == "url":
+            env = None
+            url = f"http://{etcd_username}:{etcd_password}@{host}:{port}/prefix?timeout=5"
+            show_cmd = [tt_cmd, "cluster", "show", url]
+        elif auth == "flag":
+            env = None
+            url = f"{endpoint}/prefix?timeout=5"
+            show_cmd = [tt_cmd, "cluster", "show", url,
+                        "-u", etcd_username, "-p", etcd_password]
+        elif auth == "env":
+            env = {"TT_CLI_ETCD_USERNAME": etcd_username,
+                   "TT_CLI_ETCD_PASSWORD": etcd_password}
+            url = f"{endpoint}/prefix?timeout=5"
+            show_cmd = [tt_cmd, "cluster", "show", url]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            env=env,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        show_output = instance_process.stdout.read()
+        assert config in show_output
+    finally:
+        etcd_stop(popen)
 
 
 def test_cluster_show_config_etcd_instance(tt_cmd, tmpdir_with_cfg):
@@ -749,7 +837,68 @@ def test_cluster_publish_config_etcd_not_exist(tt_cmd, tmpdir_with_cfg):
     assert expected in publish_output
 
 
-def test_cluster_publish_cluster_etcd(tt_cmd, tmpdir_with_cfg):
+def test_cluster_publish_config_etcd_no_auth(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    src_cfg_path = os.path.join(tmpdir, "src.yaml")
+    with open(src_cfg_path, 'w') as f:
+        f.write(valid_cluster_cfg)
+    host = "http://localhost:12388"
+    popen = etcd_start(host, tmpdir)
+    assert popen
+    etcd_enable_auth(popen, host)
+
+    try:
+        show_cmd = [tt_cmd, "cluster", "publish",
+                    f"{host}/prefix?timeout=0.1", "src.yaml"]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        publish_output = instance_process.stdout.read()
+
+    finally:
+        etcd_stop(popen)
+
+    expected = (r"   ⨯ failed to fetch data from etcd: etcdserver: user name is empty")
+    assert expected in publish_output
+
+
+def test_cluster_publish_config_etcd_bad_auth(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    src_cfg_path = os.path.join(tmpdir, "src.yaml")
+    with open(src_cfg_path, 'w') as f:
+        f.write(valid_cluster_cfg)
+    host = "localhost:12388"
+    popen = etcd_start(f"http://{host}", tmpdir)
+    assert popen
+    etcd_enable_auth(popen, f"http://{host}")
+
+    try:
+        show_cmd = [tt_cmd, "cluster", "publish",
+                    f"http://invalid_user:invalid_pass@{host}/prefix?timeout=0.1",
+                    "src.yaml"]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        publish_output = instance_process.stdout.read()
+
+    finally:
+        etcd_stop(popen)
+
+    expected = (r"   ⨯ failed to connect to etcd: " +
+                "etcdserver: authentication failed, invalid user ID or password")
+    assert expected in publish_output
+
+
+@pytest.mark.parametrize('auth', [False, "url", "flag", "env"])
+def test_cluster_publish_cluster_etcd(tt_cmd, tmpdir_with_cfg, auth):
     tmpdir = tmpdir_with_cfg
     src_cfg_path = os.path.join(tmpdir, "src.yaml")
     with open(src_cfg_path, 'w') as f:
@@ -761,23 +910,46 @@ def test_cluster_publish_cluster_etcd(tt_cmd, tmpdir_with_cfg):
     assert popen
 
     try:
-        etcd = etcd3.client(host=host, port=port)
-        show_cmd = [tt_cmd, "cluster", "publish",
-                    f"{endpoint}/prefix?timeout=5", "src.yaml"]
+        if auth:
+            etcd_enable_auth(popen, endpoint)
+
+        if not auth:
+            env = None
+            url = f"{endpoint}/prefix?timeout=5"
+            publish_cmd = [tt_cmd, "cluster", "publish", url, "src.yaml"]
+        elif auth == "url":
+            env = None
+            url = f"http://{etcd_username}:{etcd_password}@{host}:{port}/prefix?timeout=5"
+            publish_cmd = [tt_cmd, "cluster", "publish", url, "src.yaml"]
+        elif auth == "flag":
+            env = None
+            url = f"{endpoint}/prefix?timeout=5"
+            publish_cmd = [tt_cmd, "cluster", "publish", url, "src.yaml",
+                           "-u", etcd_username, "-p", etcd_password]
+        elif auth == "env":
+            env = {"TT_CLI_ETCD_USERNAME": etcd_username,
+                   "TT_CLI_ETCD_PASSWORD": etcd_password}
+            url = f"{endpoint}/prefix?timeout=5"
+            publish_cmd = [tt_cmd, "cluster", "publish", url, "src.yaml"]
+
         instance_process = subprocess.Popen(
-            show_cmd,
+            publish_cmd,
+            env=env,
             cwd=tmpdir,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             text=True
         )
         publish_output = instance_process.stdout.read()
+
+        if auth:
+            etcd_disable_auth(endpoint)
+        etcd = etcd3.client(host=host, port=port)
         etcd_content, _ = etcd.get('/prefix/config/all')
+        assert "" == publish_output
+        assert valid_cluster_cfg == etcd_content.decode("utf-8")
     finally:
         etcd_stop(popen)
-
-    assert "" == publish_output
-    assert valid_cluster_cfg == etcd_content.decode("utf-8")
 
 
 def test_cluster_publish_instance_etcd(tt_cmd, tmpdir_with_cfg):


### PR DESCRIPTION
The patch adds etcd credentials pass via environment variables and command flags.

Part of https://github.com/tarantool/roadmap-internal/issues/281