### PR TITLE
ci: set tests timeout of self-hosted runners

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -116,6 +116,7 @@ jobs:
         github.event.action == 'synchronize' &&
         contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@master
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
         github.event.pull_request.head.repo.owner.login != 'tarantool' &&
         !contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
-
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
Sometimes tests may hang and block other jobs.
Set not too big timeout for the jobs to avoid blocking forever.

Closes #713