### PR TITLE
replicaset: add `expel` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  cluster config (3.0) or cartridge orchestrator.
 - `tt replicaset demote`: command to demote an instance in the tarantool replicaset with
  cluster config (3.0) orchestrator.
+- `tt replicaset expel`:  command to expel an instance from the tarantool replicaset with
+ cluster config (3.0) or cartridge orchestrator.
 - `tt cluster replicaset`: module to manage replicaset via 3.0 cluster config storage.
   * `tt cluster replicaset promote`: command to promote an instance in the replicaset.
   * `tt cluster replicaset demote`: command to demote an instance in the replicaset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt cluster replicaset`: module to manage replicaset via 3.0 cluster config storage.
   * `tt cluster replicaset promote`: command to promote an instance in the replicaset.
   * `tt cluster replicaset demote`: command to demote an instance in the replicaset.
+  * `tt cluster replicaset expel`: command to expel an instance from the replicaset.
 - `tt connect --binary`: connect to instance using binary port.
 - `tt kill`: command to stop instance(s) with SIGQUIT and SIGKILL signals.
 

--- a/cli/cluster/cmd/replicaset.go
+++ b/cli/cluster/cmd/replicaset.go
@@ -93,7 +93,7 @@ func pickPatchKey(keys []string, force bool) (int, error) {
 			return 0, err
 		}
 	}
-	log.Infof("Patch the config by the key: %q", keys[pos])
+	log.Infof("Patching the config by the key: %q", keys[pos])
 	return pos, nil
 }
 
@@ -214,6 +214,52 @@ func Demote(uri *url.URL, ctx DemoteCtx) error {
 	source := replicaset.NewCConfigSource(collector, publisher,
 		replicaset.KeyPicker(pickPatchKey))
 	err = source.Demote(replicaset.DemoteCtx{
+		InstName: ctx.InstName,
+		Force:    ctx.Force,
+	})
+	if err == nil {
+		log.Info("Done.")
+	}
+	return err
+}
+
+// ExpelCtx describes the context to expel an instance.
+type ExpelCtx struct {
+	// InstName is an instance name to demote.
+	InstName string
+	// Publishers is data publisher factory.
+	Publishers libcluster.DataPublisherFactory
+	// Collectors is data collector factory.
+	Collectors libcluster.DataCollectorFactory
+	// Username defines a username for connection.
+	Username string
+	// Password defines a password for connection.
+	Password string
+	// Force true if the key selection for patching the config
+	// should be skipped.
+	Force bool
+}
+
+// Expel expels an instance by patching the cluster config.
+func Expel(uri *url.URL, ctx ExpelCtx) error {
+	opts, err := ParseUriOpts(uri)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", uri, err)
+	}
+	connOpts := connectOpts{
+		Username: ctx.Username,
+		Password: ctx.Password,
+	}
+
+	collector, publisher, closeFunc, err := createDataCollectorAndKeyPublisher(
+		ctx.Collectors, ctx.Publishers, opts, connOpts)
+	if err != nil {
+		return err
+	}
+	defer closeFunc()
+	source := replicaset.NewCConfigSource(collector, publisher,
+		replicaset.KeyPicker(pickPatchKey))
+	err = source.Expel(replicaset.ExpelCtx{
 		InstName: ctx.InstName,
 		Force:    ctx.Force,
 	})

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -21,6 +21,9 @@ var (
 	//go:embed lua/cartridge/edit_replicasets_body.lua
 	cartridgeEditReplicasetsBody string
 
+	//go:embed lua/cartridge/edit_instances_body.lua
+	cartridgeEditInstancesBody string
+
 	//go:embed lua/cartridge/failover_promote_body.lua
 	cartridgeFailoverPromoteBody string
 
@@ -268,7 +271,29 @@ func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 
 // Expel expels an instance from a Cartridge replicasets.
 func (c *CartridgeApplication) Expel(ctx ExpelCtx) error {
-	return newErrExpelByAppNotSupported(OrchestratorCartridge)
+	replicasets, err := c.Discovery()
+	if err != nil {
+		return fmt.Errorf("failed to discovery: %w", err)
+	}
+
+	var (
+		uuid  string
+		found bool
+	)
+	for _, replicaset := range replicasets.Replicasets {
+		for _, instance := range replicaset.Instances {
+			if instance.Alias == ctx.InstName {
+				uuid = instance.UUID
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("instance %q not found in a configured replicaset", ctx.InstName)
+	}
+
+	return cartridgeExpel(c.runningCtx, replicasets, ctx.InstName, uuid, ctx.Timeout)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.
@@ -385,6 +410,18 @@ type cartridgeEditReplicasetsOpts struct {
 	FailoverPriority []string `msgpack:"failover_priority,omitempty"`
 }
 
+// cartridgeEditInstancesOpts describes options for instances editing.
+type cartridgeEditInstancesOpts struct {
+	URI        *string  `msgpack:"uri,omitempty"`
+	UUID       *string  `msgpack:"uuid,omitempty"`
+	Zone       *string  `msgpack:"zone,omitempty"`
+	Labels     []string `msgpack:"labels,omitempty"`
+	Disabled   *bool    `msgpack:"disabled,omitempty"`
+	Electable  *bool    `msgpack:"electable,omitempty"`
+	Rebalancer *bool    `msgpack:"rebalancer,omitempty"`
+	Expelled   *bool    `msgpack:"expelled,omitempty"`
+}
+
 // cartridgeWaitHealthy waits until the cluster becomes healthy.
 func cartridgeWaitHealthy(evaler connector.Evaler, timeout int) error {
 	var reqOpts connector.RequestOpts
@@ -402,6 +439,26 @@ func cartridgeEditReplicasets(evaler connector.Evaler,
 	args := []any{opts}
 	if _, err := evaler.Eval(cartridgeEditReplicasetsBody, args, reqOpts); err != nil {
 		return fmt.Errorf("failed to edit replicasets: %w", err)
+	}
+	healthCheckIsNeeded, err := cartridgeHealthCheckIsNeeded(evaler)
+	if err != nil {
+		return err
+	}
+	if healthCheckIsNeeded {
+		if err := cartridgeWaitHealthy(evaler, timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cartridgeEditInstances edits instances in the cartridge app.
+func cartridgeEditInstances(evaler connector.Evaler,
+	opts []cartridgeEditInstancesOpts, timeout int) error {
+	var reqOpts connector.RequestOpts
+	args := []any{opts}
+	if _, err := evaler.Eval(cartridgeEditInstancesBody, args, reqOpts); err != nil {
+		return fmt.Errorf("failed to edit instances: %w", err)
 	}
 	healthCheckIsNeeded, err := cartridgeHealthCheckIsNeeded(evaler)
 	if err != nil {
@@ -464,4 +521,45 @@ func cartridgePromote(evaler connector.Evaler,
 		return fmt.Errorf("unexpected failover")
 	}
 	return waitRW(evaler, timeout)
+}
+
+// cartridgeExpel expels an instance from the replicaset.
+func cartridgeExpel(runningCtx running.RunningCtx,
+	discovered Replicasets, name, uuid string, timeout int) error {
+
+	found := false
+	var lastErr error
+	eval := func(instance running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+		if instance.InstName == name {
+			return false, nil
+		}
+		found = true
+		expelled := true
+		opts := cartridgeEditInstancesOpts{
+			UUID:     &uuid,
+			Expelled: &expelled,
+		}
+		err := cartridgeEditInstances(evaler, []cartridgeEditInstancesOpts{opts}, timeout)
+		if err != nil {
+			// Try again with another instance.
+			lastErr = err
+			return false, nil
+		}
+
+		lastErr = nil
+		return true, nil
+	}
+
+	err := EvalForeachAliveDiscovered(runningCtx.Instances, discovered, InstanceEvalFunc(eval))
+	for _, e := range []error{err, lastErr} {
+		if e != nil {
+			return fmt.Errorf("failed to expel instance: %w", e)
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("not found any other instance joined to cluster")
+	}
+
+	return nil
 }

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -50,6 +50,7 @@ type cartridgeTopology struct {
 
 // CartridgeInstance is an instance with the Cartridge orchestrator.
 type CartridgeInstance struct {
+	cachedDiscoverer
 	evaler connector.Evaler
 }
 
@@ -62,9 +63,11 @@ type cartridgeInstance struct {
 
 // NewCartridgeInstance creates a new CartridgeInstance object for the evaler.
 func NewCartridgeInstance(evaler connector.Evaler) *CartridgeInstance {
-	return &CartridgeInstance{
+	inst := &CartridgeInstance{
 		evaler: evaler,
 	}
+	inst.discoverer = inst
+	return inst
 }
 
 // getCartridgeTopology returns a cartridge topology received from an instance.
@@ -110,7 +113,7 @@ func getCartridgeReplicasets(topology cartridgeTopology) Replicasets {
 
 // Promote promotes a cartridge instance.
 func (c *CartridgeInstance) Promote(ctx PromoteCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(UseCache)
 	if err != nil {
 		return err
 	}
@@ -145,9 +148,9 @@ func (c *CartridgeInstance) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByInstanceNotSupported(OrchestratorCartridge)
 }
 
-// GetReplicasets returns a replicaset topology for a single instance with the
+// discovery returns a replicaset topology for a single instance with the
 // Cartridge orchestrator.
-func (c *CartridgeInstance) Discovery() (Replicasets, error) {
+func (c *CartridgeInstance) discovery() (Replicasets, error) {
 	replicasets := Replicasets{
 		State:        StateUnknown,
 		Orchestrator: OrchestratorCartridge,
@@ -174,19 +177,22 @@ func (c *CartridgeInstance) Expel(ctx ExpelCtx) error {
 
 // CartridgeApplication is an application with the Cartridge orchestrator.
 type CartridgeApplication struct {
+	cachedDiscoverer
 	runningCtx running.RunningCtx
 }
 
 // NewCartridgeApplication creates a new CartridgeApplication object.
 func NewCartridgeApplication(runningCtx running.RunningCtx) *CartridgeApplication {
-	return &CartridgeApplication{
+	app := &CartridgeApplication{
 		runningCtx: runningCtx,
 	}
+	app.discoverer = app
+	return app
 }
 
-// Discovery returns a replicaset topology for an application with
+// discovery returns a replicaset topology for an application with
 // the Cartridge orchestrator.
-func (c *CartridgeApplication) Discovery() (Replicasets, error) {
+func (c *CartridgeApplication) discovery() (Replicasets, error) {
 	replicasets := Replicasets{
 		State:        StateUnknown,
 		Orchestrator: OrchestratorCartridge,
@@ -229,7 +235,7 @@ func (c *CartridgeApplication) Discovery() (Replicasets, error) {
 
 // Promote promotes an instance in the cartridge application.
 func (c *CartridgeApplication) Promote(ctx PromoteCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(UseCache)
 	if err != nil {
 		return err
 	}
@@ -271,7 +277,7 @@ func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 
 // Expel expels an instance from a Cartridge replicasets.
 func (c *CartridgeApplication) Expel(ctx ExpelCtx) error {
-	replicasets, err := c.Discovery()
+	replicasets, err := c.Discovery(UseCache)
 	if err != nil {
 		return fmt.Errorf("failed to discovery: %w", err)
 	}

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -137,6 +137,11 @@ loop:
 	return cartridgePromote(c.evaler, inst, ctx.Force, ctx.Timeout)
 }
 
+// Demote is not supported for a single instance by the Cartridge orchestrator.
+func (c *CartridgeInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // GetReplicasets returns a replicaset topology for a single instance with the
 // Cartridge orchestrator.
 func (c *CartridgeInstance) Discovery() (Replicasets, error) {
@@ -249,6 +254,11 @@ loop:
 
 	return cartridgePromote(MakeInstanceEvalFunc(targetInstance.InstanceCtx),
 		inst, ctx.Force, ctx.Timeout)
+}
+
+// Demote is not supported for an application by the Cartridge orchestrator.
+func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -164,6 +164,11 @@ func (c *CartridgeInstance) Discovery() (Replicasets, error) {
 	return recalculateMasters(replicasets), nil
 }
 
+// Expel is not supported for a single instance by the Cartridge orchestrator.
+func (c *CartridgeInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // CartridgeApplication is an application with the Cartridge orchestrator.
 type CartridgeApplication struct {
 	runningCtx running.RunningCtx
@@ -259,6 +264,11 @@ loop:
 // Demote is not supported for an application by the Cartridge orchestrator.
 func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
+}
+
+// Expel expels an instance from a Cartridge replicasets.
+func (c *CartridgeApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCartridge)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -10,10 +10,30 @@ import (
 
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CartridgeInstance{}
+var _ replicaset.Promoter = &replicaset.CartridgeInstance{}
+var _ replicaset.Demoter = &replicaset.CartridgeInstance{}
+
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
+var _ replicaset.Promoter = &replicaset.CartridgeApplication{}
+var _ replicaset.Demoter = &replicaset.CartridgeApplication{}
+
+func TestCartridgeApplication_Demote(t *testing.T) {
+	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
+	err := app.Demote(replicaset.DemoteCtx{})
+	assert.EqualError(t, err,
+		`demote is not supported for an application by "cartridge" orchestrator`)
+}
+
+func TestCartridgeInstance_Demote(t *testing.T) {
+	inst := replicaset.NewCartridgeInstance(nil)
+	err := inst.Demote(replicaset.DemoteCtx{})
+	assert.EqualError(t, err,
+		`demote is not supported for a single instance by "cartridge" orchestrator`)
+}
 
 func TestCartridgeInstance_Discovery(t *testing.T) {
 	cases := []struct {

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -16,10 +16,12 @@ import (
 var _ replicaset.Discoverer = &replicaset.CartridgeInstance{}
 var _ replicaset.Promoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Demoter = &replicaset.CartridgeInstance{}
+var _ replicaset.Expeller = &replicaset.CartridgeInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
 var _ replicaset.Promoter = &replicaset.CartridgeApplication{}
 var _ replicaset.Demoter = &replicaset.CartridgeApplication{}
+var _ replicaset.Expeller = &replicaset.CartridgeApplication{}
 
 func TestCartridgeApplication_Demote(t *testing.T) {
 	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
@@ -880,4 +882,18 @@ func TestCartridgeInstancePromote_errs(t *testing.T) {
 			require.EqualError(t, err, tc.expected)
 		})
 	}
+}
+
+func TestCartridgeInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCartridgeInstance(nil)
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for a single instance by "cartridge" orchestrator`)
+}
+
+func TestCartridgeApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCartridgeApplication(running.RunningCtx{})
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for an application by "cartridge" orchestrator`)
 }

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -890,10 +890,3 @@ func TestCartridgeInstance_Expel(t *testing.T) {
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "cartridge" orchestrator`)
 }
