### PR TITLE
tt: fix returning status code on unsuccessful dependency install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Sorted by name order of columns for `table` and `ttable` formats.
 - `tt switch tt`: does not work with `x.x.x` version format.
+- `tt install tt` returns expected exit status code on unsuccessful dependency check.
 
 ### Changed
 

--- a/cli/util/errors.go
+++ b/cli/util/errors.go
@@ -1,0 +1,8 @@
+package util
+
+import "errors"
+
+var (
+	// ErrCmdAbort is reported when user aborts the program.
+	ErrCmdAbort = errors.New("aborted by user")
+)

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -923,6 +923,9 @@ func HandleCmdErr(cmd *cobra.Command, err error) {
 			cmd.Usage()
 			os.Exit(1)
 		}
+		if errors.Is(err, ErrCmdAbort) {
+			os.Exit(1)
+		}
 		log.Fatalf(err.Error())
 	}
 }

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -15,7 +15,7 @@ from utils import config_name, is_valid_tarantool_installed
 def test_install_tt_unexisted_commit(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, config_name)
 
-    # Create test config
+    # Create test config.
     tmp_dir = tempfile.mkdtemp(dir=tmpdir)
     tmp_name = tmp_dir.rpartition('/')[2]
     with open(configPath, 'w') as f:
@@ -55,7 +55,7 @@ def test_install_tt_unexisted_commit(tt_cmd, tmpdir):
 @pytest.mark.slow
 def test_install_tt(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, config_name)
-    # Create test config
+    # Create test config.
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -89,7 +89,7 @@ def test_install_tt(tt_cmd, tmpdir):
 @pytest.mark.slow
 def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, config_name)
-    # Create test config
+    # Create test config.
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -138,7 +138,7 @@ def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
 @pytest.mark.slow
 def test_wrong_format_hash(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, config_name)
-    # Create test config
+    # Create test config.
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -182,7 +182,7 @@ def test_wrong_format_hash(tt_cmd, tmpdir):
 @pytest.mark.slow
 def test_install_tt_specific_version(tt_cmd, tmpdir):
     configPath = os.path.join(tmpdir, config_name)
-    # Create test config
+    # Create test config.
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 


### PR DESCRIPTION
Fixed a bug related with case when program finishes with 0 status code in unsuccessful way.
To do this I edit returning type from `bool` to `error` in `programDependenciesInstalled` function to finish program with error exit code in right way on higher layer.

Closes #651 