### PR TITLE
doc: add a note about box.cfg.background usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Tarantool-based applications.
   * [Setting Tarantool configuration parameters via environment variables](#setting-tarantool-configuration-parameters-via-environment-variables)
   * [Add current environment binaries location to the PATH variable](#add-current-environment-binaries-location-to-the-path-variable)
 * [Migration from older TT versions](doc/migration_from_older_versions.md)
+* [Known issues](doc/known_issues.md)
 * [Commands](#commands)
 
 ## Intro

--- a/doc/known_issues.md
+++ b/doc/known_issues.md
@@ -1,0 +1,22 @@
+# Known issues
+
+The file includes built-in errors we expect people to encounter and common
+problems reported by users. For the latest list of all issues see
+the [Github Issues page](https://github.com/tarantool/tt/issues).
+
+## Contents
+
+* [Do not set the box.cfg.background](#do-not-set-the-boxcfgbackground)
+
+## Do not set the box.cfg.background
+
+`tt start` daemonizes a Tarantool process itself. The [box.cfg.background
+setting][cfg-background] does the same thing from a Tarantool process. These
+features conflict with each other. As a result, `tt status` shows an invalid
+status of a Tarantool instance, and it is unable to stop the instance
+with `tt stop`.
+
+You should never set `box.cfg.background = true` in an application code that
+is started by `tt`.
+
+[cfg-background]: https://www.tarantool.io/en/doc/latest/reference/configuration/#confval-background


### PR DESCRIPTION
@TarantoolBot document
Title: User should not to set `box.cfg.background = true` with `tt start`

`tt start` daemonizes a Tarantool process itself. The `box.cfg.background` setting does the same thing from a Tarantool process. These features conflict with each other. As a result, `tt status` shows an invalid status of a Tarantool instance, and it is unable to stop the instance with `tt stop`.

A user should never set `box.cfg.backround = true` in an application code that is started by `tt`.

Closes #780