### PR TITLE
cluster: bump yaml to v3 

### DIFF
--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/tarantool/go-tarantool"
 	"github.com/tarantool/tt/cli/connect"

--- a/cli/cluster/config_test.go
+++ b/cli/cluster/config_test.go
@@ -313,9 +313,9 @@ foo:
   bar: 1
   zoo: 1
 zoo:
-- "1"
-- "2"
-- "3"
+  - "1"
+  - "2"
+  - "3"
 `
 	assert.Equal(t, expected, config.String())
 }

--- a/cli/cluster/integration_test.go
+++ b/cli/cluster/integration_test.go
@@ -442,7 +442,7 @@ func TestGetClusterConfig_etcd(t *testing.T) {
 config:
   etcd:
     endpoints:
-    - http://127.0.0.1:12379
+      - http://127.0.0.1:12379
     http:
       request:
         timeout: 2.5
@@ -523,7 +523,7 @@ func TestGetClusterConfig_etcd_connect_from_env(t *testing.T) {
 config:
   etcd:
     endpoints:
-    - http://127.0.0.1:12379
+      - http://127.0.0.1:12379
     http:
       request:
         timeout: 2.5

--- a/cli/cluster/yaml.go
+++ b/cli/cluster/yaml.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/tarantool/tt/cli/integrity"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // YamlCollector collects a configuration from YAML data.

--- a/cli/cluster/yaml_test.go
+++ b/cli/cluster/yaml_test.go
@@ -274,9 +274,9 @@ func TestYamlConfigPublisher_Publish_publish_data(t *testing.T) {
 	assert.Equal(t, `foo: bar
 zoo:
   foo:
-  - 1
-  - 2
-  - 3
+    - 1
+    - 2
+    - 3
 `, string(input))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	google.golang.org/grpc v1.58.3
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -100,7 +101,6 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (

--- a/test/integration/cluster/test_cluster.py
+++ b/test/integration/cluster/test_cluster.py
@@ -15,13 +15,13 @@ test_simple_app_cfg = r"""groups:
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
           storage:
             database:
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3302
+                - uri: 127.0.0.1:3302
 """
 
 valid_cluster_cfg = r"""groups:
@@ -34,7 +34,7 @@ valid_cluster_cfg = r"""groups:
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
 """
 
 invalid_cluster_cfg = r"""groups:
@@ -47,21 +47,21 @@ invalid_cluster_cfg = r"""groups:
               mode: any
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
 """
 
 valid_instance_cfg = r"""database:
   mode: rw
 iproto:
   listen:
-  - uri: 127.0.0.1:3303
+    - uri: 127.0.0.1:3303
 """
 
 invalid_instance_cfg = r"""database:
   mode: any
 iproto:
   listen:
-  - uri: 127.0.0.1:3303
+    - uri: 127.0.0.1:3303
 """
 
 # The root user requires the least amount of steps to work.
@@ -226,7 +226,7 @@ def test_cluster_show_config_app_validate_error(tt_cmd, tmpdir_with_cfg):
               txn_timeout: asd
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
    ⨯ an invalid instance "master" configuration:"""
     expected += r""" invalid path "database.mode": value "rs" should be one of [ro rw]
 invalid path "database.txn_timeout": failed to parse value "asd" to type number
@@ -274,7 +274,7 @@ def test_cluster_show_config_app_instance(tt_cmd, tmpdir_with_cfg, app_name):
   mode: rw
 iproto:
   listen:
-  - uri: 127.0.0.1:3302
+    - uri: 127.0.0.1:3302
 """ in show_output
 
 
@@ -413,7 +413,7 @@ def test_cluster_show_config_etcd_cluster(tt_cmd, tmpdir_with_cfg, auth):
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
 """
     popen = etcd_start(endpoint, tmpdir)
     assert popen
@@ -477,7 +477,7 @@ def test_cluster_show_config_etcd_instance(tt_cmd, tmpdir_with_cfg):
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3301
+                - uri: 127.0.0.1:3301
 """)
         show_cmd = [tt_cmd, "cluster", "show",
                     f"{endpoint}/prefix?timeout=5&name=master"]
@@ -496,7 +496,7 @@ def test_cluster_show_config_etcd_instance(tt_cmd, tmpdir_with_cfg):
   mode: rw
 iproto:
   listen:
-  - uri: 127.0.0.1:3301
+    - uri: 127.0.0.1:3301
 """ in show_output
 
 
@@ -555,7 +555,7 @@ def test_cluster_show_config_etcd_key_instance(tt_cmd, tmpdir_with_cfg):
   mode: rw
 iproto:
   listen:
-  - uri: 127.0.0.1:3301
+    - uri: 127.0.0.1:3301
 """ in show_output
 
 
@@ -831,13 +831,13 @@ def test_cluster_publish_valid_instance(tt_cmd, tmpdir_with_cfg, app_name):
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3303
+                - uri: 127.0.0.1:3303
           storage:
             database:
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3302\n""" == uploaded
+                - uri: 127.0.0.1:3302\n""" == uploaded
 
 
 @pytest.mark.parametrize("app_name", ["test_simple_app", "testsimpleapp"])
@@ -903,13 +903,13 @@ def test_cluster_publish_invalid_instance_force(tt_cmd, tmpdir_with_cfg, app_nam
               mode: any
             iproto:
               listen:
-              - uri: 127.0.0.1:3303
+                - uri: 127.0.0.1:3303
           storage:
             database:
               mode: rw
             iproto:
               listen:
-              - uri: 127.0.0.1:3302\n""" == uploaded
+                - uri: 127.0.0.1:3302\n""" == uploaded
 
 
 def test_cluster_publish_config_etcd_not_exist(tt_cmd, tmpdir_with_cfg):


### PR DESCRIPTION
Since v2 has unexpected artifacts like `on/off` to bool parsing, let's bump this dependency as it was changed in the v3.

Since v3 can parse maps to `map[string|any]string` depending on the weather, let's get rid of ambiguities performing converting to the `map[any]any`.