### PR TITLE
cluster: some improvements 

### DIFF
--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -479,7 +479,7 @@ func mapValuesFromConfig[T any](cfg *libcluster.Config, mapFunc func(val T) (T, 
 	for _, cfgMapping := range maps {
 		value, err := cfg.Get(cfgMapping.path)
 		if err != nil {
-			var eNotExist *libcluster.NotExistError
+			var eNotExist libcluster.NotExistError
 			if errors.As(err, &eNotExist) {
 				continue
 			} else {

--- a/lib/cluster/config.go
+++ b/lib/cluster/config.go
@@ -80,7 +80,7 @@ func (config *Config) getMap(path []string) (map[any]any, error) {
 			return nil, fmt.Errorf(fmtPathNotMap, path[0:i])
 		} else if i < len(path) {
 			if _, ok := m[path[i]]; !ok {
-				return nil, &NotExistError{path[0 : i+1]}
+				return nil, NotExistError{path[0 : i+1]}
 			} else {
 				currentValue = m[path[i]]
 			}

--- a/lib/cluster/config_test.go
+++ b/lib/cluster/config_test.go
@@ -93,19 +93,25 @@ func TestConfig_Set_intersection(t *testing.T) {
 }
 
 func TestConfig_Get_non_exist(t *testing.T) {
-	paths := [][]string{
-		[]string{"foo"},
-		[]string{"zoo", "bar"},
+	cases := []struct {
+		path    []string
+		errPath []string
+	}{
+		{[]string{"foo"}, []string{"foo"}},
+		{[]string{"zoo", "bar"}, []string{"zoo", "bar"}},
+		{[]string{"baz", "zoo", "bar"}, []string{"baz", "zoo"}},
 	}
 
 	c := cluster.NewConfig()
 	err := c.Set([]string{"zoo", "foo"}, 1)
 	require.NoError(t, err)
+	err = c.Set([]string{"baz"}, map[any]any{})
+	require.NoError(t, err)
 
-	for _, p := range paths {
-		t.Run(fmt.Sprintf("%v", p), func(t *testing.T) {
-			_, err := c.Get(p)
-			expected := fmt.Sprintf("path %q does not exist", p)
+	for _, p := range cases {
+		t.Run(fmt.Sprintf("%v", p.path), func(t *testing.T) {
+			_, err := c.Get(p.path)
+			expected := fmt.Sprintf("path %q does not exist", p.errPath)
 			require.EqualError(t, err, expected)
 			require.ErrorAs(t, err, &cluster.NotExistError{})
 		})

--- a/lib/cluster/storages.go
+++ b/lib/cluster/storages.go
@@ -53,3 +53,13 @@ func parseHashPath(path, prefix string) (bool, string, string) {
 
 	return true, split[0], split[1]
 }
+
+// GetStorageKey extracts the key from the source that contains the config prefix.
+func GetStorageKey(prefix, source string) (string, error) {
+	cfgPrefix := getConfigPrefix(prefix)
+	key, ok := strings.CutPrefix(source, cfgPrefix)
+	if !ok {
+		return "", fmt.Errorf("source must begin with: %s", cfgPrefix)
+	}
+	return key, nil
+}

--- a/lib/cluster/storages_test.go
+++ b/lib/cluster/storages_test.go
@@ -1,0 +1,33 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/cluster"
+)
+
+func TestStorage_GetStorageKey(t *testing.T) {
+	cases := []struct {
+		prefix string
+		source string
+		key    string
+		err    string
+	}{
+		{"/foo", "/foo/config/all", "all", ""},
+		{"/foo/", "/foo/config/all", "all", ""},
+		{"/foo///", "/foo/config/all", "all", ""},
+		{"/foo", "/bar/config/all", "", "source must begin with: /foo/config/"},
+	}
+	for _, cs := range cases {
+		t.Run(cs.source, func(t *testing.T) {
+			key, err := cluster.GetStorageKey(cs.prefix, cs.source)
+			if cs.err != "" {
+				require.EqualError(t, err, cs.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, cs.key, key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch makes the handling of cluster.NotExistError unambiguous. There is one place where we return it by pointer, while in other places it's returned by value. Let's always return it by value.

Also, adds an ability to extract key from the config source. This will be convenient if, after retrieving keys using the DataCollector, we want to upload them back.