### PR TITLE
ci: remove installing python form ci on macOS

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -185,7 +185,6 @@ jobs:
       - name: Install dependencies
         run: |
           brew install --overwrite go mage
-          brew install python3
           pip3 install -r test/requirements.txt
 
       - name: Build tt


### PR DESCRIPTION
This patch remove installing python on macOS because it broke running tests. On macOS already installed python 3.9.