-
-func TestCartridgeApplication_Expel(t *testing.T) {
-	instance := replicaset.NewCartridgeApplication(running.RunningCtx{})
-	err := instance.Expel(replicaset.ExpelCtx{})
-	assert.EqualError(t, err,
-		`expel is not supported for an application by "cartridge" orchestrator`)
-}

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -91,6 +91,12 @@ func (c *CConfigInstance) Promote(ctx PromoteCtx) error {
 	return cconfigPromoteElection(c.evaler, ctx.Timeout)
 }
 
+// Demote is not supported for a single instance by the centralized config
+// orchestrator.
+func (c *CConfigInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -97,6 +97,12 @@ func (c *CConfigInstance) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByInstanceNotSupported(OrchestratorCentralizedConfig)
 }
 
+// Expel is not supported for a single instance by the centralized config
+// orchestrator.
+func (c *CConfigInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {
@@ -147,6 +153,11 @@ func (c *CConfigApplication) Discovery() (Replicasets, error) {
 	}
 
 	return mergeCConfigTopologies(topologies)
+}
+
+// Expel expels an instance from the cetralized config's replicasets.
+func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCentralizedConfig)
 }
 
 // getCConfigInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -274,11 +274,59 @@ func TestCConfigInstance_Discovery(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCConfigInstance(tc.Evaler)
