### PR TITLE
test: add yet one locked python dependency

### DIFF
--- a/.github/actions/static-code-check/action.yml
+++ b/.github/actions/static-code-check/action.yml
@@ -7,7 +7,7 @@ runs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: Install tests requirements
         run: |

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GO_VERSION: '>=1.20.10'
-  PYTHON_VERSION: '3.x'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   full-ci-ce:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GO_VERSION: '>=1.20.10'
-  PYTHON_VERSION: '3.x'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   tests-ce:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -10,3 +10,4 @@ codespell==2.2.5
 netifaces==0.11.0
 etcd3==0.12.0
 protobuf==3.20.3
+importlib-metadata<4.3


### PR DESCRIPTION
We are using a method that was deprecated in the
importlib-metadata v5.0.0 release, let's lock the library version used.