### PR TITLE
ci: install stringer tool for update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         go install github.com/magefile/mage@latest
         go install golang.org/x/tools/cmd/goimports@latest
+        go install golang.org/x/tools/cmd/stringer@v0.16.1
+      shell: bash
 
     - name: Generate code
       run: mage generate


### PR DESCRIPTION
`mage generate` requires `stringer` tool for code generation.