-			replicasets, err := instance.Discovery()
+			replicasets, err := instance.Discovery(replicaset.SkipCache)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.Expected, replicasets)
 		})
 	}
+}
+
+func TestCConfigInstance_Discovery_force(t *testing.T) {
+	evaler := &instanceMockEvaler{
+		Ret: [][]any{
+			[]any{
+				map[any]any{
+					"uuid": "foo1",
+				},
+			},
+			[]any{
+				map[any]any{
+					"uuid": "foo2",
+				},
+			},
+		},
+	}
+
+	getter := replicaset.NewCConfigInstance(evaler)
+
+	replicasets, err := getter.Discovery(replicaset.SkipCache)
+	require.NoError(t, err)
+	expected := replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCentralizedConfig,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo1",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
+
+	// Force re-discovery.
+	replicasets, err = getter.Discovery(replicaset.SkipCache)
+	require.NoError(t, err)
+	expected = replicaset.Replicasets{
+		State:        replicaset.StateBootstrapped,
+		Orchestrator: replicaset.OrchestratorCentralizedConfig,
+		Replicasets: []replicaset.Replicaset{
+			replicaset.Replicaset{
+				UUID:   "foo2",
+				Master: replicaset.MasterNo,
+			},
+		},
+	}
+	require.Equal(t, expected, replicasets)
 }
 
 func TestCConfigInstance_Discovery_failover(t *testing.T) {
@@ -319,7 +367,7 @@ func TestCConfigInstance_Discovery_failover(t *testing.T) {
 
 			getter := replicaset.NewCConfigInstance(evaler)
 
-			replicasets, err := getter.Discovery()
+			replicasets, err := getter.Discovery(replicaset.SkipCache)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, replicasets)
 		})
