### PR TITLE
ci: update go version to >=1.21.2

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -10,7 +10,7 @@ on:
     types: [labeled]
 
 env:
-  GO_VERSION: '>=1.20.10'
+  GO_VERSION: '>=1.21.2'
   PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '>=1.20.10'
+  GO_VERSION: '>=1.21.2'
 
 jobs:
   create-packages-linux:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
     types: [labeled]
 
 env:
-  GO_VERSION: '>=1.20.10'
+  GO_VERSION: '>=1.21.2'
   PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '>=1.20.10'
+  GO_VERSION: '>=1.21.2'
 
 jobs:
   update:


### PR DESCRIPTION
Some vulnerabilities were found in previous versions of go. Let's switches to the latest release 1.21.