### PR TITLE
replicaset: add `vshard bootstrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt status`: added `pretty` option for pretty-formatted table output.
 - `TT_CLI_CFG`: environment variable to specify the path to the configuration file.
 - `tt pack`: systemd unit parameterizing support.
+- `tt replicaset vshard`: module to manage vshard in the tarantool replicaset.
+  * `tt replicaset vshard bootstrap`: command to bootstrap vshard.
 
 ### Fixed
 
@@ -37,12 +39,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  cluster config (3.0) or cartridge orchestrator.
 - `tt replicaset demote`: command to demote an instance in the tarantool replicaset with
  cluster config (3.0) orchestrator.
-- `tt replicaset expel`:  command to expel an instance from the tarantool replicaset with
- cluster config (3.0) or cartridge orchestrator.
 - `tt cluster replicaset`: module to manage replicaset via 3.0 cluster config storage.
   * `tt cluster replicaset promote`: command to promote an instance in the replicaset.
   * `tt cluster replicaset demote`: command to demote an instance in the replicaset.
-  * `tt cluster replicaset expel`: command to expel an instance from the replicaset.
 - `tt connect --binary`: connect to instance using binary port.
 - `tt kill`: command to stop instance(s) with SIGQUIT and SIGKILL signals.
 

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -152,6 +152,46 @@ func newExpelCmd() *cobra.Command {
 	return cmd
 }
 
+// newBootstrapVShardCmd creates a "vshard bootstrap" command.
+func newBootstrapVShardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "bootstrap [--cartridge|--config|--custom] [--timeout secs] [flags] " +
+			"(<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)\n\n" +
+			replicasetUriHelp,
+		DisableFlagsInUseLine: true,
+		Short:                 "Bootstrap vshard in the cluster",
+		Long: "Bootstrap vshard in the cluster.\n\n" +
+			replicasetEnvHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdCtx.CommandName = cmd.Name()
+			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
+				internalReplicasetBootstrapVShardModule, args)
+			handleCmdErr(cmd, err)
+		},
+		Args: cobra.ExactArgs(1),
+	}
+
+	addOrchestratorFlags(cmd)
+	addTarantoolConnectFlags(cmd)
+	integrity.RegisterWithIntegrityFlag(cmd.Flags(), &replicasetIntegrityPrivateKey)
+	cmd.Flags().IntVarP(&replicasetTimeout, "timeout", "",
+		replicasetcmd.VShardBootstrapDefaultTimeout, "timeout")
+
+	return cmd
+}
+
+// newVShardCmd creates a "replicaset vshard" subcommand.
+func newVShardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "vshard",
+		Short:   "Manage vshard",
+		Aliases: []string{"vs"},
+	}
+
+	cmd.AddCommand(newBootstrapVShardCmd())
+	return cmd
+}
+
 // NewReplicasetCmd creates a replicaset command.
 func NewReplicasetCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -164,6 +204,7 @@ func NewReplicasetCmd() *cobra.Command {
 	cmd.AddCommand(newPromoteCmd())
 	cmd.AddCommand(newDemoteCmd())
 	cmd.AddCommand(newExpelCmd())
+	cmd.AddCommand(newVShardCmd())
 
 	return cmd
 }
@@ -385,6 +426,32 @@ func internalReplicasetExpelModule(cmdCtx *cmdcontext.CmdCtx, args []string) err
 		RunningCtx:   ctx.RunningCtx,
 		Force:        replicasetForce,
 		Timeout:      replicasetTimeout,
+	})
+}
+
+// internalReplicasetBootstrapVShardModule is a "bootstrap" command for
+// the "replicaset vshard" module.
+func internalReplicasetBootstrapVShardModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	var ctx replicasetCtx
+	if err := replicasetFillCtx(cmdCtx, &ctx, args, false); err != nil {
+		return err
+	}
+	if ctx.IsInstanceConnect {
+		defer ctx.Conn.Close()
+	}
+	collectors, publishers, err := createDataCollectorsAndDataPublishers(
+		cmdCtx.Integrity, replicasetIntegrityPrivateKey)
+	if err != nil {
+		return err
+	}
+	return replicasetcmd.BootstrapVShard(replicasetcmd.VShardCmdCtx{
+		IsApplication: ctx.IsApplication,
+		RunningCtx:    ctx.RunningCtx,
+		Conn:          ctx.Conn,
+		Orchestrator:  ctx.Orchestrator,
+		Publishers:    publishers,
+		Collectors:    collectors,
+		Timeout:       replicasetTimeout,
 	})
 }
 

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -175,6 +175,11 @@ func (c *CartridgeInstance) Expel(ctx ExpelCtx) error {
 	return newErrExpelByInstanceNotSupported(OrchestratorCartridge)
 }
 
