### PR TITLE
create: add built-in vshard cluster template

### DIFF
--- a/.github/actions/prepare-ce-test-env/action.yml
+++ b/.github/actions/prepare-ce-test-env/action.yml
@@ -58,17 +58,13 @@ runs:
     # Here is a workaround for Tarantool 3.0 installation until it is supported
     # by setup-tarantool. This step will install the latest pre-released
     # Tarantool 3.0 from repository.
-    #
-    # Now it installs alpha3 version, because the latest versions fail some tests due to
-    # the issue: https://github.com/tarantool/tarantool/issues/9275
     - name: Install Tarantool from repo
       if: |
         inputs.skip-tarantool-install == 'false' &&
         startsWith(inputs.tarantool-version, '3.')
       run: |
-        sudo curl -L https://tarantool.io/iqJapRm/release/3/installer.sh | \
-        sed 's|repo_type="release"|repo_type="pre-release"|' | bash
-        sudo apt install tarantool=3.0.0~alpha3-1 tarantool-dev=3.0.0~alpha3-1
+        sudo curl -L https://tarantool.io/iqJapRm/release/3/installer.sh | bash
+        sudo apt install tarantool tarantool-dev
       shell: bash
 
     - name: Install etcd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Module ``tt replicaset``, to manage replicasets:
   - ``tt replicaset status`` to show a cluster status information.
