### PR TITLE
test: fix 'etcd_helper'

### DIFF
--- a/test/etcd_helper.py
+++ b/test/etcd_helper.py
@@ -17,7 +17,7 @@ class EtcdInstance():
 
     def start(self):
         popen = subprocess.Popen(
-            [os.getenv("ETCD_PATH") + "etcd"],
+            [os.getenv("ETCD_PATH", default="") + "etcd"],
             env={"ETCD_LISTEN_CLIENT_URLS": self.endpoint,
                  "ETCD_ADVERTISE_CLIENT_URLS": self.endpoint,
                  "PATH": os.getenv("PATH")},


### PR DESCRIPTION
Added default value to 'os.getenv()', so tests won't fail if 'ETCD_PATH' is not set.