### PR TITLE
install: fix checkout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `tt rocks`: not working on macOs.
+- `tt install tarantool` fails due to checkout error.
 
 ## [2.1.1] - 2024-01-15
 


### PR DESCRIPTION
git checkout fails in tt install due to missing submodule. The solution is to checkout and init submodules separately.