+// BootstrapVShard is not supported for a single instance by the Cartridge orchestrator.
+func (c *CartridgeInstance) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // CartridgeApplication is an application with the Cartridge orchestrator.
 type CartridgeApplication struct {
 	cachedDiscoverer
@@ -300,6 +305,11 @@ func (c *CartridgeApplication) Expel(ctx ExpelCtx) error {
 	}
 
 	return cartridgeExpel(c.runningCtx, replicasets, ctx.InstName, uuid, ctx.Timeout)
+}
+
+// BootstrapVShard is not supported for an application by the Cartridge orchestrator.
+func (c *CartridgeApplication) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByAppNotSupported(OrchestratorCartridge)
 }
 
 // getCartridgeInstanceInfo returns an additional instance information.

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -31,13 +31,6 @@ func TestCartridgeApplication_Demote(t *testing.T) {
 		`demote is not supported for an application by "cartridge" orchestrator`)
 }
 
-func TestCartridgeApplication_BootstrapVShard(t *testing.T) {
-	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
-	err := app.BootstrapVShard(replicaset.VShardBootstrapCtx{})
-	assert.EqualError(t, err,
-		`bootstrap vshard is not supported for an application by "cartridge" orchestrator`)
-}
-
 func TestCartridgeInstance_Demote(t *testing.T) {
 	inst := replicaset.NewCartridgeInstance(nil)
 	err := inst.Demote(replicaset.DemoteCtx{})
@@ -965,11 +958,4 @@ func TestCartridgeInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "cartridge" orchestrator`)
-}
-
-func TestCartridgeInstance_BootstrapVShard(t *testing.T) {
-	instance := replicaset.NewCartridgeInstance(nil)
-	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
-	assert.EqualError(t, err,
-		`bootstrap vshard is not supported for a single instance by "cartridge" orchestrator`)
 }

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -17,6 +17,7 @@ var _ replicaset.Discoverer = &replicaset.CartridgeInstance{}
 var _ replicaset.Promoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Demoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Expeller = &replicaset.CartridgeInstance{}
+var _ replicaset.VShardBootstrapper = &replicaset.CartridgeInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
 var _ replicaset.Promoter = &replicaset.CartridgeApplication{}
@@ -28,6 +29,13 @@ func TestCartridgeApplication_Demote(t *testing.T) {
 	err := app.Demote(replicaset.DemoteCtx{})
 	assert.EqualError(t, err,
 		`demote is not supported for an application by "cartridge" orchestrator`)
+}
+
+func TestCartridgeApplication_BootstrapVShard(t *testing.T) {
+	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
+	err := app.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap vshard is not supported for an application by "cartridge" orchestrator`)
 }
 
 func TestCartridgeInstance_Demote(t *testing.T) {
@@ -957,4 +965,11 @@ func TestCartridgeInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "cartridge" orchestrator`)
+}
+
+func TestCartridgeInstance_BootstrapVShard(t *testing.T) {
+	instance := replicaset.NewCartridgeInstance(nil)
+	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap vshard is not supported for a single instance by "cartridge" orchestrator`)
 }

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -106,6 +106,12 @@ func (c *CConfigInstance) Expel(ctx ExpelCtx) error {
 	return newErrExpelByInstanceNotSupported(OrchestratorCentralizedConfig)
 }
 
