### PR TITLE
replicaset: add `bootstrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   versions >= 3.2.
 - `tt enable`: create a symbolic link in 'instances_enabled' directory to a script or
   an application directory.
+- `tt replicaset bootstrap`: command to bootstrap a Cartridge cluster or an instance.
 
 ### Fixed
 

--- a/cli/replicaset/bootstrap.go
+++ b/cli/replicaset/bootstrap.go
@@ -1,0 +1,38 @@
+package replicaset
+
+import "fmt"
+
+// BootstrapCtx describes the context to bootstrap an instance/application.
+type BootstrapCtx struct {
+	// ReplicasetsFile is a Cartridge replicasets file.
+	ReplicasetsFile string
+	// Timeout describes a timeout in seconds.
+	// We keep int as it can be passed to the target instance.
+	Timeout int
+	// BootstrapVShard is true when the vshard must be bootstrapped.
+	BootstrapVShard bool
+	// Instance is an instance name to bootstrap.
+	Instance string
+	// Replicaset is a replicaset name for an instance bootstrapping.
+	Replicaset string
+}
+
+// Bootstrapper is an interface to bootstrap an instance/application.
+type Bootstrapper interface {
+	// Bootstrap bootstraps an instance/application.
+	Bootstrap(ctx BootstrapCtx) error
+}
+
+// newErrBootstrapByInstanceNotSupported creates a new error that bootstrap is not
+// supported by the orchestrator for a single instance.
+func newErrBootstrapByInstanceNotSupported(orhestrator Orchestrator) error {
+	return fmt.Errorf("bootstrap is not supported for a single instance by %q orchestrator",
+		orhestrator)
+}
+
+// newErrBootstrapByAppNotSupported creates a new error that bootstrap is not
+// supported by the orchestrator for an application.
+func newErrBootstrapByAppNotSupported(orhestrator Orchestrator) error {
+	return fmt.Errorf("bootstrap is not supported for an application by %q orchestrator",
+		orhestrator)
+}

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -3,13 +3,24 @@ package replicaset
 import (
 	_ "embed"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/apex/log"
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v2"
 
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/running"
+	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
+)
+
+const (
+	defaultCartridgeReplicasetsFilename = "replicasets.yml"
+	defaultCartridgeInstancesFilename   = "instances.yml"
 )
 
 var (
@@ -293,9 +304,314 @@ func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
 }
 
-// Bootstrap is not supported for an application by the Cartridge orchestrator.
-func (c *CartridgeApplication) Bootstrap(BootstrapCtx) error {
-	return newErrBootstrapByAppNotSupported(OrchestratorCartridge)
+// cartridgeReplicasetConfig describes a replicaset config for the cartridge application.
+type cartridgeReplicasetConfig struct {
+	Alias       string   `yaml:"alias,omitempty"`
+	Instances   []string `yaml:"instances"`
+	Roles       []string `yaml:"roles"`
+	Weight      *float64 `yaml:"weight,omitempty"`
+	AllRW       *bool    `yaml:"all_rw,omitempty"`
+	VShardGroup *string  `yaml:"vshard_group,omitempty"`
+}
+
+// cartridgeInstanceConfig describes a instance config for the cartridge application.
+type cartridgeInstanceConfig struct {
+	URI string `yaml:"advertise_uri"`
+}
+
+// parseYaml parses YAML to the specified type.
+func parseYaml[T any](filename string) (T, error) {
+	content, err := os.ReadFile(filename)
+	var ret T
+	if err != nil {
+		return ret, err
+	}
+	err = yaml.Unmarshal(content, &ret)
+	return ret, err
+}
+
+// getCartridgeReplicasetsConfig extracts a replicasets config.
+func getCartridgeReplicasetsConfig(appDir,
+	filename string) (map[string]cartridgeReplicasetConfig, string, error) {
+	if filename == "" {
+		filename = filepath.Join(appDir, defaultCartridgeReplicasetsFilename)
+	}
+	filename, err := util.GetYamlFileName(filename, true)
+	if err != nil {
+		return nil, "", err
+	}
+	cfg, err := parseYaml[map[string]cartridgeReplicasetConfig](filename)
+	if err != nil {
+		return nil, filename, err
+	}
+	return cfg, filename, nil
+}
+
+// getCartridgeInstancesConfig extracts a instances config.
+func getCartridgeInstancesConfig(appName,
+	appDir string) (map[string]cartridgeInstanceConfig, error) {
+	filename, err := util.GetYamlFileName(
+		filepath.Join(appDir, defaultCartridgeInstancesFilename), true)
+	if err != nil {
+		return nil, err
+	}
+	rawCfg, err := parseYaml[map[string]cartridgeInstanceConfig](filename)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := map[string]cartridgeInstanceConfig{}
+	appPrefix := fmt.Sprintf("%s.", appName)
+	for key, instCfg := range rawCfg {
+		instName, found := strings.CutPrefix(key, appPrefix)
+		if found {
+			cfg[instName] = instCfg
+		}
+	}
+	return cfg, nil
+}
+
+// Bootstrap bootstraps replicasets or a certain instance by the Cartridge orchestrator.
+func (c *CartridgeApplication) Bootstrap(ctx BootstrapCtx) error {
+	if len(c.runningCtx.Instances) == 0 {
+		return fmt.Errorf("failed to bootstrap: there are no running instances")
+	}
+	var (
+		appDir  = c.runningCtx.Instances[0].AppDir
+		appName = c.runningCtx.Instances[0].AppName
+	)
+	instancesCfg, err := getCartridgeInstancesConfig(appName, appDir)
+	if err != nil {
+		return fmt.Errorf("failed to get instances config: %w", err)
+	}
+	discovered, err := c.Discovery(SkipCache)
+	if err != nil {
+		return fmt.Errorf("failed to discovery: %w", err)
+	}
+
+	fmt.Println("DISCOVERED", discovered)
+
+	var (
+		eval      InstanceEvalFunc
+		instances = filterDiscovered(c.runningCtx.Instances, discovered)
+	)
+	if ctx.Instance != "" {
+		// Bootstrap an instance.
+		eval = func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+			return true,
+				c.bootstrapInstance(ctx.Instance, ctx.Replicaset, evaler, discovered,
+					instancesCfg, ctx.Timeout)
+		}
+	} else {
+		// Bootstrap a replicasets from the config.
+		replicasetCfg, replicasetscCfgPath, err := getCartridgeReplicasetsConfig(appDir,
+			ctx.ReplicasetsFile)
+		if err != nil {
+			return fmt.Errorf("failed to get replicasets config: %w", err)
+		}
+		log.Infof("Bootstrap replicasets described in %s", replicasetscCfgPath)
+		eval = func(_ running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+			return true,
+				c.bootstrapReplicasets(evaler, discovered, replicasetCfg, instancesCfg, ctx.Timeout)
+		}
+		if discovered.State != StateBootstrapped {
+			// Initial bootstrapping, use some instance from the config.
+			cfgInstNames := map[string]struct{}{}
+			for _, replicaset := range replicasetCfg {
+				for _, inst := range replicaset.Instances {
+					cfgInstNames[inst] = struct{}{}
+				}
+			}
+			instances = filterInstances(c.runningCtx.Instances, func(
+				inst running.InstanceCtx) bool {
+				_, ok := cfgInstNames[inst.InstName]
+				return ok
+			})
+		}
+	}
+
+	if len(instances) == 0 {
+		return fmt.Errorf("not found any instance to perform bootstrapping")
+	}
+	err = EvalForeach(instances, InstanceEvalFunc(eval))
+	if err != nil {
+		return err
+	}
+
+	if ctx.BootstrapVShard {
+		// VShard bootstrapping takes the instances from the discovery cache, so re-discovery.
+		_, err = c.Discovery(SkipCache)
+		if err != nil {
+			return fmt.Errorf("failed to re-discovery: %w", err)
+		}
+		// Bootstrap vshard.
+		err = c.BootstrapVShard(VShardBootstrapCtx{Timeout: ctx.Timeout})
+	}
+	return err
+}
+
+// bootstrapInstance bootstrap an instance.
+func (c *CartridgeApplication) bootstrapInstance(instanceName, replicasetName string,
+	evaler connector.Evaler, discovered Replicasets,
+	instancesCfg map[string]cartridgeInstanceConfig, timeout int) error {
+	if replicasetName == "" {
+		return fmt.Errorf("a replicaset name is empty")
+	}
+	var (
+		replicasetUUID string
+		found          bool
+	)
+	for _, replicaset := range discovered.Replicasets {
+		if replicaset.Alias == replicasetName {
+			found = true
+			replicasetUUID = replicaset.UUID
+			break
+		}
+		for _, instance := range replicaset.Instances {
+			if instance.Alias == instanceName {
+				return fmt.Errorf("instance %q is bootstrapped already", instanceName)
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("a replicaset %q not found in the bootstrapped cluster", replicasetName)
+	}
+	instancesUUID := map[string]string{}
+	joinOpts, err := getCartridgeJoinServersOpts(instancesCfg, []string{instanceName},
+		instancesUUID)
+	if err != nil {
+		return err
+	}
+	opts := []cartridgeEditReplicasetsOpts{{
+		UUID:        &replicasetUUID,
+		JoinServers: joinOpts,
+	}}
+	return cartridgeEditReplicasets(evaler, opts, timeout)
+}
+
+// bootstrapReplicasets bootstraps replicasets from the config.
+func (c *CartridgeApplication) bootstrapReplicasets(evaler connector.Evaler, discovered Replicasets,
+	replicasetsCfg map[string]cartridgeReplicasetConfig,
+	instancesCfg map[string]cartridgeInstanceConfig,
+	timeout int) error {
+
+	majorVer, err := getCartridgeMajorVersion(evaler)
+	if err != nil {
+		return fmt.Errorf("failed to get cartridge major version: %w", err)
+	}
+	if majorVer < 2 && discovered.State != StateBootstrapped {
+		if len(replicasetsCfg) == 0 {
+			return fmt.Errorf("empty replicasets config")
+		}
+		for rname, cfg := range replicasetsCfg {
+			// Create first replicaset with single instance, since in the old Cartridge
+			// bootstrapping cluster from scratch should be performed
+			// on a single-server replicaset only.
+			if len(cfg.Instances) == 0 {
+				return fmt.Errorf("replicaset %q is empty", rname)
+			}
+			instances := cfg.Instances
+			initialReplicasetCfg := cfg
+			initialReplicasetCfg.Instances, cfg.Instances = instances[:1], instances[1:]
+
+			initialCfg := map[string]cartridgeReplicasetConfig{}
+			initialCfg[rname] = initialReplicasetCfg
+			if len(cfg.Instances) == 0 {
+				// There are no more instances to bootstrap.
+				delete(replicasetsCfg, rname)
+			} else {
+				replicasetsCfg[rname] = cfg
+			}
+
+			if err := updateCartridgeReplicasets(evaler, discovered, initialCfg,
+				instancesCfg, timeout); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	if err := updateCartridgeReplicasets(evaler, discovered, replicasetsCfg,
+		instancesCfg, timeout); err != nil {
+		return err
+	}
+
+	return err
+}
+
+// getCartridgeJoinServersOpts returns opts to join new servers.
+// It lookups for an instance in the UUID map and if an instance is not found,
+// generates new UUID and adds the instance to the join options.
+func getCartridgeJoinServersOpts(instancesCfg map[string]cartridgeInstanceConfig,
+	instances []string, instancesUUID map[string]string) ([]cartridgeJoinServersOpts, error) {
+	opts := make([]cartridgeJoinServersOpts, 0)
+	for _, instance := range instances {
+		if _, UUIDExists := instancesUUID[instance]; UUIDExists {
+			continue
+		}
+		cfg, found := instancesCfg[instance]
+		if !found {
+			return nil, fmt.Errorf("instance %q not found in the instance config", instance)
+		}
+		instanceUUID := uuid.New().String()
+		instancesUUID[instance] = instanceUUID
+		opts = append(opts, cartridgeJoinServersOpts{
+			URI:  cfg.URI,
+			UUID: &instanceUUID,
+		})
+	}
+	return opts, nil
+}
+
+// updateCartridgeReplicasets updates replicasets using the config.
+// If some instance was not discovered, creates it.
+func updateCartridgeReplicasets(evaler connector.Evaler, discovered Replicasets,
+	replicasetCfg map[string]cartridgeReplicasetConfig,
+	instancesCfg map[string]cartridgeInstanceConfig,
+	timeout int) error {
+	instanceUUID := map[string]string{}
+	replicasetUUID := map[string]string{}
+	for _, replicaset := range discovered.Replicasets {
+		replicasetUUID[replicaset.Alias] = replicaset.UUID
+		for _, instance := range replicaset.Instances {
+			instanceUUID[instance.Alias] = instance.UUID
+		}
+	}
+
+	var editOpts []cartridgeEditReplicasetsOpts
+	for rname, rcfg := range replicasetCfg {
+		replicasetName := rname
+		opts := cartridgeEditReplicasetsOpts{
+			Alias:       &replicasetName,
+			Roles:       rcfg.Roles,
+			AllRW:       rcfg.AllRW,
+			Weight:      rcfg.Weight,
+			VshardGroup: rcfg.VShardGroup,
+		}
+		if uuid, found := replicasetUUID[replicasetName]; found {
+			// Link opts to the existing replicaset.
+			// admin_edit_topology() recognizes replicasets by UUID.
+			opts.UUID = &uuid
+		}
+		var err error
+		opts.JoinServers, err = getCartridgeJoinServersOpts(instancesCfg,
+			rcfg.Instances, instanceUUID)
+		if err != nil {
+			return err
+		}
+		var failoverPriority []string
+		for _, inst := range rcfg.Instances {
+			uuid, ok := instanceUUID[inst]
+			if !ok {
+				return fmt.Errorf("instance %q uuid not found", inst)
+			}
+			failoverPriority = append(failoverPriority, uuid)
+		}
+		opts.FailoverPriority = failoverPriority
+		editOpts = append(editOpts, opts)
+	}
+
+	return cartridgeEditReplicasets(evaler, editOpts, timeout)
 }
 
 // Expel expels an instance from a Cartridge replicasets.
@@ -447,18 +763,22 @@ func cartridgeHealthCheckIsNeeded(evaler connector.Evaler) (bool, error) {
 	return major < 2, nil
 }
 
+// cartridgeJoinServersOpts describes options for server joining.
+type cartridgeJoinServersOpts struct {
+	URI  string  `msgpack:"uri"`
+	UUID *string `msgpack:"uuid,omitempty"`
+}
+
 // cartridgeEditReplicasetsOpts describes options for replicaset editing.
 type cartridgeEditReplicasetsOpts struct {
-	UUID        *string  `msgpack:"uuid,omitempty"`
-	Alias       *string  `msgpack:"alias,omitempty"`
-	Roles       []string `msgpack:"roles,omitempty"`
-	AllRW       *bool    `msgpack:"all_rw,omitempty"`
-	Weight      *float64 `msgpack:"weight,omitempty"`
-	VshardGroup *string  `msgpack:"vshard_group,omitempty"`
-	JoinServers []struct {
-		URI string `msgpack:"uri"`
-	} `msgpack:"join_servers,omitempty"`
-	FailoverPriority []string `msgpack:"failover_priority,omitempty"`
+	UUID             *string                    `msgpack:"uuid,omitempty"`
+	Alias            *string                    `msgpack:"alias,omitempty"`
+	Roles            []string                   `msgpack:"roles,omitempty"`
+	AllRW            *bool                      `msgpack:"all_rw,omitempty"`
+	Weight           *float64                   `msgpack:"weight,omitempty"`
+	VshardGroup      *string                    `msgpack:"vshard_group,omitempty"`
+	JoinServers      []cartridgeJoinServersOpts `msgpack:"join_servers,omitempty"`
+	FailoverPriority []string                   `msgpack:"failover_priority,omitempty"`
 }
 
 // cartridgeEditInstancesOpts describes options for instances editing.

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -179,6 +179,11 @@ func (c *CartridgeInstance) Expel(ctx ExpelCtx) error {
 	return newErrExpelByInstanceNotSupported(OrchestratorCartridge)
 }
 
+// Bootstrap is not supported for a single instance by the Cartridge orchestrator.
+func (c *CartridgeInstance) Bootstrap(ctx BootstrapCtx) error {
+	return newErrBootstrapByInstanceNotSupported(OrchestratorCartridge)
+}
+
 // BootstrapVShard bootstraps the vshard for a single instance by the Cartridge orchestrator.
 func (c *CartridgeInstance) BootstrapVShard(ctx VShardBootstrapCtx) error {
 	err := cartridgeBootstrapVShard(c.evaler, ctx.Timeout)
@@ -286,6 +291,11 @@ loop:
 // Demote is not supported for an application by the Cartridge orchestrator.
 func (c *CartridgeApplication) Demote(ctx DemoteCtx) error {
 	return newErrDemoteByAppNotSupported(OrchestratorCartridge)
+}
+
+// Bootstrap is not supported for an application by the Cartridge orchestrator.
+func (c *CartridgeApplication) Bootstrap(BootstrapCtx) error {
+	return newErrBootstrapByAppNotSupported(OrchestratorCartridge)
 }
 
 // Expel expels an instance from a Cartridge replicasets.

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -18,11 +18,13 @@ var _ replicaset.Promoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Demoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Expeller = &replicaset.CartridgeInstance{}
 var _ replicaset.VShardBootstrapper = &replicaset.CartridgeInstance{}
+var _ replicaset.Bootstrapper = &replicaset.CartridgeInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
 var _ replicaset.Promoter = &replicaset.CartridgeApplication{}
 var _ replicaset.Demoter = &replicaset.CartridgeApplication{}
 var _ replicaset.Expeller = &replicaset.CartridgeApplication{}
+var _ replicaset.Bootstrapper = &replicaset.CartridgeApplication{}
 
 func TestCartridgeApplication_Demote(t *testing.T) {
 	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
@@ -31,11 +33,25 @@ func TestCartridgeApplication_Demote(t *testing.T) {
 		`demote is not supported for an application by "cartridge" orchestrator`)
 }
 
+func TestCartridgeApplication_Bootstrap(t *testing.T) {
+	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
+	err := app.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for an application by "cartridge" orchestrator`)
+}
+
 func TestCartridgeInstance_Demote(t *testing.T) {
 	inst := replicaset.NewCartridgeInstance(nil)
 	err := inst.Demote(replicaset.DemoteCtx{})
 	assert.EqualError(t, err,
 		`demote is not supported for a single instance by "cartridge" orchestrator`)
+}
+
+func TestCartridgeInstance_Bootstrap(t *testing.T) {
+	inst := replicaset.NewCartridgeInstance(nil)
+	err := inst.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for a single instance by "cartridge" orchestrator`)
 }
 
 func TestCartridgeInstance_Discovery(t *testing.T) {

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -37,7 +37,7 @@ func TestCartridgeApplication_Bootstrap(t *testing.T) {
 	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
 	err := app.Bootstrap(replicaset.BootstrapCtx{})
 	assert.EqualError(t, err,
-		`bootstrap is not supported for an application by "cartridge" orchestrator`)
+		`failed to bootstrap: there are no running instances`)
 }
 
 func TestCartridgeInstance_Demote(t *testing.T) {

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -111,6 +111,12 @@ func (c *CConfigInstance) Expel(ctx ExpelCtx) error {
 	return newErrExpelByInstanceNotSupported(OrchestratorCentralizedConfig)
 }
 
+// Bootstrap is not supported for a single instance by the centralized config
+// orchestrator.
+func (c *CConfigInstance) Bootstrap(BootstrapCtx) error {
+	return newErrBootstrapByInstanceNotSupported(OrchestratorCentralizedConfig)
+}
+
 // BootstrapVShard bootstraps vshard for a single instance by the centralized config
 // orchestrator.
 func (c *CConfigInstance) BootstrapVShard(ctx VShardBootstrapCtx) error {
@@ -443,6 +449,12 @@ func (c *CConfigApplication) BootstrapVShard(ctx VShardBootstrapCtx) error {
 		return fmt.Errorf("not found any vshard router in replicaset")
 	}
 	return nil
+}
+
+// Bootstrap is not supported for an application by the centralized config
+// orchestrator.
+func (c *CConfigApplication) Bootstrap(BootstrapCtx) error {
+	return newErrBootstrapByAppNotSupported(OrchestratorCentralizedConfig)
 }
 
 // cconfigPromoteElection tries to promote an instance via `box.ctl.promote()`.

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var _ replicaset.Discoverer = &replicaset.CConfigInstance{}
@@ -16,12 +17,28 @@ var _ replicaset.Promoter = &replicaset.CConfigInstance{}
 var _ replicaset.Demoter = &replicaset.CConfigInstance{}
 var _ replicaset.Expeller = &replicaset.CConfigInstance{}
 var _ replicaset.VShardBootstrapper = &replicaset.CConfigInstance{}
+var _ replicaset.Bootstrapper = &replicaset.CConfigInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CConfigApplication{}
 var _ replicaset.Promoter = &replicaset.CConfigApplication{}
 var _ replicaset.Demoter = &replicaset.CConfigApplication{}
 var _ replicaset.Expeller = &replicaset.CConfigApplication{}
 var _ replicaset.VShardBootstrapper = &replicaset.CConfigApplication{}
+var _ replicaset.Bootstrapper = &replicaset.CConfigApplication{}
+
+func TestCconfigApplication_Bootstrap(t *testing.T) {
+	app := replicaset.NewCConfigApplication(running.RunningCtx{}, nil, nil)
+	err := app.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for an application by "centralized config" orchestrator`)
+}
+
+func TestCConfigInstance_Bootstrap(t *testing.T) {
+	app := replicaset.NewCConfigInstance(nil)
+	err := app.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for a single instance by "centralized config" orchestrator`)
+}
 
 func TestCConfigInstance_Discovery(t *testing.T) {
 	cases := []struct {

--- a/cli/replicaset/cmd/bootstrap.go
+++ b/cli/replicaset/cmd/bootstrap.go
@@ -1,0 +1,73 @@
+package replicasetcmd
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
+)
+
+// BootstrapCtx describes context to bootstrap an instance or application.
+type BootstapCtx struct {
+	// ReplicasetsFile is a Cartridge replicasets file.
+	ReplicasetsFile string
+	// Orchestrator is a forced orchestator choice.
+	Orchestrator replicaset.Orchestrator
+	// RunningCtx is an application running context.
+	RunningCtx running.RunningCtx
+	// Timeout describes a timeout in seconds.
+	// We keep int as it can be passed to the target instance.
+	Timeout int
+	// BootstrapVShard is true when the vshard must be bootstrapped.
+	BootstrapVShard bool
+	// Instance is an instance name to bootstrap.
+	Instance string
+	// Replicaset is a replicaset name for an instance bootstrapping.
+	Replicaset string
+}
+
+// Bootstrap bootstraps an instance or application.
+func Bootstrap(ctx BootstapCtx) error {
+	if ctx.Instance != "" {
+		if ctx.Replicaset == "" {
+			return fmt.Errorf("the replicaset must be specified to bootstrap an instance")
+		}
+	} else {
+		if ctx.Replicaset != "" {
+			return fmt.Errorf(
+				"the replicaset can not be specified in the case of application bootstrapping")
+		}
+	}
+
+	orchestratorType, err := getApplicationOrchestrator(ctx.Orchestrator,
+		ctx.RunningCtx)
+	if err != nil {
+		return err
+	}
+
+	orchestrator, err := makeApplicationOrchestrator(orchestratorType,
+		ctx.RunningCtx, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	err = orchestrator.Bootstrap(replicaset.BootstrapCtx{
+		ReplicasetsFile: ctx.ReplicasetsFile,
+		Timeout:         ctx.Timeout,
+		Instance:        ctx.Instance,
+		Replicaset:      ctx.Replicaset,
+		BootstrapVShard: ctx.BootstrapVShard,
+	})
+	if err == nil {
+		// Re-discovery and log topology.
+		replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
+		if err != nil {
+			return err
+		}
+		statusReplicasets(replicasets)
+		fmt.Println()
+		log.Info("Done.")
+	}
+	return err
+}

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -21,6 +21,7 @@ type replicasetOrchestrator interface {
 	replicaset.Demoter
 	replicaset.Expeller
 	replicaset.VShardBootstrapper
+	replicaset.Bootstrapper
 }
 
 // makeApplicationOrchestrator creates an orchestrator for the application.

--- a/cli/replicaset/common.go
+++ b/cli/replicaset/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/running"
 )
 
 var (
@@ -35,4 +36,31 @@ func waitRO(eval connector.Evaler, timeout int) error {
 		return fmt.Errorf("failed to wait ro: %w", err)
 	}
 	return nil
+}
+
+// filterDiscovered filters only discovered instances from the instances bunch.
+func filterDiscovered(instances []running.InstanceCtx,
+	discovered Replicasets) []running.InstanceCtx {
+	discoveredMap := map[string]struct{}{}
+	for _, replicaset := range discovered.Replicasets {
+		for _, instance := range replicaset.Instances {
+			discoveredMap[instance.Alias] = struct{}{}
+		}
+	}
+	return filterInstances(instances, func(instance running.InstanceCtx) bool {
+		_, ok := discoveredMap[instance.InstName]
+		return ok
+	})
+}
+
+// filterInstances filter instances with the predicate.
+func filterInstances(instances []running.InstanceCtx,
+	filter func(running.InstanceCtx) bool) []running.InstanceCtx {
+	var filtered []running.InstanceCtx
+	for _, instance := range instances {
+		if filter(instance) {
+			filtered = append(filtered, instance)
+		}
+	}
+	return filtered
 }

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -88,6 +88,11 @@ func (c *CustomInstance) BootstrapVShard(VShardBootstrapCtx) error {
 	return newErrBootstrapVShardByInstanceNotSupported(OrchestratorCustom)
 }
 
+// Bootstrap is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) Bootstrap(BootstrapCtx) error {
+	return newErrBootstrapByInstanceNotSupported(OrchestratorCustom)
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	cachedDiscoverer
@@ -150,6 +155,11 @@ func (c *CustomApplication) Expel(ctx ExpelCtx) error {
 // BootstrapVShard is not supported for an application the Custom orchestrator.
 func (c *CustomApplication) BootstrapVShard(VShardBootstrapCtx) error {
 	return newErrBootstrapVShardByAppNotSupported(OrchestratorCustom)
+}
+
+// Bootstrap is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) Bootstrap(BootstrapCtx) error {
+	return newErrBootstrapByAppNotSupported(OrchestratorCustom)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -16,12 +16,14 @@ var _ replicaset.Promoter = &replicaset.CustomInstance{}
 var _ replicaset.Demoter = &replicaset.CustomInstance{}
 var _ replicaset.Expeller = &replicaset.CustomInstance{}
 var _ replicaset.VShardBootstrapper = &replicaset.CustomInstance{}
+var _ replicaset.Bootstrapper = &replicaset.CustomInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CustomApplication{}
 var _ replicaset.Promoter = &replicaset.CustomApplication{}
 var _ replicaset.Demoter = &replicaset.CustomApplication{}
 var _ replicaset.Expeller = &replicaset.CustomApplication{}
 var _ replicaset.VShardBootstrapper = &replicaset.CustomApplication{}
+var _ replicaset.Bootstrapper = &replicaset.CustomApplication{}
 
 func TestCustomApplication_Promote(t *testing.T) {
 	app := replicaset.NewCustomApplication(running.RunningCtx{})
@@ -49,6 +51,13 @@ func TestCustomApplication_BootstrapVShard(t *testing.T) {
 	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
 	assert.EqualError(t, err,
 		`bootstrap vshard is not supported for an application by "custom" orchestrator`)
+}
+
+func TestCustomApplication_Bootstrap(t *testing.T) {
+	instance := replicaset.NewCustomApplication(running.RunningCtx{})
+	err := instance.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for an application by "custom" orchestrator`)
 }
 
 func TestCustomInstance_Discovery(t *testing.T) {
@@ -425,4 +434,11 @@ func TestCustomInstance_BootstrapVShard(t *testing.T) {
 	err := instance.BootstrapVShard(replicaset.VShardBootstrapCtx{})
 	assert.EqualError(t, err,
 		`bootstrap vshard is not supported for a single instance by "custom" orchestrator`)
+}
+
+func TestCustomInstance_Bootstrap(t *testing.T) {
+	instance := replicaset.NewCustomInstance(nil)
+	err := instance.Bootstrap(replicaset.BootstrapCtx{})
+	assert.EqualError(t, err,
+		`bootstrap is not supported for a single instance by "custom" orchestrator`)
 }

--- a/cli/replicaset/eval.go
+++ b/cli/replicaset/eval.go
@@ -74,19 +74,7 @@ func EvalAny(instances []running.InstanceCtx, ievaler InstanceEvaler) error {
 // EvalForeachAliveDiscovered calls evaler for only connectable instances among discovered.
 func EvalForeachAliveDiscovered(instances []running.InstanceCtx,
 	discovered Replicasets, ievaler InstanceEvaler) error {
-	discoveredMap := map[string]struct{}{}
-	for _, replicaset := range discovered.Replicasets {
-		for _, instance := range replicaset.Instances {
-			discoveredMap[instance.Alias] = struct{}{}
-		}
-	}
-	var filteredInstances []running.InstanceCtx
-	for _, inst := range instances {
-		if _, ok := discoveredMap[inst.InstName]; ok {
-			filteredInstances = append(filteredInstances, inst)
-		}
-	}
-	return EvalForeachAlive(filteredInstances, ievaler)
+	return EvalForeachAlive(filterDiscovered(instances, discovered), ievaler)
 }
 
 // evalForeach is an internal implementation of iteration over instances with

--- a/cli/replicaset/lua/cartridge/get_instance_info_body.lua
+++ b/cli/replicaset/lua/cartridge/get_instance_info_body.lua
@@ -1,4 +1,18 @@
+local rw = false
+local uuid = '00000000-0000-0000-0000-000000000000'
+
+if type(box.cfg) ~= 'function' then
+    local ok, is_rw = pcall(function()
+        return box.cfg.read_only == false
+    end)
+    if ok then
+        rw = is_rw
+    end
+    uuid = box.info().uuid
+end
+
+
 return {
-    uuid = box.info().uuid,
-    rw   = box.cfg.read_only == false,
+    uuid = uuid,
+    rw   = rw,
 }

--- a/cli/replicaset/lua/cartridge/get_topology_replicasets_body.lua
+++ b/cli/replicaset/lua/cartridge/get_topology_replicasets_body.lua
@@ -45,12 +45,15 @@ end
 local failover_params = require('cartridge').failover_get_params()
 local issues = require('cartridge.issues').list_on_cluster()
 local is_critical = false
-local uuid = box.info().uuid
 
-for _, issue in pairs(issues) do
-    if issue.level == 'critical' and issue.instance_uuid == uuid then
-        is_critical = true
-        break
+if type(box.cfg) ~= 'function' then
+    local uuid = box.info().uuid
+
+    for _, issue in pairs(issues) do
+        if issue.level == 'critical' and issue.instance_uuid == uuid then
+            is_critical = true
+            break
+        end
     end
 end
 

--- a/test/integration/replicaset/test_replicaset_bootstrap.py
+++ b/test/integration/replicaset/test_replicaset_bootstrap.py
@@ -3,8 +3,12 @@ import re
 import shutil
 
 import pytest
+import yaml
+from cartridge_helper import cartridge_name, wait_inst_start
+from replicaset_helpers import eval_on_instance
 
-from utils import get_tarantool_version, run_command_and_get_output, wait_file
+from utils import (find_ports, get_tarantool_version,
+                   run_command_and_get_output, wait_file)
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
 
@@ -122,3 +126,115 @@ def test_bootstrap_app_replicaset_specified(tt_cmd, tmpdir_with_cfg):
         stop_cmd = [tt_cmd, "stop", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--cartridge"])
+def test_replicaset_bootstrap_cartridge_app_second_bootstrap(tt_cmd, cartridge_app, flag):
+    # Change the config.
+    replicasets_cfg = {
+        "router": {
+            "instances": ["router"],
+            "roles": ["failover-coordinator", "vshard-router", "app.roles.custom"],
+            "all_rw": False,
+        },
+        "s-1": {
+            "instances": ["s1-master", "s1-replica"],
+            "roles": ["vshard-storage"],
+            "weight": 3,  # Changed weight.
+            "all_rw": False,
+            "vshard_group": "default"
+        },
+        "s-2": {
+            "instances": ["s2-master", "s2-replica-1", "s2-replica-2"],
+            "roles": ["vshard-storage"],
+            "weight": 2,  # Changed weight.
+            "all_rw": False,
+            "vshard_group": "default"
+        },
+    }
+    with open(os.path.join(cartridge_app.workdir, cartridge_name, "replicasets.yml"), "w") as f:
+        f.write(yaml.dump(replicasets_cfg))
+
+    # Run bootstrap after initial bootstrap again.
+    cmd = [tt_cmd, "rs", "bootstrap"]
+    if flag:
+        cmd.append(flag)
+    cmd.append(cartridge_name)
+    rc, out = run_command_and_get_output(cmd, cwd=cartridge_app.workdir)
+    assert rc == 0
+    assert "Done." in out
+
+    # Check that updated config is applied.
+    expr = """\
+    local replicasets = require('cartridge').admin_get_replicasets()
+    local weights = {}
+    for _, replicaset in ipairs(replicasets) do
+        if replicaset.alias ~= 'router' then
+            table.insert(weights, replicaset.weight)
+        end
+    end
+    table.sort(weights)
+    return weights
+"""
+    out = eval_on_instance(tt_cmd, cartridge_name, "router", cartridge_app.workdir, expr)
+    assert re.search(r"2\n.*3", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+def test_replicaset_bootstrap_cartridge_instance_bootstrapped_already(tt_cmd, cartridge_app):
+    cmd = [tt_cmd, "rs", "bootstrap", "--replicaset", "s1", f"{cartridge_name}:s1-master"]
+    rc, out = run_command_and_get_output(cmd, cwd=cartridge_app.workdir)
+    assert rc != 0
+    assert '⨯ instance "s1-master" is bootstrapped already' in out
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+def test_replicaset_bootstrap_cartridge_new_instance(tt_cmd, cartridge_app):
+    instances_yml_path = os.path.join(cartridge_app.workdir, cartridge_name, "instances.yml")
+    with open(instances_yml_path, "r") as f:
+        old_instances_yml = f.read()
+
+    try:
+        # Append new instance to the instances file.
+        ports = find_ports(2)
+        with open(instances_yml_path, "a") as f:
+            cfg = {
+                f"{cartridge_name}.new_inst": {
+                    "advertise_uri": f"localhost:{ports[0]}",
+                    "http_port": ports[1],
+                },
+            }
+            f.write(yaml.dump(cfg))
+        with open(instances_yml_path, "r") as f:
+            print(f.read())
+
+        # Start new instance.
+        start_cmd = [tt_cmd, "start", f"{cartridge_name}:new_inst"]
+        rc, _ = run_command_and_get_output(start_cmd, cwd=cartridge_app.workdir)
+        assert rc == 0
+        wait_inst_start(cartridge_app.workdir, "new_inst")
+
+        # Bootstrap the instance.
+        cmd = [tt_cmd, "rs", "bootstrap", "--replicaset", "s-1", f"{cartridge_name}:new_inst"]
+        rc, out = run_command_and_get_output(cmd, cwd=cartridge_app.workdir)
+        assert rc == 0
+        expected = r"""\
+• s-1
+  Failover: off
+  Provider: none
+  Master:   single
+  Roles:    vshard-storage
+    • new_inst .* read
+    ★ s1-master .* rw
+    • s1-replica .* read"""
+        assert re.search(expected, out)
+    finally:
+        # Get rid of the tested instance.
+        stop_cmd = [tt_cmd, "stop", f"{cartridge_name}:new_inst"]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=cartridge_app.workdir)
+        with open(instances_yml_path, "w") as f:
+            f.write(old_instances_yml)

--- a/test/integration/replicaset/test_replicaset_bootstrap.py
+++ b/test/integration/replicaset/test_replicaset_bootstrap.py
@@ -1,0 +1,124 @@
+import os
+import re
+import shutil
+
+import pytest
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("case", [["--config", "--custom"],
+                                  ["--custom", "--cartridge"],
+                                  ["--config", "--cartridge"],
+                                  ["--config", "--custom", "--cartridge"]])
+def test_bootstrap(tt_cmd, tmpdir_with_cfg, case):
+    cmd = [tt_cmd, "rs", "bootstrap"] + case + ["app:instance"]
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ only one type of orchestrator can be forced", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+def test_bootstrap_no_instance(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+
+    status_cmd = [tt_cmd, "rs", "bootstrap", "test_custom_app:unexist"]
+    rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+    assert re.search(r"   ⨯ instance \"unexist\" not found", out)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+@pytest.mark.parametrize("flag", [None, "--custom"])
+def test_bootstrap_custom_app(tt_cmd, tmpdir_with_cfg, flag):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        cmd = [tt_cmd, "rs", "bootstrap"]
+        if flag:
+            cmd.append(flag)
+        cmd.append("test_custom_app")
+
+        rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+        assert rc == 1
+        expected = '⨯ bootstrap is not supported for an application by "custom" orchestrator'
+        assert expected in out
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+def test_bootstrap_instance_no_replicaset_specified(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        cmd = [tt_cmd, "rs", "bootstrap", "test_custom_app:test_custom_app"]
+        rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+        assert rc != 0
+        assert "⨯ the replicaset must be specified to bootstrap an instance" in out
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+def test_bootstrap_app_replicaset_specified(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        cmd = [tt_cmd, "rs", "bootstrap", "--replicaset", "r1", "test_custom_app"]
+        rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+        assert rc != 0
+        expected = "⨯ the replicaset can not be specified in the case of application bootstrapping"
+        assert expected in out
+    finally:
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
+        assert rc == 0

--- a/test/utils.py
+++ b/test/utils.py
@@ -345,9 +345,11 @@ def find_ports(n=1, port=8000):
     ports = []
     while len(ports) < n:
         busy = False
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if s.connect_ex(("localhost", port)) == 0:
-                busy = True
+        for proto in [socket.AF_INET, socket.AF_INET6]:
+            with socket.socket(proto, socket.SOCK_STREAM) as s:
+                if s.connect_ex(("localhost", port)) == 0:
+                    busy = True
+                    break
         if not busy:
             ports.append(port)
         port += 1


### PR DESCRIPTION
@TarantoolBot document
Title: `tt replicaset bootstrap` bootstraps a Cartridge app or an instance

This patch adds new subcommand for the replicaset module.
`tt replicaset bootstrap [flags] <APP_NAME|APP_NAME:INSTANCE_NAME>` bootstraps a Cartridge cluster
or an instance.

The command combines two old cartridge-cli commands: `setup` and `join`.
Examples:

`tt replicaset bootstrap cartridge_app` bootstraps the cluster from the default
config file ("replicasets.yml" in the app directory), the file can be specified with `--file` option.

`tt replicaset bootstrap --bootstrap-vshard cartridge_app` bootstraps the cluster and vshard.

`tt replicaset bootstrap --replicaset replicaset cartridge_app:inst` joins the instance "inst" to the replicaset "replicaset".

Part of https://github.com/tarantool/tt/issues/316