### PR TITLE
running: changes in `instances.yml` parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Default log file name for an instance is `tarantool.log`. `tarantool`'s
 stdout/stderr and `tt` logs go to `tt.log` file.
 - Remove URI with creds from console title and prompt.
 - Ignore app-instance delimiters for Tarantool 3.0 instances.
+- Don't use dash as an app-instance delimiter. At the same time, `cartridge_app-stateboard`
+treated as a special case.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ paths. Default names are changed for PID-files, control sockets and log files.
 Default log file name for an instance is `tarantool.log`. `tarantool`'s
 stdout/stderr and `tt` logs go to `tt.log` file.
 - Remove URI with creds from console title and prompt.
+- Ignore app-instance delimiters for Tarantool 3.0 instances.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -455,8 +455,10 @@ instance_name:
   parameter: value
 ```
 
-The dot and dash characters in instance names are reserved for system
-use. if it is necessary for a certain instance to work on a source file
+The dot character in instance names is reserved for system use.
+Also, if an instance name ends with `-stateboard`, it will be recognized
+as `stateboard`.
+If it is necessary for a certain instance to work on a source file
 other than `init.lua`, then you need to create a script with a name in
 the format: `instance_name.init.lua`.
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -270,8 +270,12 @@ func collectAppDirFiles(appDir string) (appDirCtx appDirCtx, err error) {
 	return
 }
 
-// getInstanceName gets instance name from app name + instance name
-func getInstanceName(fullInstanceName string) string {
+// getInstanceName gets instance name from app name + instance name.
+func getInstanceName(fullInstanceName string, isClusterInstance bool) string {
+	if isClusterInstance {
+		// If we have a cluster instance, delimiters are ignored.
+		return fullInstanceName
+	}
 	sepIndex := strings.IndexAny(fullInstanceName, ".-")
 	if sepIndex == -1 {
 		return fullInstanceName
@@ -345,7 +349,7 @@ func collectInstancesFromAppDir(appDir string, selectedInstName string) (
 	}
 	for inst := range instParams {
 		instance := InstanceCtx{AppDir: appDir, ClusterConfigPath: appDirFiles.clusterCfgPath}
-		instance.InstName = getInstanceName(inst)
+		instance.InstName = getInstanceName(inst, instance.ClusterConfigPath != "")
 		if selectedInstName != "" && instance.InstName != selectedInstName {
 			continue
 		}

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -25,6 +25,9 @@ import (
 
 const defaultDirPerms = 0770
 
+// stateBoardInstName is cartridge stateboard instance name.
+const stateBoardInstName = "stateboard"
+
 var (
 	instStateStopped = process_utils.ProcStateStopped
 	instStateDead    = process_utils.ProcStateDead
@@ -276,7 +279,12 @@ func getInstanceName(fullInstanceName string, isClusterInstance bool) string {
 		// If we have a cluster instance, delimiters are ignored.
 		return fullInstanceName
 	}
-	sepIndex := strings.IndexAny(fullInstanceName, ".-")
+	// Consider `-stateboard` suffix for the cartridge application compatibility.
+	if strings.HasSuffix(fullInstanceName, fmt.Sprintf("-%s", stateBoardInstName)) {
+		return stateBoardInstName
+	}
+
+	sepIndex := strings.Index(fullInstanceName, ".")
 	if sepIndex == -1 {
 		return fullInstanceName
 	}

--- a/cli/running/running_test.go
+++ b/cli/running/running_test.go
@@ -331,3 +331,23 @@ func Test_collectInstancesSingleInstanceTntCtlLayout(t *testing.T) {
 	assert.Equal(t, "", inst.ClusterConfigPath)
 	assert.Equal(t, filepath.Join(instancesEnabled, appName), inst.AppDir)
 }
+
+func Test_getInstanceName(t *testing.T) {
+	for _, tc := range []struct {
+		fullInstanceName  string
+		isClusterInstance bool
+		expected          string
+	}{
+		{"master", false, "master"},
+		{"app.master", false, "master"},
+		{"app-stateboard", false, "stateboard"},
+		{"app-master", false, "app-master"},
+		{"app.inst-001", false, "inst-001"},
+		{"app-master", true, "app-master"},
+		{"app-stateboard", true, "app-stateboard"},
+		{"app.inst-001", true, "app.inst-001"},
+	} {
+		actual := getInstanceName(tc.fullInstanceName, tc.isClusterInstance)
+		assert.Equal(t, tc.expected, actual)
+	}
+}

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -172,7 +172,7 @@ func (inst *scriptInstance) Start() error {
 		"TARANTOOL_WORKDIR="+inst.walDir)
 
 	// Setup variables for the cartridge application compatibility.
-	if inst.instName != "stateboard" {
+	if inst.instName != stateBoardInstName {
 		cmd.Env = append(cmd.Env, "TARANTOOL_APP_NAME="+inst.appName)
 		cmd.Env = append(cmd.Env, "TARANTOOL_INSTANCE_NAME="+inst.instName)
 	} else {

--- a/cli/running/testdata/instances_enabled/cluster_app/instances.yml
+++ b/cli/running/testdata/instances_enabled/cluster_app/instances.yml
@@ -1,3 +1,3 @@
-cluster_app.instance-001:
-cluster_app.instance-002:
-cluster_app.instance-003:
+instance-001:
+instance-002:
+instance-003:

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -56,8 +56,8 @@ while true do
 end
 ```
 
