### PR TITLE
replicaset: extract discover methods

### DIFF
--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -1,0 +1,62 @@
+package replicaset
+
+import (
+	"fmt"
+
+	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/running"
+)
+
+// DiscoveryApplication retrieves replicasets information for instances in an
+// application. If orchestrator == OrchestratorUnknown then it tries to
+// determinate an orchestrator.
+func DiscoveryApplication(app running.RunningCtx,
+	orchestrator Orchestrator) (Replicasets, error) {
+	if orchestrator == OrchestratorUnknown {
+		eval := func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+			var err error
+			orchestrator, err = EvalOrchestrator(evaler)
+			return true, err
+		}
+
+		if err := EvalAny(app.Instances, InstanceEvalFunc(eval)); err != nil {
+			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
+		}
+	}
+
+	switch orchestrator {
+	case OrchestratorCartridge:
+		return NewCartridgeApplication(app, nil).GetReplicasets()
+	case OrchestratorCentralizedConfig:
+		return NewCConfigApplication(app).GetReplicasets()
+	case OrchestratorCustom:
+		return NewCustomApplication(app).GetReplicasets()
+	default:
+		return Replicasets{}, fmt.Errorf("orchestrator is not supported: %s", orchestrator)
+	}
+}
+
+// DiscoveryInstance retrieves replicasets information from a connection.
+// If orchestrator == OrchestratorUnknown then it tries to determinate an
+// orchestrator.
+func DiscoveryInstance(evaler connector.Evaler,
+	orchestrator Orchestrator) (Replicasets, error) {
+	if orchestrator == OrchestratorUnknown {
+		var err error
+		orchestrator, err = EvalOrchestrator(evaler)
+		if err != nil {
+			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
+		}
+	}
+
+	switch orchestrator {
+	case OrchestratorCartridge:
+		return NewCartridgeInstance(evaler).GetReplicasets()
+	case OrchestratorCentralizedConfig:
+		return NewCConfigInstance(evaler).GetReplicasets()
+	case OrchestratorCustom:
+		return NewCustomInstance(evaler).GetReplicasets()
+	default:
+		return Replicasets{}, fmt.Errorf("orchestartor is not supported: %s", orchestrator)
+	}
+}

--- a/cli/replicaset/instance.go
+++ b/cli/replicaset/instance.go
@@ -1,5 +1,9 @@
 package replicaset
 
+import (
+	"github.com/tarantool/tt/cli/running"
+)
+
 // Instance describes an instance in a replicaset.
 type Instance struct {
 	// Alias is a human-readable instance name.
@@ -10,4 +14,10 @@ type Instance struct {
 	URI string
 	// Mode of the instance.
 	Mode Mode
+	// InstanceCtx is an instance application context. It is configured if
+	// InstanceCtxFound == true.
+	InstanceCtx running.InstanceCtx
+	// InstanceCtxFound is true if an instance is connectable and could be
+	// determined.
+	InstanceCtxFound bool
 }


### PR DESCRIPTION
The patch extracts two methods into the `replicaset` subpackage:

* `DiscoveryApplication(app RunningCtx, orchestrator Orchestrator)` to discovery replicasets information for an application running context.
* `DiscoveryInstance(evaler Evaler, orchestrator Orchestrator)` to discovery replicasets information for a connection.

An orchestrator type can be forced manually using the second argument or you can use OrchestratorUnknown for automatic mode.