### PR TITLE
rocks: fix macOs not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `tt replicaset`: prefer cartridge instances without critical issues on it during discovery.
 
+### Fixed
+
+- `tt rocks`: not working on macOs.
+
 ## [2.1.1] - 2024-01-15
 
 ### Added

--- a/cli/rocks/extra/macosx.lua
+++ b/cli/rocks/extra/macosx.lua
@@ -1,0 +1,7 @@
+-- It is a workaround for https://github.com/tarantool/tt/issues/640
+-- Probably won't be needed after these patches will go into release:
+-- https://github.com/yuin/gopher-lua/pull/456
+-- https://github.com/yuin/gopher-lua/pull/458
+-- Original macosx.lua is not needed for any luarocks operation.
+local macosx = {}
+return macosx

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -195,6 +195,7 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) err
 		"luarocks.tools.zip":               rocks_path + "luarocks/tools/zip.lua",
 		"luarocks.tools.tar":               rocks_path + "luarocks/tools/tar.lua",
 		"luarocks.fs.unix":                 rocks_path + "luarocks/fs/unix.lua",
+		"luarocks.fs.macosx":               extra_path + "macosx.lua",
 		"luarocks.fs.unix.tools":           rocks_path + "luarocks/fs/unix/tools.lua",
 		"luarocks.fs.lua":                  rocks_path + "luarocks/fs/lua.lua",
 		"luarocks.fs.tools":                rocks_path + "luarocks/fs/tools.lua",


### PR DESCRIPTION
Added workaround to fix crashes on macOS: override of macosx.lua. It is not needed
and is a cause of crashes on macOs.
This workaround is not perfect and can be removed later.

Closes #640