-`instances.yml` (The dot and dash characters in instance names are
-reserved for system use.):
+`instances.yml` (The dot character in instance names is
+reserved for system use):
 
 ``` yaml
 router:

--- a/test/integration/running/multi_inst_app/instances.yml
+++ b/test/integration/running/multi_inst_app/instances.yml
@@ -3,3 +3,5 @@ router:
 master:
 
 replica:
+
+app-stateboard:

--- a/test/integration/running/small_cluster_app/config.yaml
+++ b/test/integration/running/small_cluster_app/config.yaml
@@ -8,12 +8,12 @@ groups:
     replicasets:
       replicaset-001:
         instances:
-          master:
+          storage-master:
             iproto:
               listen: '127.0.0.1:3301'
             database:
               mode: rw
-          storage:
+          storage-replica:
             iproto:
               listen: '127.0.0.1:3302'
             database:

--- a/test/integration/running/small_cluster_app/instances.yml
+++ b/test/integration/running/small_cluster_app/instances.yml
@@ -1,4 +1,4 @@
-master:
+storage-master:
 
-storage:
+storage-replica:
 

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -216,6 +216,7 @@ def test_clean(tt_cmd, tmpdir_with_cfg):
 
 def test_running_base_functionality_working_dir_app(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
+    instances = ["router", "master", "replica", "stateboard"]
 
     # Default temporary directory may have very long path. This can cause socket path buffer
     # overflow. Create our own temporary directory.
@@ -236,10 +237,11 @@ def test_running_base_functionality_working_dir_app(tt_cmd):
                 text=True
             )
             start_output = instance_process.stdout.readline()
-            assert re.search(r"Starting an instance \[app:(router|master|replica)\]", start_output)
+            assert re.search(r"Starting an instance \[app:(router|master|replica|stateboard)\]",
+                             start_output)
 
             # Check status.
-            for instName in ["master", "replica", "router"]:
+            for instName in instances:
                 print(os.path.join(test_app_path, "run", "app", instName))
                 file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
                 assert file != ""
@@ -248,15 +250,15 @@ def test_running_base_functionality_working_dir_app(tt_cmd):
             status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
             assert status_rc == 0
             status_out = extract_status(status_out)
-            assert status_out["app:router"]["STATUS"] == "RUNNING"
-            assert status_out["app:master"]["STATUS"] == "RUNNING"
-            assert status_out["app:replica"]["STATUS"] == "RUNNING"
+
+            for instName in instances:
+                assert status_out[f"app:{instName}"]["STATUS"] == "RUNNING"
 
             # Stop the application.
             stop_cmd = [tt_cmd, "stop", "app"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert status_rc == 0
-            assert re.search(r"The Instance app:(router|master|replica) \(PID = \d+\) "
+            assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
                              r"has been terminated.", stop_out)
 
             # Check that the process was terminated correctly.
@@ -266,6 +268,7 @@ def test_running_base_functionality_working_dir_app(tt_cmd):
 
 def test_running_base_functionality_working_dir_app_no_app_name(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
+    instances = ["router", "master", "replica", "stateboard"]
 
     # Default temporary directory may have very long path. This can cause socket path buffer
     # overflow. Create our own temporary directory.
@@ -286,10 +289,11 @@ def test_running_base_functionality_working_dir_app_no_app_name(tt_cmd):
                 text=True
             )
             start_output = instance_process.stdout.readline()
-            assert re.search(r"Starting an instance \[app:(router|master|replica)\]", start_output)
+            assert re.search(r"Starting an instance \[app:(router|master|replica|stateboard)\]",
+                             start_output)
 
             # Check status.
-            for instName in ["master", "replica", "router"]:
+            for instName in instances:
                 print(os.path.join(test_app_path, "run", "app", instName))
                 file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
                 assert file != ""
@@ -298,13 +302,15 @@ def test_running_base_functionality_working_dir_app_no_app_name(tt_cmd):
             status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
             assert status_rc == 0
             status_out = extract_status(status_out)
-            assert status_out[f"app:{instName}"]["STATUS"] == "RUNNING"
+
+            for instName in instances:
+                assert status_out[f"app:{instName}"]["STATUS"] == "RUNNING"
 
             # Stop the application.
             stop_cmd = [tt_cmd, "stop"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert status_rc == 0
-            assert re.search(r"The Instance app:(router|master|replica) \(PID = \d+\) "
+            assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
                              r"has been terminated.", stop_out)
 
             # Check that the process was terminated correctly.
@@ -654,6 +660,7 @@ def test_running_tarantoolctl_layout(tt_cmd, tmpdir):
 # Test bugfix https://github.com/tarantool/tt/issues/451
 def test_running_start(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
+    instances = ["master", "replica", "router", "stateboard"]
 
     with tempfile.TemporaryDirectory() as tmpdir:
         test_app_path = os.path.join(tmpdir, "app")
@@ -673,11 +680,11 @@ def test_running_start(tt_cmd):
             )
             for i in range(0, 3):
                 start_output = instance_process.stdout.readline()
-                assert re.search(r"Starting an instance \[app:(router|master|replica)\]",
+                assert re.search(r"Starting an instance \[app:(router|master|replica|stateboard)\]",
                                  start_output)
 
             # Check status.
-            for instName in ["master", "replica", "router"]:
+            for instName in instances:
                 file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
                 assert file != ""
 
@@ -685,9 +692,9 @@ def test_running_start(tt_cmd):
             status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
             assert status_rc == 0
             status_out = extract_status(status_out)
-            assert status_out['app:router']["STATUS"] == "RUNNING"
-            assert status_out['app:master']["STATUS"] == "RUNNING"
-            assert status_out['app:replica']["STATUS"] == "RUNNING"
+
+            for instName in instances:
+                assert status_out[f'app:{instName}']["STATUS"] == "RUNNING"
 
             status_cmd = [tt_cmd, "stop", "app:router"]
             status_rc, stop_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
@@ -702,6 +709,7 @@ def test_running_start(tt_cmd):
             assert status_out['app:router']["STATUS"] == "NOT RUNNING"
             assert status_out['app:master']["STATUS"] == "RUNNING"
             assert status_out['app:replica']["STATUS"] == "RUNNING"
+            assert status_out['app:stateboard']["STATUS"] == "RUNNING"
 
             # Start all instances again.
             start_cmd = [tt_cmd, "start"]
@@ -710,13 +718,13 @@ def test_running_start(tt_cmd):
 
             # Check the log output that some instances are already up.
             for i in range(0, 3):
-                assert re.search(r"The instance app:(master|replica) \(PID = \d+\) "
+                assert re.search(r"The instance app:(master|replica|stateboard) \(PID = \d+\) "
                                  r"is already running.",
                                  start_out)
 
             # Check the stopped instance is being started.
             assert re.search(r"Starting an instance \[app:router\]", start_out)
-            for instName in ["master", "replica", "router"]:
+            for instName in instances:
                 file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
             assert file != ""
 
@@ -725,15 +733,14 @@ def test_running_start(tt_cmd):
             status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
             assert status_rc == 0
             status_out = extract_status(status_out)
-            assert status_out['app:router']["STATUS"] == "RUNNING"
-            assert status_out['app:master']["STATUS"] == "RUNNING"
-            assert status_out['app:replica']["STATUS"] == "RUNNING"
+            for instName in instances:
+                assert status_out[f'app:{instName}']["STATUS"] == "RUNNING"
 
             # Stop all applications.
             stop_cmd = [tt_cmd, "stop"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert status_rc == 0
-            assert re.search(r"The Instance app:(router|master|replica) \(PID = \d+\) "
+            assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
                              r"has been terminated.", stop_out)
 
             # Check that the process was terminated correctly.


### PR DESCRIPTION
This patch adds changes to the `instances.yml` parsing logic:
1. Ignore app-instance delimiters for Tarantool 3.0 instances.
2. Don't use dash as an app-instance delimiter. At the same time, `cartridge_app-stateboard`
treated as a special case.

I didn't forget about:
1. [x] tests
2. [x] changelog
3. [x] docs  

Closes #565  