### PR TITLE
replicaset: add `expel` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  cluster config (3.0) or cartridge orchestrator.
 - `tt replicaset demote`: command to demote an instance in the tarantool replicaset with
  cluster config (3.0) orchestrator.
+- `tt replicaset expel`:  command to expel an instance from the tarantool replicaset with
+ cluster config (3.0) or cartridge orchestrator.
 - `tt cluster replicaset`: module to manage replicaset via 3.0 cluster config storage.
   * `tt cluster replicaset promote`: command to promote an instance in the replicaset.
   * `tt cluster replicaset demote`: command to demote an instance in the replicaset.

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -164,6 +164,11 @@ func (c *CartridgeInstance) Discovery() (Replicasets, error) {
 	return recalculateMasters(replicasets), nil
 }
 
+// Expel is not supported for a single instance by the Cartridge orchestrator.
+func (c *CartridgeInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // CartridgeApplication is an application with the Cartridge orchestrator.
 type CartridgeApplication struct {
 	runningCtx running.RunningCtx
@@ -259,6 +264,11 @@ loop:
 // Demote is not supported for a cartridge application.
 func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
+}
+
+// Expel expels an instance from a Cartridge replicasets.
+func (c *CartridgeApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCartridge)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -137,6 +137,11 @@ loop:
 	return cartridgePromote(c.evaler, inst, ctx.Force, ctx.Timeout)
 }
 
+// Demote is not supported for a single instance by the cartridge orchestrator.
+func (c *CartridgeInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // GetReplicasets returns a replicaset topology for a single instance with the
 // Cartridge orchestrator.
 func (c *CartridgeInstance) Discovery() (Replicasets, error) {
@@ -249,6 +254,11 @@ loop:
 
 	return cartridgePromote(MakeInstanceEvalFunc(targetInstance.InstanceCtx),
 		inst, ctx.Force, ctx.Timeout)
+}
+
+// Demote is not supported for a cartridge application.
+func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -484,11 +484,79 @@ func TestCartridgeInstance_Discovery(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCartridgeInstance(tc.Evaler)
-			replicasets, err := instance.Discovery()
+			replicasets, err := instance.Discovery(false)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.Expected, replicasets)
 		})
 	}
+}
+
+func TestCartridgeInstance_Discovery_force(t *testing.T) {
+	evaler := &instanceMockEvaler{
+		Ret: [][]any{
+			[]any{
+				map[any]any{
+					"replicasets": []any{
+						map[any]any{
+							"uuid": "foo1",
+						},
+					},
+				},
+			},
+			[]any{
+				map[any]any{
+					"uuid": "foo1",
+					"rw":   false,
+				},
+			},
+			[]any{
+				map[any]any{
+					"replicasets": []any{
+						map[any]any{
+							"uuid": "foo2",
+						},
+					},
+				},
+			},
+			[]any{
+				map[any]any{
+					"uuid": "foo2",
+					"rw":   false,
+				},
+			},
+		},
+	}
+
+	getter := replicaset.NewCartridgeInstance(evaler)
+
+	replicasets, err := getter.Discovery(false)
+	require.NoError(t, err)
+	expected := replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCartridge,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo1",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
+
+	// Force re-discovery.
+	replicasets, err = getter.Discovery(true)
+	require.NoError(t, err)
+	expected = replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCartridge,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo2",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
 }
 
 func TestCartridgeInstance_Discovery_failover(t *testing.T) {
@@ -546,7 +614,7 @@ func TestCartridgeInstance_Discovery_failover(t *testing.T) {
 
 			getter := replicaset.NewCartridgeInstance(evaler)
 
-			replicasets, err := getter.Discovery()
+			replicasets, err := getter.Discovery(false)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, replicasets)
 		})
@@ -608,7 +676,7 @@ func TestCartridgeInstance_Discovery_provider(t *testing.T) {
 
 			getter := replicaset.NewCartridgeInstance(evaler)
 
-			replicasets, err := getter.Discovery()
+			replicasets, err := getter.Discovery(false)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, replicasets)
 		})
@@ -698,7 +766,7 @@ func TestCartridgeInstance_Discovery_errors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCartridgeInstance(tc.Evaler)
-			_, err := instance.Discovery()
+			_, err := instance.Discovery(false)
 			assert.ErrorContains(t, err, tc.Expected)
 		})
 	}

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -10,10 +10,27 @@ import (
 
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CartridgeInstance{}
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
+
+func TestCartridgeApplication_Demote(t *testing.T) {
+	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
+	err := app.Demote(replicaset.DemoteCtx{})
+
+	assert.EqualError(t, err,
+		`demote is not supported for an application by "cartridge" orchestrator`)
+}
+
+func TestCartridgeInstance_Demote(t *testing.T) {
+	inst := replicaset.NewCartridgeInstance(nil)
+	err := inst.Demote(replicaset.DemoteCtx{})
+
+	assert.EqualError(t, err,
+		`demote is not supported for a single instance by "cartridge" orchestrator`)
+}
 
 func TestCartridgeInstance_Discovery(t *testing.T) {
 	cases := []struct {

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -889,12 +889,3 @@ func TestCartridgeInstance_Expel(t *testing.T) {
 	assert.EqualError(t, err,
 		"expel is not supported for a single instance by \"cartridge\" orchestrator")
 }
-
-func TestCartridgeApplication_Expel(t *testing.T) {
-	instance := replicaset.NewCartridgeApplication(running.RunningCtx{})
-
-	err := instance.Expel(replicaset.ExpelCtx{})
-
-	assert.EqualError(t, err,
-		"expel is not supported for an application by \"cartridge\" orchestrator")
-}

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 var _ replicaset.Discoverer = &replicaset.CartridgeInstance{}
+var _ replicaset.Expeller = &replicaset.CartridgeInstance{}
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
+var _ replicaset.Expeller = &replicaset.CartridgeApplication{}
 
 func TestCartridgeApplication_Demote(t *testing.T) {
 	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
@@ -877,4 +879,22 @@ func TestCartridgeInstancePromote_errs(t *testing.T) {
 			require.EqualError(t, err, tc.expected)
 		})
 	}
+}
+
+func TestCartridgeInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCartridgeInstance(nil)
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for a single instance by \"cartridge\" orchestrator")
+}
+
+func TestCartridgeApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCartridgeApplication(running.RunningCtx{})
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for an application by \"cartridge\" orchestrator")
 }

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -91,6 +91,12 @@ func (c *CConfigInstance) Promote(ctx PromoteCtx) error {
 	return cconfigPromoteElection(c.evaler, ctx.Timeout)
 }
 
