### PR TITLE
connect: change completion behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Make cartridge app dependencies less strict.
+- `tt connect` auto-completion shows directories and files when there are no
+running apps.
 
 ### Added
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -75,10 +75,11 @@ func NewConnectCmd() *cobra.Command {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			return internal.ValidArgsFunction(
+			validArgs, _ := internal.ValidArgsFunction(
 				cliOpts, &cmdCtx, cmd, toComplete,
 				running.ExtractActiveAppNames,
 				running.ExtractActiveInstanceNames)
+			return validArgs, cobra.ShellCompDirectiveDefault
 		},
 	}
 


### PR DESCRIPTION
This patch changes the behavior of `tt connect` auto-completion, when there are no running apps now. 
In this case `tt connect` completion should show directories and files.