### PR TITLE
build(deps): bump go-tarantool to v1.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tarantool/cartridge-cli v0.0.0-20220605082730-53e6a5be9a61
 	github.com/tarantool/go-prompt v1.0.0
-	github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d
+	github.com/tarantool/go-tarantool v1.12.2
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/yuin/gopher-lua v1.1.1-0.20230219103905-71163b697a8f
 	go.etcd.io/etcd/api/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/tarantool/go-prompt v0.2.6-tarantool h1:/dYMRBuM5nE3mleka/mqJWPf8SrJ1
 github.com/tarantool/go-prompt v0.2.6-tarantool/go.mod h1:8enZKIgoGFEQu2XPBK79TguJG2XF3SR4QU2iYI28NSo=
 github.com/tarantool/go-prompt v1.0.0 h1:7lDXh+SBCf4/S3xmDPNOxTA4yfWugD+t82AZOkQviAE=
 github.com/tarantool/go-prompt v1.0.0/go.mod h1:9Vuvi60Bk+3yaXqgYaXNTpLbwPPaaEOeaUgpFW1jqTU=
-github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d h1:qkKjWaxX8GPdHSP2WETv096vm/MH2iBPOZa6hnJ780s=
-github.com/tarantool/go-tarantool v1.10.1-0.20230309143354-e257ff30dd4d/go.mod h1:oMCTx0UAjEkHjdVdgnh3DjwUxs0xgyvIcaOBV8i4CF4=
+github.com/tarantool/go-tarantool v1.12.2 h1:u4g+gTOHNxbUDJv0EIUFkRurU/lTQSzWrz8o7bHVAqI=
+github.com/tarantool/go-tarantool v1.12.2/go.mod h1:QRiXv0jnxwgxHtr9ZmifSr/eRba76gTUBgp69pDMX1U=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=


### PR DESCRIPTION
The bump needed to fix svacer issues.