+// BootstrapVShard is not supported for a single instance by the
+// centralized config orchestrator.
+func (c *CConfigInstance) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {
@@ -388,6 +394,11 @@ func (c *CConfigApplication) Demote(ctx DemoteCtx) error {
 		err = errors.Join(err, reloadCConfig(instances))
 	}
 	return err
+}
+
+// BootstrapVShard is not supported for an application by the centralized config orchestrator.
+func (c *CConfigApplication) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByAppNotSupported(OrchestratorCentralizedConfig)
 }
 
 // cconfigPromoteElection tries to promote an instance via `box.ctl.promote()`.

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,17 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
 var _ replicaset.Promoter = &replicaset.CConfigInstance{}
 var _ replicaset.Demoter = &replicaset.CConfigInstance{}
 var _ replicaset.Expeller = &replicaset.CConfigInstance{}
+var _ replicaset.VShardBootstrapper = &replicaset.CConfigInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CConfigApplication{}
 var _ replicaset.Promoter = &replicaset.CConfigApplication{}
 var _ replicaset.Demoter = &replicaset.CConfigApplication{}
 var _ replicaset.Expeller = &replicaset.CConfigApplication{}
+var _ replicaset.VShardBootstrapper = &replicaset.CConfigApplication{}
+
+func TestCConfigApplication_BootstrapVShard(t *testing.T) {
+	app := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
+	err := app.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap vshard is not supported for an application by "centralized config" orchestrator`)
+}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -446,4 +456,11 @@ func TestCConfigInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "centralized config" orchestrator`)
+}
+
+func TestCConfigInstance_BootstrapVShard(t *testing.T) {
+	instance := replicaset.NewCConfigInstance(nil)
+	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err, `bootstrap vshard is not supported for a single instance by `+
+		`"centralized config" orchestrator`)
 }

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
-	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
@@ -23,13 +22,6 @@ var _ replicaset.Promoter = &replicaset.CConfigApplication{}
 var _ replicaset.Demoter = &replicaset.CConfigApplication{}
 var _ replicaset.Expeller = &replicaset.CConfigApplication{}
 var _ replicaset.VShardBootstrapper = &replicaset.CConfigApplication{}
