### PR TITLE
Update help for `create` ang `completion` commands.

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -25,6 +25,10 @@ func NewCompletionCmd() *cobra.Command {
 			handleCmdErr(cmd, err)
 		},
 		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Example: `
+# Enable auto-completion in current bash shell.
+
+    $ . <(tt completion bash)`,
 	}
 
 	return cmd

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -47,7 +47,8 @@ func NewCreateCmd() *cobra.Command {
 		Long: `Create an application from a template.
 
 Built-in templates:
-	cartridge: a simple Cartridge application.`,
+	cartridge: a simple Cartridge application.
+	vshard_cluster: Tarantool 3 vshard cluster application.`,
 		Example: `
 # Create an application app1 from a template.
 
@@ -57,7 +58,11 @@ Built-in templates:
 # (cartridge_app) if it exists. ` +
 			`User interaction is disabled.
 
-    $ tt create cartridge --name cartridge_app -f --non-interactive --dst /opt/tt/apps/`,
+    $ tt create cartridge --name cartridge_app -f --non-interactive --dst /opt/tt/apps/
+
+# Create Tarantool 3 vshard cluster.
+
+    $ tt create vshard_cluster --name cluster_app`,
 	}
 
 	createCmd.Flags().StringVarP(&appName, "name", "n", "", "Application name")


### PR DESCRIPTION
- Added `vshard_cluster` template  info for `create` command.
- Added an example of enabling bash completion for `completion` command.