### PR TITLE
tt: add tt debug build support

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -33,7 +33,6 @@ const (
 
 var (
 	ldflags = []string{
-		"-s", "-w",
 		"-X ${PACKAGE}/version.gitTag=${GIT_TAG}",
 		"-X ${PACKAGE}/version.gitCommit=${GIT_COMMIT}",
 		"-X ${PACKAGE}/version.gitCommitSinceTag=${GIT_COMMIT_SINCE_TAG}",
@@ -48,6 +47,10 @@ var (
 	ttExecutableName     = "tt"
 
 	generateModePath = filepath.Join(packagePath, "codegen", "generate_code.go")
+
+	Aliases = map[string]any{
+		"build": Build.Release,
+	}
 )
 
 type BuildType string
@@ -159,9 +162,7 @@ func PatchCC() error {
 
 // Building tt executable. Supported environment variables:
 // TT_CLI_BUILD_SSL=(no|static|shared)
-func Build() error {
-	fmt.Println("Building tt...")
-
+func buildTt(ldflags []string) error {
 	mg.Deps(PatchCC)
 	mg.Deps(GenerateGoCode)
 
@@ -202,6 +203,22 @@ func Build() error {
 	}
 
 	return nil
+}
+
+type Build mg.Namespace
+
+// Building release tt executable without debug info.
+func (Build) Release() error {
+	fmt.Println("Building release tt...")
+
+	return buildTt(append(ldflags, "-s", "-w"))
+}
+
+// Building debug tt executable.
+func (Build) Debug() error {
+	fmt.Println("Building debug tt...")
+
+	return buildTt(ldflags)
 }
 
 // Run license checker.


### PR DESCRIPTION
Debug build can be performed with `mage build:debug` command. Default build type is release.
Building example:
```
$ mage build && readelf -S ./tt | grep debug
Building release tt...
Apply cartridge-cli patches...

$ mage build:debug && readelf -S ./tt | grep debug
Building debug tt...
Apply cartridge-cli patches...
  [13] .debug_abbrev     PROGBITS         0000000000000000  013e9000
  [14] .debug_line       PROGBITS         0000000000000000  013e9135
  [15] .debug_frame      PROGBITS         0000000000000000  015554d7
  [16] .debug_gdb_s[...] PROGBITS         0000000000000000  015aeac4
  [17] .debug_info       PROGBITS         0000000000000000  015aeaf1
  [18] .debug_loc        PROGBITS         0000000000000000  01832513
  [19] .debug_ranges     PROGBITS         0000000000000000  01a1ecb9
```