### PR TITLE
tarantool-ee: search and install development build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ stdout/stderr and `tt` logs go to `tt.log` file.
 ### Added
 
 - tt completion: added luarocks completions.
+- tarantool-ee: search and install development builds.
 
 ### Fixed
 - ``tt rocks``: broken ``--verbose`` option.

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -62,6 +62,8 @@ func newInstallTarantoolEeCmd() *cobra.Command {
 		},
 	}
 
+	tntCmd.Flags().BoolVar(&installCtx.DevBuild, "dev", false, "install development build")
+
 	return tntCmd
 }
 

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -63,6 +63,8 @@ func newSearchTarantoolEeCmd() *cobra.Command {
 		"search for debug builds of tarantool-ee SDK")
 	tntCmd.Flags().StringVar(&searchCtx.ReleaseVersion, "version", searchCtx.ReleaseVersion,
 		"specify version")
+	tntCmd.Flags().BoolVar(&searchCtx.DevBuilds, "dev", false,
+		"search for development builds of tarantool-ee SDK")
 
 	return tntCmd
 }

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -107,6 +107,8 @@ type InstallCtx struct {
 	buildDir string
 	// IncDir is the directory, where the tarantool headers are located.
 	IncDir string
+	// Install development build.
+	DevBuild bool
 }
 
 // Package is a struct containing sys and install name of the package.
@@ -1177,7 +1179,8 @@ func installTarantoolEE(binDir string, includeDir string, installCtx InstallCtx,
 		}
 	}
 
-	ver, err := search.GetTarantoolBundleInfo(cliOpts, installCtx.Local, files, tarVersion)
+	ver, err := search.GetTarantoolBundleInfo(cliOpts, installCtx.Local,
+		installCtx.DevBuild, files, tarVersion)
 	if err != nil {
 		return err
 	}
@@ -1200,7 +1203,8 @@ func installTarantoolEE(binDir string, includeDir string, installCtx InstallCtx,
 
 	log.Infof("Getting bundle name for %s", tarVersion)
 	bundleName := ver.Version.Tarball
-	bundleSource, err := search.TntIoMakePkgURI(ver.Package, ver.Release, bundleName)
+	bundleSource, err := search.TntIoMakePkgURI(ver.Package, ver.Release,
+		bundleName, installCtx.DevBuild)
 	if err != nil {
 		return err
 	}

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -35,6 +35,8 @@ type SearchCtx struct {
 	ReleaseVersion string
 	// Program name
 	ProgramName string
+	// Search for development builds.
+	DevBuilds bool
 }
 
 const (
@@ -465,7 +467,7 @@ func FetchBundlesInfo(searchCtx SearchCtx, cliOpts *config.CliOpts) ([]BundleInf
 
 // GetTarantoolBundleInfo returns the available EE SDK bundle for user's OS,
 // corresponding to the passed expected version argument.
-func GetTarantoolBundleInfo(cliOpts *config.CliOpts, local bool,
+func GetTarantoolBundleInfo(cliOpts *config.CliOpts, local bool, devBuild bool,
 	files []string, expectedVersion string) (BundleInfo, error) {
 	bundles := BundleInfoSlice{}
 	var err error
@@ -483,8 +485,9 @@ func GetTarantoolBundleInfo(cliOpts *config.CliOpts, local bool,
 	} else {
 		var token string
 		searchCtx := SearchCtx{
-			Filter:  SearchAll,
-			Package: "enterprise",
+			Filter:    SearchAll,
+			Package:   "enterprise",
+			DevBuilds: devBuild,
 		}
 		bundles, token, err = FetchBundlesInfo(searchCtx, cliOpts)
 		if err != nil {

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -24,9 +24,15 @@ type apiRequst struct {
 }
 
 // TntIoMakePkgURI generates a URI for downloading a package.
-func TntIoMakePkgURI(Package string, Release string, Tarball string) (string, error) {
+func TntIoMakePkgURI(Package string, Release string,
+	Tarball string, DevBuilds bool) (string, error) {
 	var uri string
 	var osType string
+	buildType := "release"
+
+	if DevBuilds {
+		buildType = "dev"
+	}
 
 	arch, err := util.GetArch()
 	if err != nil {
@@ -47,7 +53,8 @@ func TntIoMakePkgURI(Package string, Release string, Tarball string) (string, er
 		return "", fmt.Errorf("unsupported OS")
 	}
 
-	uri = fmt.Sprintf("%s/%s/release/%s/%s/%s/%s", PkgURI, Package, osType, arch, Release, Tarball)
+	uri = fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s",
+		PkgURI, Package, buildType, osType, arch, Release, Tarball)
 
 	return uri, nil
 }
@@ -57,6 +64,7 @@ func tntIoGetPkgVersions(cliOpts *config.CliOpts,
 	searchCtx SearchCtx) (apiReply map[string][]string, token string, err error) {
 	var query string
 	var osType string
+	buildType := "release"
 
 	arch, err := util.GetArch()
 	if err != nil {
@@ -82,12 +90,16 @@ func tntIoGetPkgVersions(cliOpts *config.CliOpts,
 		return nil, "", err
 	}
 
+	if searchCtx.DevBuilds {
+		buildType = "dev"
+	}
+
 	if len(searchCtx.ReleaseVersion) > 0 {
-		query = fmt.Sprintf("%s/release/%s/%s/%s",
-			searchCtx.Package, osType, arch, searchCtx.ReleaseVersion)
+		query = fmt.Sprintf("%s/%s/%s/%s/%s",
+			searchCtx.Package, buildType, osType, arch, searchCtx.ReleaseVersion)
 	} else {
-		query = fmt.Sprintf("%s/release/%s/%s",
-			searchCtx.Package, osType, arch)
+		query = fmt.Sprintf("%s/%s/%s/%s",
+			searchCtx.Package, buildType, osType, arch)
 	}
 
 	msg := apiRequst{

--- a/test/integration/ee/test_ee_install.py
+++ b/test/integration/ee/test_ee_install.py
@@ -35,3 +35,30 @@ def test_install_ee(tt_cmd, tmpdir):
     assert re.search("Done.", output)
     assert os.path.exists(os.path.join(tmpdir, 'bin', 'tarantool'))
     assert os.path.exists(os.path.join(tmpdir, 'include', 'include', 'tarantool'))
+
+
+@pytest.mark.slow_ee
+def test_install_ee_dev(tt_cmd, tmpdir):
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "init"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    assert rc == 0
+
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "search", "tarantool-ee", "--dev"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+
+    version = output.split('\n')[1]
+    assert re.search(r"(\d+.\d+.\d+|<unknown>)",
+                     version)
+
+    rc, output = run_command_and_get_output(
+        [tt_cmd, "install", "-f", "tarantool-ee", version, "--dev"],
+        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+
+    assert rc == 0
+    assert re.search("Installing tarantool-ee="+version, output)
+    assert re.search("Downloading tarantool-ee...", output)
+    assert re.search("Done.", output)
+    assert os.path.exists(os.path.join(tmpdir, 'bin', 'tarantool'))
+    assert os.path.exists(os.path.join(tmpdir, 'include', 'include', 'tarantool'))


### PR DESCRIPTION
Examples:
`tt search tarantool-ee --dev`
`tt search tarantool-ee --dev --version master`
`tt search tarantool-ee --dev --version 2.11`
`tt install tarantool-ee x.y.x --dev`

Closes #650