### PR TITLE
test: fix setup with master vshard

### DIFF
--- a/test/integration/running/cluster_crud_app/localcfg.lua
+++ b/test/integration/running/cluster_crud_app/localcfg.lua
@@ -19,5 +19,5 @@ return {
             },
         }, -- replicaset #2
     }, -- sharding
-    replication_connect_quorum = 0,
+    discovery_mode = 'off',
 }

--- a/test/integration/running/cluster_crud_app/router.lua
+++ b/test/integration/running/cluster_crud_app/router.lua
@@ -1,10 +1,14 @@
 -- This is a router listening network socket.
 
-local cfg = require('localcfg')
-cfg.discovery_mode = 'off'
+local vshard = require('vshard')
 
 -- Start the database with sharding
-local vshard = require('vshard')
+box.cfg{
+    listen = 3300,
+    replication_connect_quorum = 0,
+}
+
+local cfg = require('localcfg')
 vshard.router.cfg(cfg)
 vshard.router.bootstrap()
 


### PR DESCRIPTION
Since commit [1], it is forbidden to call box.cfg as a part of vshard.router.cfg: it is expected that user will separate their setups. This patch should satisfy both older and newer vshard versions.

1. https://github.com/tarantool/vshard/commit/bc1c3c46ee474640ff1fe7dceacda45f7290c368