### PR TITLE
tt: add enable module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `--follow` print appended data as log files grow.
 - `tt connect`: support format for Tarantool tuples for Tarantool
   versions >= 3.2.
+- `tt enable`: create a symbolic link in 'instances_enabled' directory to a script or
+  an application directory.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -644,6 +644,8 @@ Common description. For a detailed description, use `tt help command` .
 -   `env` - add current environment binaries location to the PATH variable.
 -   `replicasets` - manage replicasets.
 -   `download` - download Tarantool SDK.
+-   `enable` - create a symbolic link in 'instances_enabled' directory to a script or
+    an application directory.
 
 [godoc-badge]: https://pkg.go.dev/badge/github.com/tarantool/tt.svg
 [godoc-url]: https://pkg.go.dev/github.com/tarantool/tt

--- a/cli/cmd/enable.go
+++ b/cli/cmd/enable.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/enable"
+	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// NewEnableCmd creates a new enable command.
+func NewEnableCmd() *cobra.Command {
+	var initCmd = &cobra.Command{
+		Use: "enable <APP_PATH> | <SCRIPT_PATH>",
+		Short: "Create a symbolic link in 'instances_enabled' directory " +
+			"to a script or an application directory",
+		Example: `
+# Create a symbolic link in 'instances_enabled' directory to a script.
+	$ tt enable Users/myuser/my_scripts/script.lua
+# Create a symbolic link in 'instances_enabled' directory to an application directory.
+	$ tt enable ../myuser/my_cool_app`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
+				internalEnableModule, args)
+			util.HandleCmdErr(cmd, err)
+		},
+	}
+
+	return initCmd
+}
+
+// internalEnableModule is a default enable module.
+func internalEnableModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("provide the path to a script or application directory")
+	}
+
+	if cliOpts.Env.InstancesEnabled == "." {
+		return fmt.Errorf("enabling application for instances enabled '.' is not supported")
+	}
+
+	return enable.Enable(args[0], cliOpts)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -188,6 +188,7 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		NewDownloadCmd(),
 		NewKillCmd(),
 		NewLogCmd(),
+		NewEnableCmd(),
 	)
 	if err := injectCmds(rootCmd); err != nil {
 		panic(err.Error())

--- a/cli/enable/enable.go
+++ b/cli/enable/enable.go
@@ -1,0 +1,59 @@
+package enable
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// defaultDirPermissions is rights used to create folders.
+// 0755 - drwxr-xr-x
+// We need to give permission for all to execute
+// read,write for user and only read for others.
+const defaultDirPermissions = 0755
+
+// Enable creates a symbolic link in 'instances_enabled' directory
+// to a script or an application directory.
+func Enable(path string, cliOpts *config.CliOpts) error {
+	var err error
+
+	if _, err := os.Stat(cliOpts.Env.InstancesEnabled); os.IsNotExist(err) {
+		err = os.MkdirAll(cliOpts.Env.InstancesEnabled, defaultDirPermissions)
+		if err != nil {
+			return fmt.Errorf("unable to create %q\n Error: %s",
+				cliOpts.Env.InstancesEnabled, err)
+		}
+		log.Infof("Instances enabled directory is created: %q", cliOpts.Env.InstancesEnabled)
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	pathInfo, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("cannot get info of %q: %s", path, err)
+	}
+
+	if pathInfo.IsDir() {
+		if !util.IsApp(path) {
+			return fmt.Errorf("directory %q is not an application", path)
+		}
+	} else if filepath.Ext(path) != ".lua" {
+		return fmt.Errorf("script %q does not have '.lua' extension", path)
+	}
+
+	err = util.CreateSymlink(path, filepath.Join(cliOpts.Env.InstancesEnabled,
+		filepath.Base(path)), true)
+	if err != nil {
+		return err
+	}
+	log.Infof("Symbolic link for %q was created in instances enabled directory", path)
+
+	return nil
+}

--- a/cli/enable/enable_test.go
+++ b/cli/enable/enable_test.go
@@ -1,0 +1,78 @@
+package enable
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/util"
+)
+
+func TestEnableBase(t *testing.T) {
+	tempDir := t.TempDir()
+
+	err := copy.Copy("./testdata", tempDir)
+	assert.Nil(t, err)
+	cliOpts := &config.CliOpts{
+		Env: &config.TtEnvOpts{InstancesEnabled: filepath.Join(tempDir, "in_en")}}
+
+	// Test enable application.
+	appPath := filepath.Join(tempDir, "test_app")
+	err = Enable(appPath, cliOpts)
+	assert.Nil(t, err)
+	appLink, err := util.ResolveSymlink(filepath.Join(cliOpts.Env.InstancesEnabled, "test_app"))
+	assert.Nil(t, err)
+	assert.Contains(t, appLink, appPath)
+
+	// Test enable script.
+	appPath = filepath.Join(tempDir, "test_script", "test.lua")
+	err = Enable(appPath, cliOpts)
+	assert.Nil(t, err)
+	appLink, err = util.ResolveSymlink(filepath.Join(cliOpts.Env.InstancesEnabled, "test.lua"))
+	assert.Nil(t, err)
+	assert.Contains(t, appLink, appPath)
+}
+
+func TestEnableNoFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cliOpts := &config.CliOpts{
+		Env: &config.TtEnvOpts{InstancesEnabled: filepath.Join(tempDir, "in_en")}}
+
+	// Test enable script.
+	appPath := filepath.Join(tempDir, "test_script", "test.foo")
+	err := Enable(appPath, cliOpts)
+	require.ErrorContains(t, err, "cannot get info of")
+}
+
+func TestEnableWrongScript(t *testing.T) {
+	tempDir := t.TempDir()
+
+	err := copy.Copy("./testdata", tempDir)
+	assert.Nil(t, err)
+	cliOpts := &config.CliOpts{
+		Env: &config.TtEnvOpts{InstancesEnabled: filepath.Join(tempDir, "in_en")}}
+
+	// Test enable script.
+	appPath := filepath.Join(tempDir, "test_script", "foo.foo")
+	err = Enable(appPath, cliOpts)
+	require.ErrorContains(t, err, "does not have '.lua' extension")
+}
+
+func TestEnableDirNotApp(t *testing.T) {
+	tempDir := t.TempDir()
+
+	appPath := filepath.Join(tempDir, "notAppDir")
+	err := os.Mkdir(appPath, defaultDirPermissions)
+	assert.Nil(t, err)
+	cliOpts := &config.CliOpts{
+		Env: &config.TtEnvOpts{InstancesEnabled: filepath.Join(tempDir, "in_en")}}
+
+	// Test enable empty directory.
+	err = Enable(appPath, cliOpts)
+	require.ErrorContains(t, err, "is not an application")
+}

