### PR TITLE
clean: fix attempt to remove files multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `tt clean` no longer tries to clean files multiple times.
+
 ## [2.2.1] - 2024-04-03
 
 ### Added

--- a/test/integration/running/test_data_app/test_data_app.lua
+++ b/test/integration/running/test_data_app/test_data_app.lua
@@ -1,0 +1,11 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+box.cfg{}
+
+-- Create something to generate xlogs.
+box.schema.space.create('customers')
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -173,7 +173,8 @@ def test_logrotate(tt_cmd, tmpdir_with_cfg):
 
 
 def assert_file_cleaned(filepath, cmd_out):
-    assert re.search(r"• " + str(filepath), cmd_out)
+    # https://github.com/tarantool/tt/issues/735
+    assert len(re.findall(r"• " + str(filepath), cmd_out)) == 1
     assert os.path.exists(filepath) is False
 
 
@@ -230,6 +231,7 @@ def test_clean(tt_cmd, tmpdir_with_cfg):
     # Check that clean is working.
     clean_rc, clean_out = run_command_and_get_output(clean_cmd, cwd=tmpdir)
     assert clean_rc == 0
+    assert re.search(r"\[ERR\]", clean_out) is None
 
     assert_file_cleaned(os.path.join(log_dir, log_file), clean_out)
     assert_file_cleaned(os.path.join(lib_dir, initial_snap), clean_out)

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,12 +12,15 @@ import tarantool
 import yaml
 
 var_path = "var"
+lib_path = os.path.join(var_path, "lib")
 run_path = os.path.join(var_path, "run")
 log_path = os.path.join(var_path, "log")
 config_name = "tt.yaml"
 control_socket = "tarantool.control"
 pid_file = "tt.pid"
 log_file = "tt.log"
+initial_snap = "00000000000000000000.snap"
+initial_xlog = "00000000000000000000.xlog"
 
 
 def run_command_and_get_output(


### PR DESCRIPTION
Before this patch, `tt clean` could list files multiple times since it is possible that memtx_dir, wal_dir, vinyl_dir and log_dir are the same directory (and the first three are the same by default). It also had tried to removed them several times, which had resulted in `[ERR]` message in logs. This patch fixes the issue.

Closes #735