### PR TITLE
cluster: support revision 

### DIFF
--- a/cli/cluster/cmd/publish.go
+++ b/cli/cluster/cmd/publish.go
@@ -55,7 +55,7 @@ func PublishUri(publishCtx PublishCtx, uri *url.URL) error {
 
 	if instance == "" {
 		// The easy case, just publish the configuration as is.
-		return publisher.Publish(publishCtx.Src)
+		return publisher.Publish(0, publishCtx.Src)
 	}
 
 	return replaceInstanceConfig(instance, publishCtx.Config, collector, publisher)
@@ -74,7 +74,7 @@ func PublishCluster(publishCtx PublishCtx, path, instance string) error {
 
 	if instance == "" {
 		// The easy case, just publish the configuration as is.
-		return publisher.Publish(publishCtx.Src)
+		return publisher.Publish(0, publishCtx.Src)
 	}
 
 	collector, err := publishCtx.Collectors.NewFile(path)

--- a/cli/cluster/file.go
+++ b/cli/cluster/file.go
@@ -55,7 +55,11 @@ func NewFileDataPublisher(path string) FileDataPublisher {
 }
 
 // Publish publishes the data to a file for the given path.
-func (publisher FileDataPublisher) Publish(data []byte) error {
+func (publisher FileDataPublisher) Publish(revision int64, data []byte) error {
+	if revision != 0 {
+		return fmt.Errorf("failed to publish data into file: target revision %d is not supported",
+			revision)
+	}
 	if publisher.path == "" {
 		return fmt.Errorf("file path is empty")
 	}

--- a/cli/cluster/file_test.go
+++ b/cli/cluster/file_test.go
@@ -64,20 +64,27 @@ func TestNewFileDataPublisher(t *testing.T) {
 }
 
 func TestFileDataPublisher_Publish_empty_path(t *testing.T) {
-	err := cluster.NewFileDataPublisher("").Publish([]byte{})
+	err := cluster.NewFileDataPublisher("").Publish(0, []byte{})
 
 	assert.EqualError(t, err, "file path is empty")
 }
 
 func TestFileDataPublisher_Publish_empty_data(t *testing.T) {
-	err := cluster.NewFileDataPublisher("foo").Publish(nil)
+	err := cluster.NewFileDataPublisher("foo").Publish(0, nil)
 
 	assert.EqualError(t, err,
 		"failed to publish data into \"foo\": data does not exist")
 }
 
+func TestFileDataPublisher_Publish_revision(t *testing.T) {
+	err := cluster.NewFileDataPublisher("foo").Publish(1, []byte{})
+
+	assert.EqualError(t, err,
+		"failed to publish data into file: target revision 1 is not supported")
+}
+
 func TestFileDataPublisher_Publish_error(t *testing.T) {
-	err := cluster.NewFileDataPublisher("/some/invalid/path").Publish([]byte{})
+	err := cluster.NewFileDataPublisher("/some/invalid/path").Publish(0, []byte{})
 
 	assert.Error(t, err)
 }
@@ -87,7 +94,7 @@ func TestFileDataPublisher_Publish_data(t *testing.T) {
 	path := filepath.Join(dir, "testfile")
 
 	data := []byte("foo")
-	err := cluster.NewFileDataPublisher(path).Publish(data)
+	err := cluster.NewFileDataPublisher(path).Publish(0, data)
 	require.NoError(t, err)
 
 	read, err := os.ReadFile(path)
@@ -110,7 +117,7 @@ func TestFileDataPublisher_Publish_data_exist_file(t *testing.T) {
 	originalMode := fi.Mode()
 
 	data := []byte("foo")
-	err = cluster.NewFileDataPublisher(path).Publish(data)
+	err = cluster.NewFileDataPublisher(path).Publish(0, data)
 	require.NoError(t, err)
 
 	read, err := os.ReadFile(path)

--- a/cli/cluster/tarantool_test.go
+++ b/cli/cluster/tarantool_test.go
@@ -43,6 +43,13 @@ func TestNewTarantoolDataPublishers(t *testing.T) {
 	}
 }
 
+func TestAllTarantoolDataPublisher_Publish_revision(t *testing.T) {
+	publisher := cluster.NewTarantoolAllDataPublisher(nil, "", 0)
+	err := publisher.Publish(1, []byte{})
+	assert.EqualError(
+		t, err, "failed to publish data into tarantool: target revision 1 is not supported")
+}
+
 func TestNewTarantoolDataPublishers_Publish_nil_evaler(t *testing.T) {
 	cases := []struct {
 		Name      string
@@ -55,7 +62,7 @@ func TestNewTarantoolDataPublishers_Publish_nil_evaler(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			assert.Panics(t, func() {
-				tc.Publisher.Publish([]byte{})
+				tc.Publisher.Publish(0, []byte{})
 			})
 		})
 	}

--- a/cli/cluster/yaml.go
+++ b/cli/cluster/yaml.go
@@ -86,5 +86,5 @@ func (publisher YamlConfigPublisher) Publish(config *Config) error {
 		return fmt.Errorf("config does not exist")
 	}
 
-	return publisher.publisher.Publish([]byte(config.String()))
+	return publisher.publisher.Publish(0, []byte(config.String()))
 }

--- a/cli/cluster/yaml_test.go
+++ b/cli/cluster/yaml_test.go
@@ -230,10 +230,10 @@ func TestYamlCollectorDecorator_unique(t *testing.T) {
 	assert.Error(t, err)
 }
 
-type dataPublishFunc func(data []byte) error
+type dataPublishFunc func(revision int64, data []byte) error
 
-func (f dataPublishFunc) Publish(data []byte) error {
-	return f(data)
+func (f dataPublishFunc) Publish(revision int64, data []byte) error {
+	return f(revision, data)
 }
 
 func TestNewYamlConfigPublisher(t *testing.T) {
@@ -261,7 +261,7 @@ func TestYamlConfigPublisher_Publish_nil_config(t *testing.T) {
 func TestYamlConfigPublisher_Publish_publish_data(t *testing.T) {
 	var input []byte
 	publisher := cluster.NewYamlConfigPublisher(dataPublishFunc(
-		func(data []byte) error {
+		func(revision int64, data []byte) error {
 			input = data
 			return nil
 		}))
@@ -283,7 +283,7 @@ zoo:
 func TestYamlConfigPublisher_Publish_error(t *testing.T) {
 	err := fmt.Errorf("any")
 	publisher := cluster.NewYamlConfigPublisher(dataPublishFunc(
-		func([]byte) error {
+		func(int64, []byte) error {
 			return err
 		}))
 	config := cluster.NewConfig()

--- a/cli/integrity/datacollector.go
+++ b/cli/integrity/datacollector.go
@@ -13,6 +13,8 @@ type Data struct {
 	Source string
 	// Value is data collected.
 	Value []byte
+	// Revision is data revision.
+	Revision int64
 }
 
 // DataCollector interface must be implemented by a source collector.

--- a/cli/integrity/datapublisher.go
+++ b/cli/integrity/datapublisher.go
@@ -10,7 +10,7 @@ import (
 // DataPublisher interface must be implemented by a raw data publisher.
 type DataPublisher interface {
 	// Publish publishes the interface or returns an error.
-	Publish(data []byte) error
+	Publish(revision int64, data []byte) error
 }
 
 // Data publisher factory creates new data publishers.

--- a/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
+++ b/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
@@ -14,7 +14,7 @@ local replicaset = {
     leaderuuid = leader_uuid,
     instances = {},
     instanceuuid = box_info.uuid,
-    instancerw = box.cfg.read_only == false,
+    instancerw = box.info.ro == false,
 }
 
 for _, instance in ipairs(box_info.replication) do


### PR DESCRIPTION
This patch introduces several changes:

* add `mod_revision` field support to the cluster etcd/tcs publishers/collectors.

* fix a bug with tcs response decoding.

* use the option `box.info.ro` instead of the `box.cfg.read_only` to determine instance mode.

Part of https://github.com/tarantool/tt/issues/315