### PR TITLE
search: sdk 3.0 was missing

### DIFF
--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -356,7 +356,7 @@ func SearchVersionsLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, pro
 
 // compileVersionRegexp compiles a regular expression for cutting version from SDK bundle names.
 func compileVersionRegexp() (*regexp.Regexp, error) {
-	matchRe := "^(?P<tarball>tarantool-enterprise-sdk-(?P<version>.*r[0-9]{3}).*\\.tar\\.gz)$"
+	matchRe := "^(?P<tarball>tarantool-enterprise-sdk-(?P<version>.*r[0-9]{1,3}).*\\.tar\\.gz)$"
 
 	re := regexp.MustCompile(matchRe)
 


### PR DESCRIPTION
Fix regular expression for cutting version from SDK bundle names. The revision number in 3.0 consists of two numbers.