### PR TITLE
cd: add publishing to universal static repo

### DIFF
--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -33,6 +33,9 @@ var targetDistros = []Distro{
 	{OS: "debian", Dist: "stretch"},  // 9
 	{OS: "debian", Dist: "buster"},   // 10
 	{OS: "debian", Dist: "bullseye"}, // 11
+
+	{OS: "linux-deb", Dist: "static"},
+	{OS: "linux-rpm", Dist: "static"},
 }
 
 // walkMatch walks through directory and collects file paths satisfying patterns.
@@ -70,11 +73,11 @@ func walkMatch(root string, patterns []string) ([]string, error) {
 // getPatterns returns patterns to select goreleaser build artifacts.
 func getPatterns(distro Distro) ([]string, error) {
 
-	if distro.OS == "el" || distro.OS == "fedora" {
-		return []string{"*.rpm", "*.noarch.rpm"}, nil
+	if distro.OS == "el" || distro.OS == "fedora" || distro.OS == "linux-rpm" {
+		return []string{"*.rpm"}, nil
 	}
 
-	if distro.OS == "ubuntu" || distro.OS == "debian" {
+	if distro.OS == "ubuntu" || distro.OS == "debian" || distro.OS == "linux-deb"{
 		return []string{"*.deb", "*.dsc"}, nil
 	}
 


### PR DESCRIPTION
Because we are using a universal static repo for tarantool since 3.0
version, we need to publish `tt` to simular repo. It helps us avoid
a lot of problems with supporting OS and their versions.

Related https://github.com/tarantool/installer.sh/issues/36