--- a/cli/enable/testdata/test_app/init.lua
+++ b/cli/enable/testdata/test_app/init.lua
@@ -1,0 +1,1 @@
+print("I am a test app")

--- a/cli/enable/testdata/test_script/test.lua
+++ b/cli/enable/testdata/test_script/test.lua
@@ -1,0 +1,1 @@
+print("I am a test app")

--- a/test/integration/enable/test_app/init.lua
+++ b/test/integration/enable/test_app/init.lua
@@ -1,0 +1,11 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+while true do
+    if app_name ~= nil and inst_name ~= nil then
+        print(app_name .. ":" .. inst_name)
+    else
+        print("unknown instance")
+    end
+    require("fiber").sleep(1)
+end

--- a/test/integration/enable/test_enable.py
+++ b/test/integration/enable/test_enable.py
@@ -1,0 +1,237 @@
+import os
+import re
+import shutil
+import subprocess
+
+import yaml
+
+
+def test_enable_application(tt_cmd, tmpdir):
+    test_app_path_src = os.path.join(os.path.dirname(__file__), "test_app")
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    instances_enabled_path = os.path.join(tmpdir, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+    test_app_path = os.path.join(tmpdir, "test_app")
+    shutil.copytree(test_app_path_src, test_app_path)
+
+    # Enable test application.
+    enable_cmd = [tt_cmd, "enable", test_app_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+
+    # Check that symlink is created.
+    link_path = os.path.join(instances_enabled_path, "test_app")
+    os.path.islink(link_path)
+
+    # Check that application is enabled.
+    instances_cmd = [tt_cmd, "instances"]
+    instance_process = subprocess.Popen(
+        instances_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    instances_output = instance_process.stdout.read()
+    assert re.search("test_app", instances_output)
+
+
+def test_enable_script(tt_cmd, tmpdir):
+    test_script_path_src = os.path.join(os.path.dirname(__file__), "test_script", "test.lua")
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    instances_enabled_path = os.path.join(tmpdir, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+    test_script_path = os.path.join(tmpdir, "test.lua")
+    shutil.copyfile(test_script_path_src, test_script_path)
+
+    # Enable test script.
+    enable_cmd = [tt_cmd, "enable", test_script_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+
+    # Check that symlink is created.
+    link_path = os.path.join(instances_enabled_path, "test.lua")
+    os.path.islink(link_path)
+
+    # Check that script is enabled.
+    instances_cmd = [tt_cmd, "instances"]
+    instance_process = subprocess.Popen(
+        instances_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    instances_output = instance_process.stdout.read()
+    assert re.search("test.lua", instances_output)
+
+
+def test_enable_invalid_path(tt_cmd, tmpdir):
+    test_path = os.path.join(tmpdir)
+    config_path = os.path.join(test_path, "tt.yaml")
+    instances_enabled_path = os.path.join(test_path, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+    test_script_path = os.path.join(tmpdir, "test.lua")
+
+    # Enable with incorrect path.
+    enable_cmd = [tt_cmd, "enable", test_script_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+    enable_output = enable_process.stdout.read()
+    assert re.search("cannot get info of", enable_output)
+
+
+def test_enable_no_path(tt_cmd, tmpdir):
+    test_path = os.path.join(tmpdir)
+    config_path = os.path.join(test_path, "tt.yaml")
+    instances_enabled_path = os.path.join(test_path, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+
+    # Enable with incorrect path.
+    enable_cmd = [tt_cmd, "enable"]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+    enable_output = enable_process.stdout.read()
+    assert re.search("provide the path to a script or application directory", enable_output)
+
+
+def test_enable_instances_enable_not_exist(tt_cmd, tmpdir):
+    test_script_path_src = os.path.join(os.path.dirname(__file__), "test_script", "test.lua")
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    instances_enabled_path = os.path.join(tmpdir, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    test_script_path = os.path.join(tmpdir, "test.lua")
+    shutil.copyfile(test_script_path_src, test_script_path)
+
+    # Enable test script.
+    enable_cmd = [tt_cmd, "enable", test_script_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+    enable_output = enable_process.stdout.read()
+    assert re.search("Instances enabled directory is created", enable_output)
+
+    # Check that symlink is created.
+    link_path = os.path.join(instances_enabled_path, "test.lua")
+    os.path.islink(link_path)
+
+    # Check that script is enabled.
+    instances_cmd = [tt_cmd, "instances"]
+    instance_process = subprocess.Popen(
+        instances_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    instances_output = instance_process.stdout.read()
+    assert re.search("test.lua", instances_output)
+
+
+def test_enable_invalid_script(tt_cmd, tmpdir):
+    test_path = os.path.join(tmpdir)
+    config_path = os.path.join(test_path, "tt.yaml")
+    instances_enabled_path = os.path.join(test_path, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+    test_script_path = os.path.join(tmpdir, "test")
+
+    # Enable with incorrect script.
+    enable_cmd = [tt_cmd, "enable", test_script_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+    enable_output = enable_process.stdout.read()
+    assert re.search("cannot get info of", enable_output)
+
+
+def test_enable_instances_enabled_dot(tt_cmd, tmpdir):
+    test_path = os.path.join(tmpdir)
+    config_path = os.path.join(test_path, "tt.yaml")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": '.'}}, f)
+    fakeApp = open(os.path.join(test_path, "init.lua"), "a")
+    fakeApp.write("I am an app!")
+    fakeApp.close()
+    test_script_path = os.path.join(tmpdir, "test")
+
+    # Enable with incorrect script.
+    enable_cmd = [tt_cmd, "enable", test_script_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+    enable_output = enable_process.stdout.read()
+    assert re.search("instances enabled '.' is not supported", enable_output)
+
+
+def test_enable_application_dir_empty(tt_cmd, tmpdir):
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    instances_enabled_path = os.path.join(tmpdir, "bar")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
+    os.makedirs(instances_enabled_path)
+    test_app_path = os.path.join(tmpdir, "notAppDir")
+    os.makedirs(test_app_path)
+
+    # Enable test application.
+    enable_cmd = [tt_cmd, "enable", test_app_path]
+    enable_process = subprocess.Popen(
+        enable_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    enable_process.wait()
+
+    enable_output = enable_process.stdout.read()
+    assert re.search("is not an application", enable_output)

--- a/test/integration/enable/test_script/test.lua
+++ b/test/integration/enable/test_script/test.lua
@@ -1,0 +1,11 @@
+local inst_name = os.getenv('TARANTOOL_INSTANCE_NAME')
+local app_name = os.getenv('TARANTOOL_APP_NAME')
+
+while true do
+    if app_name ~= nil and inst_name ~= nil then
+        print(app_name .. ":" .. inst_name)
+    else
+        print("unknown instance")
+    end
+    require("fiber").sleep(1)
+end


### PR DESCRIPTION
@TarantoolBot document
Title: `tt enable` creates a symbolic link in `instances_enabled` directory to a script or an application directory.

This patch adds new command.
`tt enable <APP_PATH> | <SCRIPT_PATH>` creates a symbolic link in `instances_enabled` directory
to a script or an application directory.

Examples:

Create a symbolic link in `instances_enabled` directory to a script:
	```$ tt enable Users/myuser/my_scripts/script.lua```

Create a symbolic link in  `instances_enabled`directory to an application directory:
	```$ tt enable ../myuser/my_cool_app```