### PR TITLE
replicaset: use extracted functional

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -219,7 +219,17 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: macos-12
     steps:
+      # `ref` as merge request is needed for pull_request_target because this
+      # target runs in the context of the base commit of the pull request.
       - uses: actions/checkout@master
+        if: github.event_name == 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: actions/checkout@master
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
@@ -314,7 +324,17 @@ jobs:
         tarantool-version: ["1.10", "2.10"]
       fail-fast: false
     steps:
+      # `ref` as merge request is needed for pull_request_target because this
+      # target runs in the context of the base commit of the pull request.
       - uses: actions/checkout@master
+        if: github.event_name == 'pull_request_target'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - uses: actions/checkout@master
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -29,7 +29,7 @@ jobs:
         tarantool-version: ["1.10", "2.10", "3.0"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -61,7 +61,7 @@ jobs:
       image: tarantool/testing:tt-build
       options: '--init --privileged'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -108,14 +108,14 @@ jobs:
     steps:
         # `ref` as merge request is needed for pull_request_target because this
         # target runs in the context of the base commit of the pull request.
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
     runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -221,14 +221,14 @@ jobs:
     steps:
       # `ref` as merge request is needed for pull_request_target because this
       # target runs in the context of the base commit of the pull request.
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
@@ -277,14 +277,14 @@ jobs:
     steps:
       # `ref` as merge request is needed for pull_request_target because this
       # target runs in the context of the base commit of the pull request.
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
@@ -326,14 +326,14 @@ jobs:
     steps:
       # `ref` as merge request is needed for pull_request_target because this
       # target runs in the context of the base commit of the pull request.
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
@@ -366,7 +366,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   create-packages-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -81,7 +81,7 @@ jobs:
     container:
       image: tarantool/testing:tt-build
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -123,7 +123,7 @@ jobs:
   create-packages-macos:
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -178,7 +178,7 @@ jobs:
     needs: [create-packages-linux, create-packages-macos]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         tarantool-version: ["1.10", "2.10", "3.0"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -58,7 +58,7 @@ jobs:
       image: tarantool/testing:tt-build
       options: '--init --privileged'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -105,14 +105,14 @@ jobs:
     steps:
         # `ref` as merge request is needed for pull_request_target because this
         # target runs in the context of the base commit of the pull request.
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
@@ -146,7 +146,7 @@ jobs:
     runs-on: [self-hosted, macOS-13-self-hosted, x86_64, regular]
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
   update:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Setup Go
       uses: actions/setup-go@v4

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -158,12 +158,12 @@ func newBootstrapVShardCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Bootstrap vshard in the cluster",
 		Long: "Bootstrap vshard in the cluster.\n\n" +
-			replicasetEnvHelp,
+			libconnect.EnvCredentialsHelp + "\n\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
 				internalReplicasetBootstrapVShardModule, args)
-			handleCmdErr(cmd, err)
+			util.HandleCmdErr(cmd, err)
 		},
 		Args: cobra.ExactArgs(1),
 	}

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -71,6 +71,5 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 	if err == nil {
 		log.Info("Done.")
 	}
-
 	return err
 }


### PR DESCRIPTION
- Some common functions have been moved to separate packages, let's use it.

- CI: add missing `ref` parameters to checkout in full-ci workflow triggered by pull_request_target event.

- CI: fix actions/checkout version.