### PR TITLE
test: remove not-needed code from cartridge test

### DIFF
--- a/test/integration/cartridge/test_cartridge.py
+++ b/test/integration/cartridge/test_cartridge.py
@@ -54,16 +54,13 @@ def test_cartridge_base_functionality(tt_cmd, tmpdir_with_cfg):
     assert build_rc == 0
     assert re.search(r'Application was successfully built', build_out)
 
-    test_env = os.environ.copy()
-    test_env['TT_LISTEN'] = ''
     start_cmd = [tt_cmd, "start", cartridge_name]
     subprocess.Popen(
         start_cmd,
         cwd=tmpdir,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        text=True,
-        env=test_env
+        text=True
     )
 
     instances = ["router", "stateboard", "s1-master", "s1-replica", "s2-master", "s2-replica"]
@@ -177,16 +174,13 @@ def test_cartridge_base_functionality_in_app_dir(tt_cmd, tmpdir_with_cfg):
     assert rc == 0
     assert 'Application was successfully built' in out
 
-    test_env = os.environ.copy()
-    test_env['TT_LISTEN'] = ''
     cmd = [tt_cmd, "start"]
     subprocess.Popen(
         cmd,
         cwd=app_dir,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        text=True,
-        env=test_env
+        text=True
     )
 
     instances = ["router", "stateboard", "s1-master", "s1-replica", "s2-master", "s2-replica"]


### PR DESCRIPTION
Removed not-needed code from cartridge integration testing.

Follow up #574