-
-func TestCConfigApplication_BootstrapVShard(t *testing.T) {
-	app := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
-	err := app.BootstrapVShard(replicaset.VShardBootstrapCtx{})
-	assert.EqualError(t, err,
-		`bootstrap vshard is not supported for an application by "centralized config" orchestrator`)
-}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {
@@ -456,11 +448,4 @@ func TestCConfigInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "centralized config" orchestrator`)
-}
-
-func TestCConfigInstance_BootstrapVShard(t *testing.T) {
-	instance := replicaset.NewCConfigInstance(nil)
-	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
-	assert.EqualError(t, err, `bootstrap vshard is not supported for a single instance by `+
-		`"centralized config" orchestrator`)
 }

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -20,6 +20,7 @@ type replicasetOrchestrator interface {
 	replicaset.Promoter
 	replicaset.Demoter
 	replicaset.Expeller
+	replicaset.VShardBootstrapper
 }
 
 // makeApplicationOrchestrator creates an orchestrator for the application.
@@ -97,4 +98,15 @@ func getApplicationOrchestrator(manual replicaset.Orchestrator,
 			fmt.Errorf("unable to determinate an orchestrator type: %w", err)
 	}
 	return orchestrator, nil
+}
+
+// getOrchestratorType determines a used orchestrator.
+func getOrchestratorType(
+	orchestrator replicaset.Orchestrator,
+	conn connector.Connector,
+	runningCtx running.RunningCtx) (replicaset.Orchestrator, error) {
+	if conn != nil {
+		return getInstanceOrchestrator(orchestrator, conn)
+	}
+	return getApplicationOrchestrator(orchestrator, runningCtx)
 }

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -25,7 +25,8 @@ type StatusCtx struct {
 
 // Status shows a replicaset status.
 func Status(statusCtx StatusCtx) error {
-	orchestratorType, err := getOrchestratorType(statusCtx)
+	orchestratorType, err := getOrchestratorType(statusCtx.Orchestrator,
+		statusCtx.Conn, statusCtx.RunningCtx)
 	if err != nil {
 		return err
 	}
@@ -49,14 +50,6 @@ func Status(statusCtx StatusCtx) error {
 	}
 
 	return statusReplicasets(replicasets)
-}
-
-// getOrchestratorType determines a used orchestrator for a status context.
-func getOrchestratorType(statusCtx StatusCtx) (replicaset.Orchestrator, error) {
-	if statusCtx.Conn != nil {
-		return getInstanceOrchestrator(statusCtx.Orchestrator, statusCtx.Conn)
-	}
-	return getApplicationOrchestrator(statusCtx.Orchestrator, statusCtx.RunningCtx)
 }
 
 // statusReplicasets show the current status of known replicasets.

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -1,0 +1,76 @@
+package replicasetcmd
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
+	libcluster "github.com/tarantool/tt/lib/cluster"
+)
+
+const (
+	// VShardBootstrapDefaultTimeout is a default timeout for vshard bootstrapping.
+	VShardBootstrapDefaultTimeout = 10
+)
+
+// VShardCmdCtx describes context for vshard commands.
+type VShardCmdCtx struct {
+	// IsApplication true if an application passed.
+	IsApplication bool
+	// RunningCtx is an application running context.
+	RunningCtx running.RunningCtx
+	// Conn is an active connection to a passed instance.
+	Conn connector.Connector
+	// Orchestrator is a forced orchestator choice.
+	Orchestrator replicaset.Orchestrator
+	// Publishers is data publisher factory.
+	Publishers libcluster.DataPublisherFactory
+	// Collectors is data collector factory.
+	Collectors libcluster.DataCollectorFactory
+	// Timeout describes a timeout in seconds.
+	// We keep int as it can be passed to the target instance.
+	Timeout int
+}
+
+// BootstrapVShard bootstraps vshard in the cluster.
+func BootstrapVShard(ctx VShardCmdCtx) error {
+	orchestratorType, err := getOrchestratorType(ctx.Orchestrator, ctx.Conn, ctx.RunningCtx)
+	if err != nil {
+		return err
+	}
+
+	var orchestrator replicasetOrchestrator
+	if ctx.IsApplication {
+		if orchestrator, err = makeApplicationOrchestrator(
+			orchestratorType, ctx.RunningCtx, ctx.Collectors, ctx.Publishers); err != nil {
+			return err
+		}
+	} else {
+		if orchestrator, err = makeInstanceOrchestrator(
+			orchestratorType, ctx.Conn); err != nil {
+			return err
+		}
+	}
+
+	log.Info("Discovery application...")
+	fmt.Println("")
+
+	// Get and print status.
+	replicasets, err := orchestrator.Discovery(true)
+	if err != nil {
+		return err
+	}
+	statusReplicasets(replicasets)
+
+	fmt.Println("")
+	log.Info("Bootstrapping vshard")
+
+	err = orchestrator.BootstrapVShard(replicaset.VShardBootstrapCtx{Timeout: ctx.Timeout})
+	if err == nil {
+		log.Info("Done.")
+	}
+
+	return err
+}

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -83,6 +83,11 @@ func (c *CustomInstance) Expel(ctx ExpelCtx) error {
 	return newErrExpelByInstanceNotSupported(OrchestratorCustom)
 }
 
+// BootstrapVShard is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	cachedDiscoverer
@@ -140,6 +145,11 @@ func (c *CustomApplication) Demote(ctx DemoteCtx) error {
 // Expel is not supported for an application by the Custom orchestrator.
 func (c *CustomApplication) Expel(ctx ExpelCtx) error {
 	return newErrExpelByAppNotSupported(OrchestratorCustom)
+}
+
+// BootstrapVShard is not supported for an application the Custom orchestrator.
+func (c *CustomApplication) BootstrapVShard(VShardBootstrapCtx) error {
+	return newErrBootstrapVShardByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -15,11 +15,13 @@ var _ replicaset.Discoverer = &replicaset.CustomInstance{}
 var _ replicaset.Promoter = &replicaset.CustomInstance{}
 var _ replicaset.Demoter = &replicaset.CustomInstance{}
 var _ replicaset.Expeller = &replicaset.CustomInstance{}
+var _ replicaset.VShardBootstrapper = &replicaset.CustomInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
 var _ replicaset.Promoter = &replicaset.CustomApplication{}
 var _ replicaset.Demoter = &replicaset.CustomApplication{}
 var _ replicaset.Expeller = &replicaset.CustomApplication{}
+var _ replicaset.VShardBootstrapper = &replicaset.CustomApplication{}
 
 func TestCustomApplication_Promote(t *testing.T) {
 	app := replicaset.NewCustomApplication(running.RunningCtx{})
@@ -40,6 +42,13 @@ func TestCustomApplication_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for an application by "custom" orchestrator`)
+}
+
+func TestCustomApplication_BootstrapVShard(t *testing.T) {
+	instance := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap vshard is not supported for an application by "custom" orchestrator`)
 }
 
 func TestCustomInstance_Discovery(t *testing.T) {
@@ -409,4 +418,11 @@ func TestCustomInstance_Expel(t *testing.T) {
 	err := instance.Expel(replicaset.ExpelCtx{})
 	assert.EqualError(t, err,
 		`expel is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_BootstrapVShard(t *testing.T) {
+	instance := replicaset.NewCustomInstance(nil)
+	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap vshard is not supported for a single instance by "custom" orchestrator`)
 }

--- a/cli/replicaset/lua/cartridge/bootstrap_vshard_body.lua
+++ b/cli/replicaset/lua/cartridge/bootstrap_vshard_body.lua
@@ -1,0 +1,28 @@
+local cartridge = require('cartridge')
+local fiber = require('fiber')
+
+local bootstrap_function = cartridge.admin_bootstrap_vshard
+if bootstrap_function == nil then
+    bootstrap_function = require('cartridge.admin').bootstrap_vshard
+end
+
+local timeout = ...
+local deadline = fiber.time() + timeout
+local ok, err
+
+while fiber.time() < deadline do
+    ok, err = bootstrap_function()
+    if ok then
+        break
+    end
+    if err.err:find("already bootstrapped") then
+        error(err.err)
+    end
+    fiber.sleep(0.1)
+end
+
+if err ~= nil then
+    err = err.err
+end
+
+assert(ok, tostring(err))

--- a/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
+++ b/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
@@ -1,0 +1,37 @@
+local ok, vshard = pcall(require, 'vshard')
+if not ok then
+    error("failed to require vshard module")
+end
+local fiber = require('fiber')
+local config = require('config')
+
+local is_router = false
+for _, role in ipairs(config:get().sharding.roles) do
+    if role == "router" then
+        is_router = true
+        break
+    end
+end
+
+if not is_router then
+    error("instance must be a router to bootstrap vshard")
+end
+
+pcall(vshard.router.master_search_wakeup)
+
+local timeout = ...
+local deadline = fiber.time() + timeout
+local ok, err
+
+while fiber.time() < deadline do
+    ok, err = vshard.router.bootstrap()
+    if ok then
+        break
+    end
+    if err.message:find("already bootstrapped") then
+        error(err.message)
+    end
+    fiber.sleep(0.1)
+end
+
+assert(ok, tostring(err))

--- a/cli/replicaset/vshard.go
+++ b/cli/replicaset/vshard.go
@@ -1,0 +1,30 @@
+package replicaset
+
+import "fmt"
+
+// VShardBootstrapCtx describes context to bootstrap vshard.
+type VShardBootstrapCtx struct {
+	// Timeout is a timeout for bootstrapping in seconds.
+	// Keep int, because it can be passed to the target instance.
+	Timeout int
+}
+
+// VShardBootstrapper performs vshard bootstrapping.
+type VShardBootstrapper interface {
+	// BootstrapVShard bootstraps vshard in the cluster.
+	BootstrapVShard(ctx VShardBootstrapCtx) error
+}
+
+// newErrBootstrapVShardByInstanceNotSupported creates a new error that vshard bootstrap is not
+// supported by the orchestrator for a single instance.
+func newErrBootstrapVShardByInstanceNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("bootstrap vshard is not supported for a single instance by %q orchestrator",
+		orchestrator)
+}
+
+// newErrBootstrapVShardByAppNotSupported creates a new error that vshard bootstrap is not
+// supported by the orhestrator for an application.
+func newErrBootstrapVShardByAppNotSupported(orchestrator Orchestrator) error {
+	return fmt.Errorf("bootstrap vshard is not supported for an application by %q orchestrator",
+		orchestrator)
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -136,6 +136,11 @@ def cartridge_app_session(request, tt_cmd):
 
 
 @pytest.fixture
-def cartridge_app(cartridge_app_session):
-    cartridge_app_session.truncate()
+def cartridge_app(request, cartridge_app_session):
+    bootstrap_vshard = True
+    if hasattr(request, "param"):
+        params = request.param
+        if "bootstrap_vshard" in params:
+            bootstrap_vshard = params["bootstrap_vshard"]
+    cartridge_app_session.truncate(bootstrap_vshard=bootstrap_vshard)
     return cartridge_app_session

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,15 +2,13 @@ import os
 import platform
 import signal
 import subprocess
-import tempfile
 
 import psutil
-import py
 import pytest
 from cartridge_helper import CartridgeApp
 from etcd_helper import EtcdInstance
 
-from utils import create_tt_config, kill_procs
+from utils import create_tt_config, get_tmpdir, kill_procs
 
 
 # ######## #
@@ -24,12 +22,6 @@ def sigterm_handler():
     original = signal.signal(signal.SIGTERM, signal.getsignal(signal.SIGINT))
     yield
     signal.signal(signal.SIGTERM, original)
-
-
-def get_tmpdir(request):
-    tmpdir = py.path.local(tempfile.mkdtemp())
-    request.addfinalizer(lambda: tmpdir.remove(rec=1))
-    return str(tmpdir)
 
 
 @pytest.fixture(scope="session")

--- a/test/integration/replicaset/test_replicaset_vshard.py
+++ b/test/integration/replicaset/test_replicaset_vshard.py
@@ -1,10 +1,15 @@
+import io
 import os
 import re
 import shutil
 
 import pytest
+from cartridge_helper import (cartridge_name, cartridge_password,
+                              cartridge_username)
+from replicaset_helpers import eval_on_instance, parse_status
 
-from utils import get_tarantool_version, run_command_and_get_output, wait_file
+from utils import (get_tarantool_version, run_command_and_get_output,
+                   wait_event, wait_file)
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
 
@@ -78,3 +83,38 @@ Replicasets state: bootstrapped
         stop_cmd = [tt_cmd, "stop", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--cartridge"])
+@pytest.mark.parametrize("target", ["uri", "app", "instance"])
+@pytest.mark.parametrize("cartridge_app", [{"bootstrap_vshard": False}], indirect=True)
+def test_vshard_bootstrap_cartridge(cartridge_app, tt_cmd, target, flag):
+    cmd = [tt_cmd, "rs", "vs", "bootstrap"]
+    if flag:
+        cmd.append(flag)
+    if target == "uri":
+        cmd.extend(["--username", cartridge_username, "--password", cartridge_password])
+        cmd.append(cartridge_app.uri["s1-replica"])
+    elif target == "app":
+        cmd.append(cartridge_name)
+    elif target == "instance":
+        cmd.append(f"{cartridge_name}:s1-replica")
+
+    rc, out = run_command_and_get_output(cmd, cwd=cartridge_app.workdir)
+    assert rc == 0
+    buf = io.StringIO(out)
+    assert "• Discovery application..." in buf.readline()
+    buf.readline()
+    # Skip init status in the output.
+    parse_status(buf)
+    assert "Bootstrapping vshard" in buf.readline()
+    assert "Done." in buf.readline()
+
+    def have_buckets_created():
+        expr = "vshard.storage.buckets_count() == 0"
+        out = eval_on_instance(tt_cmd, cartridge_name, "s1-replica", cartridge_app.workdir, expr)
+        return out.find("false") != -1
+
+    assert wait_event(10, have_buckets_created)

--- a/test/integration/replicaset/test_replicaset_vshard.py
+++ b/test/integration/replicaset/test_replicaset_vshard.py
@@ -1,0 +1,80 @@
+import os
+import re
+import shutil
+
+import pytest
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("case", [["--config", "--custom"],
+                                  ["--custom", "--cartridge"],
+                                  ["--config", "--cartridge"],
+                                  ["--config", "--custom", "--cartridge"]])
+def test_vshard_bootstrap(tt_cmd, tmpdir_with_cfg, case):
+    cmd = [tt_cmd, "rs", "vs", "bootstrap"] + case + ["app:instance"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ only one type of orchestrator can be forced", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+def test_vshard_bootstrap_no_instance(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+
+    status_cmd = [tt_cmd, "rs", "vs", "bootstrap", "test_custom_app:unexist"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ instance \"unexist\" not found", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--custom"])
+def test_vshard_bootstrap_custom_app(tt_cmd, tmpdir_with_cfg, flag):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        cmd = [tt_cmd, "rs", "vs", "bootstrap"]
+        if flag:
+            cmd.append(flag)
+        cmd.append("test_custom_app:test_custom_app")
+
+        rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+        assert rc == 1
+        assert re.search(r"""  • Discovery application...*
+
+Orchestrator:      custom
+Replicasets state: bootstrapped
+
+• .*
+  Failover: unknown
+  Master:   single
+    • test_custom_app .* rw
+
+   • Bootstrapping vshard.*
+   ⨯ bootstrap vshard is not supported for an application by "custom" orchestrator
+""", out)
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0

--- a/test/integration/replicaset/test_vshard_app/config.yaml
+++ b/test/integration/replicaset/test_vshard_app/config.yaml
@@ -1,0 +1,51 @@
+credentials:
+  users:
+    client:
+      password: 'secret'
+      roles: [super]
+    replicator:
+      password: 'secret'
+      roles: [replication]
+    storage:
+      password: 'secret'
+      roles: [sharding]
+
+iproto:
+  listen:
+    - uri: 'unix/:./{{ instance_name }}.iproto'
+  advertise:
+    peer:
+      login: replicator
+    sharding:
+      login: storage
+
+sharding:
+  bucket_count: 3000
+
+app:
+  file: 'init.lua'
+
+groups:
+  storages:
+    sharding:
+      roles: [storage]
+    replication:
+      failover: manual
+    replicasets:
+      storage-001:
+        leader: storage-001-a
+        instances:
+          storage-001-a: {}
+          storage-001-b: {}
+      storage-002:
+        leader: storage-002-a
+        instances:
+          storage-002-a: {}
+          storage-002-b: {}
+  routers:
+    sharding:
+      roles: [router]
+    replicasets:
+      router-001:
+        instances:
+          router-001-a: {}

--- a/test/integration/replicaset/test_vshard_app/init.lua
+++ b/test/integration/replicaset/test_vshard_app/init.lua
@@ -1,0 +1,22 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+while true do
+    if type(box.info.name) == 'string' then
+        break
+    end
+    fiber.sleep(0.1)
+end
+
+while true do
+    if not box.cfg.replication then
+        break
+    end
+    if #box.cfg.replication <= #box.info.replication then
+        break
+    end
+    fiber.sleep(0.1)
+end
+
+local fh = fio.open('ready-' .. box.info.name, {'O_WRONLY', 'O_CREAT'}, tonumber('644', 8))
+fh:close()

--- a/test/integration/replicaset/test_vshard_app/instances.yaml
+++ b/test/integration/replicaset/test_vshard_app/instances.yaml
@@ -1,0 +1,9 @@
+storage-001-a:
+
+storage-001-b:
+
+storage-002-a:
+
+storage-002-b:
+
+router-001-a:

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,10 +4,12 @@ import re
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 
 import netifaces
 import psutil
+import py
 import tarantool
 import yaml
 
@@ -21,6 +23,12 @@ pid_file = "tt.pid"
 log_file = "tt.log"
 initial_snap = "00000000000000000000.snap"
 initial_xlog = "00000000000000000000.xlog"
+
+
+def get_tmpdir(request):
+    tmpdir = py.path.local(tempfile.mkdtemp())
+    request.addfinalizer(lambda: tmpdir.remove(rec=1))
+    return str(tmpdir)
 
 
 def run_command_and_get_output(


### PR DESCRIPTION
@TarantoolBot document
Title: `tt replicaset vshard bootstrap` - bootstraps vshard in the cluster

This patch introduces new subcommand for the replicaset module.
`tt replicaset vshard` - manages vshard in the cluster.

`tt replicaset vshard bootstrap [--cartridge|--config|--custom] [flags] (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)`

* Bootstraps vshard in the replicaset.

* Cartridge: by fact, it is the clone of `cartridge-cli replicasets bootstrap-vshard`.

* Centralized config (3.0): lookups for the router in the cluster and calls `vshard.router.bootstrap()` on it.

Part of https://github.com/tarantool/tt/issues/316