### PR TITLE
connect: support Tarantool tuple format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `--lines` number of lines to print.
   * `--follow` print appended data as log files grow.
 
+### Fixed
+
+- Sorted by name order of columns for `table` and `ttable` formats.
+
 ## [2.3.1] - 2024-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt log`: a module for viewing instances logs. Supported options:
   * `--lines` number of lines to print.
   * `--follow` print appended data as log files grow.
+- `tt connect`: support format for Tarantool tuples for Tarantool
+  versions >= 3.2.
 
 ### Fixed
 

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -27,7 +27,6 @@ var luaCodeFiles = []generateLuaCodeOpts{
 		PackageName: "connect",
 		FileName:    "cli/connect/lua_code_gen.go",
 		VariablesMap: map[string]string{
-			"consoleEvalFuncBody":    "cli/connect/lua/console_eval_func_body.lua",
 			"evalFuncBody":           "cli/connect/lua/eval_func_body.lua",
 			"getSuggestionsFuncBody": "cli/connect/lua/get_suggestions_func_body.lua",
 		},

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -218,7 +218,10 @@ func getExecutor(console *Console) func(string) {
 		}
 
 		var results []string
-		args := []interface{}{console.input}
+		needMetaInfo := console.format == formatter.TableFormat ||
+			console.format == formatter.TTableFormat
+		args := []interface{}{console.input, console.language == SQLLanguage,
+			needMetaInfo}
 		opts := connector.RequestOpts{
 			PushCallback: func(pushedData interface{}) {
 				encodedData, err := yaml.Marshal(pushedData)
@@ -233,7 +236,7 @@ func getExecutor(console *Console) func(string) {
 		}
 
 		var data string
-		if _, err := console.conn.Eval(consoleEvalFuncBody, args, opts); err != nil {
+		if _, err := console.conn.Eval(evalFuncBody, args, opts); err != nil {
 			if err == io.EOF {
 				// We need to call 'console.Close()' here because in some cases (e.g 'os.exit()')
 				// it won't be called from 'defer console.Close' in 'connect.runConsole()'.

--- a/cli/connect/language.go
+++ b/cli/connect/language.go
@@ -60,7 +60,7 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 	}
 
 	languageCmd := setLanguagePrefix + " " + lang.String()
-	response, err := evaler.Eval(consoleEvalFuncBody,
+	response, err := evaler.Eval(evalFuncBody,
 		[]interface{}{languageCmd},
 		connector.RequestOpts{},
 	)

--- a/cli/connect/language_test.go
+++ b/cli/connect/language_test.go
@@ -2,6 +2,7 @@ package connect_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,11 @@ func (evaler *inputEvaler) Eval(fun string,
 }
 
 func TestChangeLanguage_requestInputs(t *testing.T) {
-	expectedFun := "return require('console').eval(...)\n"
+	rawFun, err := os.ReadFile("./lua/eval_func_body.lua")
+	if err != nil {
+		t.Fatal("Failed to read lua file:", err)
+	}
+	expectedFun := string(rawFun)
 	expectedOpts := connector.RequestOpts{}
 	cases := []struct {
 		lang Language

--- a/cli/connect/lua/console_eval_func_body.lua
+++ b/cli/connect/lua/console_eval_func_body.lua
@@ -1,1 +1,0 @@
-return require('console').eval(...)

--- a/cli/connect/lua/eval_func_body.lua
+++ b/cli/connect/lua/eval_func_body.lua
@@ -1,6 +1,18 @@
 local yaml = require('yaml')
+yaml.cfg{ encode_use_tostring = true }
 local args = {...}
 local cmd = table.remove(args, 1)
+local is_sql_language = table.remove(args, 1)
+local need_metainfo = table.remove(args, 1)
+
+local function is_command(line)
+    return line:sub(1, 1) == '\\'
+end
+
+if is_command(cmd) or is_sql_language == true then
+    return require('console').eval(cmd)
+end
+
 local fun, errmsg = loadstring("return "..cmd)
 if not fun then
     fun, errmsg = loadstring(cmd)
@@ -13,9 +25,26 @@ local function table_pack(...)
     return {n = select('#', ...), ...}
 end
 
+local function format_equal(f1, f2)
+    if #f1 ~= #f2 then
+        return false
+    end
+
+    for i, field in ipairs(f1) do
+        if field.name ~= f2[i].name or field.type ~= f2[i].type then
+            return false
+        end
+    end
+    return true
+end
+
 local ret = table_pack(pcall(fun, unpack(args)))
 if not ret[1] then
-    return yaml.encode({box.NULL})
+    local err = unpack(ret, 2, ret.n)
+    if err == nil then
+        err = box.NULL
+    end
+    return yaml.encode({{error = err}})
 end
 if ret.n == 1 then
     return "---\n...\n"
@@ -25,4 +54,49 @@ for i=2,ret.n do
         ret[i] = box.NULL
     end
 end
+if not need_metainfo then
+    return yaml.encode({unpack(ret, 2, ret.n)})
+end
+
+for i=2,ret.n do
+    if box.tuple.is ~= nil and box.tuple.is(ret[i]) and ret[i].format then
+        local ret_with_format = {
+            metadata = ret[i]:format(),
+            rows = { ret[i] },
+        }
+        if #ret_with_format.metadata > 0 then
+            ret[i] = ret_with_format
+        end
+    end
+
+    if type(ret[i]) == 'table' and #ret[i] > 0 then
+        local ret_with_format = {
+            metadata = {},
+            rows = ret[i],
+        }
+
+        local same_format = true
+        for tuple_ind, tuple in ipairs(ret[i]) do
+            local is_tuple = box.tuple.is ~= nil and box.tuple.is(tuple) and tuple.format
+
+            if tuple_ind == 1 then
+                if not is_tuple then
+                    same_format = false
+                    break
+                end
+
+                ret_with_format.metadata = tuple:format()
+            elseif not is_tuple or
+                    not format_equal(tuple:format(), ret_with_format.metadata) then
+                same_format = false
+                break
+            end
+        end
+
+        if #ret_with_format.metadata > 0 and same_format then
+            ret[i] = ret_with_format
+        end
+    end
+end
+
 return yaml.encode({unpack(ret, 2, ret.n)})

--- a/cli/formatter/node.go
+++ b/cli/formatter/node.go
@@ -12,6 +12,8 @@ const (
 // getNodeType returns renderNode type.
 func getNodeType(node any) nodeType {
 	switch node.(type) {
+	case unorderedMap[any]:
+		return mapNodeType
 	case map[any]any:
 		return mapNodeType
 	case []any:

--- a/cli/formatter/unordered_map.go
+++ b/cli/formatter/unordered_map.go
@@ -1,0 +1,28 @@
+package formatter
+
+type unorderedMap[T comparable] struct {
+	innerMap map[T]any
+	keys     []T
+}
+
+func createUnorderedMap[T comparable](len int) unorderedMap[T] {
+	return unorderedMap[T]{
+		innerMap: make(map[T]any),
+		keys:     make([]T, 0, len),
+	}
+}
+
+func (u *unorderedMap[T]) len() int {
+	return len(u.keys)
+}
+
+func (u *unorderedMap[T]) insert(key T, value any) {
+	u.keys = append(u.keys, key)
+	u.innerMap[key] = value
+}
+
+func (u *unorderedMap[T]) forEach(f func(key T, value any)) {
+	for _, key := range u.keys {
+		f(key, u.innerMap[key])
+	}
+}

--- a/cli/formatter/yaml.go
+++ b/cli/formatter/yaml.go
@@ -1,0 +1,20 @@
+package formatter
+
+// lazyMessage is used for lazy Unmarshal.
+type lazyMessage struct {
+	unmarshal func(any) error
+}
+
+// UnmarshalYAML makes lazyMessage an instance of yaml.Unmarshaler.
+func (msg *lazyMessage) UnmarshalYAML(unmarshal func(any) error) error {
+	msg.unmarshal = unmarshal
+	return nil
+}
+
+// Unmarshal the lazyMessage.
+func (msg *lazyMessage) Unmarshal(v any) error {
+	if msg.unmarshal == nil {
+		return nil
+	}
+	return msg.unmarshal(v)
+}

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -1123,11 +1123,11 @@ def test_table_output_format(tt_cmd, tmpdir_with_cfg):
                 stdin="box.execute('select 1 as FOO, 30, 50, 4+4 as DATA')",
                 opts={'-x': 'table'})
             assert ret
-            assert output == ("+----------+----------+------+-----+\n"
-                              "| COLUMN_1 | COLUMN_2 | DATA | FOO |\n"
-                              "+----------+----------+------+-----+\n"
-                              "| 30       | 50       | 8    | 1   |\n"
-                              "+----------+----------+------+-----+\n")
+            assert output == ("+-----+----------+----------+------+\n"
+                              "| FOO | COLUMN_1 | COLUMN_2 | DATA |\n"
+                              "+-----+----------+----------+------+\n"
+                              "| 1   | 30       | 50       | 8    |\n"
+                              "+-----+----------+----------+------+\n")
 
             # Execute stdin.
             if (tarantool_major_version >= 3 or


### PR DESCRIPTION
Support format for Tarantool tuples. This support only works for Tarantool versions >= 3.2.

Closes https://github.com/tarantool/tt/issues/832

@TarantoolBot document
Title: Support Tarantool tuple format

This patch adds support for formatting Tarantool tuples. Installed Tarantool version must be >= 3.2. Otherwise, there will be no change.

Examples:
```
> f = box.tuple.format.new({{'id', 'number'}, {'name', 'string'}})
---
...

> t = box.tuple.new({1, 'Flint', true}, {format = f})
---
...

> \xt
> t
+----+-------+------+
| id | name  | col1 |
+----+-------+------+
| 1  | Flint | true |
+----+-------+------+
> box.space.customers:select()
+----+-----------+-----+
| id | name      | age |
+----+-----------+-----+
| 1  | Elizabeth | 12  |
+----+-----------+-----+
| 2  | Mary      | 46  |
+----+-----------+-----+
> \xT
> t
+------+-------+
| id   | 1     |
+------+-------+
| name | Flint |
+------+-------+
| col1 | true  |
+------+-------+
> box.space.customers:select()
+------+-----------+------+
| id   | 1         | 2    |
+------+-----------+------+
| name | Elizabeth | Mary |
+------+-----------+------+
| age  | 12        | 46   |
+------+-----------+------+
```