### PR TITLE
integrity: scaffolding for integrity check

### DIFF
--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/tarantool/tt/cli/integrity"
 	"github.com/tarantool/tt/cli/version"
 )
 
@@ -16,6 +17,9 @@ type CmdCtx struct {
 	Cli CliCtx
 	// CommandName contains name of the command.
 	CommandName string
+	// FileRepository is used for reading files that require
+	// integrity control.
+	FileRepository integrity.Repository
 }
 
 // TarantoolCli describes tarantool executable.
@@ -80,4 +84,6 @@ type CliCtx struct {
 	Verbose bool
 	// TarantoolCli is current tarantool cli.
 	TarantoolCli TarantoolCli
+	// IntegrityCheck is a public key used for integrity check.
+	IntegrityCheck string
 }

--- a/cli/integrity/dummy_repository.go
+++ b/cli/integrity/dummy_repository.go
@@ -1,0 +1,27 @@
+package integrity
+
+import (
+	"io"
+	"os"
+)
+
+// dummyRepository implements repository with no checks performed.
+type dummyRepository struct{}
+
+// AddHash is a stub of method used to add hashing algorithm in the
+// proper implementation.
+func (dummyRepository) AddHash(hasher any) {}
+
+// Add is a stub of method used to add file with hashes to a repository.
+func (dummyRepository) Add(path string) error { return nil }
+
+// Read opens the supplied file.
+func (dummyRepository) Read(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+// ValidateAll doesn't do anything since dummyRepository does not implement
+// validation.
+func (dummyRepository) ValidateAll() error { return nil }
+
+var _ Repository = dummyRepository{}

--- a/cli/integrity/integrity.go
+++ b/cli/integrity/integrity.go
@@ -6,6 +6,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var FileRepository Repository = dummyRepository{}
+
+var HashesName = ""
+
 // Signer implements high-level API for package signing.
 type Signer interface {
 	// Sign generates data to sign a package.
@@ -20,3 +24,16 @@ func NewSigner(path string) (Signer, error) {
 // RegisterWithIntegrityFlag is a noop function that is intended to add
 // flags to `tt pack` command.
 func RegisterWithIntegrityFlag(flagset *pflag.FlagSet, dst *string) {}
+
+// RegisterIntegrityCheckFlag is a noop function that is intended to add
+// root flag enabling integrity checks.
+func RegisterIntegrityCheckFlag(flagset *pflag.FlagSet, dst *string) {}
+
+// RegisterIntegrityCheckPeriodFlag is a noop function that is intended to
+// add flag specifying how often should integrity checks run in watchdog.
+func RegisterIntegrityCheckPeriodFlag(flagset *pflag.FlagSet, dst *int) {}
+
+// InitializeIntegrityCheck is a noop setup of integrity checking.
+func InitializeIntegrityCheck(publicKeyPath string, configDir string) error {
+	return errors.New("integrity checks should never be initialized in ce")
+}

--- a/cli/integrity/integrity_test.go
+++ b/cli/integrity/integrity_test.go
@@ -32,6 +32,42 @@ func TestNewSigner(t *testing.T) {
 	}
 }
 
+func InitializeIntegrityCheck(t *testing.T) {
+	testCases := []struct {
+		name          string
+		publicKeyPath string
+		configDir     string
+	}{
+		{
+			name:          "Empty key and config path",
+			publicKeyPath: "",
+			configDir:     "",
+		},
+		{
+			name:          "Arbitrary key path, empty config path",
+			publicKeyPath: "public.pem",
+			configDir:     "",
+		},
+		{
+			name:          "Empty key path, arbitrary config path",
+			publicKeyPath: "",
+			configDir:     "app",
+		},
+		{
+			name:          "Arbitrary key and config path",
+			publicKeyPath: "public.pem",
+			configDir:     "app",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := integrity.InitializeIntegrityCheck(testCase.publicKeyPath, testCase.configDir)
+			require.EqualError(t, err, "integrity checks should never be initialized in ce", "an error should be produced")
+		})
+	}
+}
+
 func TestRegisterWithIntegritySigner(t *testing.T) {
 	someStr := ""
 
@@ -65,6 +101,90 @@ func TestRegisterWithIntegritySigner(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			integrity.RegisterWithIntegrityFlag(testCase.flagSet, testCase.dst)
+
+			if testCase.flagSet != nil {
+				require.False(t, testCase.flagSet.HasFlags(),
+					"command must not be modified")
+			}
+		})
+	}
+}
+
+func TestRegisterIntegrityCheckFlag(t *testing.T) {
+	someStr := ""
+
+	testCases := []struct {
+		name    string
+		flagSet *pflag.FlagSet
+		dst     *string
+	}{
+		{
+			name:    "Empty flagSet and dst",
+			flagSet: nil,
+			dst:     nil,
+		},
+		{
+			name:    "Empty dst",
+			flagSet: &pflag.FlagSet{},
+			dst:     nil,
+		},
+		{
+			name:    "Empty flagSet",
+			flagSet: nil,
+			dst:     &someStr,
+		},
+		{
+			name:    "Nothing empty",
+			flagSet: &pflag.FlagSet{},
+			dst:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			integrity.RegisterIntegrityCheckFlag(testCase.flagSet, testCase.dst)
+
+			if testCase.flagSet != nil {
+				require.False(t, testCase.flagSet.HasFlags(),
+					"command must not be modified")
+			}
+		})
+	}
+}
+
+func TestRegisterIntegrityCheckPeriodFlag(t *testing.T) {
+	someInt := 0
+
+	testCases := []struct {
+		name    string
+		flagSet *pflag.FlagSet
+		dst     *int
+	}{
+		{
+			name:    "Empty flagSet and dst",
+			flagSet: nil,
+			dst:     nil,
+		},
+		{
+			name:    "Empty dst",
+			flagSet: &pflag.FlagSet{},
+			dst:     nil,
+		},
+		{
+			name:    "Empty flagSet",
+			flagSet: nil,
+			dst:     &someInt,
+		},
+		{
+			name:    "Nothing empty",
+			flagSet: &pflag.FlagSet{},
+			dst:     nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			integrity.RegisterIntegrityCheckPeriodFlag(testCase.flagSet, testCase.dst)
 
 			if testCase.flagSet != nil {
 				require.False(t, testCase.flagSet.HasFlags(),

--- a/cli/integrity/repository.go
+++ b/cli/integrity/repository.go
@@ -1,0 +1,18 @@
+package integrity
+
+import "io"
+
+// Repository provides utilities for working with files and
+// ensuring that they were not compomised.
+type Repository interface {
+	// AddHash extends the list of supported hashes.
+	AddHash(h any)
+	// Add checks signature of provided hashes file, and adds files
+	// to the repository.
+	Add(path string) error
+	// Read makes sure the file is not modified and reads it.
+	Read(path string) (io.ReadCloser, error)
+	// ValidateAll checks that all the files stored in the repository
+	// were not modified.
+	ValidateAll() error
+}

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/integrity"
 	"github.com/tarantool/tt/cli/util"
 )
 
@@ -36,6 +37,11 @@ func RunCmd(cmdCtx *cmdcontext.CmdCtx, cmdPath string, modulesInfo *ModulesInfo,
 		return internal(cmdCtx, args)
 	}
 
+	f, err := integrity.FileRepository.Read(info.ExternalPath)
+	if err != nil {
+		return fmt.Errorf("integrity check failed for %q: %w", info.ExternalPath, err)
+	}
+	f.Close()
 	if rc := RunExec(info.ExternalPath, args); rc != 0 {
 		os.Exit(rc)
 	}

--- a/cli/running/cluster_instance_test.go
+++ b/cli/running/cluster_instance_test.go
@@ -75,7 +75,7 @@ func TestClusterInstance_Start(t *testing.T) {
 		ClusterConfigPath: configPath,
 		InstName:          "instance-001",
 		AppDir:            tmpDir,
-	}, ttlog.NewCustomLogger(&outputBuf, "test", 0))
+	}, ttlog.NewCustomLogger(&outputBuf, "test", 0), false)
 
 	require.NoError(t, err)
 	require.NotNil(t, clusterInstance)
@@ -116,7 +116,7 @@ func TestClusterInstance_StartChangeDefaults(t *testing.T) {
 		VinylDir:          "vinyl_dir",
 		ConsoleSocket:     "run/tt.control",
 		AppDir:            tmpAppDir,
-	}, ttlog.NewCustomLogger(&outputBuf, "test", 0))
+	}, ttlog.NewCustomLogger(&outputBuf, "test", 0), false)
 	require.NoError(t, err)
 	require.NotNil(t, clusterInstance)
 
