### PR TITLE
run: disable flag parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 running apps.
 - `tt rocks --server` now accepts several URL's.
 - Disable ``tt run`` tarantool flag parsing.
+- Now ``tt run`` starts instance without our wrapper.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Module ``tt replicaset``, to manage replicasets:
   - ``tt replicaset status`` to show a cluster status information.
 
+### Changed
+
+- Disable ``tt run`` tarantool flag parsing.
+
 ## [2.1.0] - 2023-12-15
 
 ### Changed
@@ -20,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt connect` auto-completion shows directories and files when there are no
 running apps.
 - `tt rocks --server` now accepts several URL's.
+- Disable ``tt run`` tarantool flag parsing.
 
 ### Added
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
@@ -85,29 +81,10 @@ func internalRunModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	}
 
 	runInfo := newRunInfo(*cmdCtx)
-	scriptPath := ""
-	startIndex := 0
-	if len(args) > 0 {
-		for i, option := range args {
-			if strings.HasSuffix(option, ".lua") {
-				scriptPath = option
-				if _, err := os.Stat(scriptPath); err != nil {
-					return fmt.Errorf("there was some problem locating script: %s", err)
-				}
-				startIndex = i
-				break
-			}
-		}
-	}
 
-	if len(args) != 0 && scriptPath != "" {
-		runInfo.RunOpts.RunArgs = args[startIndex+1:]
-		runInfo.RunOpts.RunFlags = args[:startIndex]
-	} else if scriptPath == "" {
-		runInfo.RunOpts.RunFlags = args
-	}
+	runInfo.RunOpts.RunArgs = args
 
-	if err := running.Run(runInfo, scriptPath); err != nil {
+	if err := running.Run(runInfo); err != nil {
 		return err
 	}
 

--- a/cli/running/cluster_instance.go
+++ b/cli/running/cluster_instance.go
@@ -147,7 +147,6 @@ func (inst *clusterInstance) Run(opts RunOpts) error {
 	}
 	f.Close()
 
-	args = append(args, opts.RunFlags...)
 	args = append(args, opts.RunArgs...)
 	log.Debugf("Running Tarantool with args: %s", strings.Join(args[1:], " "))
 	execErr := syscall.Exec(inst.tarantoolPath, args, newInstanceEnv)

--- a/cli/running/cluster_instance.go
+++ b/cli/running/cluster_instance.go
@@ -137,11 +137,9 @@ func (inst *clusterInstance) Start() error {
 }
 
 // Run runs tarantool instance.
-func (inst *clusterInstance) Run(flags RunFlags) error {
+func (inst *clusterInstance) Run(opts RunOpts) error {
 	newInstanceEnv := os.Environ()
 	args := []string{inst.tarantoolPath}
-	args = append(args, convertFlagsToTarantoolOpts(flags)...)
-	args = append(args, flags.RunArgs...)
 
 	f, err := integrity.FileRepository.Read(inst.tarantoolPath)
 	if err != nil {
@@ -149,6 +147,8 @@ func (inst *clusterInstance) Run(flags RunFlags) error {
 	}
 	f.Close()
 
+	args = append(args, opts.RunFlags...)
+	args = append(args, opts.RunArgs...)
 	log.Debugf("Running Tarantool with args: %s", strings.Join(args[1:], " "))
 	execErr := syscall.Exec(inst.tarantoolPath, args, newInstanceEnv)
 	if execErr != nil {

--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -11,7 +11,7 @@ type Instance interface {
 	Start() error
 
 	// Run runs tarantool interpreter.
-	Run(flags RunFlags) error
+	Run(opts RunOpts) error
 
 	// Wait waits for the process to complete.
 	Wait() error

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -97,8 +97,6 @@ type InstanceCtx struct {
 type RunOpts struct {
 	// RunArgs contains command args.
 	RunArgs []string
-	// RunFlags contains command flags.
-	RunFlags []string
 }
 
 // RunInfo contains information for tt run.
@@ -675,9 +673,8 @@ func Stop(run *InstanceCtx) error {
 }
 
 // Run runs an Instance.
-func Run(runInfo *RunInfo, scriptPath string) error {
-	inst := scriptInstance{tarantoolPath: runInfo.CmdCtx.Cli.TarantoolCli.Executable,
-		appPath: scriptPath}
+func Run(runInfo *RunInfo) error {
+	inst := scriptInstance{tarantoolPath: runInfo.CmdCtx.Cli.TarantoolCli.Executable}
 	err := inst.Run(runInfo.RunOpts)
 	return err
 }

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -93,27 +93,19 @@ type InstanceCtx struct {
 	// AppHashes
 }
 
-// RunFlags contains flags for tt run.
-type RunFlags struct {
-	// RunEval contains "-e" flag content.
-	RunEval string
-	// RunLib contains "-l" flag content.
-	RunLib string
-	// RunInteractive contains "-i" flag content.
-	RunInteractive bool
-	// RunStdin contains "-" flag content.
-	RunStdin string
-	// RunVersion contains "-v" flag content.
-	RunVersion bool
+// RunOpts contains flags and args for tt run.
+type RunOpts struct {
 	// RunArgs contains command args.
 	RunArgs []string
+	// RunFlags contains command flags.
+	RunFlags []string
 }
 
-// RunOpts contains information for tt run.
-type RunOpts struct {
+// RunInfo contains information for tt run.
+type RunInfo struct {
 	CmdCtx     cmdcontext.CmdCtx
 	RunningCtx RunningCtx
-	RunFlags   RunFlags
+	RunOpts    RunOpts
 }
 
 // providerImpl is an implementation of Provider interface.
@@ -683,10 +675,10 @@ func Stop(run *InstanceCtx) error {
 }
 
 // Run runs an Instance.
-func Run(runOpts *RunOpts, scriptPath string) error {
-	inst := scriptInstance{tarantoolPath: runOpts.CmdCtx.Cli.TarantoolCli.Executable,
+func Run(runInfo *RunInfo, scriptPath string) error {
+	inst := scriptInstance{tarantoolPath: runInfo.CmdCtx.Cli.TarantoolCli.Executable,
 		appPath: scriptPath}
-	err := inst.Run(runOpts.RunFlags)
+	err := inst.Run(runInfo.RunOpts)
 	return err
 }
 

--- a/test/integration/run/test_run.py
+++ b/test/integration/run/test_run.py
@@ -79,7 +79,7 @@ def test_running_missing_script(tt_cmd, tmpdir_with_cfg):
         text=True
     )
     run_output = instance_process.stdout.readline()
-    assert re.search(r"was some problem locating script", run_output)
+    assert re.search(r"Can't open script", run_output)
 
 
 def test_running_multi_instance(tt_cmd, tmpdir_with_cfg):


### PR DESCRIPTION
Disabled flag parsing for 'run' command.
Done that so there will be no more differences in behaviour between 'tt run' and 'tarantool'.
e.g positional flag parsing, missing/more flags than tarantool has.