### PR TITLE
replicaset: prefer cartridge instances without critical issues during discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Built-in vshard cluster application template.
 
+### Changed
+
+- `tt replicaset`: prefer cartridge instances without critical issues on it during discovery.
+
 ## [2.1.1] - 2024-01-15
 
 ### Added

--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -26,7 +26,7 @@ func DiscoveryApplication(app running.RunningCtx,
 
 	switch orchestrator {
 	case OrchestratorCartridge:
-		return NewCartridgeApplication(app, nil).GetReplicasets()
+		return NewCartridgeApplication(app).GetReplicasets()
 	case OrchestratorCentralizedConfig:
 		return NewCConfigApplication(app).GetReplicasets()
 	case OrchestratorCustom:

--- a/cli/replicaset/lua/cartridge/get_topology_replicasets_body.lua
+++ b/cli/replicaset/lua/cartridge/get_topology_replicasets_body.lua
@@ -43,8 +43,20 @@ for _, replicaset in pairs(replicasets) do
 end
 
 local failover_params = require('cartridge').failover_get_params()
+local issues = require('cartridge.issues').list_on_cluster()
+local is_critical = false
+local uuid = box.info().uuid
+
+for _, issue in pairs(issues) do
+    if issue.level == 'critical' and issue.instance_uuid == uuid then
+        is_critical = true
+        break
+    end
+end
+
 return {
     failover = failover_params.mode,
     provider = failover_params.state_provider or "none",
     replicasets = topology_replicasets,
+    is_critical = is_critical,
 }


### PR DESCRIPTION
Now, discovery prefers instances without critical issues during search.

Currently, there is no way to determine whether an instance has been expelled from the replicaset. However, critical issues are likely to be the reason for expelling an instance. Also, expelling an instance leads to the critical issues with replication in some cases. Therefore, we can identify expelled instances based on indirect reasons.

Closes https://github.com/tarantool/tt/issues/747