### PR TITLE
switch: fix 'switch tt'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Sorted by name order of columns for `table` and `ttable` formats.
+- `tt switch tt`: does not work with `x.x.x` version format.
 
 ## [2.3.1] - 2024-06-13
 

--- a/cli/binary/switch.go
+++ b/cli/binary/switch.go
@@ -91,7 +91,13 @@ func ChooseVersion(binDir string, programName string) (string, error) {
 // switchTt switches 'tt' program.
 func switchTt(switchCtx SwitchCtx) error {
 	log.Infof("Switching to %s %s.", switchCtx.ProgramName, switchCtx.Version)
-	versionStr := search.ProgramTt + version.FsSeparator + switchCtx.Version
+
+	ttVersion := switchCtx.Version
+	if !strings.HasPrefix(switchCtx.Version, "v") {
+		ttVersion = "v" + ttVersion
+	}
+	versionStr := search.ProgramTt + version.FsSeparator + ttVersion
+
 	if util.IsRegularFile(filepath.Join(switchCtx.BinDir, versionStr)) {
 		err := util.CreateSymlink(versionStr, filepath.Join(switchCtx.BinDir, "tt"), true)
 		if err != nil {

--- a/test/integration/binaries/test_switch.py
+++ b/test/integration/binaries/test_switch.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import subprocess
 
+import yaml
+
 from utils import config_name
 
 
@@ -108,3 +110,67 @@ def test_switch_invalid_program(tt_cmd, tmpdir):
     output = install_process.stdout.read()
     assert "not supported program: nodejs" in output
     assert install_process_rc != 0
+
+
+def test_switch_tt(tt_cmd, tmpdir):
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    bin_dir_path = os.path.join(tmpdir, "bin")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"bin_dir": bin_dir_path}}, f)
+
+    fake_tt_path = os.path.join(bin_dir_path, "tt_v7.7.7")
+    os.makedirs(bin_dir_path)
+    shutil.copyfile(tt_cmd, fake_tt_path)
+
+    switch_cmd = [
+        tt_cmd,
+        "--cfg", config_path,
+        "binaries", "switch", "tt", "7.7.7"
+    ]
+
+    switch_process = subprocess.Popen(
+        switch_cmd,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    switch_process_rc = switch_process.wait()
+    output = switch_process.stdout.read()
+    assert "Switching to tt 7.7.7" in output
+    assert switch_process_rc == 0
+
+    expected_bin = os.path.join(bin_dir_path, "tt_v7.7.7")
+    tt_bin = os.path.realpath(os.path.join(bin_dir_path, "tt"))
+    assert tt_bin == expected_bin
+
+
+def test_switch_tt_full_version_name(tt_cmd, tmpdir):
+    config_path = os.path.join(tmpdir, "tt.yaml")
+    bin_dir_path = os.path.join(tmpdir, "bin")
+    with open(config_path, "w") as f:
+        yaml.dump({"env": {"bin_dir": bin_dir_path}}, f)
+
+    fake_tt_path = os.path.join(bin_dir_path, "tt_v7.7.7")
+    os.makedirs(bin_dir_path)
+    shutil.copyfile(tt_cmd, fake_tt_path)
+
+    switch_cmd = [
+        tt_cmd,
+        "--cfg", config_path,
+        "binaries", "switch", "tt", "v7.7.7"
+    ]
+
+    switch_process = subprocess.Popen(
+        switch_cmd,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    switch_process_rc = switch_process.wait()
+    output = switch_process.stdout.read()
+    assert "Switching to tt v7.7.7" in output
+    assert switch_process_rc == 0
+
+    expected_bin = os.path.join(bin_dir_path, "tt_v7.7.7")
+    tt_bin = os.path.realpath(os.path.join(bin_dir_path, "tt"))
+    assert tt_bin == expected_bin


### PR DESCRIPTION
'switch tt' now works with 'x.x.x' version format.

Closes #876