### PR TITLE
cluster: add `key` argument to URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ running apps.
 ### Added
 
 - `tt env`: add current environment binaries location to the PATH variable.
+- `tt cluster`: add an ability to specify a key for `show`/`publish` via URI.
 
 ## [2.0.0] - 2023-11-13
 

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -306,7 +306,7 @@ func collectEtcdConfig(clusterConfig ClusterConfig) (*Config, error) {
 		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
 	}
 
-	etcdCollector := NewEtcdCollector(etcd, opts.Prefix, opts.Timeout)
+	etcdCollector := NewEtcdAllCollector(etcd, opts.Prefix, opts.Timeout)
 	etcdRawConfig, err := etcdCollector.Collect()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config from etcd: %w", err)

--- a/cli/cluster/cmd/show.go
+++ b/cli/cluster/cmd/show.go
@@ -35,8 +35,15 @@ func ShowEtcd(showCtx ShowCtx, uri *url.URL) error {
 	}
 	defer etcdcli.Close()
 
-	prefix, timeout := etcdOpts.Prefix, etcdOpts.Timeout
-	config, err := cluster.NewEtcdCollector(etcdcli, prefix, timeout).Collect()
+	prefix, key, timeout := etcdOpts.Prefix, etcdOpts.Key, etcdOpts.Timeout
+	var collector cluster.Collector
+	if key == "" {
+		collector = cluster.NewEtcdAllCollector(etcdcli, prefix, timeout)
+	} else {
+		collector = cluster.NewEtcdKeyCollector(etcdcli, prefix, key, timeout)
+	}
+
+	config, err := collector.Collect()
 	if err != nil {
 		return fmt.Errorf("failed to collect a configuration from etcd: %w", err)
 	}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -74,8 +74,8 @@ environment variables < command flags < URL credentials.
 			" from etcd URI.\n\n" + uriHelp,
 		Example: "tt cluster show application_name\n" +
 			"  tt cluster show application_name:instance_name\n" +
-			"  tt cluster show https://user@pass@localhost:2379/tt\n" +
-			"  tt cluster show https://user@pass@localhost:2379/tt?name=instance",
+			"  tt cluster show https://user:pass@localhost:2379/tt\n" +
+			"  tt cluster show https://user:pass@localhost:2379/tt?name=instance",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
@@ -116,9 +116,9 @@ environment variables < command flags < URL credentials.
 		Example: "tt cluster publish application_name cluster.yaml\n" +
 			"  tt cluster publish application_name:instance_name instance.yaml\n" +
 			"  tt cluster publish " +
-			"https://user@pass@localhost:2379/tt cluster.yaml\n" +
+			"https://user:pass@localhost:2379/tt cluster.yaml\n" +
 			"  tt cluster publish " +
-			"https://user@pass@localhost:2379/tt?name=instance " +
+			"https://user:pass@localhost:2379/tt?name=instance " +
 			"instance.yaml",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -48,6 +48,7 @@ http(s)://[username:password@]host:port[/prefix][?arguments]
 
 Possible arguments:
 
+* key - a target configuration key in the prefix.
 * name - a name of an instance in the cluster configuration.
 * timeout - a request timeout in seconds (default %.1f).
 * ssl_key_file - a path to a private SSL key file.
@@ -108,7 +109,10 @@ environment variables < command flags < URL credentials.
 		Short: "Publish a cluster configuration",
 		Long: "Publish an application or an instance configuration to a cluster " +
 			"configuration file or to a etcd URI.\n\n" +
-			uriHelp,
+			uriHelp + "\n" +
+			"By default, the command removes all keys in etcd with prefix " +
+			"'/prefix/config/' and writes the result to '/prefix/config/all'. " +
+			"You could work and update a target key with the 'key' argument.",
 		Example: "tt cluster publish application_name cluster.yaml\n" +
 			"  tt cluster publish application_name:instance_name instance.yaml\n" +
 			"  tt cluster publish " +


### PR DESCRIPTION
@TarantoolBot document
Title: new argument for `tt cluster show` and `tt cluster publish`

The patch adds a new argument `key` that could be specified via etcd URI:

* key - a target configuration key in the prefix.

A user can now perform operations (`show` and `publish`) on individual keys in etcd, not just for entire prefixes.

As example:

```
$ tt cluster show https://user:pass@localhost:2379/prefix?key=target
```