@@ -162,7 +162,7 @@ func TestClusterInstance_StartChangeSomeDefaults(t *testing.T) {
 		ConsoleSocket:     "run/tt.control",
 		AppDir:            tmpAppDir,
 		LogDir:            tmpAppDir,
-	}, ttlog.NewCustomLogger(&outputBuf, "test", 0))
+	}, ttlog.NewCustomLogger(&outputBuf, "test", 0), false)
 	require.NoError(t, err)
 	require.NotNil(t, clusterInstance)
 

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -43,7 +43,7 @@ func startTestInstance(t *testing.T, app string, consoleSock string,
 		VinylDir:       instTestDataDir,
 		MemtxDir:       instTestDataDir,
 	},
-		logger)
+		logger, false)
 	assert.Nilf(err, `Can't create an instance. Error: "%v".`, err)
 
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
@@ -202,7 +202,7 @@ func TestInstanceLogs(t *testing.T) {
 		MemtxDir:       instTestDataDir,
 		LogDir:         instTestDataDir,
 	},
-		logger)
+		logger, false)
 	require.NoError(t, err)
 
 	t.Cleanup(func() { cleanupTestInstance(t, inst) })

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -42,7 +42,7 @@ func (provider *providerTestImpl) CreateInstance(logger *ttlog.Logger) (Instance
 		InstanceScript: provider.appPath,
 		AppDir:         provider.t.TempDir(),
 	},
-		logger)
+		logger, false)
 }
 
 // UpdateLogger updates the logger settings or creates a new logger, if passed nil.
@@ -73,7 +73,7 @@ func createTestWatchdog(t *testing.T, restartable bool) *Watchdog {
 	provider := providerTestImpl{tarantool: tarantoolBin, appPath: appPath, logger: logger,
 		dataDir: dataDir, restartable: restartable, t: t}
 	testPreAction := func() error { return nil }
-	wd := NewWatchdog(restartable, wdTestRestartTimeout, logger, &provider, testPreAction)
+	wd := NewWatchdog(restartable, wdTestRestartTimeout, logger, &provider, testPreAction, 0)
 
 	return wd
 }


### PR DESCRIPTION
This patch adds necessary scaffolding for performing integrity checks,
along with an appropriate instrumentation of operations with files
that must be scrutinized before working with them.