### PR TITLE
pack: unit test refactor

### DIFF
--- a/cli/pack/systemd_dir_test.go
+++ b/cli/pack/systemd_dir_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/otiai10/copy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/configure"
-	"github.com/tarantool/tt/cli/pack/test_helpers"
 	"github.com/tarantool/tt/cli/running"
 )
 
@@ -30,18 +28,12 @@ func compareFiles(t *testing.T, resultFile string, expectedFile string) {
 }
 
 func Test_initSystemdDir(t *testing.T) {
-	baseTestDir := t.TempDir()
-
 	prefixToUnit := filepath.Join("usr", "lib", "systemd", "system")
 	fakeCfgPath := "/path/to/cfg"
 
 	var (
-		test1Dir        = "test_default_template_values"
-		test2Dir        = "test_default_template_partly_defined_values"
-		test3Dir        = "test_default_template_fully_defined_values"
-		testMultiAppDir = "test_multi_app_env"
-		appDir          = "app"
-		appsInfo        = map[string][]running.InstanceCtx{
+		appDir   = "app"
+		appsInfo = map[string][]running.InstanceCtx{
 			"app": {
 				running.InstanceCtx{
 					AppName:   "app",
@@ -50,49 +42,24 @@ func Test_initSystemdDir(t *testing.T) {
 			},
 		}
 	)
-	testDirs := []string{
-		filepath.Join(test1Dir, appDir),
-		filepath.Join(test2Dir, appDir),
-		filepath.Join(test3Dir, appDir),
-		testMultiAppDir,
-	}
-
-	err := test_helpers.CreateDirs(baseTestDir, testDirs)
-	require.NoError(t, err)
-
-	require.NoError(t, copy.Copy(filepath.Join("testdata", "partly-defined-params.yaml"),
-		filepath.Join(baseTestDir, test2Dir, "partly-defined-params.yaml")))
-	require.NoError(t, copy.Copy(filepath.Join("testdata", "fully-defined-params.yaml"),
-		filepath.Join(baseTestDir, test3Dir, "fully-defined-params.yaml")))
-
-	require.NoError(t, copy.Copy(filepath.Join("testdata", "expected-unit-content-1.txt"),
-		filepath.Join(baseTestDir, test1Dir, prefixToUnit, "expected-unit-content-1.txt")))
-	require.NoError(t, copy.Copy(filepath.Join("testdata", "expected-unit-content-2.txt"),
-		filepath.Join(baseTestDir, test2Dir, prefixToUnit, "expected-unit-content-2.txt")))
-	require.NoError(t, copy.Copy(filepath.Join("testdata", "expected-unit-content-3.txt"),
-		filepath.Join(baseTestDir, test3Dir, prefixToUnit, "expected-unit-content-3.txt")))
 
 	type args struct {
-		baseDirPath string
-		pathToEnv   string
-		opts        *config.CliOpts
-		packCtx     *PackCtx
+		pathToEnv string
+		opts      *config.CliOpts
+		packCtx   *PackCtx
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr assert.ErrorAssertionFunc
-		check   func() error
+		check   func(baseTestDir string) error
 	}{
 		{
 			name: "Default template and values test 1",
 			args: args{
-				baseDirPath: filepath.Join(baseTestDir, test1Dir),
-				pathToEnv:   fakeCfgPath,
+				pathToEnv: fakeCfgPath,
 				opts: &config.CliOpts{
-					Env: &config.TtEnvOpts{
-						InstancesEnabled: filepath.Join(baseTestDir, test1Dir),
-					},
+					Env: &config.TtEnvOpts{},
 				},
 				packCtx: &PackCtx{
 					Name:     "pack",
@@ -100,85 +67,67 @@ func Test_initSystemdDir(t *testing.T) {
 					AppsInfo: appsInfo,
 				},
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return err == nil
-			},
-			check: func() error {
-				compareFiles(t, filepath.Join(baseTestDir, test1Dir, prefixToUnit, "app@.service"),
-					filepath.Join(baseTestDir, test1Dir, prefixToUnit,
-						"expected-unit-content-1.txt"))
+			wantErr: assert.NoError,
+			check: func(baseTestDir string) error {
+				compareFiles(t, filepath.Join(baseTestDir, prefixToUnit, "app@.service"),
+					filepath.Join("testdata", "expected-unit-content-1.txt"))
 				return nil
 			},
 		},
 		{
 			name: "Default template and partly defined values test 2",
 			args: args{
-				baseDirPath: filepath.Join(baseTestDir, test2Dir),
-				pathToEnv:   fakeCfgPath,
+				pathToEnv: fakeCfgPath,
 				opts: &config.CliOpts{
-					Env: &config.TtEnvOpts{
-						InstancesEnabled: filepath.Join(baseTestDir, test2Dir),
-					},
+					Env: &config.TtEnvOpts{},
 				},
 				packCtx: &PackCtx{
 					Name:    "pack",
 					AppList: []string{appDir},
 					RpmDeb: RpmDebCtx{
-						SystemdUnitParamsFile: filepath.Join(baseTestDir,
-							test2Dir, "partly-defined-params.yaml"),
+						SystemdUnitParamsFile: filepath.Join("testdata",
+							"partly-defined-params.yaml"),
 					},
 					AppsInfo: appsInfo,
 				},
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return err == nil
-			},
-			check: func() error {
-				compareFiles(t, filepath.Join(baseTestDir, test2Dir, prefixToUnit, "app@.service"),
-					filepath.Join(baseTestDir, test2Dir, prefixToUnit,
-						"expected-unit-content-2.txt"))
+			wantErr: assert.NoError,
+			check: func(baseTestDir string) error {
+				compareFiles(t, filepath.Join(baseTestDir, prefixToUnit, "app@.service"),
+					filepath.Join("testdata", "expected-unit-content-2.txt"))
 				return nil
 			},
 		},
 		{
 			name: "Default template and fully defined values test 3",
 			args: args{
-				baseDirPath: filepath.Join(baseTestDir, test3Dir),
-				pathToEnv:   fakeCfgPath,
+				pathToEnv: fakeCfgPath,
 				opts: &config.CliOpts{
-					Env: &config.TtEnvOpts{
-						InstancesEnabled: filepath.Join(baseTestDir, test3Dir),
-					},
+					Env: &config.TtEnvOpts{},
 				},
 				packCtx: &PackCtx{
 					Name:    "pack",
 					AppList: []string{appDir},
 					RpmDeb: RpmDebCtx{
-						SystemdUnitParamsFile: filepath.Join(baseTestDir,
-							test3Dir, "fully-defined-params.yaml"),
+						SystemdUnitParamsFile: filepath.Join("testdata",
+							"fully-defined-params.yaml"),
 					},
 					AppsInfo: appsInfo,
 				},
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return err == nil
-			},
-			check: func() error {
-				compareFiles(t, filepath.Join(baseTestDir, test3Dir, prefixToUnit, "app@.service"),
-					filepath.Join(baseTestDir, test3Dir, prefixToUnit,
-						"expected-unit-content-3.txt"))
+			wantErr: assert.NoError,
+			check: func(baseTestDir string) error {
+				compareFiles(t, filepath.Join(baseTestDir, prefixToUnit, "app@.service"),
+					filepath.Join("testdata", "expected-unit-content-3.txt"))
 				return nil
 			},
 		},
 		{
 			name: "Systemd units generation for multiple applications env",
 			args: args{
-				baseDirPath: filepath.Join(baseTestDir, testMultiAppDir),
-				pathToEnv:   fakeCfgPath,
+				pathToEnv: fakeCfgPath,
 				opts: &config.CliOpts{
-					Env: &config.TtEnvOpts{
-						InstancesEnabled: filepath.Join(baseTestDir, test3Dir),
-					},
+					Env: &config.TtEnvOpts{},
 				},
 				packCtx: &PackCtx{
 					Name:    "pack",
@@ -199,10 +148,8 @@ func Test_initSystemdDir(t *testing.T) {
 					},
 				},
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return err == nil
-			},
-			check: func() error {
+			wantErr: assert.NoError,
+			check: func(baseTestDir string) error {
 				unitTemplate, err := template.ParseFiles("templates/app-inst-unit-template.txt")
 				require.NoError(t, err)
 				// app1 systemd unit check.
@@ -216,8 +163,7 @@ func Test_initSystemdDir(t *testing.T) {
 				strBuilder := strings.Builder{}
 				unitTemplate.Execute(&strBuilder, appInstData)
 
-				buf, err := os.ReadFile(filepath.Join(baseTestDir, testMultiAppDir, prefixToUnit,
-					"app1@.service"))
+				buf, err := os.ReadFile(filepath.Join(baseTestDir, prefixToUnit, "app1@.service"))
 				require.NoError(t, err)
 				actualContent := string(buf)
 				assert.Equal(t, strBuilder.String(), actualContent)
@@ -228,8 +174,7 @@ func Test_initSystemdDir(t *testing.T) {
 				strBuilder.Reset()
 				unitTemplate.Execute(&strBuilder, appInstData)
 				// app2 is single instance app, so unit file is not template unit file.
-				buf, err = os.ReadFile(filepath.Join(baseTestDir, testMultiAppDir, prefixToUnit,
-					"app2.service"))
+				buf, err = os.ReadFile(filepath.Join(baseTestDir, prefixToUnit, "app2.service"))
 				require.NoError(t, err)
 				actualContent = string(buf)
 				assert.Equal(t, strBuilder.String(), actualContent)
@@ -240,12 +185,14 @@ func Test_initSystemdDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.wantErr(t, initSystemdDir(tt.args.packCtx, tt.args.opts,
-				tt.args.baseDirPath, tt.args.pathToEnv),
-				fmt.Sprintf("initSystemdDir(%v, %v, %v, %v)",
-					tt.args.baseDirPath, tt.args.pathToEnv, tt.args.opts, tt.args.packCtx))
+			baseTestDir := t.TempDir()
+			tt.args.opts.Env.InstancesEnabled = baseTestDir
+			tt.wantErr(t, initSystemdDir(tt.args.packCtx, tt.args.opts, baseTestDir,
+				tt.args.pathToEnv),
+				fmt.Sprintf("initSystemdDir(%v, %v, %v, %v)", baseTestDir, tt.args.pathToEnv,
+					tt.args.opts, tt.args.packCtx))
 
-			assert.NoError(t, tt.check())
+			assert.NoError(t, tt.check(baseTestDir))
 		})
 	}
 }


### PR DESCRIPTION
Remove unnecessary files copying, directories creation. Replace wanterr check with existing `NoError` function.