### PR TITLE
build: fix build on aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Built-in vshard cluster application template.
+- Building tt in Linux-aarch64, FreeBSD environments.
 
 ### Changed
 

--- a/cli/build/local.go
+++ b/cli/build/local.go
@@ -85,10 +85,10 @@ func buildLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, buildCtx *Bu
 		}
 		defer devNull.Close()
 
-		if err = syscall.Dup2(int(devNull.Fd()), syscall.Stdout); err != nil {
+		if err = Dup2(int(devNull.Fd()), syscall.Stdout); err != nil {
 			return err
 		}
-		defer syscall.Dup2(savedStdoutFd, syscall.Stdout)
+		defer Dup2(savedStdoutFd, syscall.Stdout)
 	}
 
 	rocksMakeCmd := []string{"make"}
@@ -98,7 +98,7 @@ func buildLocal(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, buildCtx *Bu
 	if err := rocks.Exec(cmdCtx, cliOpts, rocksMakeCmd); err != nil {
 		return err
 	}
-	if err := syscall.Dup2(savedStdoutFd, syscall.Stdout); err != nil {
+	if err := Dup2(savedStdoutFd, syscall.Stdout); err != nil {
 		return err
 	}
 

--- a/cli/build/syscall_wrapper_darwin.go
+++ b/cli/build/syscall_wrapper_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package build
+
+import (
+	"syscall"
+)
+
+func Dup2(oldfd int, newfd int) (err error) {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/cli/build/syscall_wrapper_freebsd.go
+++ b/cli/build/syscall_wrapper_freebsd.go
@@ -1,0 +1,11 @@
+//go:build freebsd
+
+package build
+
+import (
+	"syscall"
+)
+
+func Dup2(oldfd int, newfd int) (err error) {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/cli/build/syscall_wrapper_linux.go
+++ b/cli/build/syscall_wrapper_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package build
+
+import (
+	"syscall"
+)
+
+func Dup2(oldfd int, newfd int) (err error) {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/magefile.go
+++ b/magefile.go
@@ -371,7 +371,7 @@ func getDefaultConfigPath() string {
 	switch runtime.GOOS {
 	case "linux":
 		return defaultLinuxConfigPath
-	case "darwin":
+	case "darwin", "freebsd":
 		return defaultDarwinConfigPath
 
 	}


### PR DESCRIPTION
This patch fix build error:

cli/build/local.go:88:20: undefined: syscall.Dup2
cli/build/local.go:91:17: undefined: syscall.Dup2
cli/build/local.go:101:20: undefined: syscall.Dup2

syscall.Dup3 does not exists on darwin (OSX).
syscall.Dup2 does not exists on linux (aarch64).
    
So a syscall wrapper was added.

Part of #400