+// Demote is not supported for a single instance by the centralized config
+// orchestrator.
+func (c *CConfigInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -53,19 +53,22 @@ type cconfigInstance struct {
 
 // CConfigInstance is an instance with the centralized config orchestrator.
 type CConfigInstance struct {
+	cachedDiscoverer
 	evaler connector.Evaler
 }
 
 // NewCConfigInstance create a new CConfigInstance object for the evaler.
 func NewCConfigInstance(evaler connector.Evaler) *CConfigInstance {
-	return &CConfigInstance{
+	inst := &CConfigInstance{
 		evaler: evaler,
 	}
+	inst.cachedDiscoverer = newCachedDiscoverer(inst)
+	return inst
 }
 
-// Discovery returns a replicasets topology for a single instance with
+// discoveryImpl returns a replicasets topology for a single instance with
 // the centralized config orchestrator.
-func (c *CConfigInstance) Discovery() (Replicasets, error) {
+func (c *CConfigInstance) discoveryImpl() (Replicasets, error) {
 	topology, err := getCConfigInstanceTopology(c.evaler)
 	if err != nil {
 		return Replicasets{}, err
@@ -106,6 +109,7 @@ func (c *CConfigInstance) Expel(ctx ExpelCtx) error {
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {
+	cachedDiscoverer
 	runningCtx running.RunningCtx
 	publishers libcluster.DataPublisherFactory
 	collectors libcluster.DataCollectorFactory
@@ -116,16 +120,18 @@ func NewCConfigApplication(
 	runningCtx running.RunningCtx,
 	collectors libcluster.DataCollectorFactory,
 	publishers libcluster.DataPublisherFactory) *CConfigApplication {
-	return &CConfigApplication{
+	app := &CConfigApplication{
 		runningCtx: runningCtx,
 		publishers: publishers,
 		collectors: collectors,
 	}
+	app.cachedDiscoverer = newCachedDiscoverer(app)
+	return app
 }
 
-// Discovery returns a replicasets topology for an application with
+// discoveryImpl returns a replicasets topology for an application with
 // the centralized config orchestrator.
-func (c *CConfigApplication) Discovery() (Replicasets, error) {
+func (c *CConfigApplication) discoveryImpl() (Replicasets, error) {
 	var topologies []cconfigTopology
 
 	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(
@@ -157,7 +163,7 @@ func (c *CConfigApplication) Discovery() (Replicasets, error) {
 
 // Expel expels an instance from the cetralized config's replicasets.
 func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(false)
 	if err != nil {
 		return fmt.Errorf("failed to get replicasets: %s", err)
 	}
@@ -308,7 +314,7 @@ func updateCConfigInstances(replicaset *Replicaset, topology cconfigTopology) {
 
 // Promote promotes an instance in the application.
 func (c *CConfigApplication) Promote(ctx PromoteCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(false)
 	if err != nil {
 		return fmt.Errorf("failed to get replicasets: %w", err)
 	}
@@ -347,7 +353,7 @@ func (c *CConfigApplication) Promote(ctx PromoteCtx) error {
 
 // Demote demotes an instance in the application.
 func (c *CConfigApplication) Demote(ctx DemoteCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(false)
 	if err != nil {
 		return fmt.Errorf("failed to get replicasets: %w", err)
 	}

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -97,6 +97,12 @@ func (c *CConfigInstance) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByInstanceNotSupported(OrchestratorCentralizedConfig)
 }
 
+// Expel is not supported for a single instance by the centralized config
+// orchestrator.
+func (c *CConfigInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {
@@ -147,6 +153,11 @@ func (c *CConfigApplication) Discovery() (Replicasets, error) {
 	}
 
 	return mergeCConfigTopologies(topologies)
+}
+
+// Expel expels an instance from the cetralized config's replicasets.
+func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCentralizedConfig)
 }
 
 // getCConfigInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -378,3 +378,11 @@ func TestCConfigInstance_Promote_error(t *testing.T) {
 	actual := instance.Promote(replicaset.PromoteCtx{})
 	require.ErrorIs(t, actual, err)
 }
+
+func TestCConfigInstance_Demote(t *testing.T) {
+	instance := replicaset.NewCConfigInstance(nil)
+	err := instance.Demote(replicaset.DemoteCtx{})
+
+	require.EqualError(t, err,
+		`demote is not supported for a single instance by "centralized config" orchestrator`)
+}

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
+var _ replicaset.Expeller = &replicaset.CConfigInstance{}
 var _ replicaset.Discoverer = &replicaset.CConfigApplication{}
+var _ replicaset.Expeller = &replicaset.CConfigApplication{}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -385,4 +388,22 @@ func TestCConfigInstance_Demote(t *testing.T) {
 
 	require.EqualError(t, err,
 		`demote is not supported for a single instance by "centralized config" orchestrator`)
+}
+
+func TestCConfigInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCConfigInstance(nil)
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for a single instance by \"centralized config\" orchestrator")
+}
+
+func TestCConfigApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for an application by \"centralized config\" orchestrator")
 }

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
-	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
@@ -397,13 +396,4 @@ func TestCConfigInstance_Expel(t *testing.T) {
 
 	assert.EqualError(t, err,
 		"expel is not supported for a single instance by \"centralized config\" orchestrator")
-}
-
-func TestCConfigApplication_Expel(t *testing.T) {
-	instance := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
-
-	err := instance.Expel(replicaset.ExpelCtx{})
-
-	assert.EqualError(t, err,
-		"expel is not supported for an application by \"centralized config\" orchestrator")
 }

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -1,8 +1,12 @@
 package replicasetcmd
 
 import (
+	"fmt"
+
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
+	libcluster "github.com/tarantool/tt/lib/cluster"
 )
 
 const (
@@ -15,6 +19,49 @@ type replicasetOrchestrator interface {
 	replicaset.Discoverer
 	replicaset.Promoter
 	replicaset.Demoter
+}
+
+// makeApplicationOrchestrator creates an orchestrator for the application.
+func makeApplicationOrchestrator(
+	orchestratorType replicaset.Orchestrator,
+	runningCtx running.RunningCtx,
+	collectors libcluster.DataCollectorFactory,
+	publishers libcluster.DataPublisherFactory) (replicasetOrchestrator, error) {
+	var (
+		orchestrator replicasetOrchestrator
+		err          error
+	)
+	switch orchestratorType {
+	case replicaset.OrchestratorCentralizedConfig:
+		orchestrator = replicaset.NewCConfigApplication(runningCtx, collectors, publishers)
+	case replicaset.OrchestratorCartridge:
+		orchestrator = replicaset.NewCartridgeApplication(runningCtx)
+	case replicaset.OrchestratorCustom:
+		orchestrator = replicaset.NewCustomApplication(runningCtx)
+	default:
+		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	}
+	return orchestrator, err
+}
+
+// makeInstanceOrchestrator creates an orchestrator for the single instance.
+func makeInstanceOrchestrator(orchestratorType replicaset.Orchestrator,
+	conn connector.Connector) (replicasetOrchestrator, error) {
+	var (
+		orchestrator replicasetOrchestrator
+		err          error
+	)
+	switch orchestratorType {
+	case replicaset.OrchestratorCentralizedConfig:
+		orchestrator = replicaset.NewCConfigInstance(conn)
+	case replicaset.OrchestratorCartridge:
+		orchestrator = replicaset.NewCartridgeInstance(conn)
+	case replicaset.OrchestratorCustom:
+		orchestrator = replicaset.NewCustomInstance(conn)
+	default:
+		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	}
+	return orchestrator, err
 }
 
 // getOrchestratorInstance determinates a used orchestrator type for an instance.

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -38,20 +38,10 @@ func Demote(ctx DemoteCtx) error {
 		return err
 	}
 
-	var orchestrator interface {
-		replicaset.Discoverer
-		replicaset.Demoter
-	}
-	switch orchestratorType {
-	case replicaset.OrchestratorCentralizedConfig:
-		orchestrator = replicaset.NewCConfigApplication(ctx.RunningCtx, ctx.Collectors,
-			ctx.Publishers)
-	case replicaset.OrchestratorCartridge:
-		fallthrough
-	case replicaset.OrchestratorCustom:
-		fallthrough
-	default:
-		return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	orchestrator, err := makeApplicationOrchestrator(orchestratorType,
+		ctx.RunningCtx, ctx.Collectors, ctx.Publishers)
+	if err != nil {
+		return err
 	}
 
 	log.Info("Discovery application...")

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -48,7 +48,7 @@ func Demote(ctx DemoteCtx) error {
 	fmt.Println()
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(true)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/expel.go
+++ b/cli/replicaset/cmd/expel.go
@@ -48,7 +48,7 @@ func Expel(expelCtx ExpelCtx) error {
 	fmt.Println("")
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(true)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -57,7 +57,7 @@ func Promote(ctx PromoteCtx) error {
 	fmt.Println()
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(true)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -41,32 +41,15 @@ func Promote(ctx PromoteCtx) error {
 		return err
 	}
 
-	var orchestrator interface {
-		replicaset.Discoverer
-		replicaset.Promoter
-	}
+	var orchestrator replicasetOrchestrator
 	if ctx.IsApplication {
-		switch orchestratorType {
-		case replicaset.OrchestratorCentralizedConfig:
-			orchestrator = replicaset.NewCConfigApplication(ctx.RunningCtx, ctx.Collectors,
-				ctx.Publishers)
-		case replicaset.OrchestratorCartridge:
-			orchestrator = replicaset.NewCartridgeApplication(ctx.RunningCtx)
-		case replicaset.OrchestratorCustom:
-			fallthrough
-		default:
-			return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		if orchestrator, err = makeApplicationOrchestrator(
+			orchestratorType, ctx.RunningCtx, ctx.Collectors, ctx.Publishers); err != nil {
+			return err
 		}
 	} else {
-		switch orchestratorType {
-		case replicaset.OrchestratorCentralizedConfig:
-			orchestrator = replicaset.NewCConfigInstance(ctx.Conn)
-		case replicaset.OrchestratorCartridge:
-			orchestrator = replicaset.NewCartridgeInstance(ctx.Conn)
-		case replicaset.OrchestratorCustom:
-			fallthrough
-		default:
-			return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		if orchestrator, err = makeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
+			return err
 		}
 	}
 

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -36,7 +36,7 @@ type PromoteCtx struct {
 
 // Promote promotes an instance.
 func Promote(ctx PromoteCtx) error {
-	orchestratorType, err := getOrchestratorInstance(ctx.Orchestrator, ctx.Conn)
+	orchestratorType, err := getInstanceOrchestrator(ctx.Orchestrator, ctx.Conn)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -51,31 +51,12 @@ func Status(statusCtx StatusCtx) error {
 	return statusReplicasets(replicasets)
 }
 
-// getOrchestratorType determinates a used orchestrator type.
+// getOrchestratorType determines a used orchestrator for a status context.
 func getOrchestratorType(statusCtx StatusCtx) (replicaset.Orchestrator, error) {
-	if statusCtx.Orchestrator != replicaset.OrchestratorUnknown {
-		return statusCtx.Orchestrator, nil
-	}
-
 	if statusCtx.Conn != nil {
-		return replicaset.EvalOrchestrator(statusCtx.Conn)
+		return getInstanceOrchestrator(statusCtx.Orchestrator, statusCtx.Conn)
 	}
-
-	var orchestrator replicaset.Orchestrator
-	eval := func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-		instanceOrchestrator, err := replicaset.EvalOrchestrator(evaler)
-		if err == nil {
-			orchestrator = instanceOrchestrator
-		}
-		return true, err
-	}
-
-	instances := statusCtx.RunningCtx.Instances
-	if err := replicaset.EvalAny(instances, replicaset.InstanceEvalFunc(eval)); err != nil {
-		return orchestrator,
-			fmt.Errorf("unable to determinate orchestrator: %w", err)
-	}
-	return orchestrator, nil
+	return getApplicationOrchestrator(statusCtx.Orchestrator, statusCtx.RunningCtx)
 }
 
 // statusReplicasets show the current status of known replicasets.

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -43,7 +43,7 @@ func Status(statusCtx StatusCtx) error {
 		}
 	}
 
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(true)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -33,19 +33,22 @@ type customTopology struct {
 // CustomInstance is an instance with custom/unknown orchestrator. In this
 // case, we can obtain a minimum of information for a replicaset.
 type CustomInstance struct {
+	cachedDiscoverer
 	evaler connector.Evaler
 }
 
 // NewCustomInstance creates a new CustomInstance object for the evaler.
 func NewCustomInstance(evaler connector.Evaler) *CustomInstance {
-	return &CustomInstance{
+	inst := &CustomInstance{
 		evaler: evaler,
 	}
+	inst.cachedDiscoverer = newCachedDiscoverer(inst)
+	return inst
 }
 
-// Discovery returns a replicasets topology for a single
+// discoveryImpl returns a replicasets topology for a single
 // instance with a custom type of orchestrator.
-func (c *CustomInstance) Discovery() (Replicasets, error) {
+func (c *CustomInstance) discoveryImpl() (Replicasets, error) {
 	topology, err := getCustomInstanceTopology("", c.evaler)
 	if err != nil {
 		return Replicasets{}, err
@@ -82,20 +85,23 @@ func (c *CustomInstance) Expel(ctx ExpelCtx) error {
 
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
+	cachedDiscoverer
 	runningCtx running.RunningCtx
 	conn       connector.Connector
 }
 
 // NewCustomApplication creates a new CustomApplication object.
 func NewCustomApplication(runningCtx running.RunningCtx) *CustomApplication {
-	return &CustomApplication{
+	app := &CustomApplication{
 		runningCtx: runningCtx,
 	}
+	app.cachedDiscoverer = newCachedDiscoverer(app)
+	return app
 }
 
-// Discovery returns a replicasets configuration for an application with
+// discoveryImpl returns a replicasets configuration for an application with
 // a custom orchestrator.
-func (c *CustomApplication) Discovery() (Replicasets, error) {
+func (c *CustomApplication) discoveryImpl() (Replicasets, error) {
 	var topologies []customTopology
 
 	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -65,6 +65,16 @@ func (c *CustomInstance) Discovery() (Replicasets, error) {
 	}), nil
 }
 
+// Promote is not supported for a single instance with custom orchestrator.
+func (c *CustomInstance) Promote(ctx PromoteCtx) error {
+	return newErrPromoteByInstanceNotSupported(OrchestratorCustom)
+}
+
+// Demote is not supported for a single instance with custom orchestrator.
+func (c *CustomInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	runningCtx running.RunningCtx
@@ -104,6 +114,16 @@ func (c *CustomApplication) Discovery() (Replicasets, error) {
 	}
 
 	return mergeCustomTopologies(topologies)
+}
+
+// Promote is not supported for a custom application.
+func (c *CustomApplication) Promote(ctx PromoteCtx) error {
+	return newErrPromoteByAppNotSupported(OrchestratorCustom)
+}
+
+// Demote is not supported for a custom application.
+func (c *CustomApplication) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -75,6 +75,11 @@ func (c *CustomInstance) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByInstanceNotSupported(OrchestratorCustom)
 }
 
+// Expel is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	runningCtx running.RunningCtx
@@ -124,6 +129,11 @@ func (c *CustomApplication) Promote(ctx PromoteCtx) error {
 // Demote is not supported for a custom application.
 func (c *CustomApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCustom)
+}
+
+// Expel is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 var _ replicaset.Discoverer = &replicaset.CustomInstance{}
+var _ replicaset.Expeller = &replicaset.CustomInstance{}
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
+var _ replicaset.Expeller = &replicaset.CustomApplication{}
 
 func TestCustomApplication_Promote(t *testing.T) {
 	app := replicaset.NewCustomApplication(running.RunningCtx{})
@@ -343,4 +345,22 @@ func TestCustomInstance_Demote(t *testing.T) {
 
 	assert.EqualError(t, err,
 		`demote is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCustomInstance(nil)
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for a single instance by \"custom\" orchestrator")
+}
+
+func TestCustomApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCustomApplication(running.RunningCtx{})
+
+	err := instance.Expel(replicaset.ExpelCtx{})
+
+	assert.EqualError(t, err,
+		"expel is not supported for an application by \"custom\" orchestrator")
 }

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
 	"github.com/tarantool/tt/cli/running"
@@ -274,11 +275,59 @@ func TestCustomInstance_Discovery(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCustomInstance(tc.Evaler)
-			replicasets, err := instance.Discovery()
+			replicasets, err := instance.Discovery(false)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.Expected, replicasets)
 		})
 	}
+}
+
+func TestCustomInstance_Discovery_force(t *testing.T) {
+	evaler := &instanceMockEvaler{
+		Ret: [][]any{
+			[]any{
+				map[any]any{
+					"uuid": "foo1",
+				},
+			},
+			[]any{
+				map[any]any{
+					"uuid": "foo2",
+				},
+			},
+		},
+	}
+
+	getter := replicaset.NewCustomInstance(evaler)
+
+	replicasets, err := getter.Discovery(false)
+	require.NoError(t, err)
+	expected := replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCustom,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo1",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
+
+	// Force re-discovery.
+	replicasets, err = getter.Discovery(true)
+	require.NoError(t, err)
+	expected = replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCustom,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo2",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
 }
 
 func TestCustomInstance_Discovery_errors(t *testing.T) {
@@ -325,7 +374,7 @@ func TestCustomInstance_Discovery_errors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCustomInstance(tc.Evaler)
-			_, err := instance.Discovery()
+			_, err := instance.Discovery(false)
 			assert.ErrorContains(t, err, tc.Expected)
 		})
 	}

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -7,10 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CustomInstance{}
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
+
+func TestCustomApplication_Promote(t *testing.T) {
+	app := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := app.Promote(replicaset.PromoteCtx{})
+
+	assert.EqualError(t, err,
+		`promote is not supported for an application by "custom" orchestrator`)
+}
+
+func TestCustomApplication_Demote(t *testing.T) {
+	app := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := app.Demote(replicaset.DemoteCtx{})
+
+	assert.EqualError(t, err,
+		`demote is not supported for an application by "custom" orchestrator`)
+}
 
 func TestCustomInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -310,4 +327,20 @@ func TestCustomInstance_Discovery_errors(t *testing.T) {
 			assert.ErrorContains(t, err, tc.Expected)
 		})
 	}
+}
+
+func TestCustomInstance_Promote(t *testing.T) {
+	inst := replicaset.NewCustomInstance(nil)
+	err := inst.Promote(replicaset.PromoteCtx{})
+
+	assert.EqualError(t, err,
+		`promote is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_Demote(t *testing.T) {
+	inst := replicaset.NewCustomInstance(nil)
+	err := inst.Demote(replicaset.DemoteCtx{})
+
+	assert.EqualError(t, err,
+		`demote is not supported for a single instance by "custom" orchestrator`)
 }

--- a/cli/replicaset/demote.go
+++ b/cli/replicaset/demote.go
@@ -1,5 +1,7 @@
 package replicaset
 
+import "fmt"
+
 // DemoteCtx describes a context for an instance demoting.
 type DemoteCtx struct {
 	// InstName is an instance name to demote.
@@ -16,4 +18,18 @@ type DemoteCtx struct {
 type Demoter interface {
 	// Demote demotes an instance.
 	Demote(DemoteCtx) error
+}
+
+// newErrDemoteByInstanceNotSupported creates a new error that demote is not
+// supported by the orchestrator for a single instance.
+func newErrDemoteByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("demote is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrDemoteByAppNotSupported creates a new error that demote is not
+// supported by the orchestrator for an application.
+func newErrDemoteByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("demote is not supported for an application by %q orchestrator",
+		orchestrator)
 }

--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -1,69 +1,8 @@
 package replicaset
 
-import (
-	"fmt"
-
-	"github.com/tarantool/tt/cli/connector"
-	"github.com/tarantool/tt/cli/running"
-)
-
 // Discoverer is an interface for discovering information about
 // replicasets.
 type Discoverer interface {
 	// Discovery returns replicasets information or an error.
 	Discovery() (Replicasets, error)
-}
-
-// DiscoveryApplication retrieves replicasets information for instances in an
-// application. If orchestrator == OrchestratorUnknown then it tries to
-// determinate an orchestrator.
-func DiscoveryApplication(app running.RunningCtx,
-	orchestrator Orchestrator) (Replicasets, error) {
-	if orchestrator == OrchestratorUnknown {
-		eval := func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-			var err error
-			orchestrator, err = EvalOrchestrator(evaler)
-			return true, err
-		}
-
-		if err := EvalAny(app.Instances, InstanceEvalFunc(eval)); err != nil {
-			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
-		}
-	}
-
-	switch orchestrator {
-	case OrchestratorCartridge:
-		return NewCartridgeApplication(app).Discovery()
-	case OrchestratorCentralizedConfig:
-		return NewCConfigApplication(app, nil, nil).Discovery()
-	case OrchestratorCustom:
-		return NewCustomApplication(app).Discovery()
-	default:
-		return Replicasets{}, fmt.Errorf("orchestrator is not supported: %s", orchestrator)
-	}
-}
-
-// DiscoveryInstance retrieves replicasets information from a connection.
-// If orchestrator == OrchestratorUnknown then it tries to determinate an
-// orchestrator.
-func DiscoveryInstance(evaler connector.Evaler,
-	orchestrator Orchestrator) (Replicasets, error) {
-	if orchestrator == OrchestratorUnknown {
-		var err error
-		orchestrator, err = EvalOrchestrator(evaler)
-		if err != nil {
-			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
-		}
-	}
-
-	switch orchestrator {
-	case OrchestratorCartridge:
-		return NewCartridgeInstance(evaler).Discovery()
-	case OrchestratorCentralizedConfig:
-		return NewCConfigInstance(evaler).Discovery()
-	case OrchestratorCustom:
-		return NewCustomInstance(evaler).Discovery()
-	default:
-		return Replicasets{}, fmt.Errorf("orchestartor is not supported: %s", orchestrator)
-	}
 }

--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -4,5 +4,41 @@ package replicaset
 // replicasets.
 type Discoverer interface {
 	// Discovery returns replicasets information or an error.
-	Discovery() (Replicasets, error)
+	Discovery(force bool) (Replicasets, error)
 }
+
+// discovererImpl is an interface that unconditionally performs discovering.
+type discovererImpl interface {
+	discoveryImpl() (Replicasets, error)
+}
+
+// cachedDiscoverer allows to automatically cache discovery results.
+type cachedDiscoverer struct {
+	discovererImpl
+	cached     bool
+	discovered Replicasets
+}
+
+// newCachedDiscoverer creates cachedDiscoverer.
+func newCachedDiscoverer(impl discovererImpl) cachedDiscoverer {
+	return cachedDiscoverer{discovererImpl: impl}
+}
+
+// Discovery discovers via underlying type.
+// If force is false and there is a cached result, returns it.
+func (c *cachedDiscoverer) Discovery(force bool) (Replicasets, error) {
+	if !force && c.cached {
+		return c.discovered, nil
+	}
+	c.cached = false
+	var err error
+	c.discovered, err = c.discoveryImpl()
+	if err != nil {
+		return c.discovered, err
+	}
+	c.cached = true
+	return c.discovered, nil
+}
+
+// Type assertion that cachedDiscoverer satisfy Discoverer.
+var _ Discoverer = (*cachedDiscoverer)(nil)

--- a/cli/replicaset/expel.go
+++ b/cli/replicaset/expel.go
@@ -9,6 +9,9 @@ type ExpelCtx struct {
 	// Force is true when expelling can skip
 	// some non-critical checks.
 	Force bool
+	// Timeout is a timeout for expelling waitings in seconds.
+	// Keep int, because it can be passed to the target instance.
+	Timeout int
 }
 
 // Expeller is an interface for expelling instances from a replicaset.

--- a/cli/replicaset/expel.go
+++ b/cli/replicaset/expel.go
@@ -1,0 +1,32 @@
+package replicaset
+
+import "fmt"
+
+// ExpelCtx describes a context for an instance expelling.
+type ExpelCtx struct {
+	// InstName is an instance name to expel.
+	InstName string
+	// Force is true when expelling can skip
+	// some non-critical checks.
+	Force bool
+}
+
+// Expeller is an interface for expelling instances from a replicaset.
+type Expeller interface {
+	// Expel expels instance from a replicasets by its name.
+	Expel(ctx ExpelCtx) error
+}
+
+// newErrExpelByInstanceNotSupported creates a new error that expel is not
+// supported by the orchestrator for a single instance.
+func newErrExpelByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("expel is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrExpelByAppNotSupported creates a new error that expel by URI is not
+// supported by the orchestrator for an application.
+func newErrExpelByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("expel is not supported for an application by %q orchestrator",
+		orchestrator)
+}

--- a/cli/replicaset/lua/cartridge/edit_instances_body.lua
+++ b/cli/replicaset/lua/cartridge/edit_instances_body.lua
@@ -1,0 +1,8 @@
+local cartridge = require('cartridge')
+local servers = ...
+
+local res, err = cartridge.admin_edit_topology({
+    servers = servers,
+})
+
+assert(res, tostring(err))

--- a/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
+++ b/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
@@ -21,7 +21,7 @@ for _, instance in ipairs(box_info.replication) do
     local uri = nil
     if instance.upstream ~= nil then
         uri = instance.upstream.peer
-    elseif box.cfg.listen ~= nil then
+    elseif box.cfg.listen ~= nil and instance.uuid == box_info.uuid then
         if type(box.cfg.listen) == 'string' then
             uri = box.cfg.listen
         elseif #box.cfg.listen > 0 then

--- a/cli/replicaset/orchestrators_test.go
+++ b/cli/replicaset/orchestrators_test.go
@@ -93,7 +93,7 @@ func TestReplicasetGetter_Discovery_panics_with_invalid_evaler(t *testing.T) {
 			t.Run(oc.Name+"_"+tc.Name, func(t *testing.T) {
 				getter := oc.New(tc.Evaler)
 				assert.Panics(t, func() {
-					getter.Discovery()
+					getter.Discovery(true)
 				})
 			})
 		}

--- a/cli/replicaset/promote.go
+++ b/cli/replicaset/promote.go
@@ -1,5 +1,7 @@
 package replicaset
 
+import "fmt"
+
 // PromoteCtx describes a context for an instance promoting.
 type PromoteCtx struct {
 	// InstName is an instance name to promote.
@@ -16,4 +18,18 @@ type PromoteCtx struct {
 type Promoter interface {
 	// Promote promotes an instance.
 	Promote(PromoteCtx) error
+}
+
+// newErrPromoteByInstanceNotSupported creates a new error that promote is not
+// supported by the orchestrator for a single instance.
+func newErrPromoteByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("promote is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrPromoteByAppNotSupported creates a new error that promote is not
+// supported by the orchestrator for an application.
+func newErrPromoteByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("promote is not supported for an application by %q orchestrator",
+		orchestrator)
 }

--- a/test/integration/cluster/test_cluster_expel.py
+++ b/test/integration/cluster/test_cluster_expel.py
@@ -1,0 +1,61 @@
+from utils import run_command_and_get_output
+
+
+def to_etcd_key(key):
+    return f"/prefix/config/{key}"
+
+
+def test_cluster_expel_missing_instance(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    uri = "http://localhost:2379"  # Fictive.
+    cmd = [tt_cmd, "cluster", "rs", "expel", uri]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc != 0
+    assert "Error: accepts 2 arg(s), received 1" in out
+
+
+cfg = """\
+groups:
+  group-1:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001: {}
+          instance-002: {}
+"""
+
+
+def test_cluster_expel_no_instance(tt_cmd, etcd, tmpdir_with_cfg):
+    etcdcli = etcd.conn()
+    tmpdir = tmpdir_with_cfg
+    etcdcli.put(to_etcd_key("all"), cfg)
+    url = f"{etcd.endpoint}/prefix?timeout=5"
+    cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-003"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc != 0
+    assert 'instance "instance-003" not found in the cluster configuration' in out
+
+
+def test_cluster_expel_single_key(tt_cmd, etcd, tmpdir_with_cfg):
+    etcdcli = etcd.conn()
+    tmpdir = tmpdir_with_cfg
+    key = to_etcd_key("all")
+    etcdcli.put(key, cfg)
+    url = f"{etcd.endpoint}/prefix?timeout=5"
+    cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-002"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 0
+    assert f'Patch the config by the key: "{key}"' in out
+
+    actual, _ = etcdcli.get(key)
+    assert actual.decode("utf-8") == """\
+groups:
+  group-1:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001: {}
+          instance-002:
+            iproto:
+              listen: {}
+"""

--- a/test/integration/replicaset/test_ccluster_app/init.lua
+++ b/test/integration/replicaset/test_ccluster_app/init.lua
@@ -10,7 +10,7 @@ while true do
 end
 
 while true do
-    if #box.cfg.replication == #box.info.replication then
+    if #box.cfg.replication <= #box.info.replication then
         break
     end
     fiber.sleep(0.1)

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -145,3 +145,74 @@ Replicasets state: uninitialized
                 break
             time.sleep(1)
         assert rs_out == status_expelled
+
+
+@pytest.mark.skipif(tarantool_major_version < 3,
+                    reason="skip centralized config test for Tarantool < 3")
+@pytest.mark.parametrize("flag", [None, "--config"])
+def test_expel_cconfig(tt_cmd, tmpdir_with_cfg, flag):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_ccluster_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        for i in range(1, 6):
+            file = wait_file(os.path.join(tmpdir, app_name), f'ready-instance-00{i}', [])
+            assert file != ""
+
+        expel_cmd = [tt_cmd, "replicaset", "expel"]
+        if flag:
+            expel_cmd.append(flag)
+        expel_cmd.append(f"{app_name}:instance-003")
+
+        rc, out = run_command_and_get_output(expel_cmd, cwd=tmpdir)
+        assert rc == 0
+        assert re.search("""   • Discovery application...*
+
+Orchestrator:      centralized config
+Replicasets state: bootstrapped
+
+• replicaset-001
+  Failover: off
+  Master:   single
+    • instance-001 unix/:./instance-001.iproto rw
+    • instance-002 unix/:./instance-002.iproto read
+    • instance-003 unix/:./instance-003.iproto read
+• replicaset-002
+  Failover: off
+  Master:   multi
+    • instance-004 unix/:./instance-004.iproto rw
+    • instance-005 unix/:./instance-005.iproto rw
+
+   • Expel instance: instance-003
+   • Done.*
+""", out)
+
+        # Check that the instance has been expelled.
+        status_cmd = [tt_cmd, "replicaset", "status", app_name]
+        rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+        assert rc == 0
+        assert """Orchestrator:      centralized config
+Replicasets state: bootstrapped
+
+• replicaset-001
+  Failover: off
+  Master:   single
+    • instance-001 unix/:./instance-001.iproto rw
+    • instance-002 unix/:./instance-002.iproto read
+• replicaset-002
+  Failover: off
+  Master:   multi
+    • instance-004 unix/:./instance-004.iproto rw
+    • instance-005 unix/:./instance-005.iproto rw
+""" == out
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -1,0 +1,85 @@
+
+
+import os
+import re
+import shutil
+
+import pytest
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+
+@pytest.mark.parametrize("case", [["--config", "--custom"],
+                                  ["--custom", "--cartridge"],
+                                  ["--config", "--cartridge"],
+                                  ["--config", "--custom", "--cartridge"]])
+def test_expel_orchestrators_force_mix(tt_cmd, tmpdir_with_cfg, case):
+    status_cmd = [tt_cmd, "replicaset", "expel"] + case + ["app:instance"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ only one type of orchestrator can be forced", out)
+
+
+def test_expel_invalid_argument(tt_cmd, tmpdir_with_cfg):
+    status_cmd = [tt_cmd, "replicaset", "expel", "app"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ the command expects argument application_name:instance_name", out)
+
+
+def test_expel_no_instance(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+
+    status_cmd = [tt_cmd, "replicaset", "expel", "test_custom_app:unexist"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ instance \"unexist\" not found", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--custom"])
+def test_expel_custom_app(tt_cmd, tmpdir_with_cfg, flag):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        expel_cmd = [tt_cmd, "replicaset", "expel"]
+        if flag:
+            expel_cmd.append(flag)
+        expel_cmd.append("test_custom_app:test_custom_app")
+
+        rc, out = run_command_and_get_output(expel_cmd, cwd=tmpdir)
+        assert rc == 1
+        assert re.search(r"""  • Discovery application...*
+
+Orchestrator:      custom
+Replicasets state: bootstrapped
+
+• .*
+  Failover: unknown
+  Master:   single
+    • test_custom_app .* rw
+
+   • Expel instance: test_custom_app
+   ⨯ expel is not supported for an application by "custom" orchestrator
+""", out)
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0


### PR DESCRIPTION
@TarantoolBot document
Title: new commands: `tt replicaset expel`, `tt cluster replicaset expel`

The patch introduces a new command for the `tt replicaset` module:

* `tt replicaset expel APP_NAME:INSTANCE_NAME` - to expel an instance from a cluster.

The command automatically determines a replicaset orchestrator. Currently, it supports:

* cartridge - the Cartridge orchestrator for Tarantool <= 2.
* config - the centralized config orchestrator for Tarantool >= 3.

Usage:

tt replicaset expel [--cartridge|--config|--custom] <APP_NAME:INSTANCE_NAME>

The example of execution:

```
$ tt replicaset expel myapp:instance-003
   • Discovery application...

Orchestrator:      centralized config
Replicasets state: bootstrapped

• replicaset-001
  Failover: off
  Master:   single
    • instance-001 unix/:./instance-001.iproto rw
    • instance-002 unix/:./instance-002.iproto read
    • instance-003 unix/:./instance-003.iproto read
• replicaset-002
  Failover: off
  Master:   multi
    • instance-004 unix/:./instance-004.iproto rw
    • instance-005 unix/:./instance-005.iproto rw

   • Expel instance: instance-003
   • Done.
$ tt replicaset status myapp
Orchestrator:      centralized config
Replicasets state: bootstrapped

• replicaset-001
  Failover: off
  Master:   single
    • instance-001 unix/:./instance-001.iproto rw
    • instance-002 unix/:./instance-002.iproto read
• replicaset-002
  Failover: off
  Master:   multi
    • instance-004 unix/:./instance-004.iproto rw
    • instance-005 unix/:./instance-005.iproto rw
```

Also, new command for `cluster` module:
* `tt cluster replicaset expel [-f] [flags] <URI> <INSTANCE_NAME>` expels an instance from the 3.0 replicaset by patching the config in storage (etcd or tarantool config storage). 

The example of execution:
```sh
$ tt cluster show http://localhost:2379/foo

credentials:
  users:
    guest:
      roles:
        - super
groups:
  group-001:
    replicasets:
      replicaset-001:
        instances:
          instance-001:
            iproto:
              listen:
                - uri: localhost:3301
          instance-002:
            iproto:
              listen:
                - uri: localhost:3302

$ tt cluster rs expel http://localhost:2379/foo instance-002
   • Patch the config by the key: "/foo/config/all"
   • Done.   

$ tt cluster show http://localhost:2379/foo
credentials:
  users:
    guest:
      roles:
        - super
groups:
  group-001:
    replicasets:
      replicaset-001:
        instances:
          instance-001:
            iproto:
              listen:
                - uri: localhost:3301
          instance-002:
            iproto:
              listen: {}
```

Closes https://github.com/tarantool/tt/issues/318