@@ -370,7 +418,7 @@ func TestCConfigInstance_Discovery_errors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			instance := replicaset.NewCConfigInstance(tc.Evaler)
-			_, err := instance.Discovery()
+			_, err := instance.Discovery(replicaset.SkipCache)
 			assert.ErrorContains(t, err, tc.Expected)
 		})
 	}

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -12,7 +12,12 @@ import (
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
+var _ replicaset.Promoter = &replicaset.CConfigInstance{}
+var _ replicaset.Demoter = &replicaset.CConfigInstance{}
+
 var _ replicaset.Discoverer = &replicaset.CConfigApplication{}
+var _ replicaset.Promoter = &replicaset.CConfigApplication{}
+var _ replicaset.Demoter = &replicaset.CConfigApplication{}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -377,4 +382,11 @@ func TestCConfigInstance_Promote_error(t *testing.T) {
 	instance := replicaset.NewCConfigInstance(evaler)
 	actual := instance.Promote(replicaset.PromoteCtx{})
 	require.ErrorIs(t, actual, err)
+}
+
+func TestCConfigInstance_Demote(t *testing.T) {
+	instance := replicaset.NewCConfigInstance(nil)
+	err := instance.Demote(replicaset.DemoteCtx{})
+	require.EqualError(t, err,
+		`demote is not supported for a single instance by "centralized config" orchestrator`)
 }

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
-	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
@@ -399,11 +398,4 @@ func TestCConfigInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "centralized config" orchestrator`)
-}
-
-func TestCConfigApplication_Expel(t *testing.T) {
-	instance := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
-	err := instance.Expel(replicaset.ExpelCtx{})
-	assert.EqualError(t, err,
-		`expel is not supported for an application by "centralized config" orchestrator`)
 }

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,15 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
 var _ replicaset.Promoter = &replicaset.CConfigInstance{}
 var _ replicaset.Demoter = &replicaset.CConfigInstance{}
+var _ replicaset.Expeller = &replicaset.CConfigInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CConfigApplication{}
 var _ replicaset.Promoter = &replicaset.CConfigApplication{}
 var _ replicaset.Demoter = &replicaset.CConfigApplication{}
+var _ replicaset.Expeller = &replicaset.CConfigApplication{}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -389,4 +392,18 @@ func TestCConfigInstance_Demote(t *testing.T) {
 	err := instance.Demote(replicaset.DemoteCtx{})
 	require.EqualError(t, err,
 		`demote is not supported for a single instance by "centralized config" orchestrator`)
+}
+
+func TestCConfigInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCConfigInstance(nil)
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for a single instance by "centralized config" orchestrator`)
+}
+
+func TestCConfigApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for an application by "centralized config" orchestrator`)
 }

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -1,8 +1,12 @@
 package replicasetcmd
 
 import (
+	"fmt"
+
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
+	libcluster "github.com/tarantool/tt/lib/cluster"
 )
 
 const (
@@ -15,6 +19,49 @@ type replicasetOrchestrator interface {
 	replicaset.Discoverer
 	replicaset.Promoter
 	replicaset.Demoter
+}
+
+// makeApplicationOrchestrator creates an orchestrator for the application.
+func makeApplicationOrchestrator(
+	orchestratorType replicaset.Orchestrator,
+	runningCtx running.RunningCtx,
+	collectors libcluster.DataCollectorFactory,
+	publishers libcluster.DataPublisherFactory) (replicasetOrchestrator, error) {
+	var (
+		orchestrator replicasetOrchestrator
+		err          error
+	)
+	switch orchestratorType {
+	case replicaset.OrchestratorCentralizedConfig:
+		orchestrator = replicaset.NewCConfigApplication(runningCtx, collectors, publishers)
+	case replicaset.OrchestratorCartridge:
+		orchestrator = replicaset.NewCartridgeApplication(runningCtx)
+	case replicaset.OrchestratorCustom:
+		orchestrator = replicaset.NewCustomApplication(runningCtx)
+	default:
+		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	}
+	return orchestrator, err
+}
+
+// makeInstanceOrchestrator creates an orchestrator for the single instance.
+func makeInstanceOrchestrator(orchestratorType replicaset.Orchestrator,
+	conn connector.Connector) (replicasetOrchestrator, error) {
+	var (
+		orchestrator replicasetOrchestrator
+		err          error
+	)
+	switch orchestratorType {
+	case replicaset.OrchestratorCentralizedConfig:
+		orchestrator = replicaset.NewCConfigInstance(conn)
+	case replicaset.OrchestratorCartridge:
+		orchestrator = replicaset.NewCartridgeInstance(conn)
+	case replicaset.OrchestratorCustom:
+		orchestrator = replicaset.NewCustomInstance(conn)
+	default:
+		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	}
+	return orchestrator, err
 }
 
 // getOrchestratorInstance determinates a used orchestrator type for an instance.

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -48,7 +48,7 @@ func Demote(ctx DemoteCtx) error {
 	fmt.Println()
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -38,20 +38,10 @@ func Demote(ctx DemoteCtx) error {
 		return err
 	}
 
-	var orchestrator interface {
-		replicaset.Discoverer
-		replicaset.Demoter
-	}
-	switch orchestratorType {
-	case replicaset.OrchestratorCentralizedConfig:
-		orchestrator = replicaset.NewCConfigApplication(ctx.RunningCtx, ctx.Collectors,
-			ctx.Publishers)
-	case replicaset.OrchestratorCartridge:
-		fallthrough
-	case replicaset.OrchestratorCustom:
-		fallthrough
-	default:
-		return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+	orchestrator, err := makeApplicationOrchestrator(orchestratorType,
+		ctx.RunningCtx, ctx.Collectors, ctx.Publishers)
+	if err != nil {
+		return err
 	}
 
 	log.Info("Discovery application...")

--- a/cli/replicaset/cmd/expel.go
+++ b/cli/replicaset/cmd/expel.go
@@ -48,7 +48,7 @@ func Expel(expelCtx ExpelCtx) error {
 	fmt.Println("")
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -41,32 +41,15 @@ func Promote(ctx PromoteCtx) error {
 		return err
 	}
 
-	var orchestrator interface {
-		replicaset.Discoverer
-		replicaset.Promoter
-	}
+	var orchestrator replicasetOrchestrator
 	if ctx.IsApplication {
-		switch orchestratorType {
-		case replicaset.OrchestratorCentralizedConfig:
-			orchestrator = replicaset.NewCConfigApplication(ctx.RunningCtx, ctx.Collectors,
-				ctx.Publishers)
-		case replicaset.OrchestratorCartridge:
-			orchestrator = replicaset.NewCartridgeApplication(ctx.RunningCtx)
-		case replicaset.OrchestratorCustom:
-			fallthrough
-		default:
-			return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		if orchestrator, err = makeApplicationOrchestrator(
+			orchestratorType, ctx.RunningCtx, ctx.Collectors, ctx.Publishers); err != nil {
+			return err
 		}
 	} else {
-		switch orchestratorType {
-		case replicaset.OrchestratorCentralizedConfig:
-			orchestrator = replicaset.NewCConfigInstance(ctx.Conn)
-		case replicaset.OrchestratorCartridge:
-			orchestrator = replicaset.NewCartridgeInstance(ctx.Conn)
-		case replicaset.OrchestratorCustom:
-			fallthrough
-		default:
-			return fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		if orchestrator, err = makeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
+			return err
 		}
 	}
 

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -57,7 +57,7 @@ func Promote(ctx PromoteCtx) error {
 	fmt.Println()
 
 	// Get and print status.
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -36,7 +36,7 @@ type PromoteCtx struct {
 
 // Promote promotes an instance.
 func Promote(ctx PromoteCtx) error {
-	orchestratorType, err := getOrchestratorInstance(ctx.Orchestrator, ctx.Conn)
+	orchestratorType, err := getInstanceOrchestrator(ctx.Orchestrator, ctx.Conn)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -51,31 +51,12 @@ func Status(statusCtx StatusCtx) error {
 	return statusReplicasets(replicasets)
 }
 
-// getOrchestratorType determinates a used orchestrator type.
+// getOrchestratorType determines a used orchestrator for a status context.
 func getOrchestratorType(statusCtx StatusCtx) (replicaset.Orchestrator, error) {
-	if statusCtx.Orchestrator != replicaset.OrchestratorUnknown {
-		return statusCtx.Orchestrator, nil
-	}
-
 	if statusCtx.Conn != nil {
-		return replicaset.EvalOrchestrator(statusCtx.Conn)
+		return getInstanceOrchestrator(statusCtx.Orchestrator, statusCtx.Conn)
 	}
-
-	var orchestrator replicaset.Orchestrator
-	eval := func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-		instanceOrchestrator, err := replicaset.EvalOrchestrator(evaler)
-		if err == nil {
-			orchestrator = instanceOrchestrator
-		}
-		return true, err
-	}
-
-	instances := statusCtx.RunningCtx.Instances
-	if err := replicaset.EvalAny(instances, replicaset.InstanceEvalFunc(eval)); err != nil {
-		return orchestrator,
-			fmt.Errorf("unable to determinate orchestrator: %w", err)
-	}
-	return orchestrator, nil
+	return getApplicationOrchestrator(statusCtx.Orchestrator, statusCtx.RunningCtx)
 }
 
 // statusReplicasets show the current status of known replicasets.

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -43,7 +43,7 @@ func Status(statusCtx StatusCtx) error {
 		}
 	}
 
-	replicasets, err := orchestrator.Discovery()
+	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -33,19 +33,22 @@ type customTopology struct {
 // CustomInstance is an instance with custom/unknown orchestrator. In this
 // case, we can obtain a minimum of information for a replicaset.
 type CustomInstance struct {
+	cachedDiscoverer
 	evaler connector.Evaler
 }
 
 // NewCustomInstance creates a new CustomInstance object for the evaler.
 func NewCustomInstance(evaler connector.Evaler) *CustomInstance {
-	return &CustomInstance{
+	inst := &CustomInstance{
 		evaler: evaler,
 	}
+	inst.discoverer = inst
+	return inst
 }
 
-// Discovery returns a replicasets topology for a single
+// discovery returns a replicasets topology for a single
 // instance with a custom type of orchestrator.
-func (c *CustomInstance) Discovery() (Replicasets, error) {
+func (c *CustomInstance) discovery() (Replicasets, error) {
 	topology, err := getCustomInstanceTopology("", c.evaler)
 	if err != nil {
 		return Replicasets{}, err
@@ -82,20 +85,23 @@ func (c *CustomInstance) Expel(ctx ExpelCtx) error {
 
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
+	cachedDiscoverer
 	runningCtx running.RunningCtx
 	conn       connector.Connector
 }
 
 // NewCustomApplication creates a new CustomApplication object.
 func NewCustomApplication(runningCtx running.RunningCtx) *CustomApplication {
-	return &CustomApplication{
+	app := &CustomApplication{
 		runningCtx: runningCtx,
 	}
+	app.discoverer = app
+	return app
 }
 
-// Discovery returns a replicasets configuration for an application with
+// discovery returns a replicasets configuration for an application with
 // a custom orchestrator.
-func (c *CustomApplication) Discovery() (Replicasets, error) {
+func (c *CustomApplication) discovery() (Replicasets, error) {
 	var topologies []customTopology
 
 	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -75,6 +75,11 @@ func (c *CustomInstance) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByInstanceNotSupported(OrchestratorCustom)
 }
 
+// Expel is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) Expel(ctx ExpelCtx) error {
+	return newErrExpelByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	runningCtx running.RunningCtx
@@ -124,6 +129,11 @@ func (c *CustomApplication) Promote(ctx PromoteCtx) error {
 // Demote is not supported for an application by the Custom orchestrator.
 func (c *CustomApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCustom)
+}
+
+// Expel is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) Expel(ctx ExpelCtx) error {
+	return newErrExpelByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -65,6 +65,16 @@ func (c *CustomInstance) Discovery() (Replicasets, error) {
 	}), nil
 }
 
+// Promote is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) Promote(ctx PromoteCtx) error {
+	return newErrPromoteByInstanceNotSupported(OrchestratorCustom)
+}
+
+// Demote is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	runningCtx running.RunningCtx
@@ -104,6 +114,16 @@ func (c *CustomApplication) Discovery() (Replicasets, error) {
 	}
 
 	return mergeCustomTopologies(topologies)
+}
+
+// Promote is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) Promote(ctx PromoteCtx) error {
+	return newErrPromoteByAppNotSupported(OrchestratorCustom)
+}
+
+// Demote is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) Demote(ctx DemoteCtx) error {
+	return newErrDemoteByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -7,10 +7,30 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CustomInstance{}
+var _ replicaset.Promoter = &replicaset.CustomInstance{}
+var _ replicaset.Demoter = &replicaset.CustomInstance{}
+
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
+var _ replicaset.Promoter = &replicaset.CustomApplication{}
+var _ replicaset.Demoter = &replicaset.CustomApplication{}
+
+func TestCustomApplication_Promote(t *testing.T) {
+	app := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := app.Promote(replicaset.PromoteCtx{})
+	assert.EqualError(t, err,
+		`promote is not supported for an application by "custom" orchestrator`)
+}
+
+func TestCustomApplication_Demote(t *testing.T) {
+	app := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := app.Demote(replicaset.DemoteCtx{})
+	assert.EqualError(t, err,
+		`demote is not supported for an application by "custom" orchestrator`)
+}
 
 func TestCustomInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -310,4 +330,18 @@ func TestCustomInstance_Discovery_errors(t *testing.T) {
 			assert.ErrorContains(t, err, tc.Expected)
 		})
 	}
+}
+
+func TestCustomInstance_Promote(t *testing.T) {
+	inst := replicaset.NewCustomInstance(nil)
+	err := inst.Promote(replicaset.PromoteCtx{})
+	assert.EqualError(t, err,
+		`promote is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_Demote(t *testing.T) {
+	inst := replicaset.NewCustomInstance(nil)
+	err := inst.Demote(replicaset.DemoteCtx{})
+	assert.EqualError(t, err,
+		`demote is not supported for a single instance by "custom" orchestrator`)
 }

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -13,10 +13,12 @@ import (
 var _ replicaset.Discoverer = &replicaset.CustomInstance{}
 var _ replicaset.Promoter = &replicaset.CustomInstance{}
 var _ replicaset.Demoter = &replicaset.CustomInstance{}
+var _ replicaset.Expeller = &replicaset.CustomInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
 var _ replicaset.Promoter = &replicaset.CustomApplication{}
 var _ replicaset.Demoter = &replicaset.CustomApplication{}
+var _ replicaset.Expeller = &replicaset.CustomApplication{}
 
 func TestCustomApplication_Promote(t *testing.T) {
 	app := replicaset.NewCustomApplication(running.RunningCtx{})
@@ -30,6 +32,13 @@ func TestCustomApplication_Demote(t *testing.T) {
 	err := app.Demote(replicaset.DemoteCtx{})
 	assert.EqualError(t, err,
 		`demote is not supported for an application by "custom" orchestrator`)
+}
+
+func TestCustomApplication_Expel(t *testing.T) {
+	instance := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for an application by "custom" orchestrator`)
 }
 
 func TestCustomInstance_Discovery(t *testing.T) {
@@ -344,4 +353,11 @@ func TestCustomInstance_Demote(t *testing.T) {
 	err := inst.Demote(replicaset.DemoteCtx{})
 	assert.EqualError(t, err,
 		`demote is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_Expel(t *testing.T) {
+	instance := replicaset.NewCustomInstance(nil)
+	err := instance.Expel(replicaset.ExpelCtx{})
+	assert.EqualError(t, err,
+		`expel is not supported for a single instance by "custom" orchestrator`)
 }

--- a/cli/replicaset/demote.go
+++ b/cli/replicaset/demote.go
@@ -1,5 +1,7 @@
 package replicaset
 
+import "fmt"
+
 // DemoteCtx describes a context for an instance demoting.
 type DemoteCtx struct {
 	// InstName is an instance name to demote.
@@ -16,4 +18,18 @@ type DemoteCtx struct {
 type Demoter interface {
 	// Demote demotes an instance.
 	Demote(DemoteCtx) error
+}
+
+// newErrDemoteByInstanceNotSupported creates a new error that demote is not
+// supported by the orchestrator for a single instance.
+func newErrDemoteByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("demote is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrDemoteByAppNotSupported creates a new error that demote is not
+// supported by the orchestrator for an application.
+func newErrDemoteByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("demote is not supported for an application by %q orchestrator",
+		orchestrator)
 }

--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -1,69 +1,8 @@
 package replicaset
 
-import (
-	"fmt"
-
-	"github.com/tarantool/tt/cli/connector"
-	"github.com/tarantool/tt/cli/running"
-)
-
 // Discoverer is an interface for discovering information about
 // replicasets.
 type Discoverer interface {
 	// Discovery returns replicasets information or an error.
 	Discovery() (Replicasets, error)
-}
-
-// DiscoveryApplication retrieves replicasets information for instances in an
-// application. If orchestrator == OrchestratorUnknown then it tries to
-// determinate an orchestrator.
-func DiscoveryApplication(app running.RunningCtx,
-	orchestrator Orchestrator) (Replicasets, error) {
-	if orchestrator == OrchestratorUnknown {
-		eval := func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-			var err error
-			orchestrator, err = EvalOrchestrator(evaler)
-			return true, err
-		}
-
-		if err := EvalAny(app.Instances, InstanceEvalFunc(eval)); err != nil {
-			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
-		}
-	}
-
-	switch orchestrator {
-	case OrchestratorCartridge:
-		return NewCartridgeApplication(app).Discovery()
-	case OrchestratorCentralizedConfig:
-		return NewCConfigApplication(app, nil, nil).Discovery()
-	case OrchestratorCustom:
-		return NewCustomApplication(app).Discovery()
-	default:
-		return Replicasets{}, fmt.Errorf("orchestrator is not supported: %s", orchestrator)
-	}
-}
-
-// DiscoveryInstance retrieves replicasets information from a connection.
-// If orchestrator == OrchestratorUnknown then it tries to determinate an
-// orchestrator.
-func DiscoveryInstance(evaler connector.Evaler,
-	orchestrator Orchestrator) (Replicasets, error) {
-	if orchestrator == OrchestratorUnknown {
-		var err error
-		orchestrator, err = EvalOrchestrator(evaler)
-		if err != nil {
-			return Replicasets{}, fmt.Errorf("unable to determinate orchestrator: %w", err)
-		}
-	}
-
-	switch orchestrator {
-	case OrchestratorCartridge:
-		return NewCartridgeInstance(evaler).Discovery()
-	case OrchestratorCentralizedConfig:
-		return NewCConfigInstance(evaler).Discovery()
-	case OrchestratorCustom:
-		return NewCustomInstance(evaler).Discovery()
-	default:
-		return Replicasets{}, fmt.Errorf("orchestartor is not supported: %s", orchestrator)
-	}
 }

--- a/cli/replicaset/discovery.go
+++ b/cli/replicaset/discovery.go
@@ -1,8 +1,47 @@
 package replicaset
 
+// CacheBehavior describes a cache behavior.
+type CacheBehavior bool
+
+const (
+	UseCache  CacheBehavior = false
+	SkipCache               = true
+)
+
 // Discoverer is an interface for discovering information about
 // replicasets.
 type Discoverer interface {
 	// Discovery returns replicasets information or an error.
-	Discovery() (Replicasets, error)
+	Discovery(behavior CacheBehavior) (Replicasets, error)
 }
+
+// discoverer is an interface that unconditionally performs discovering.
+type discoverer interface {
+	discovery() (Replicasets, error)
+}
+
+// cachedDiscoverer allows to automatically cache discovery results.
+type cachedDiscoverer struct {
+	discoverer
+	cached      bool
+	replicasets Replicasets
+}
+
+// Discovery discovers via underlying type.
+// If behavior is UseCache and there is a cached result, returns it.
+func (c *cachedDiscoverer) Discovery(behavior CacheBehavior) (Replicasets, error) {
+	if behavior == UseCache && c.cached {
+		return c.replicasets, nil
+	}
+	c.cached = false
+	var err error
+	c.replicasets, err = c.discovery()
+	if err != nil {
+		return c.replicasets, err
+	}
+	c.cached = true
+	return c.replicasets, nil
+}
+
+// Type assertion that cachedDiscoverer satisfy Discoverer.
+var _ Discoverer = (*cachedDiscoverer)(nil)

--- a/cli/replicaset/eval.go
+++ b/cli/replicaset/eval.go
@@ -71,6 +71,24 @@ func EvalAny(instances []running.InstanceCtx, ievaler InstanceEvaler) error {
 		}))
 }
 
+// EvalForeachAliveDiscovered calls evaler for only connectable instances among discovered.
+func EvalForeachAliveDiscovered(instances []running.InstanceCtx,
+	discovered Replicasets, ievaler InstanceEvaler) error {
+	discoveredMap := map[string]struct{}{}
+	for _, replicaset := range discovered.Replicasets {
+		for _, instance := range replicaset.Instances {
+			discoveredMap[instance.Alias] = struct{}{}
+		}
+	}
+	var filteredInstances []running.InstanceCtx
+	for _, inst := range instances {
+		if _, ok := discoveredMap[inst.InstName]; ok {
+			filteredInstances = append(filteredInstances, inst)
+		}
+	}
+	return EvalForeachAlive(filteredInstances, ievaler)
+}
+
 // evalForeach is an internal implementation of iteration over instances with
 // an evaler object.
 func evalForeach(instances []running.InstanceCtx,

--- a/cli/replicaset/expel.go
+++ b/cli/replicaset/expel.go
@@ -9,6 +9,9 @@ type ExpelCtx struct {
 	// Force is true when expelling can skip
 	// some non-critical checks.
 	Force bool
+	// Timeout is a timeout for expelling waitings in seconds.
+	// Keep int, because it can be passed to the target instance.
+	Timeout int
 }
 
 // Expeller is an interface for expelling instances from a replicaset.

--- a/cli/replicaset/expel.go
+++ b/cli/replicaset/expel.go
@@ -1,0 +1,32 @@
+package replicaset
+
+import "fmt"
+
+// ExpelCtx describes a context for an instance expelling.
+type ExpelCtx struct {
+	// InstName is an instance name to expel.
+	InstName string
+	// Force is true when expelling can skip
+	// some non-critical checks.
+	Force bool
+}
+
+// Expeller is an interface for expelling instances from a replicaset.
+type Expeller interface {
+	// Expel expels instance from a replicasets by its name.
+	Expel(ctx ExpelCtx) error
+}
+
+// newErrExpelByInstanceNotSupported creates a new error that expel is not
+// supported by the orchestrator for a single instance.
+func newErrExpelByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("expel is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrExpelByAppNotSupported creates a new error that expel by URI is not
+// supported by the orchestrator for an application.
+func newErrExpelByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("expel is not supported for an application by %q orchestrator",
+		orchestrator)
+}

--- a/cli/replicaset/lua/cartridge/edit_instances_body.lua
+++ b/cli/replicaset/lua/cartridge/edit_instances_body.lua
@@ -1,0 +1,8 @@
+local cartridge = require('cartridge')
+local servers = ...
+
+local res, err = cartridge.admin_edit_topology({
+    servers = servers,
+})
+
+assert(res, tostring(err))

--- a/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
+++ b/cli/replicaset/lua/cconfig/get_instance_topology_body.lua
@@ -21,7 +21,7 @@ for _, instance in ipairs(box_info.replication) do
     local uri = nil
     if instance.upstream ~= nil then
         uri = instance.upstream.peer
-    elseif box.cfg.listen ~= nil then
+    elseif box.cfg.listen ~= nil and instance.uuid == box_info.uuid then
         if type(box.cfg.listen) == 'string' then
             uri = box.cfg.listen
         elseif #box.cfg.listen > 0 then

--- a/cli/replicaset/orchestrators_test.go
+++ b/cli/replicaset/orchestrators_test.go
@@ -93,7 +93,7 @@ func TestReplicasetGetter_Discovery_panics_with_invalid_evaler(t *testing.T) {
 			t.Run(oc.Name+"_"+tc.Name, func(t *testing.T) {
 				getter := oc.New(tc.Evaler)
 				assert.Panics(t, func() {
-					getter.Discovery()
+					getter.Discovery(replicaset.SkipCache)
 				})
 			})
 		}

--- a/cli/replicaset/promote.go
+++ b/cli/replicaset/promote.go
@@ -1,5 +1,7 @@
 package replicaset
 
+import "fmt"
+
 // PromoteCtx describes a context for an instance promoting.
 type PromoteCtx struct {
 	// InstName is an instance name to promote.
@@ -16,4 +18,18 @@ type PromoteCtx struct {
 type Promoter interface {
 	// Promote promotes an instance.
 	Promote(PromoteCtx) error
+}
+
+// newErrPromoteByInstanceNotSupported creates a new error that promote is not
+// supported by the orchestrator for a single instance.
+func newErrPromoteByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("promote is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrPromoteByAppNotSupported creates a new error that promote is not
+// supported by the orchestrator for an application.
+func newErrPromoteByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("promote is not supported for an application by %q orchestrator",
+		orchestrator)
 }

--- a/test/integration/cluster/test_cluster_demote.py
+++ b/test/integration/cluster/test_cluster_demote.py
@@ -40,7 +40,7 @@ def test_cluster_demote_single_key(tt_cmd, tmpdir_with_cfg, etcd):
     demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
     rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir)
     assert rc == 0
-    assert f'Patch the config by the key: "{key}"' in out
+    assert f'Patching the config by the key: "{key}"' in out
 
     actual, _ = etcdcli.get(key)
     actual = actual.decode("utf-8")
@@ -70,7 +70,7 @@ def test_cluster_demote_many_keys(tt_cmd, tmpdir_with_cfg, etcd, key):
     demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-002"]
     rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir)
     assert rc == 0
-    assert f'Patch the config by the key: "{b_key}"' in out
+    assert f'Patching the config by the key: "{b_key}"' in out
 
     actual, _ = etcdcli.get(a_key)
     actual = actual.decode("utf-8")
@@ -150,7 +150,7 @@ def test_cluster_demote_auth(tt_cmd, tmpdir_with_cfg, etcd, auth):
 
         rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir, env=env)
         assert rc == 0
-        assert f'Patch the config by the key: "{key}"' in out
+        assert f'Patching the config by the key: "{key}"' in out
 
         etcd.disable_auth()
         etcdcli = etcd.conn()

--- a/test/integration/cluster/test_cluster_expel.py
+++ b/test/integration/cluster/test_cluster_expel.py
@@ -1,0 +1,61 @@
+from utils import run_command_and_get_output
+
+
+def to_etcd_key(key):
+    return f"/prefix/config/{key}"
+
+
+def test_cluster_expel_missing_instance_arg(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    uri = "http://localhost:2379"  # Fictive.
+    cmd = [tt_cmd, "cluster", "rs", "expel", uri]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc != 0
+    assert "Error: accepts 2 arg(s), received 1" in out
+
+
+cfg = """\
+groups:
+  group-1:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001: {}
+          instance-002: {}
+"""
+
+
+def test_cluster_expel_no_instance(tt_cmd, etcd, tmpdir_with_cfg):
+    etcdcli = etcd.conn()
+    tmpdir = tmpdir_with_cfg
+    etcdcli.put(to_etcd_key("all"), cfg)
+    url = f"{etcd.endpoint}/prefix?timeout=5"
+    cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-003"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc != 0
+    assert 'instance "instance-003" not found in the cluster configuration' in out
+
+
+def test_cluster_expel_single_key(tt_cmd, etcd, tmpdir_with_cfg):
+    etcdcli = etcd.conn()
+    tmpdir = tmpdir_with_cfg
+    key = to_etcd_key("all")
+    etcdcli.put(key, cfg)
+    url = f"{etcd.endpoint}/prefix?timeout=5"
+    cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-002"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc == 0
+    assert f'Patching the config by the key: "{key}"' in out
+
+    actual, _ = etcdcli.get(key)
+    assert actual.decode("utf-8") == """\
+groups:
+  group-1:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001: {}
+          instance-002:
+            iproto:
+              listen: {}
+"""

--- a/test/integration/cluster/test_cluster_promote.py
+++ b/test/integration/cluster/test_cluster_promote.py
@@ -81,7 +81,7 @@ def test_cluster_promote_single_key(
         assert err_text in out
         return
     assert rc == 0
-    assert 'Patch the config by the key: "/prefix/config/all"' in out
+    assert 'Patching the config by the key: "/prefix/config/all"' in out
 
     expected = kv["expected"]
     actual, _ = etcdcli.get("/prefix/config/all")
@@ -147,7 +147,7 @@ def test_cluster_promote_many_keys(
         return
 
     assert rc == 0
-    assert f'Patch the config by the key: "{to_etcd_key(exp_key)}"' in out
+    assert f'Patching the config by the key: "{to_etcd_key(exp_key)}"' in out
 
     expected_kv = kvs
     expected_kv[exp_key] = exp_config
@@ -181,7 +181,7 @@ def test_cluster_promote_key_specified(tt_cmd, etcd, tmpdir_with_cfg):
     # Despite the fact that the config for key a is more prioritized,
     # b will be patched as it is explicitly specified.
     expected_key = to_etcd_key("b")
-    assert f'Patch the config by the key: "{expected_key}"' in out
+    assert f'Patching the config by the key: "{expected_key}"' in out
 
     expected_kv = kvs
     expected_kv["b"] = exp_config
@@ -274,7 +274,7 @@ def test_cluster_promote_auth(tt_cmd, etcd, tmpdir_with_cfg, auth):
 
         rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir, env=env)
         assert rc == 0
-        assert f'Patch the config by the key: "{key}"' in out
+        assert f'Patching the config by the key: "{key}"' in out
 
         etcd.disable_auth()
         etcdcli = etcd.conn()

--- a/test/integration/replicaset/test_ccluster_app/init.lua
+++ b/test/integration/replicaset/test_ccluster_app/init.lua
@@ -10,7 +10,7 @@ while true do
 end
 
 while true do
-    if #box.cfg.replication == #box.info.replication then
+    if #box.cfg.replication <= #box.info.replication then
         break
     end
     fiber.sleep(0.1)

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -1,8 +1,10 @@
 import os
 import re
 import shutil
+import time
 
 import pytest
+from cartridge_helper import cartridge_name
 
 from utils import get_tarantool_version, run_command_and_get_output, wait_file
 
@@ -81,3 +83,63 @@ Replicasets state: bootstrapped
         stop_cmd = [tt_cmd, "stop", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+def test_expel_cartridge(tt_cmd, cartridge_app):
+    status_expelled = """Orchestrator:      cartridge
+Replicasets state: bootstrapped
+
+• router
+  Failover: off
+  Provider: none
+  Master:   single
+  Roles:    failover-coordinator, vshard-router, app.roles.custom
+    ★ router localhost:3301 rw
+• s-1
+  Failover: off
+  Provider: none
+  Master:   single
+  Roles:    vshard-storage
+    ★ s1-master localhost:3302 rw
+    • s1-replica localhost:3303 read
+• s-2
+  Failover: off
+  Provider: none
+  Master:   single
+  Roles:    vshard-storage
+    ★ s2-master localhost:3304 rw
+"""
+    status_unexpelled = status_expelled + "    • s2-replica localhost:3305 read\n"
+
+    # Wait for the configurated state.
+    for _ in range(100):
+        rs_cmd = [tt_cmd, "replicaset", "status", f"{cartridge_name}:s2-master"]
+        rs_rc, rs_out = run_command_and_get_output(rs_cmd, cwd=cartridge_app.workdir)
+        assert rs_rc == 0
+        if rs_out != """Orchestrator:      cartridge
+Replicasets state: uninitialized
+""":
+            break
+        time.sleep(1)
+
+        rs_cmd = [tt_cmd, "replicaset", "expel", f"{cartridge_name}:s2-replica"]
+        rs_rc, rs_out = run_command_and_get_output(rs_cmd, cwd=cartridge_app.workdir)
+        assert rs_rc == 0
+        assert re.search("""   • Discovery application...*
+
+""" + status_unexpelled + """\n   • Expel instance: s2-replica
+   • Done.*
+""", rs_out)
+
+        # Check that the instance has been expelled.
+        for _ in range(100):
+            rs_cmd = [tt_cmd, "replicaset", "status", f"{cartridge_name}:s2-master"]
+            rs_rc, rs_out = run_command_and_get_output(rs_cmd, cwd=cartridge_app.workdir)
+            assert rs_rc == 0
+            if rs_out != status_unexpelled:
+                # Changes are not applied immediately on the whole cluster.
+                break
+            time.sleep(1)
+        assert rs_out == status_expelled

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -1,0 +1,83 @@
+import os
+import re
+import shutil
+
+import pytest
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+
+@pytest.mark.parametrize("case", [["--config", "--custom"],
+                                  ["--custom", "--cartridge"],
+                                  ["--config", "--cartridge"],
+                                  ["--config", "--custom", "--cartridge"]])
+def test_expel_orchestrators_force_mix(tt_cmd, tmpdir_with_cfg, case):
+    status_cmd = [tt_cmd, "replicaset", "expel"] + case + ["app:instance"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ only one type of orchestrator can be forced", out)
+
+
+def test_expel_invalid_argument(tt_cmd, tmpdir_with_cfg):
+    status_cmd = [tt_cmd, "replicaset", "expel", "app"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ the command expects argument application_name:instance_name", out)
+
+
+def test_expel_no_instance(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+
+    status_cmd = [tt_cmd, "replicaset", "expel", "test_custom_app:unexist"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ instance \"unexist\" not found", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--custom"])
+def test_expel_custom_app(tt_cmd, tmpdir_with_cfg, flag):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        expel_cmd = [tt_cmd, "replicaset", "expel"]
+        if flag:
+            expel_cmd.append(flag)
+        expel_cmd.append("test_custom_app:test_custom_app")
+
+        rc, out = run_command_and_get_output(expel_cmd, cwd=tmpdir)
+        assert rc == 1
+        assert re.search(r"""  • Discovery application...*
+
+Orchestrator:      custom
+Replicasets state: bootstrapped
+
+• .*
+  Failover: unknown
+  Master:   single
+    • test_custom_app .* rw
+
+   • Expel instance: test_custom_app
+   ⨯ expel is not supported for an application by "custom" orchestrator
+""", out)
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0


### PR DESCRIPTION
@TarantoolBot document
Title: new commands: `tt replicaset expel`, `tt cluster replicaset expel`

The patch introduces a new command for the `tt replicaset` module:

* `tt replicaset expel APP_NAME:INSTANCE_NAME` - to expel an instance from a cluster.

The command automatically determines a replicaset orchestrator. Currently, it supports:

* cartridge - the Cartridge orchestrator for Tarantool <= 2.
* config - the centralized config orchestrator for Tarantool >= 3.

Usage:

tt replicaset expel [--cartridge|--config|--custom] <APP_NAME:INSTANCE_NAME>

The example of execution:

```
$ tt replicaset expel myapp:instance-003
   • Discovery application...

Orchestrator:      centralized config
Replicasets state: bootstrapped

• replicaset-001
  Failover: off
  Master:   single
    • instance-001 unix/:./instance-001.iproto rw
    • instance-002 unix/:./instance-002.iproto read
    • instance-003 unix/:./instance-003.iproto read
• replicaset-002
  Failover: off
  Master:   multi
    • instance-004 unix/:./instance-004.iproto rw
    • instance-005 unix/:./instance-005.iproto rw

   • Expel instance: instance-003
   • Done.
$ tt replicaset status myapp
Orchestrator:      centralized config
Replicasets state: bootstrapped

• replicaset-001
  Failover: off
  Master:   single
    • instance-001 unix/:./instance-001.iproto rw
    • instance-002 unix/:./instance-002.iproto read
• replicaset-002
  Failover: off
  Master:   multi
    • instance-004 unix/:./instance-004.iproto rw
    • instance-005 unix/:./instance-005.iproto rw
```

Also, new command for `cluster` module:
* `tt cluster replicaset expel [-f] [flags] <URI> <INSTANCE_NAME>` expels an instance from the 3.0 replicaset by patching the config in storage (etcd or tarantool config storage). 

The example of execution:
```sh
$ tt cluster show http://localhost:2379/foo

credentials:
  users:
    guest:
      roles:
        - super
groups:
  group-001:
    replicasets:
      replicaset-001:
        instances:
          instance-001:
            iproto:
              listen:
                - uri: localhost:3301
          instance-002:
            iproto:
              listen:
                - uri: localhost:3302

$ tt cluster rs expel http://localhost:2379/foo instance-002
   • Patch the config by the key: "/foo/config/all"
   • Done.   

$ tt cluster show http://localhost:2379/foo
credentials:
  users:
    guest:
      roles:
        - super
groups:
  group-001:
    replicasets:
      replicaset-001:
        instances:
          instance-001:
            iproto:
              listen:
                - uri: localhost:3301
          instance-002:
            iproto:
              listen: {}
```

Closes https://github.com/tarantool/tt/issues/318