### PR TITLE
cartridge: increase bootstrap attempts

### DIFF
--- a/cli/cartridge/extra/008_increase_replicasets_bootstrap_attempts.patch
+++ b/cli/cartridge/extra/008_increase_replicasets_bootstrap_attempts.patch
@@ -1,0 +1,13 @@
+diff --git a/cli/replicasets/setup.go b/cli/replicasets/setup.go
+index 225dc36..b8c0a46 100644
+--- a/cli/replicasets/setup.go
++++ b/cli/replicasets/setup.go
+@@ -99,7 +99,7 @@ func Setup(ctx *context.Ctx, args []string) error {
+ 
+ 		retryOpts := []retry.Option{
+ 			retry.MaxDelay(1 * time.Second),
+-			retry.Attempts(5),
++			retry.Attempts(10),
+ 			retry.LastErrorOnly(true),
+ 		}
+ 

--- a/magefile.go
+++ b/magefile.go
@@ -148,6 +148,7 @@ func PatchCC() error {
 		"005_rename_tt_env.patch",
 		"006_consider_tt_run_dir.patch",
 		"007_update_project_files_search_logic.patch",
+		"008_increase_replicasets_bootstrap_attempts.patch",
 	}
 
 	for _, patch := range patches {


### PR DESCRIPTION
We have flaky tests with Cartridge on MacOS. It looks like not enough attempts are being made to bootstrap the vshard application.

This patch doubles the number of attempts.

Closes #728