### PR TITLE
pack: fix application build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt clean` no longer tries to clean files multiple times.
 - Tarantool 3 config instance fails to use 108 symbols control socket on tt start.
 - Incorrect application name in case of explicit providing config path without directories.
+- Application build failure during pack with Tarantool from the current environment.
 
 ## [2.2.1] - 2024-04-03
 

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -384,7 +384,7 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	}
 
 	if buildRocks {
-		err = buildAppRocks(cmdCtx, packCtx, newOpts, bundleEnvPath)
+		err = buildAppRocks(cmdCtx, packCtx, cliOpts, bundleEnvPath)
 		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,7 +74,7 @@ def tmpdir_with_tarantool(tt_cmd, request):
     tt_process.wait()
     assert tt_process.returncode == 0
 
-    init_cmd = [tt_cmd, "install", "tarantool", "--dynamic"]
+    init_cmd = [tt_cmd, "install", "-f", "tarantool", "--dynamic"]
     tt_process = subprocess.Popen(
         init_cmd,
         cwd=tmpdir,

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1788,3 +1788,39 @@ def test_pack_systemd_params_params_file_bad_format(tt_cmd, tmpdir):
     package_file_name = 'systemd_params-0.1.0.0-1.' + get_arch() + '.rpm'
     package_file = os.path.join(tmpdir, package_file_name)
     assert not os.path.exists(package_file)
+
+
+@pytest.mark.notarantool
+@pytest.mark.slow
+@pytest.mark.skipif(shutil.which("tarantool") is not None, reason="tarantool found in PATH")
+def test_pack_app_local_tarantool(tt_cmd, tmpdir_with_tarantool, tmpdir):
+    shutil.copytree(tmpdir_with_tarantool, tmpdir, symlinks=True, ignore=None,
+                    copy_function=shutil.copy2, dirs_exist_ok=True)
+
+    build_cmd = [tt_cmd, "create", "cartridge", "--name", "app", "--non-interactive"]
+    tt_process = subprocess.Popen(
+        build_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    tt_process.wait()
+    assert tt_process.returncode == 0
+
+    app_dir = os.path.join(tmpdir, "app")
+    assert os.path.exists(app_dir)
+
+    build_cmd = [tt_cmd, "pack", "tgz"]
+    tt_process = subprocess.Popen(
+        build_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    tt_process.wait()
+    assert tt_process.returncode == 0
+
+    build_output = tt_process.stdout.read()
+    assert "Bundle is packed successfully" in build_output


### PR DESCRIPTION
If Tarantool is used from the current environment, the application build uses the resulting package temporary directory as the Tarantool include files path. However, this directory does not exist in the resulting package. Use the current environment for building the application.