### PR TITLE
``cat``: print logs into stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ treated as a special case.
 - Log rotation functionality and configuration is removed from `tt`.
 `tt logrotate` command re-opens a log file and sends SIGHUP to the child
 `tarantool` processes.
+- ``tt cat``: all diagnostic messages are printed to stderr.
 
 ### Added
 

--- a/cli/checkpoint/lua/cat.lua
+++ b/cli/checkpoint/lua/cat.lua
@@ -141,7 +141,7 @@ local function cat(positional_arguments, keyword_arguments)
     local format_cb = cat_formats[cat_format]
     local is_printed = false
     for _, file in ipairs(positional_arguments) do
-        print(string.format('• Result of cat: the file "%s" is processed below •', file))
+        io.stderr:write(string.format('• Result of cat: the file "%s" is processed below •\n', file))
         io.stdout:flush()
         local gen, param, state = xlog.pairs(file)
         filter_xlog(gen, param, state, opts, function(record)


### PR DESCRIPTION
Now ``tt cat`` prints logs into stderr not stdout.

Closes #624