### PR TITLE
start: repairing instance launch on freebsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `tt start`: not working on FreeBSD.
+
 ## [2.1.2] - 2024-02-02
 
 ### Added

--- a/cli/running/lua/launcher.lua
+++ b/cli/running/lua/launcher.lua
@@ -247,7 +247,7 @@ local function start_instance()
         void setlinebuf(FILE *stream);
     ]])
 
-    if jit.os == 'OSX' then
+    if jit.os == 'OSX' or jit.os == 'BSD' then
         ffi.cdef([[
             FILE *__stdoutp;
         ]])


### PR DESCRIPTION
This patch fixes the `tt start` bug on FreeBSD:
`LuajitError: stdin:259: Undefined symbol "stdout"`