+- Built-in vshard cluster application template.
 
 ### Changed
 

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -39,6 +39,7 @@ func TestCreateValidArgsFunction(t *testing.T) {
 
 	templates := []string{
 		"cartridge",
+		"vshard_cluster",
 		"archive",
 		"template2",
 		tdir1Name,

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -131,6 +131,14 @@ func main() {
 	if err != nil {
 		log.Errorf("error while generating file modes: %s", err)
 	}
+	err = generateFileModeFile(
+		"cli/create/builtin_templates/templates/vshard_cluster",
+		"cli/create/builtin_templates/static/vshard_cluster_template_filemodes_gen.go",
+		"VshardCluster",
+	)
+	if err != nil {
+		log.Errorf("error while generating file modes: %s", err)
+	}
 
 	if err = generateLuaCodeVar(); err != nil {
 		log.Errorf("error while generating lua code string variables: %s", err)

--- a/cli/create/builtin_templates/builtin_templates.go
+++ b/cli/create/builtin_templates/builtin_templates.go
@@ -11,8 +11,9 @@ var TemplatesFs embed.FS
 
 // FileModes contains mapping of file modes by built-in template name.
 var FileModes = map[string]map[string]int{
-	"cartridge": static.CartridgeFileModes,
+	"cartridge":      static.CartridgeFileModes,
+	"vshard_cluster": static.VshardClusterFileModes,
 }
 
 // Names contains built-in template names.
-var Names = [...]string{"cartridge"}
+var Names = [...]string{"cartridge", "vshard_cluster"}

--- a/cli/create/builtin_templates/templates/vshard_cluster/MANIFEST.yaml
+++ b/cli/create/builtin_templates/templates/vshard_cluster/MANIFEST.yaml
@@ -1,0 +1,30 @@
+description: Vshard cluster template
+follow-up-message: |
+  What's next?
+  Build and start '{{ .name }}' application:
+      $ tt build {{ .name }}
+      $ tt start {{ .name }}
+
+  Pay attention that default passwords were generated,
+  you can change it in the config.yaml.
+
+vars:
+  - prompt: Bucket count
+    name: bucket_count
+    default: '3000'
+    re: ^[1-9]\d*$
+
+  - prompt: Storage replication sets count
+    name: replicasets_count
+    default: '2'
+    re: ^[1-9]\d*$
+
+  - prompt: Storage replicas per replication set count (>=2)
+    name: replicas_count
+    default: '2'
+    re: ^[2-9]|[1-9]\d+$
+
+  - prompt: Routers count
+    name: routers_count
+    default: '1'
+    re: ^[1-9]\d*$

--- a/cli/create/builtin_templates/templates/vshard_cluster/config.yaml.tt.template
+++ b/cli/create/builtin_templates/templates/vshard_cluster/config.yaml.tt.template
@@ -1,0 +1,52 @@
+credentials:
+  users:
+    client:
+      password: 'secret'
+      roles: [super]
+    replicator:
+      password: 'secret'
+      roles: [replication]
+    storage:
+      password: 'secret'
+      roles: [sharding]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+    sharding:
+      login: storage
+
+sharding:
+  bucket_count: {{.bucket_count}}
+
+groups:
+  storages:
+    app:
+      module: storage
+    sharding:
+      roles: [storage]
+    replication:
+      failover: manual
+    {{- $replicasets := atoi .replicasets_count}}{{$replicas := atoi .replicas_count}}
+    replicasets: {{ range replicasets "storage" $replicasets $replicas }}
+      {{.Name}}:
+        leader: {{index .InstNames 0}}
+        instances: {{range .InstNames}}
+          {{.}}:
+            iproto:
+              listen:
+                - uri: localhost:{{port}}{{end}}{{end}}
+  routers:
+    app:
+      module: router
+    sharding:
+      roles: [router]
+    {{- $routers := atoi .routers_count}}
+    replicasets: {{ range replicasets "router" $routers 1}}
+      {{.Name}}:
+        instances: {{range .InstNames}}
+          {{.}}:
+            iproto:
+              listen:
+                - uri: localhost:{{port}}{{end}}{{end}}

--- a/cli/create/builtin_templates/templates/vshard_cluster/instances.yaml.tt.template
+++ b/cli/create/builtin_templates/templates/vshard_cluster/instances.yaml.tt.template
@@ -1,0 +1,10 @@
+---
+{{- $replicasets := atoi .replicasets_count}}{{$replicas := atoi .replicas_count}}
+{{ range replicasets "storage" $replicasets $replicas }}{{range .InstNames}}{{.}}:
+
+{{end}}{{end}}
+
+{{- $routers := atoi .routers_count}}
+{{- range replicasets "router" $routers 1}}{{range .InstNames}}{{.}}:
+
+{{end}}{{end}}

--- a/cli/create/builtin_templates/templates/vshard_cluster/router.lua
+++ b/cli/create/builtin_templates/templates/vshard_cluster/router.lua
@@ -1,0 +1,34 @@
+local vshard = require('vshard')
+local log = require('log')
+
+-- Bootstrap the vshard router.
+while true do
+    local ok, err = vshard.router.bootstrap({
+        if_not_bootstrapped = true,
+    })
+    if ok then
+        break
+    end
+    log.info(('Router bootstrap error: %s'):format(err))
+end
+
+-- Put data into the cluster.
+function put(id, name, age)
+    local bucket_id = vshard.router.bucket_id_mpcrc32({id})
+    vshard.router.callrw(bucket_id, 'put', {id, bucket_id, name, age})
+end
+
+-- Get data from the cluster.
+function get(id)
+    local bucket_id = vshard.router.bucket_id_mpcrc32({id})
+    return vshard.router.callro(bucket_id, 'get', {id})
+end
+
+-- Put sample data.
+function put_sample_data()
+    put(1, 'Elizabeth', 12)
+    put(2, 'Mary', 46)
+    put(3, 'David', 33)
+    put(4, 'William', 81)
+    put(5, 'Jack', 35)
+end

--- a/cli/create/builtin_templates/templates/vshard_cluster/storage.lua
+++ b/cli/create/builtin_templates/templates/vshard_cluster/storage.lua
@@ -1,0 +1,56 @@
+local vshard = require('vshard')
+
+-- Create 'customers' space.
+box.once('customers', function()
+    box.schema.create_space('customers', {
+        format = {{
+            name = 'id',
+            type = 'unsigned'
+        }, {
+            name = 'bucket_id',
+            type = 'unsigned'
+        }, {
+            name = 'name',
+            type = 'string'
+        }, {
+            name = 'age',
+            type = 'number'
+        }}
+    })
+    box.space.customers:create_index('primary_index', {
+        parts = {{
+            field = 1,
+            type = 'unsigned'
+        }}
+    })
+    box.space.customers:create_index('bucket_id', {
+        parts = {{
+            field = 2,
+            type = 'unsigned'
+        }},
+        unique = false
+    })
+    box.space.customers:create_index('age', {
+        parts = {{
+            field = 4,
+            type = 'number'
+        }},
+        unique = false
+    })
+end)
+
+-- Put data to the 'customers' space.
+-- Function should be called by the router.
+function put(id, bucket_id, name, age)
+    box.space.customers:insert({id, bucket_id, name, age})
+end
+
+-- Get data from the 'customers' space.
+-- Function should be called by the router.
+function get(id)
+    local tuple = box.space.customers:get(id)
+    if tuple == nil then
+        return nil
+    end
+    return {tuple.id, tuple.name, tuple.age}
+end

--- a/cli/create/builtin_templates/templates/vshard_cluster/{{.name}}-scm-1.rockspec.tt.template
+++ b/cli/create/builtin_templates/templates/vshard_cluster/{{.name}}-scm-1.rockspec.tt.template
@@ -1,0 +1,11 @@
+package = '{{ .name }}'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+dependencies = {
+    'vshard == 0.1.25'
+}
+build = {
+    type = 'none';
+}

--- a/cli/running/testdata/instances_enabled/cluster_app/config.yml
+++ b/cli/running/testdata/instances_enabled/cluster_app/config.yml
@@ -4,7 +4,8 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+    - uri: 'unix/:./{{ instance_name }}.iproto'
 
 groups:
   group-001:

--- a/cli/templates/internal/engines/builtin_funcs.go
+++ b/cli/templates/internal/engines/builtin_funcs.go
@@ -1,0 +1,62 @@
+package engines
+
+import (
+	"fmt"
+)
+
+// genState describes template generation state.
+type genState struct {
+	port int
+}
+
+// newGenState creates genState.
+func newGenState() *genState {
+	return &genState{port: 3301}
+}
+
+// genPort generates port.
+func (state *genState) genPort() int {
+	ret := state.port
+	state.port++
+	return ret
+}
+
+// replicaset describes generated replicaset information.
+type replicaset struct {
+	Name      string
+	InstNames []string
+}
+
+const (
+	maxReplicasetsNumber = 1000
+	maxReplicasetSize    = 32
+)
+
+// genReplicasets generates replicasets bunch.
+func genReplicasets(
+	baseName string,
+	replicasetsNumber int,
+	replicasetSize int) ([]replicaset, error) {
+	if replicasetsNumber <= 0 || replicasetsNumber > maxReplicasetsNumber {
+		return nil, fmt.Errorf("replicasetsNumber must be in [%d, %d]", 0, maxReplicasetsNumber)
+	}
+	if replicasetSize <= 0 || replicasetSize > maxReplicasetSize {
+		return nil, fmt.Errorf("replicasetSize must be in [%d, %d]", 0, maxReplicasetSize)
+	}
+
+	replicasets := make([]replicaset, replicasetsNumber)
+	for i := range replicasets {
+		replicasetName := fmt.Sprintf("%s-%03d", baseName, i+1)
+		instNames := make([]string, replicasetSize)
+		for j := range instNames {
+			if replicasetSize <= 26 {
+				instNames[j] = fmt.Sprintf("%s-%c", replicasetName, 'a'+byte(j))
+			} else {
+				instNames[j] = fmt.Sprintf("%s-%03d", replicasetName, j+1)
+			}
+		}
+		replicasets[i].Name = replicasetName
+		replicasets[i].InstNames = instNames
+	}
+	return replicasets, nil
+}

--- a/cli/templates/internal/engines/builtin_funcs_test.go
+++ b/cli/templates/internal/engines/builtin_funcs_test.go
@@ -1,0 +1,44 @@
+package engines
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenPort(t *testing.T) {
+	state := newGenState()
+	require.Equal(t, state.genPort(), 3301)
+	require.Equal(t, state.genPort(), 3302)
+}
+
+func TestGenReplicasets(t *testing.T) {
+	replicasets, err := genReplicasets("name", 4, 3)
+	require.NoError(t, err)
+	assert.Equal(t, replicasets, []replicaset{
+		{
+			Name:      "name-001",
+			InstNames: []string{"name-001-a", "name-001-b", "name-001-c"},
+		},
+		{
+			Name:      "name-002",
+			InstNames: []string{"name-002-a", "name-002-b", "name-002-c"},
+		},
+		{
+			Name:      "name-003",
+			InstNames: []string{"name-003-a", "name-003-b", "name-003-c"},
+		},
+		{
+			Name:      "name-004",
+			InstNames: []string{"name-004-a", "name-004-b", "name-004-c"},
+		},
+	})
+
+	replicasets, err = genReplicasets("name", 1, 27)
+	require.NoError(t, err)
+	assert.Equal(t, replicasets[0].InstNames[26], "name-001-027")
+
+	_, err = genReplicasets("name", -1, 0)
+	require.Error(t, err)
+}

--- a/cli/templates/internal/engines/go_text_engine_test.go
+++ b/cli/templates/internal/engines/go_text_engine_test.go
@@ -85,4 +85,24 @@ func TestTextRendering(t *testing.T) {
 	_, err = engine.RenderText(templateText, data)
 	require.EqualError(t, err, "template execution failed: template: file:1:2: "+
 		"executing \"file\" at <.hello>: map has no entry for key \"hello\"")
+
+	// Test builtin functions.
+	templateText = "{{port}}"
+	expectedText = "3301"
+	actualText, err = engine.RenderText(templateText, nil)
+	require.NoError(t, err)
+	assert.Equal(t, expectedText, actualText)
+
+	templateText = `{{range replicasets "name" 1 1}}` +
+		"Hi, {{.Name}}! Your instances: {{ range .InstNames }}{{.}}{{end}}{{end}}"
+	expectedText = "Hi, name-001! Your instances: name-001-a"
+	actualText, err = engine.RenderText(templateText, nil)
+	require.NoError(t, err)
+	assert.Equal(t, expectedText, actualText)
+
+	templateText = `{{atoi "5"}} apples`
+	expectedText = "5 apples"
+	actualText, err = engine.RenderText(templateText, nil)
+	require.NoError(t, err)
+	assert.Equal(t, expectedText, actualText)
 }

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -1100,7 +1100,7 @@ def test_table_output_format(tt_cmd, tmpdir_with_cfg):
             # Execute stdin.
             ret, output = try_execute_on_instance(
                 tt_cmd, tmpdir, uri,
-                stdin="box.execute('select 1 as foo, 30, 50, 4+4 as data')",
+                stdin="box.execute('select 1 as FOO, 30, 50, 4+4 as DATA')",
                 opts={'-x': 'table'})
             assert ret
             assert output == ("+----------+----------+------+-----+\n"

--- a/test/integration/connect/test_output_format_app/test_app.lua
+++ b/test/integration/connect/test_output_format_app/test_app.lua
@@ -29,7 +29,7 @@ box.space.customers:insert({6, 'William', 25})
 box.space.customers:insert({7, 'Elizabeth', 18})
 
 if box.execute ~= nil then
-    box.execute([[CREATE TABLE table1 (column1 INT PRIMARY key, column2 VARCHAR(10));]])
+    box.execute([[CREATE TABLE table1 (COLUMN1 INT PRIMARY key, COLUMN2 VARCHAR(10));]])
     box.execute([[INSERT INTO table1 VALUES (10,'Hello SQL world!');]])
     box.execute([[INSERT INTO table1 VALUES (20,'Hello LUA world!');]])
     box.execute([[INSERT INTO table1 VALUES (30,'Hello YAML world!');]])

--- a/test/integration/replicaset/test_ccluster_app/config.yaml
+++ b/test/integration/replicaset/test_ccluster_app/config.yaml
@@ -8,9 +8,11 @@ credentials:
       roles: [super]
 
 iproto:
-  listen: 'unix/:./{{ instance_name }}.iproto'
+  listen:
+    - uri: 'unix/:./{{ instance_name }}.iproto'
   advertise:
-    peer: replicator@
+    peer:
+      login: replicator
 
 log:
  to: file

--- a/test/integration/running/cluster_app_changed_defaults/config.yaml
+++ b/test/integration/running/cluster_app_changed_defaults/config.yaml
@@ -14,7 +14,8 @@ groups:
         instances:
           master:
             iproto:
-              listen: '127.0.0.1:3301'
+              listen:
+                - uri: '127.0.0.1:3301'
             database:
               mode: rw
             wal:

--- a/test/integration/running/cluster_crud_app/config.yaml
+++ b/test/integration/running/cluster_crud_app/config.yaml
@@ -11,7 +11,8 @@ groups:
         instances:
           storage1:
             iproto:
-              listen: '127.0.0.1:3301'
+              listen:
+                - uri: '127.0.0.1:3301'
             database:
               instance_uuid: '8a274925-a26d-47fc-9e1b-af88ce939412'
               replicaset_uuid: 'cbf06940-0790-498b-948d-042b62cf3d29'
@@ -22,7 +23,8 @@ groups:
         instances:
           storage2:
             iproto:
-              listen: '127.0.0.1:3302'
+              listen:
+                - uri: '127.0.0.1:3302'
             database:
               instance_uuid: '1e02ae8a-afc0-4e91-ba34-843a356b8ed7'
               replicaset_uuid: 'ac522f65-aa94-4134-9f64-51ee384f1a54'
@@ -33,6 +35,7 @@ groups:
         instances:
           router:
             iproto:
-              listen: '127.0.0.1:3300'
+              listen:
+                - uri: '127.0.0.1:3300'
             app:
               file: 'router.lua'

--- a/test/integration/running/small_cluster_app/config.yaml
+++ b/test/integration/running/small_cluster_app/config.yaml
@@ -10,11 +10,13 @@ groups:
         instances:
           storage-master:
             iproto:
-              listen: '127.0.0.1:3301'
+              listen:
+                - uri: '127.0.0.1:3301'
             database:
               mode: rw
           storage-replica:
             iproto:
-              listen: '127.0.0.1:3302'
+              listen:
+                - uri: '127.0.0.1:3302'
             database:
               mode: ro

--- a/test/utils.py
+++ b/test/utils.py
@@ -155,6 +155,15 @@ def wait_instance_stop(pid_path, timeout_sec=5):
     return stopped
 
 
+def wait_event(timeout, event_func, interval=0.1):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if event_func():
+            return True
+        time.sleep(interval)
+    return False
+
+
 class TarantoolTestInstance:
     """Create test tarantool instance via subprocess.Popen with given cfg file.
 


### PR DESCRIPTION
This patch introduces built-in `vshard_cluster` template,
which uses tarantool 3.0 config.