### PR TITLE
Tests re-factoring

### DIFF
--- a/test/integration/binaries/test_list.py
+++ b/test/integration/binaries/test_list.py
@@ -5,12 +5,12 @@ import subprocess
 from utils import config_name, run_command_and_get_output
 
 
-def test_list(tt_cmd, tmpdir):
+def test_list(tt_cmd, tmp_path):
     # Copy the test bin_dir to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "bin")
-    shutil.copytree(test_app_path, tmpdir + "/bin", True)
+    shutil.copytree(test_app_path, tmp_path / "bin", True)
 
-    configPath = os.path.join(tmpdir, config_name)
+    configPath = tmp_path / config_name
     # Create test config
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir: "./bin"\n    inc_dir:\n')
@@ -19,7 +19,7 @@ def test_list(tt_cmd, tmpdir):
     binaries_cmd = [tt_cmd, "--cfg", configPath, "binaries", "list"]
     binaries_process = subprocess.Popen(
         binaries_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -35,8 +35,8 @@ def test_list(tt_cmd, tmpdir):
     assert "2.8.1 [active]" in output
 
 
-def test_list_no_directory(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_list_no_directory(tt_cmd, tmp_path):
+    configPath = tmp_path / config_name
     # Create test config
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir: "./bin"\n    inc_dir:\n')
@@ -45,7 +45,7 @@ def test_list_no_directory(tt_cmd, tmpdir):
     binaries_cmd = [tt_cmd, "--cfg", configPath, "binaries", "list"]
     binaries_process = subprocess.Popen(
         binaries_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -57,9 +57,9 @@ def test_list_no_directory(tt_cmd, tmpdir):
     assert "there are no binaries installed in this environment of 'tt'" in output
 
 
-def test_list_empty_directory(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
-    os.mkdir(tmpdir+"/bin")
+def test_list_empty_directory(tt_cmd, tmp_path):
+    configPath = tmp_path / config_name
+    os.mkdir(tmp_path / "bin")
     # Create test config
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir: "./bin"\n    inc_dir:\n')
@@ -68,7 +68,7 @@ def test_list_empty_directory(tt_cmd, tmpdir):
     binaries_cmd = [tt_cmd, "--cfg", configPath, "binaries", "list"]
     binaries_process = subprocess.Popen(
         binaries_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -80,12 +80,12 @@ def test_list_empty_directory(tt_cmd, tmpdir):
     assert "there are no binaries installed in this environment of 'tt'" in output
 
 
-def test_list_tarantool_dev(tt_cmd, tmpdir):
+def test_list_tarantool_dev(tt_cmd, tmp_path):
     # Copy the test dir to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "tarantool_dev")
-    shutil.copytree(test_app_path, tmpdir + "/tarantool_dev", True)
+    shutil.copytree(test_app_path, tmp_path / "tarantool_dev", True)
 
-    config_path = os.path.join(tmpdir, config_name)
+    config_path = tmp_path / config_name
     # Create test config.
     with open(config_path, "w") as f:
         f.write(
@@ -94,7 +94,7 @@ def test_list_tarantool_dev(tt_cmd, tmpdir):
     binaries_cmd = [tt_cmd, "--cfg", config_path, "binaries", "list"]
     binaries_process = subprocess.Popen(
         binaries_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -108,25 +108,25 @@ def test_list_tarantool_dev(tt_cmd, tmpdir):
     assert "tarantool-dev" in output
 
 
-def test_list_tarantool_no_symlink(tt_cmd, tmpdir):
+def test_list_tarantool_no_symlink(tt_cmd, tmp_path):
     # Copy the test bin_dir to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "bin")
-    shutil.copytree(test_app_path, tmpdir + "/bin", True)
+    shutil.copytree(test_app_path, tmp_path / "bin", True)
 
-    configPath = os.path.join(tmpdir, config_name)
+    configPath = tmp_path / config_name
     # Create test config
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir: "./bin"\n    inc_dir:\n')
 
-    os.remove(os.path.join(tmpdir, "bin", "tarantool"))
-    with open(os.path.join(tmpdir, "bin", "tarantool"), "w") as tnt_file:
+    os.remove(tmp_path / "bin" / "tarantool")
+    with open(tmp_path / "bin" / "tarantool", "w") as tnt_file:
         tnt_file.write("""#!/bin/sh
 echo 'Tarantool 3.1.0-entrypoint-83-gcb0264c3c'""")
-    os.chmod(os.path.join(tmpdir, "bin", "tarantool"), 0o750)
+    os.chmod(tmp_path / "bin" / "tarantool", 0o750)
 
     # Print binaries
     binaries_cmd = [tt_cmd, "--cfg", configPath, "binaries", "list"]
-    rc, output = run_command_and_get_output(binaries_cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(binaries_cmd, cwd=tmp_path)
 
     assert rc == 0
     assert "tt" in output
@@ -137,9 +137,9 @@ echo 'Tarantool 3.1.0-entrypoint-83-gcb0264c3c'""")
     assert "3.1.0-entrypoint-83-gcb0264c3c [active]" in output
 
     # Remove non-versioned tarantool binary.
-    os.remove(os.path.join(tmpdir, "bin", "tarantool"))
+    os.remove(tmp_path / "bin" / "tarantool")
     binaries_cmd = [tt_cmd, "--cfg", configPath, "binaries", "list"]
-    rc, output = run_command_and_get_output(binaries_cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(binaries_cmd, cwd=tmp_path)
 
     assert rc == 0
     assert "tt" in output

--- a/test/integration/binaries/test_switch.py
+++ b/test/integration/binaries/test_switch.py
@@ -7,14 +7,14 @@ import yaml
 from utils import config_name
 
 
-def test_switch(tt_cmd, tmpdir):
+def test_switch(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_tarantool"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, tmp_path / "testdata", True)
+    testdata_path = tmp_path / "testdata"
 
     tt_dir = os.path.join(testdata_path, "tt")
 
@@ -45,14 +45,14 @@ def test_switch(tt_cmd, tmpdir):
     assert tarantool_inc == expected_inc
 
 
-def test_switch_with_link(tt_cmd, tmpdir):
+def test_switch_with_link(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_tarantool_link"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, tmp_path / "testdata", True)
+    testdata_path = tmp_path / "testdata"
 
     tt_dir = os.path.join(testdata_path, "tt")
 
@@ -83,14 +83,14 @@ def test_switch_with_link(tt_cmd, tmpdir):
     assert tarantool_inc == expected_inc
 
 
-def test_switch_invalid_program(tt_cmd, tmpdir):
+def test_switch_invalid_program(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_tarantool"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, tmp_path / "testdata", True)
+    testdata_path = tmp_path / "testdata"
 
     tt_dir = os.path.join(testdata_path, "tt")
 
@@ -112,11 +112,11 @@ def test_switch_invalid_program(tt_cmd, tmpdir):
     assert install_process_rc != 0
 
 
-def test_switch_tt(tt_cmd, tmpdir):
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    bin_dir_path = os.path.join(tmpdir, "bin")
+def test_switch_tt(tt_cmd, tmp_path):
+    config_path = tmp_path / "tt.yaml"
+    bin_dir_path = tmp_path / "bin"
     with open(config_path, "w") as f:
-        yaml.dump({"env": {"bin_dir": bin_dir_path}}, f)
+        yaml.dump({"env": {"bin_dir": bin_dir_path.as_posix()}}, f)
 
     fake_tt_path = os.path.join(bin_dir_path, "tt_v7.7.7")
     os.makedirs(bin_dir_path)
@@ -144,11 +144,11 @@ def test_switch_tt(tt_cmd, tmpdir):
     assert tt_bin == expected_bin
 
 
-def test_switch_tt_full_version_name(tt_cmd, tmpdir):
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    bin_dir_path = os.path.join(tmpdir, "bin")
+def test_switch_tt_full_version_name(tt_cmd, tmp_path):
+    config_path = tmp_path / "tt.yaml"
+    bin_dir_path = tmp_path / "bin"
     with open(config_path, "w") as f:
-        yaml.dump({"env": {"bin_dir": bin_dir_path}}, f)
+        yaml.dump({"env": {"bin_dir": bin_dir_path.as_posix()}}, f)
 
     fake_tt_path = os.path.join(bin_dir_path, "tt_v7.7.7")
     os.makedirs(bin_dir_path)

--- a/test/integration/cat/test_cat.py
+++ b/test/integration/cat/test_cat.py
@@ -5,33 +5,33 @@ import shutil
 from utils import run_command_and_get_output
 
 
-def test_cat_unset_arg(tt_cmd, tmpdir):
+def test_cat_unset_arg(tt_cmd, tmp_path):
     # Testing with unset .xlog or .snap file.
     cmd = [tt_cmd, "cat"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 1
     assert re.search(r"it is required to specify at least one .xlog or .snap file", output)
 
 
-def test_cat_non_existent_file(tt_cmd, tmpdir):
+def test_cat_non_existent_file(tt_cmd, tmp_path):
     # Testing with non-existent .xlog or .snap file.
     cmd = [tt_cmd, "cat", "path-to-non-existent-file"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 1
     assert re.search(r"No such file or directory", output)
 
 
-def test_cat_snap_file(tt_cmd, tmpdir):
+def test_cat_snap_file(tt_cmd, tmp_path):
     # Copy the .snap file to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_file", "test.snap")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
 
     # Testing .snap file.
     cmd = [
         tt_cmd, "cat", "test.snap", "--show-system",
         "--space=320", "--space=296", "--from=423", "--to=513"
         ]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"lsn: 423", output)
     assert re.search(r"lsn: 512", output)
@@ -39,13 +39,13 @@ def test_cat_snap_file(tt_cmd, tmpdir):
     assert re.search(r"space_id: 296", output)
 
 
-def test_cat_xlog_file(tt_cmd, tmpdir):
+def test_cat_xlog_file(tt_cmd, tmp_path):
     # Copy the .xlog file to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_file", "test.xlog")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
 
     # Testing .xlog file.
     cmd = [tt_cmd, "cat", "test.xlog", "--show-system", "--replica=1"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"replica_id: 1", output)

--- a/test/integration/cfg/test_dump.py
+++ b/test/integration/cfg/test_dump.py
@@ -5,14 +5,14 @@ import subprocess
 from utils import config_name
 
 
-def test_cfg_dump_default(tt_cmd, tmpdir):
+def test_cfg_dump_default(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "tt_cfg.yaml"),
-                os.path.join(tmpdir, config_name))
+                os.path.join(tmp_path, config_name))
 
     buid_cmd = [tt_cmd, "cfg", "dump"]
     tt_process = subprocess.Popen(
         buid_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -29,22 +29,22 @@ def test_cfg_dump_default(tt_cmd, tmpdir):
     assert f"memtx_dir: {os.path.join('lib', 'memtx')}" in output
     assert f"vinyl_dir: {os.path.join('lib', 'vinyl')}" in output
     assert f"log_dir: {os.path.join('./var', 'log')}" in output
-    assert f"inc_dir: {os.path.join(tmpdir, 'include')}" in output
-    assert f"directory: {os.path.join(tmpdir, 'new_modules')}" in output
-    assert f"distfiles: {os.path.join(tmpdir, 'distfiles')}" in output
-    assert f"instances_enabled: {tmpdir}" in output
-    assert f"templates:\n- path: {os.path.join(tmpdir, 'templates')}" in output
+    assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
+    assert f"directory: {os.path.join(tmp_path, 'new_modules')}" in output
+    assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
+    assert f"instances_enabled: {tmp_path}" in output
+    assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output
 
 
-def test_cfg_dump_raw(tt_cmd, tmpdir):
+def test_cfg_dump_raw(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "tt_cfg.yaml"),
-                os.path.join(tmpdir, config_name))
+                os.path.join(tmp_path, config_name))
 
     buid_cmd = [tt_cmd, "cfg", "dump", "--raw"]
     tt_process = subprocess.Popen(
         buid_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -55,7 +55,7 @@ def test_cfg_dump_raw(tt_cmd, tmpdir):
     assert tt_process.returncode == 0
 
     output = tt_process.stdout.read()
-    assert output == f"""{os.path.join(tmpdir, config_name)}:
+    assert output == f"""{os.path.join(tmp_path, config_name)}:
 modules:
   directory: new_modules
 app:
@@ -69,11 +69,11 @@ env:
 """
 
 
-def test_cfg_dump_no_config(tt_cmd, tmpdir):
+def test_cfg_dump_no_config(tt_cmd, tmp_path):
     buid_cmd = [tt_cmd, "cfg", "dump", "--raw"]
     tt_process = subprocess.Popen(
         buid_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -87,11 +87,11 @@ def test_cfg_dump_no_config(tt_cmd, tmpdir):
     assert "tt configuration file is not found" in output
 
 
-def test_cfg_dump_default_no_config(tt_cmd, tmpdir):
+def test_cfg_dump_default_no_config(tt_cmd, tmp_path):
     dump_cmd = [tt_cmd, "cfg", "dump"]
     tt_process = subprocess.Popen(
         dump_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -103,29 +103,29 @@ def test_cfg_dump_default_no_config(tt_cmd, tmpdir):
 
     output = tt_process.stdout.read()
     print(output)
-    assert f"bin_dir: {os.path.join(tmpdir, 'bin')}" in output
+    assert f"bin_dir: {os.path.join(tmp_path, 'bin')}" in output
     assert f"run_dir: {os.path.join('var', 'run')}" in output
     assert f"wal_dir: {os.path.join('var', 'lib')}" in output
     assert f"vinyl_dir: {os.path.join('var', 'lib')}" in output
     assert f"memtx_dir: {os.path.join('var', 'lib')}" in output
     assert f"log_dir: {os.path.join('var', 'log')}" in output
-    assert f"inc_dir: {os.path.join(tmpdir, 'include')}" in output
-    assert f"directory: {os.path.join(tmpdir, 'modules')}" in output
-    assert f"distfiles: {os.path.join(tmpdir, 'distfiles')}" in output
-    assert f"instances_enabled: {tmpdir}" in output
-    assert f"templates:\n- path: {os.path.join(tmpdir, 'templates')}" in output
+    assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
+    assert f"directory: {os.path.join(tmp_path, 'modules')}" in output
+    assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
+    assert f"instances_enabled: {tmp_path}" in output
+    assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output
 
     # Create init.lua in current dir making it an application.
 
-    script_path = os.path.join(tmpdir, "init.lua")
+    script_path = os.path.join(tmp_path, "init.lua")
     with open(script_path, "w") as f:
         f.write('print("hello")')
 
     dump_cmd = [tt_cmd, "cfg", "dump"]
     tt_process = subprocess.Popen(
         dump_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -137,15 +137,15 @@ def test_cfg_dump_default_no_config(tt_cmd, tmpdir):
 
     output = tt_process.stdout.read()
     print(output)
-    assert f"bin_dir: {os.path.join(tmpdir, 'bin')}" in output
+    assert f"bin_dir: {os.path.join(tmp_path, 'bin')}" in output
     assert f"run_dir: {os.path.join('var', 'run')}" in output
     assert f"wal_dir: {os.path.join('var', 'lib')}" in output
     assert f"vinyl_dir: {os.path.join('var', 'lib')}" in output
     assert f"memtx_dir: {os.path.join('var', 'lib')}" in output
     assert f"log_dir: {os.path.join('var', 'log')}" in output
-    assert f"inc_dir: {os.path.join(tmpdir, 'include')}" in output
-    assert f"directory: {os.path.join(tmpdir, 'modules')}" in output
-    assert f"distfiles: {os.path.join(tmpdir, 'distfiles')}" in output
+    assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
+    assert f"directory: {os.path.join(tmp_path, 'modules')}" in output
+    assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
     assert "instances_enabled: ." in output
-    assert f"templates:\n- path: {os.path.join(tmpdir, 'templates')}" in output
+    assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output

--- a/test/integration/cluster/test_cluster_publish.py
+++ b/test/integration/cluster/test_cluster_publish.py
@@ -52,23 +52,23 @@ iproto:
 """
 
 
-def test_cluster_publish_in_place_instances_enabled(tt_cmd, tmpdir):
-    env_path = os.path.join(tmpdir, "app")
-    os.mkdir(env_path)
+def test_cluster_publish_in_place_instances_enabled(tt_cmd, tmp_path):
+    env_path = tmp_path / "app"
+    env_path.mkdir(0o755)
 
-    with open(os.path.join(env_path, "tt.yml"), "w") as f:
+    with open(env_path / "tt.yml", "w") as f:
         f.write("""\
 env:
   instances.enabled: "."
 """)
-    with open(os.path.join(env_path, "init.lua"), "w") as f:
+    with open(env_path / "init.lua", "w") as f:
         f.write("print('hello world!')")
 
     cfg = """\
 database:
   mode: rw
 """
-    with open(os.path.join(env_path, "cfg.yml"), "w") as f:
+    with open(env_path / "cfg.yml", "w") as f:
         f.write(cfg)
 
     publish_cmd = [tt_cmd, "cluster", "publish", "app", "cfg.yml"]
@@ -82,7 +82,7 @@ database:
     publish_output = publish_process.stdout.read()
     assert "" == publish_output
 
-    with open(os.path.join(env_path, "config.yml")) as f:
+    with open(env_path / "config.yml") as f:
         assert f.read() == cfg
 
 

--- a/test/integration/completion/test_completion.py
+++ b/test/integration/completion/test_completion.py
@@ -3,16 +3,16 @@ import os
 from utils import run_command_and_get_output
 
 
-def test_bash_completion_loaded(tt_cmd, tmpdir):
+def test_bash_completion_loaded(tt_cmd, tmp_path):
     rc, output = run_command_and_get_output(
             [tt_cmd, "completion", "bash"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path.as_posix()))
     assert rc == 0
-    fp = open(f'{tmpdir}/bash.completion', "a")
+    fp = open(tmp_path / 'bash.completion', "a")
     fp.write(output)
     fp.close()
 
     rc, output = run_command_and_get_output(
-            ["bash", "-c", f"source {tmpdir}/bash.completion"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            ["bash", "-c", f"source {tmp_path / 'bash.completion'}"],
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path.as_posix()))
     assert rc == 0

--- a/test/integration/daemon/test_daemon.py
+++ b/test/integration/daemon/test_daemon.py
@@ -32,12 +32,12 @@ def kill_remain_processes_wrapper(tt_cmd):
     utils.kill_procs(procs)
 
 
-def test_daemon_base_functionality(tt_cmd, tmpdir):
+def test_daemon_base_functionality(tt_cmd, tmp_path):
     # Start daemon.
     start_cmd = [tt_cmd, "daemon", "start"]
     daemon_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -46,17 +46,17 @@ def test_daemon_base_functionality(tt_cmd, tmpdir):
     assert re.search(r"Starting tt daemon...", start_out)
 
     # Check status.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
     # Daemon already exist.
     daemon_process_2 = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -65,16 +65,16 @@ def test_daemon_base_functionality(tt_cmd, tmpdir):
     assert re.search(r"the process already exists. PID: \d+.", start_again_out)
 
     # Check status. PID has not been changed after second start.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out2 = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out2 = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert status_out == status_out2
 
     # Stop daemon.
     stop_cmd = [tt_cmd, "daemon", "stop"]
-    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
 
@@ -83,12 +83,12 @@ def test_daemon_base_functionality(tt_cmd, tmpdir):
     assert daemon_process_rc == 0
 
 
-def test_restart(tt_cmd, tmpdir):
+def test_restart(tt_cmd, tmp_path):
     # Start daemon.
     start_cmd = [tt_cmd, "daemon", "start"]
     daemon_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -97,10 +97,10 @@ def test_restart(tt_cmd, tmpdir):
     assert re.search(r"Starting tt daemon...", start_out)
 
     # Check status.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
@@ -108,7 +108,7 @@ def test_restart(tt_cmd, tmpdir):
     restart_cmd = [tt_cmd, "daemon", "restart"]
     daemon_process_2 = subprocess.Popen(
         restart_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -119,16 +119,16 @@ def test_restart(tt_cmd, tmpdir):
     assert re.search(r"Starting tt daemon...", restart_out)
 
     # Check status of the new daemon.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
     # Stop the new daemon.
     stop_cmd = [tt_cmd, "daemon", "stop"]
-    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
 
@@ -137,8 +137,8 @@ def test_restart(tt_cmd, tmpdir):
     assert daemon_process_2_rc == 0
 
 
-def test_daemon_with_cfg(tt_cmd, tmpdir):
-    with open(os.path.join(tmpdir, "tt_daemon.yaml"), "w") as tnt_env_file:
+def test_daemon_with_cfg(tt_cmd, tmp_path):
+    with open(os.path.join(tmp_path, "tt_daemon.yaml"), "w") as tnt_env_file:
         line = '''
         daemon:
             log_dir: "log"
@@ -150,7 +150,7 @@ def test_daemon_with_cfg(tt_cmd, tmpdir):
     start_cmd = [tt_cmd, "daemon", "start"]
     daemon_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -159,16 +159,16 @@ def test_daemon_with_cfg(tt_cmd, tmpdir):
     assert re.search(r"Starting tt daemon...", start_out)
 
     # Check status of the daemon.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
     # Stop daemon.
     stop_cmd = [tt_cmd, "daemon", "stop"]
-    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
 
@@ -178,16 +178,16 @@ def test_daemon_with_cfg(tt_cmd, tmpdir):
 
 
 def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
-    tmpdir = tmpdir_with_cfg
+    tmp_path = tmpdir_with_cfg
     # Copy the test application to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
 
     # Start daemon.
     start_cmd = [tt_cmd, "daemon", "start"]
     daemon_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -196,10 +196,10 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
     assert re.search(r"Starting tt daemon...", start_out)
 
     # Check status.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
@@ -208,7 +208,7 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
     assert response.status_code == 200
     assert re.search(r"Starting an instance", response.json()["res"])
 
-    file = utils.wait_file(os.path.join(tmpdir, "test_app", utils.run_path, "test_app"),
+    file = utils.wait_file(os.path.join(tmp_path, "test_app", utils.run_path, "test_app"),
                            utils.pid_file, [])
     assert file != ""
 
@@ -226,7 +226,7 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
 
     # Stop daemon.
     stop_cmd = [tt_cmd, "daemon", "stop"]
-    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
 
@@ -236,15 +236,15 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
 
 
 def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
-    tmpdir = tmpdir_with_cfg
+    tmp_path = tmpdir_with_cfg
     # Copy the test application to the "run" directory.
     test_app_path = os.path.join(os.path.dirname(__file__), "test_app", "test_app.lua")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
 
     iface = utils.get_test_iface()
     port = utils.find_port()
 
-    with open(os.path.join(tmpdir, "tt_daemon.yaml"), "w") as tnt_env_file:
+    with open(os.path.join(tmp_path, "tt_daemon.yaml"), "w") as tnt_env_file:
         line = '''
         daemon:
             listen_interface: {}
@@ -256,7 +256,7 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
     start_cmd = [tt_cmd, "daemon", "start"]
     daemon_process = subprocess.Popen(
         start_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -265,14 +265,14 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
     assert re.search(r"Starting tt daemon...", start_out)
 
     # Check status.
-    file = utils.wait_file(os.path.join(tmpdir, utils.run_path), 'tt_daemon.pid', [])
+    file = utils.wait_file(os.path.join(tmp_path, utils.run_path), 'tt_daemon.pid', [])
     assert file != ""
     status_cmd = [tt_cmd, "daemon", "status"]
-    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmpdir)
+    status_rc, status_out = utils.run_command_and_get_output(status_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"RUNNING. PID: \d+.", status_out)
 
-    conn = utils.get_process_conn(os.path.join(tmpdir, utils.run_path, file), port)
+    conn = utils.get_process_conn(os.path.join(tmp_path, utils.run_path, file), port)
     assert conn is not None
 
     url = "http://" + conn.laddr.ip + ":" + str(port) + "/tarantool"
@@ -282,7 +282,7 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
     assert response.status_code == 200
     assert re.search(r"Starting an instance", response.json()["res"])
 
-    file = utils.wait_file(os.path.join(tmpdir, "test_app", utils.run_path, "test_app"),
+    file = utils.wait_file(os.path.join(tmp_path, "test_app", utils.run_path, "test_app"),
                            utils.pid_file, [])
     assert file != ""
 
@@ -299,7 +299,7 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
 
     # Stop daemon.
     stop_cmd = [tt_cmd, "daemon", "stop"]
-    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmpdir)
+    stop_rc, stop_out = utils.run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     assert re.search(r"The Daemon \(PID = \d+\) has been terminated.", stop_out)
 

--- a/test/integration/ee/test_ee_download.py
+++ b/test/integration/ee/test_ee_download.py
@@ -11,15 +11,15 @@ from utils import run_command_and_get_output
 
 
 @pytest.mark.slow_ee
-def test_download_ee(tt_cmd, tmpdir):
+def test_download_ee(tt_cmd, tmp_path):
     rc, output = run_command_and_get_output(
         [tt_cmd, "init"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "search", "tarantool-ee"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     version = output.split('\n')[1]
     assert re.search(r"(\d+.\d+.\d+|<unknown>)",
@@ -27,7 +27,7 @@ def test_download_ee(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "download", version],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 0
     assert re.search("Downloading ", output)
@@ -41,15 +41,15 @@ def test_download_ee(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow_ee
-def test_download_ee_dev(tt_cmd, tmpdir):
+def test_download_ee_dev(tt_cmd, tmp_path):
     rc, output = run_command_and_get_output(
         [tt_cmd, "init"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "search", "tarantool-ee", "--dev"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     version = output.split('\n')[1]
     assert re.search(r"(\d+.\d+.\d+|<unknown>)",
@@ -57,7 +57,7 @@ def test_download_ee_dev(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "download", version, "--dev"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 0
     assert re.search("Downloading ", output)

--- a/test/integration/ee/test_ee_install.py
+++ b/test/integration/ee/test_ee_install.py
@@ -11,15 +11,15 @@ from utils import run_command_and_get_output
 
 
 @pytest.mark.slow_ee
-def test_install_ee(tt_cmd, tmpdir):
+def test_install_ee(tt_cmd, tmp_path):
     rc, output = run_command_and_get_output(
         [tt_cmd, "init"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "search", "tarantool-ee"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     version = output.split('\n')[1]
     assert re.search(r"(\d+.\d+.\d+|<unknown>)",
@@ -27,26 +27,26 @@ def test_install_ee(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "install", "-f", "tarantool-ee", version],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 0
     assert re.search("Installing tarantool-ee="+version, output)
     assert re.search("Downloading tarantool-ee...", output)
     assert re.search("Done.", output)
-    assert os.path.exists(os.path.join(tmpdir, 'bin', 'tarantool'))
-    assert os.path.exists(os.path.join(tmpdir, 'include', 'include', 'tarantool'))
+    assert os.path.exists(os.path.join(tmp_path, 'bin', 'tarantool'))
+    assert os.path.exists(os.path.join(tmp_path, 'include', 'include', 'tarantool'))
 
 
 @pytest.mark.slow_ee
-def test_install_ee_dev(tt_cmd, tmpdir):
+def test_install_ee_dev(tt_cmd, tmp_path):
     rc, output = run_command_and_get_output(
         [tt_cmd, "init"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "search", "tarantool-ee", "--dev"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     version = output.split('\n')[1]
     assert re.search(r"(\d+.\d+.\d+|<unknown>)",
@@ -54,11 +54,11 @@ def test_install_ee_dev(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "install", "-f", "tarantool-ee", version, "--dev"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 0
     assert re.search("Installing tarantool-ee="+version, output)
     assert re.search("Downloading tarantool-ee...", output)
     assert re.search("Done.", output)
-    assert os.path.exists(os.path.join(tmpdir, 'bin', 'tarantool'))
-    assert os.path.exists(os.path.join(tmpdir, 'include', 'include', 'tarantool'))
+    assert os.path.exists(os.path.join(tmp_path, 'bin', 'tarantool'))
+    assert os.path.exists(os.path.join(tmp_path, 'include', 'include', 'tarantool'))

--- a/test/integration/ee/test_ee_search.py
+++ b/test/integration/ee/test_ee_search.py
@@ -11,14 +11,14 @@ from utils import run_command_and_get_output
 
 
 @pytest.mark.slow_ee
-def test_search_ee(tt_cmd, tmpdir):
+def test_search_ee(tt_cmd, tmp_path):
     cmds = [
         [tt_cmd, "search", "tarantool-ee"],
         [tt_cmd, "search", "tarantool-ee", "--version=2.10"],
     ]
     for cmd in cmds:
         rc, output = run_command_and_get_output(
-            cmd, cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cmd, cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
         assert re.search(r"(\d+.\d+.\d+)",
                          output)
         assert rc == 0

--- a/test/integration/enable/test_enable.py
+++ b/test/integration/enable/test_enable.py
@@ -6,21 +6,21 @@ import subprocess
 import yaml
 
 
-def test_enable_application(tt_cmd, tmpdir):
+def test_enable_application(tt_cmd, tmp_path):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "test_app")
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    instances_enabled_path = os.path.join(tmpdir, "bar")
+    config_path = os.path.join(tmp_path, "tt.yaml")
+    instances_enabled_path = os.path.join(tmp_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
     os.makedirs(instances_enabled_path)
-    test_app_path = os.path.join(tmpdir, "test_app")
+    test_app_path = os.path.join(tmp_path, "test_app")
     shutil.copytree(test_app_path_src, test_app_path)
 
     # Enable test application.
     enable_cmd = [tt_cmd, "enable", test_app_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -35,7 +35,7 @@ def test_enable_application(tt_cmd, tmpdir):
     instances_cmd = [tt_cmd, "instances"]
     instance_process = subprocess.Popen(
         instances_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -44,21 +44,21 @@ def test_enable_application(tt_cmd, tmpdir):
     assert re.search("test_app", instances_output)
 
 
-def test_enable_script(tt_cmd, tmpdir):
+def test_enable_script(tt_cmd, tmp_path):
     test_script_path_src = os.path.join(os.path.dirname(__file__), "test_script", "test.lua")
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    instances_enabled_path = os.path.join(tmpdir, "bar")
+    config_path = os.path.join(tmp_path, "tt.yaml")
+    instances_enabled_path = os.path.join(tmp_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
     os.makedirs(instances_enabled_path)
-    test_script_path = os.path.join(tmpdir, "test.lua")
+    test_script_path = os.path.join(tmp_path, "test.lua")
     shutil.copyfile(test_script_path_src, test_script_path)
 
     # Enable test script.
     enable_cmd = [tt_cmd, "enable", test_script_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -73,7 +73,7 @@ def test_enable_script(tt_cmd, tmpdir):
     instances_cmd = [tt_cmd, "instances"]
     instance_process = subprocess.Popen(
         instances_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -82,20 +82,20 @@ def test_enable_script(tt_cmd, tmpdir):
     assert re.search("test.lua", instances_output)
 
 
-def test_enable_invalid_path(tt_cmd, tmpdir):
-    test_path = os.path.join(tmpdir)
+def test_enable_invalid_path(tt_cmd, tmp_path):
+    test_path = os.path.join(tmp_path)
     config_path = os.path.join(test_path, "tt.yaml")
     instances_enabled_path = os.path.join(test_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
     os.makedirs(instances_enabled_path)
-    test_script_path = os.path.join(tmpdir, "test.lua")
+    test_script_path = os.path.join(tmp_path, "test.lua")
 
     # Enable with incorrect path.
     enable_cmd = [tt_cmd, "enable", test_script_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -105,8 +105,8 @@ def test_enable_invalid_path(tt_cmd, tmpdir):
     assert re.search("cannot get info of", enable_output)
 
 
-def test_enable_no_path(tt_cmd, tmpdir):
-    test_path = os.path.join(tmpdir)
+def test_enable_no_path(tt_cmd, tmp_path):
+    test_path = os.path.join(tmp_path)
     config_path = os.path.join(test_path, "tt.yaml")
     instances_enabled_path = os.path.join(test_path, "bar")
     with open(config_path, "w") as f:
@@ -117,7 +117,7 @@ def test_enable_no_path(tt_cmd, tmpdir):
     enable_cmd = [tt_cmd, "enable"]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -127,20 +127,20 @@ def test_enable_no_path(tt_cmd, tmpdir):
     assert re.search("provide the path to a script or application directory", enable_output)
 
 
-def test_enable_instances_enable_not_exist(tt_cmd, tmpdir):
+def test_enable_instances_enable_not_exist(tt_cmd, tmp_path):
     test_script_path_src = os.path.join(os.path.dirname(__file__), "test_script", "test.lua")
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    instances_enabled_path = os.path.join(tmpdir, "bar")
+    config_path = os.path.join(tmp_path, "tt.yaml")
+    instances_enabled_path = os.path.join(tmp_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
-    test_script_path = os.path.join(tmpdir, "test.lua")
+    test_script_path = os.path.join(tmp_path, "test.lua")
     shutil.copyfile(test_script_path_src, test_script_path)
 
     # Enable test script.
     enable_cmd = [tt_cmd, "enable", test_script_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -157,7 +157,7 @@ def test_enable_instances_enable_not_exist(tt_cmd, tmpdir):
     instances_cmd = [tt_cmd, "instances"]
     instance_process = subprocess.Popen(
         instances_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -166,20 +166,20 @@ def test_enable_instances_enable_not_exist(tt_cmd, tmpdir):
     assert re.search("test.lua", instances_output)
 
 
-def test_enable_invalid_script(tt_cmd, tmpdir):
-    test_path = os.path.join(tmpdir)
+def test_enable_invalid_script(tt_cmd, tmp_path):
+    test_path = os.path.join(tmp_path)
     config_path = os.path.join(test_path, "tt.yaml")
     instances_enabled_path = os.path.join(test_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
     os.makedirs(instances_enabled_path)
-    test_script_path = os.path.join(tmpdir, "test")
+    test_script_path = os.path.join(tmp_path, "test")
 
     # Enable with incorrect script.
     enable_cmd = [tt_cmd, "enable", test_script_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -189,21 +189,21 @@ def test_enable_invalid_script(tt_cmd, tmpdir):
     assert re.search("cannot get info of", enable_output)
 
 
-def test_enable_instances_enabled_dot(tt_cmd, tmpdir):
-    test_path = os.path.join(tmpdir)
+def test_enable_instances_enabled_dot(tt_cmd, tmp_path):
+    test_path = os.path.join(tmp_path)
     config_path = os.path.join(test_path, "tt.yaml")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": '.'}}, f)
     fakeApp = open(os.path.join(test_path, "init.lua"), "a")
     fakeApp.write("I am an app!")
     fakeApp.close()
-    test_script_path = os.path.join(tmpdir, "test")
+    test_script_path = os.path.join(tmp_path, "test")
 
     # Enable with incorrect script.
     enable_cmd = [tt_cmd, "enable", test_script_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -213,20 +213,20 @@ def test_enable_instances_enabled_dot(tt_cmd, tmpdir):
     assert re.search("instances enabled '.' is not supported", enable_output)
 
 
-def test_enable_application_dir_empty(tt_cmd, tmpdir):
-    config_path = os.path.join(tmpdir, "tt.yaml")
-    instances_enabled_path = os.path.join(tmpdir, "bar")
+def test_enable_application_dir_empty(tt_cmd, tmp_path):
+    config_path = os.path.join(tmp_path, "tt.yaml")
+    instances_enabled_path = os.path.join(tmp_path, "bar")
     with open(config_path, "w") as f:
         yaml.dump({"env": {"instances_enabled": instances_enabled_path}}, f)
     os.makedirs(instances_enabled_path)
-    test_app_path = os.path.join(tmpdir, "notAppDir")
+    test_app_path = os.path.join(tmp_path, "notAppDir")
     os.makedirs(test_app_path)
 
     # Enable test application.
     enable_cmd = [tt_cmd, "enable", test_app_path]
     enable_process = subprocess.Popen(
         enable_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True

--- a/test/integration/env/test_env.py
+++ b/test/integration/env/test_env.py
@@ -1,22 +1,21 @@
-import os
 import re
 import subprocess
 
 from utils import config_name
 
 
-def test_env_output(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_env_output(tt_cmd, tmp_path):
+    configPath = tmp_path / config_name
     # Create test config
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
-    binDir = str(tmpdir + "/bin")
-    tarantoolDir = "TARANTOOL_DIR=" + str(tmpdir + "/include/include")
+    binDir = tmp_path / "bin"
+    tarantoolDir = "TARANTOOL_DIR=" + (tmp_path / "include" / "include").as_posix()
 
     env_cmd = [tt_cmd, "env"]
     instance_process = subprocess.Popen(
         env_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -29,4 +28,4 @@ def test_env_output(tt_cmd, tmpdir):
     # Check output
     output = instance_process.stdout.read()
     assert re.search(tarantoolDir, output)
-    assert re.search(binDir, output)
+    assert re.search(binDir.as_posix(), output)

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -14,7 +14,7 @@ def test_help_without_external_modules(tt_cmd, help_cmd):
     assert "EXTERNAL COMMANDS" not in output
 
 
-def test_help_internal_module(tt_cmd, tmpdir):
+def test_help_internal_module(tt_cmd, tmp_path):
     module = "version"
     commands = [
         [tt_cmd, "help", module],
@@ -23,16 +23,16 @@ def test_help_internal_module(tt_cmd, tmpdir):
     ]
 
     for cmd in commands:
-        rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+        rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
         assert rc == 0
         assert "Show Tarantool CLI version information" in output
 
 
-def test_external_help_module(tt_cmd, tmpdir):
-    create_tt_config(tmpdir, tmpdir)
-    module_message = create_external_module("help", tmpdir)
+def test_external_help_module(tt_cmd, tmp_path):
+    create_tt_config(tmp_path, tmp_path.as_posix())
+    module_message = create_external_module("help", tmp_path)
 
-    rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmpdir)
+    rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmp_path)
     assert rc == 0
     assert f"{module_message}\nList of passed args:\n" == output
 
@@ -47,36 +47,36 @@ def test_external_help_module(tt_cmd, tmpdir):
     ]
 
     for cmd in commands:
-        rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+        rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
         assert rc == 0
         assert "help\tDescription for external module help" in output
 
 
-def test_internal_help_with_external_module(tt_cmd, tmpdir):
-    create_tt_config(tmpdir, tmpdir)
-    module_message = create_external_module("version", tmpdir)
+def test_internal_help_with_external_module(tt_cmd, tmp_path):
+    create_tt_config(tmp_path, tmp_path.as_posix())
+    module_message = create_external_module("version", tmp_path)
 
     # No external help module, but external version module.
     # List of available external commands should be displayed.
-    rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmpdir)
+    rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmp_path)
     assert rc == 0
     assert "version\tDescription for external module version" in output
 
     # In this case, the external module version should be called with the --help flag.
-    rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmpdir)
+    rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmp_path)
     assert rc == 0
     assert "Help for external version module\nList of passed args: --help\n" == output
 
-    create_external_module("abc", tmpdir)
+    create_external_module("abc", tmp_path)
     # External modules without internal implementation.
-    rc, output = run_command_and_get_output([tt_cmd, "help", "abc"], cwd=tmpdir)
+    rc, output = run_command_and_get_output([tt_cmd, "help", "abc"], cwd=tmp_path)
     assert rc == 0
     assert "Help for external abc module\nList of passed args: --help\n" == output
 
     # If the external module help and version exist at the same time,
     # then the external module help should be called with the <version>
     # argument. For example, execute "path/to/external/help version" command.
-    module_message = create_external_module("help", tmpdir)
-    rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmpdir)
+    module_message = create_external_module("help", tmp_path)
+    rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmp_path)
     assert rc == 0
     assert f"{module_message}\nList of passed args: version\n" == output

--- a/test/integration/init/test_init.py
+++ b/test/integration/init/test_init.py
@@ -17,13 +17,13 @@ def check_env_dirs(dir, instances_enabled):
     assert os.path.isdir(os.path.join(dir, instances_enabled))
 
 
-def test_init_basic_functionality(tt_cmd, tmpdir):
+def test_init_basic_functionality(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "valid_cartridge.yml"),
-                os.path.join(tmpdir, ".cartridge.yml"))
+                os.path.join(tmp_path, ".cartridge.yml"))
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -34,7 +34,7 @@ def test_init_basic_functionality(tt_cmd, tmpdir):
     assert "Found existing config '.cartridge.yml'" in tt_process.stdout.readline()
     assert f"Environment config is written to '{config_name}'" in tt_process.stdout.readline()
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(tmp_path / config_name, 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "my_run_dir"
         assert data_loaded["app"]["log_dir"] == "my_log_dir"
@@ -44,13 +44,13 @@ def test_init_basic_functionality(tt_cmd, tmpdir):
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
         assert not data_loaded["env"]["tarantoolctl_layout"]
 
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_init_missing_configs(tt_cmd, tmpdir):
+def test_init_missing_configs(tt_cmd, tmp_path):
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -60,7 +60,7 @@ def test_init_missing_configs(tt_cmd, tmpdir):
     assert tt_process.returncode == 0
     assert f"Environment config is written to '{config_name}'" in tt_process.stdout.readline()
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(tmp_path / config_name, 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "var/run"
         assert data_loaded["app"]["log_dir"] == "var/log"
@@ -73,16 +73,16 @@ def test_init_missing_configs(tt_cmd, tmpdir):
         assert data_loaded["env"]["bin_dir"] == "bin"
         assert data_loaded["templates"][0]["path"] == "templates"
         assert data_loaded["repo"]["distfiles"] == "distfiles"
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_init_invalid_config_file(tt_cmd, tmpdir):
-    with open(os.path.join(tmpdir, ".cartridge.yml"), 'w') as stream:
+def test_init_invalid_config_file(tt_cmd, tmp_path):
+    with open(tmp_path / ".cartridge.yml", 'w') as stream:
         stream.write("hello")
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -94,13 +94,13 @@ def test_init_invalid_config_file(tt_cmd, tmpdir):
     assert "failed to parse cartridge app configuration" in tt_process.stdout.readline()
 
 
-def test_init_skip_config(tt_cmd, tmpdir):
+def test_init_skip_config(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "valid_cartridge.yml"),
-                os.path.join(tmpdir, ".cartridge.yml"))
+                tmp_path / ".cartridge.yml")
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init", "--skip-config"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -110,7 +110,7 @@ def test_init_skip_config(tt_cmd, tmpdir):
     assert tt_process.returncode == 0
     assert f"Environment config is written to '{config_name}'" in tt_process.stdout.readline()
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(tmp_path / config_name, 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "var/run"
         assert data_loaded["app"]["log_dir"] == "var/log"
@@ -118,11 +118,11 @@ def test_init_skip_config(tt_cmd, tmpdir):
         assert data_loaded["app"]["vinyl_dir"] == "var/lib"
         assert data_loaded["app"]["memtx_dir"] == "var/lib"
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_init_in_app_dir(tt_cmd, tmpdir):
-    app_dir = os.path.join(tmpdir, "app1")
+def test_init_in_app_dir(tt_cmd, tmp_path):
+    app_dir = tmp_path / "app1"
     shutil.copytree(os.path.join(os.path.dirname(__file__), "apps", "multi_inst_app"),
                     app_dir)
 
@@ -151,16 +151,16 @@ def test_init_in_app_dir(tt_cmd, tmpdir):
     check_env_dirs(app_dir, ".")
 
 
-def test_init_existing_tt_env_conf_overwrite(tt_cmd, tmpdir):
+def test_init_existing_tt_env_conf_overwrite(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "valid_cartridge.yml"),
-                os.path.join(tmpdir, ".cartridge.yml"))
+                os.path.join(tmp_path, ".cartridge.yml"))
 
-    with open(os.path.join(tmpdir, config_name), "w") as f:
+    with open(os.path.join(tmp_path, config_name), "w") as f:
         f.write('''app:''')
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -176,7 +176,7 @@ def test_init_existing_tt_env_conf_overwrite(tt_cmd, tmpdir):
     line = tt_process.stdout.readline()
     assert f"Environment config is written to '{config_name}'" in line
 
-    with open(os.path.join(tmpdir, "tt.yaml"), 'r') as stream:
+    with open(os.path.join(tmp_path, "tt.yaml"), 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "my_run_dir"
         assert data_loaded["app"]["log_dir"] == "my_log_dir"
@@ -185,16 +185,16 @@ def test_init_existing_tt_env_conf_overwrite(tt_cmd, tmpdir):
         assert data_loaded["app"]["memtx_dir"] == "my_data_dir"
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
 
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_init_existing_tt_env_conf_dont_overwrite(tt_cmd, tmpdir):
-    with open(os.path.join(tmpdir, config_name), "w") as f:
+def test_init_existing_tt_env_conf_dont_overwrite(tt_cmd, tmp_path):
+    with open(os.path.join(tmp_path, config_name), "w") as f:
         f.write('''app:''')
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -208,20 +208,20 @@ def test_init_existing_tt_env_conf_dont_overwrite(tt_cmd, tmpdir):
     assert f"{config_name} already exists. Overwrite? [y/n]:" in line and \
            f"Environment config is written to '{config_name}'" not in line
 
-    with open(os.path.join(tmpdir, "tt.yaml"), 'r') as stream:
+    with open(os.path.join(tmp_path, "tt.yaml"), 'r') as stream:
         assert len(stream.readlines()) == 1
 
 
-def test_init_existing_tt_env_conf_overwrite_force(tt_cmd, tmpdir):
+def test_init_existing_tt_env_conf_overwrite_force(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "valid_cartridge.yml"),
-                os.path.join(tmpdir, ".cartridge.yml"))
+                os.path.join(tmp_path, ".cartridge.yml"))
 
-    with open(os.path.join(tmpdir, config_name), "w") as f:
+    with open(os.path.join(tmp_path, config_name), "w") as f:
         f.write('''app:''')
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init", "-f"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -234,7 +234,7 @@ def test_init_existing_tt_env_conf_overwrite_force(tt_cmd, tmpdir):
     assert lines[0] == "   • Found existing config '.cartridge.yml'\n"
     assert lines[1] == f"   • Environment config is written to '{config_name}'\n"
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(os.path.join(tmp_path, config_name), 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "my_run_dir"
         assert data_loaded["app"]["log_dir"] == "my_log_dir"
@@ -243,16 +243,16 @@ def test_init_existing_tt_env_conf_overwrite_force(tt_cmd, tmpdir):
         assert data_loaded["app"]["memtx_dir"] == "my_data_dir"
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
 
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_init_basic_tarantoolctl_cfg(tt_cmd, tmpdir):
+def test_init_basic_tarantoolctl_cfg(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "tarantoolctl.lua"),
-                os.path.join(tmpdir, ".tarantoolctl"))
+                os.path.join(tmp_path, ".tarantoolctl"))
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -263,7 +263,7 @@ def test_init_basic_tarantoolctl_cfg(tt_cmd, tmpdir):
     assert "Found existing config '.tarantoolctl'" in tt_process.stdout.readline()
     assert f"Environment config is written to '{config_name}'" in tt_process.stdout.readline()
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(os.path.join(tmp_path, config_name), 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "/opt/run"
         assert data_loaded["app"]["log_dir"] == "/opt/log"
@@ -273,16 +273,16 @@ def test_init_basic_tarantoolctl_cfg(tt_cmd, tmpdir):
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
         assert data_loaded["env"]["tarantoolctl_layout"]
 
-    check_env_dirs(tmpdir, "instances.enabled")
+    check_env_dirs(tmp_path, "instances.enabled")
 
 
-def test_tarantoolctl_cfg_from_doc(tt_cmd, tmpdir):
+def test_tarantoolctl_cfg_from_doc(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs",
-                "default_ttctl_cfg_from_doc.lua"), os.path.join(tmpdir, ".tarantoolctl"))
+                "default_ttctl_cfg_from_doc.lua"), os.path.join(tmp_path, ".tarantoolctl"))
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -293,7 +293,7 @@ def test_tarantoolctl_cfg_from_doc(tt_cmd, tmpdir):
     assert "Found existing config '.tarantoolctl'" in tt_process.stdout.readline()
     assert f"Environment config is written to '{config_name}'" in tt_process.stdout.readline()
 
-    with open(os.path.join(tmpdir, config_name), 'r') as stream:
+    with open(os.path.join(tmp_path, config_name), 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         assert data_loaded["app"]["run_dir"] == "./run/tarantool"
         assert data_loaded["app"]["log_dir"] == "./log/tarantool"
@@ -303,21 +303,21 @@ def test_tarantoolctl_cfg_from_doc(tt_cmd, tmpdir):
         assert data_loaded["env"]["instances_enabled"] == "./instances"
         assert data_loaded["env"]["tarantoolctl_layout"]
 
-    check_env_dirs(tmpdir, "instances")
+    check_env_dirs(tmp_path, "instances")
 
 
 @pytest.mark.skipif(
     os.getuid() == 0,
     reason="Skipping the test, it shouldn't run as root",
 )
-def test_init_tarantoolctl_app_no_read_permissions(tt_cmd, tmpdir):
+def test_init_tarantoolctl_app_no_read_permissions(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "tarantoolctl.lua"),
-                os.path.join(tmpdir, ".tarantoolctl"))
+                os.path.join(tmp_path, ".tarantoolctl"))
 
-    os.chmod(os.path.join(tmpdir, ".tarantoolctl"), 0o222)
+    os.chmod(os.path.join(tmp_path, ".tarantoolctl"), 0o222)
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
@@ -330,15 +330,15 @@ def test_init_tarantoolctl_app_no_read_permissions(tt_cmd, tmpdir):
         ".tarantoolctl: Permission denied" in tt_process.stdout.readline()
 
 
-def test_init_multiple_existing_configs(tt_cmd, tmpdir):
+def test_init_multiple_existing_configs(tt_cmd, tmp_path):
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "tarantoolctl.lua"),
-                os.path.join(tmpdir, ".tarantoolctl"))
+                os.path.join(tmp_path, ".tarantoolctl"))
     shutil.copy(os.path.join(os.path.dirname(__file__), "configs", "valid_cartridge.yml"),
-                os.path.join(tmpdir, ".cartridge.yml"))
+                os.path.join(tmp_path, ".cartridge.yml"))
 
     tt_process = subprocess.Popen(
         [tt_cmd, "init"],
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,

--- a/test/integration/install/test_install.py
+++ b/test/integration/install/test_install.py
@@ -12,11 +12,11 @@ from utils import config_name, is_valid_tarantool_installed
 
 
 @pytest.mark.slow
-def test_install_tt_unexisted_commit(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_install_tt_unexisted_commit(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
 
-    # Create test config.
-    tmp_dir = tempfile.mkdtemp(dir=tmpdir)
+    # Create test config
+    tmp_dir = tempfile.mkdtemp(dir=tmp_path)
     tmp_name = tmp_dir.rpartition('/')[2]
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\nrepo:\n  distfiles: "%s"' % tmp_name)
@@ -36,7 +36,7 @@ def test_install_tt_unexisted_commit(tt_cmd, tmpdir):
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "--local-repo", "tt", "2df3077"]
     instance_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -53,9 +53,9 @@ def test_install_tt_unexisted_commit(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_install_tt(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
-    # Create test config.
+def test_install_tt(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
+    # Create test config
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -63,7 +63,7 @@ def test_install_tt(tt_cmd, tmpdir):
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt"]
     instance_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -74,10 +74,10 @@ def test_install_tt(tt_cmd, tmpdir):
     assert instance_process_rc == 0
     os.remove(configPath)
 
-    installed_cmd = [tmpdir + "/bin/tt", "version"]
+    installed_cmd = [tmp_path / "bin" / "tt", "version"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=tmpdir + "/bin",
+        cwd=tmp_path / "bin",
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -87,9 +87,9 @@ def test_install_tt(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
-    # Create test config.
+def test_install_uninstall_tt_specific_commit(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
+    # Create test config
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -97,7 +97,7 @@ def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt", "97c7b73"]
     instance_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -107,10 +107,10 @@ def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
     instance_process_rc = instance_process.wait()
     assert instance_process_rc == 0
 
-    installed_cmd = [tmpdir + "/bin/tt", "version"]
+    installed_cmd = [tmp_path / "bin" / "tt", "version"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=tmpdir + "/bin",
+        cwd=tmp_path / "bin",
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -123,7 +123,7 @@ def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
     uninstall_cmd = [tt_cmd, "--cfg", configPath, "uninstall", "tt", "97c7b73"]
     uninstall_instance_process = subprocess.Popen(
         uninstall_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -132,13 +132,13 @@ def test_install_uninstall_tt_specific_commit(tt_cmd, tmpdir):
     assert re.search(r"Removing binary...", first_output)
     second_output = uninstall_instance_process.stdout.readline()
     assert re.search(r"tt=97c7b73 is uninstalled", second_output)
-    assert not os.path.exists(os.path.join(tmpdir, "bin", "tt_97c7b73"))
+    assert not os.path.exists(os.path.join(tmp_path, "bin", "tt_97c7b73"))
 
 
 @pytest.mark.slow
-def test_wrong_format_hash(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
-    # Create test config.
+def test_wrong_format_hash(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
+    # Create test config
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -146,7 +146,7 @@ def test_wrong_format_hash(tt_cmd, tmpdir):
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt", "111"]
     instance_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -164,7 +164,7 @@ def test_wrong_format_hash(tt_cmd, tmpdir):
     install_cmd_second = [tt_cmd, "--cfg", configPath, "install", "tt", "zzzzzzz"]
     instance_process_second = subprocess.Popen(
         install_cmd_second,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -180,9 +180,9 @@ def test_wrong_format_hash(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_install_tt_specific_version(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
-    # Create test config.
+def test_install_tt_specific_version(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
+    # Create test config
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
 
@@ -190,7 +190,7 @@ def test_install_tt_specific_version(tt_cmd, tmpdir):
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt", "2.1.2"]
     instance_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -201,10 +201,10 @@ def test_install_tt_specific_version(tt_cmd, tmpdir):
     assert instance_process_rc == 0
     os.remove(configPath)
 
-    installed_cmd = [tmpdir + "/bin/tt", "version"]
+    installed_cmd = [tmp_path / "bin" / "tt", "version"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=tmpdir + "/bin",
+        cwd=tmp_path / "bin",
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -214,8 +214,8 @@ def test_install_tt_specific_version(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_install_tarantool_commit(tt_cmd, tmpdir):
-    config_path = os.path.join(tmpdir, config_name)
+def test_install_tarantool_commit(tt_cmd, tmp_path):
+    config_path = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(config_path, "w") as f:
         yaml.dump({"env": {"bin_dir": "", "inc_dir": "./my_inc"}}, f)
@@ -238,10 +238,10 @@ def test_install_tarantool_commit(tt_cmd, tmpdir):
     # Check that the process was shutdowned correctly.
     instance_process_rc = instance_process.wait()
     assert instance_process_rc == 0
-    installed_cmd = [tmpdir + "/bin/tarantool", "-v"]
+    installed_cmd = [tmp_path / "bin" / "tarantool", "-v"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=os.path.join(tmpdir, "/bin"),
+        cwd=os.path.join(tmp_path, "/bin"),
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -249,20 +249,20 @@ def test_install_tarantool_commit(tt_cmd, tmpdir):
 
     run_output = installed_program_process.stdout.readline()
     assert re.search(r"Tarantool", run_output)
-    assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
-    assert os.path.exists(os.path.join(tmpdir, "bin", "tarantool_00a9e59"))
+    assert os.path.exists(os.path.join(tmp_path, "my_inc", "include", "tarantool"))
+    assert os.path.exists(os.path.join(tmp_path, "bin", "tarantool_00a9e59"))
 
     assert is_valid_tarantool_installed(
-        os.path.join(tmpdir, "bin"),
-        os.path.join(tmpdir, "my_inc", "include"),
-        os.path.join(tmpdir, "bin", "tarantool_00a9e59"),
-        os.path.join(tmpdir, "my_inc", "include", "tarantool_00a9e59"),
+        os.path.join(tmp_path, "bin"),
+        os.path.join(tmp_path, "my_inc", "include"),
+        os.path.join(tmp_path, "bin", "tarantool_00a9e59"),
+        os.path.join(tmp_path, "my_inc", "include", "tarantool_00a9e59"),
     )
 
 
 @pytest.mark.slow
-def test_install_tarantool(tt_cmd, tmpdir):
-    config_path = os.path.join(tmpdir, config_name)
+def test_install_tarantool(tt_cmd, tmp_path):
+    config_path = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(config_path, "w") as f:
         yaml.dump({"env": {"bin_dir": "", "inc_dir": "./my_inc"}}, f)
@@ -285,10 +285,10 @@ def test_install_tarantool(tt_cmd, tmpdir):
     # Check that the process was shutdowned correctly.
     instance_process_rc = instance_process.wait()
     assert instance_process_rc == 0
-    installed_cmd = [tmpdir + "/bin/tarantool", "-v"]
+    installed_cmd = [tmp_path / "bin" / "tarantool", "-v"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=os.path.join(tmpdir, "/bin"),
+        cwd=os.path.join(tmp_path, "/bin"),
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -296,17 +296,17 @@ def test_install_tarantool(tt_cmd, tmpdir):
 
     run_output = installed_program_process.stdout.readline()
     assert re.search(r"Tarantool", run_output)
-    assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
-    assert os.path.exists(os.path.join(tmpdir, "bin", "tarantool_2.10.7"))
+    assert os.path.exists(os.path.join(tmp_path, "my_inc", "include", "tarantool"))
+    assert os.path.exists(os.path.join(tmp_path, "bin", "tarantool_2.10.7"))
 
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_install_tarantool_in_docker(tt_cmd, tmpdir):
+def test_install_tarantool_in_docker(tt_cmd, tmp_path):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")
 
-    config_path = os.path.join(tmpdir, config_name)
+    config_path = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(config_path, "w") as f:
         yaml.dump({"env": {"bin_dir": "", "inc_dir": "./my_inc"}}, f)
@@ -328,10 +328,10 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
 
     instance_process_rc = tt_process.wait()
     assert instance_process_rc == 0
-    installed_cmd = [tmpdir + "/bin/tarantool", "-v"]
+    installed_cmd = [tmp_path / "bin" / "tarantool", "-v"]
     installed_program_process = subprocess.Popen(
         installed_cmd,
-        cwd=os.path.join(tmpdir, "/bin"),
+        cwd=os.path.join(tmp_path, "/bin"),
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -341,11 +341,11 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
     assert re.search(r"Tarantool", run_output)
 
     # Check tarantool glibc version.
-    out = subprocess.getoutput("objdump -T " + os.path.join(tmpdir, "bin", "tarantool") +
+    out = subprocess.getoutput("objdump -T " + os.path.join(tmp_path, "bin", "tarantool") +
                                " | grep -o -E 'GLIBC_[.0-9]+' | sort -V | tail -n1")
     assert out == "GLIBC_2.27"
 
-    assert os.path.exists(os.path.join(tmpdir, "my_inc", "include", "tarantool"))
+    assert os.path.exists(os.path.join(tmp_path, "my_inc", "include", "tarantool"))
 
 
 @pytest.mark.parametrize("tt_dir, expected_bin_path, expected_inc_path", [
@@ -362,14 +362,14 @@ def test_install_tarantool_in_docker(tt_cmd, tmpdir):
 ])
 def test_install_tarantool_dev_bin_invalid(
         tt_cmd,
-        tmpdir,
+        tmp_path,
         tt_dir,
         expected_bin_path,
         expected_inc_path):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__), "testdata")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     for build_dir in ["build_invalid", "build_invalid2"]:
         build_path = os.path.join(testdata_path, build_dir)
@@ -427,7 +427,7 @@ def test_install_tarantool_dev_bin_invalid(
 ])
 def test_install_tarantool_dev_no_include_option(
         tt_cmd,
-        tmpdir,
+        tmp_path,
         build_dir,
         exec_rel_path,
         include_rel_path,
@@ -435,8 +435,8 @@ def test_install_tarantool_dev_no_include_option(
 ):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__), "testdata")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     build_path = os.path.join(testdata_path, build_dir)
     install_cmd = [
@@ -478,12 +478,12 @@ def test_install_tarantool_dev_no_include_option(
     pytest.param(1, "include/tarantool", id='dir not exists')
 ])
 def test_install_tarantool_dev_include_option(
-        tt_cmd, tmpdir, rc, include_dir, tt_dir
+        tt_cmd, tmp_path, rc, include_dir, tt_dir
 ):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__), "testdata")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     build_dir = "build_ee"
     build_path = os.path.join(testdata_path, build_dir)
@@ -512,14 +512,14 @@ def test_install_tarantool_dev_include_option(
         )
 
 
-def test_install_tarantool_already_exists(tt_cmd, tmpdir):
+def test_install_tarantool_already_exists(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_install_tarantool_already_exists"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     tt_dir = os.path.join(testdata_path, "tt")
 
@@ -548,14 +548,14 @@ def test_install_tarantool_already_exists(tt_cmd, tmpdir):
     )
 
 
-def test_install_tt_already_exists_no_symlink(tt_cmd, tmpdir):
+def test_install_tt_already_exists_no_symlink(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_install_tt_already_exists"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     tt_dir = os.path.join(testdata_path, "tt")
 
@@ -582,14 +582,14 @@ def test_install_tt_already_exists_no_symlink(tt_cmd, tmpdir):
     assert tarantool_bin == expected_bin
 
 
-def test_install_tt_already_exists_with_symlink(tt_cmd, tmpdir):
+def test_install_tt_already_exists_with_symlink(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(
         os.path.dirname(__file__),
         "testdata/test_install_tt_already_exists"
     )
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     tt_dir = os.path.join(testdata_path, "tt")
     os.symlink(tt_cmd, os.path.join(tt_dir, "bin", "tt"))
@@ -622,7 +622,7 @@ def test_install_tt_already_exists_with_symlink(tt_cmd, tmpdir):
 ])
 def test_install_tt_fail_exit_code_dependency_check(
         tt_cmd,
-        tmpdir,
+        tmp_path,
         package_to_exclude):
     # Create new PATH with excluded packages.
     original_path = os.environ['PATH']
@@ -631,13 +631,13 @@ def test_install_tt_fail_exit_code_dependency_check(
                                original_path.split(os.pathsep)))
 
     # Create test config.
-    configPath = os.path.join(tmpdir, config_name)
+    configPath = os.path.join(tmp_path, config_name)
     with open(configPath, 'w') as f:
         f.write('env:\n  bin_dir:\n  inc_dir:\n')
     install_cmd = [tt_cmd, "--cfg", configPath, "install", "tt"]
     install_process = subprocess.Popen(
         install_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         env={'PATH': new_path},
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,

--- a/test/integration/instances/test_instances.py
+++ b/test/integration/instances/test_instances.py
@@ -10,8 +10,8 @@ import yaml
 def test_instances_enabled_apps(tt_cmd):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_app")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        test_app_path = os.path.join(tmpdir, "multi_app")
+    with tempfile.TemporaryDirectory() as tmp_path:
+        test_app_path = os.path.join(tmp_path, "multi_app")
         shutil.copytree(test_app_path_src, test_app_path)
 
         config_path = os.path.join(test_app_path, "tt.yaml")
@@ -36,8 +36,8 @@ def test_instances_enabled_apps(tt_cmd):
 
 
 def test_instances_no_apps(tt_cmd):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        test_app_path = os.path.join(tmpdir)
+    with tempfile.TemporaryDirectory() as tmp_path:
+        test_app_path = os.path.join(tmp_path)
 
         config_path = os.path.join(test_app_path, "tt.yaml")
         with open(config_path, "w") as f:
@@ -57,8 +57,8 @@ def test_instances_no_apps(tt_cmd):
 
 
 def test_instances_missing_directory(tt_cmd):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        test_app_path = os.path.join(tmpdir)
+    with tempfile.TemporaryDirectory() as tmp_path:
+        test_app_path = os.path.join(tmp_path)
         config_path = os.path.join(test_app_path, "tt.yaml")
         with open(config_path, "w") as f:
             yaml.dump({"env": {"instances_enabled": "foo/bar"}}, f)
@@ -76,11 +76,11 @@ def test_instances_missing_directory(tt_cmd):
 
 
 def test_instances_dot_directory_with_app(tt_cmd):
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmp_path:
         test_app_path_src = os.path.join(os.path.dirname(__file__), "test_app")
-        test_app_path = os.path.join(tmpdir, "test_app")
+        test_app_path = os.path.join(tmp_path, "test_app")
         shutil.copytree(test_app_path_src, test_app_path)
-        test_app_path = os.path.join(tmpdir)
+        test_app_path = os.path.join(tmp_path)
         config_path = os.path.join(test_app_path, "tt.yaml")
         with open(config_path, "w") as f:
             yaml.dump({"tt": {"env": {"instances_enabled": "."}}}, f)
@@ -98,9 +98,9 @@ def test_instances_dot_directory_with_app(tt_cmd):
 
 
 def test_instances_dot_directory_with_lua_file(tt_cmd):
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmp_path:
         test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_app", "app2.lua")
-        test_app_path = os.path.join(tmpdir)
+        test_app_path = os.path.join(tmp_path)
         shutil.copyfile(test_app_path_src, os.path.join(test_app_path, "app2.lua"))
         config_path = os.path.join(test_app_path, "tt.yaml")
         with open(config_path, "w") as f:
@@ -120,9 +120,9 @@ def test_instances_dot_directory_with_lua_file(tt_cmd):
 
 # Test bugfix for https://github.com/tarantool/tt/issues/844
 def test_instances_dot_directory_with_app_explicit_cfg_option(tt_cmd):
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmp_path:
         test_app_path_src = os.path.join(os.path.dirname(__file__), "test_app")
-        test_app_path = os.path.join(tmpdir, "test_app")
+        test_app_path = os.path.join(tmp_path, "test_app")
         shutil.copytree(test_app_path_src, test_app_path)
         config_path = os.path.join(test_app_path, "tt.yaml")
 

--- a/test/integration/log/test_log.py
+++ b/test/integration/log/test_log.py
@@ -8,12 +8,12 @@ from utils import config_name
 
 
 @pytest.fixture(scope="function")
-def mock_env_dir(tmpdir):
-    with open(os.path.join(tmpdir, config_name), 'w') as f:
+def mock_env_dir(tmp_path):
+    with open(os.path.join(tmp_path, config_name), 'w') as f:
         f.write('env:\n  instances_enabled: ie\n')
 
     for app_n in range(2):
-        app = os.path.join(tmpdir, 'ie', f'app{app_n}')
+        app = os.path.join(tmp_path, 'ie', f'app{app_n}')
         os.makedirs(app, 0o755)
         with open(os.path.join(app, 'instances.yml'), 'w') as f:
             for i in range(4):
@@ -27,7 +27,7 @@ def mock_env_dir(tmpdir):
             with open(os.path.join(app, 'var', 'log', f'inst{i}', 'tt.log'), 'w') as f:
                 f.writelines([f'line {j}\n' for j in range(20)])
 
-    return tmpdir
+    return tmp_path
 
 
 def test_log_output_default_run(tt_cmd, mock_env_dir):

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -524,16 +524,16 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
 
 
 @pytest.mark.slow
-def test_pack_tgz_table(tt_cmd, tmpdir):
+def test_pack_tgz_table(tt_cmd, tmp_path):
     test_cases = prepare_tgz_test_cases(tt_cmd)
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
     for test_case in test_cases:
-        base_dir = os.path.join(tmpdir, test_case["bundle_src"])
+        base_dir = os.path.join(tmp_path, test_case["bundle_src"])
         print("BASEDIR: " + base_dir)
         print("ARGS: " + " ".join(test_case["args"]))
         rc, output = run_command_and_get_output(
@@ -579,14 +579,14 @@ def test_pack_tgz_table(tt_cmd, tmpdir):
         os.remove(package_file)
 
 
-def test_pack_tgz_missing_app(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle2")
+def test_pack_tgz_missing_app(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle2")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle2"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz", "--app-list", "unexisting-app"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -595,14 +595,14 @@ def test_pack_tgz_missing_app(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_pack_tgz_files_with_compat(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle8")
+def test_pack_tgz_files_with_compat(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle8")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle8"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz", "--cartridge-compat"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -628,14 +628,14 @@ def test_pack_tgz_files_with_compat(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_pack_tgz_git_version_compat(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle9")
+def test_pack_tgz_git_version_compat(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle9")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle9"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         ["git", "init"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -675,14 +675,14 @@ def test_pack_tgz_git_version_compat(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_pack_tgz_git_version_compat_with_instances(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle1")
+def test_pack_tgz_git_version_compat_with_instances(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     app_dir = os.path.join(base_dir, "app2")
 
     rc, output = run_command_and_get_output(
@@ -724,14 +724,14 @@ def test_pack_tgz_git_version_compat_with_instances(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_pack_tgz_compat_with_binaries(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle8")
+def test_pack_tgz_compat_with_binaries(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle8")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle8"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz", "--with-binaries", "--cartridge-compat"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -768,14 +768,14 @@ def test_pack_tgz_compat_with_binaries(tt_cmd, tmpdir):
     assert output == "Hello World"
 
 
-def test_pack_tgz_multiple_apps_compat(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle1")
+def test_pack_tgz_multiple_apps_compat(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz", "--cartridge-compat"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -783,14 +783,14 @@ def test_pack_tgz_multiple_apps_compat(tt_cmd, tmpdir):
     assert rc == 1
 
 
-def test_pack_deb_compat(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle1")
+def test_pack_deb_compat(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "dep", "--cartridge-compat"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -798,14 +798,14 @@ def test_pack_deb_compat(tt_cmd, tmpdir):
     assert rc == 1
 
 
-def test_pack_rpm_compat(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle1")
+def test_pack_rpm_compat(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "rpm", "--cartridge-compat"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -888,16 +888,16 @@ def prepare_rpm_test_cases(tt_cmd) -> list:
 
 
 @pytest.mark.slow
-def test_pack_rpm_deb_table(tt_cmd, tmpdir):
+def test_pack_rpm_deb_table(tt_cmd, tmp_path):
     test_cases = prepare_deb_test_cases(tt_cmd)
     test_cases.extend(prepare_rpm_test_cases(tt_cmd))
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
     for test_case in test_cases:
-        base_dir = os.path.join(tmpdir, test_case["bundle_src"])
+        base_dir = os.path.join(tmp_path, test_case["bundle_src"])
         rc, output = run_command_and_get_output(
             [test_case["cmd"], "pack", test_case["pack_type"], *test_case["args"]],
             cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -908,21 +908,21 @@ def test_pack_rpm_deb_table(tt_cmd, tmpdir):
         assert os.path.exists(package_file)
 
 
-def test_pack_tgz_empty_app_directory(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle2")
+def test_pack_tgz_empty_app_directory(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle2")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle2"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz", "--app-list", "empty_app"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
 
     assert rc == 1
 
-    base_dir = tmpdir
+    base_dir = tmp_path
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz"],
         cwd=base_dir, env=dict(os.environ, PWD=base_dir))
@@ -930,14 +930,14 @@ def test_pack_tgz_empty_app_directory(tt_cmd, tmpdir):
     assert rc == 1
 
 
-def test_pack_tgz_empty_enabled(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle3")
+def test_pack_tgz_empty_enabled(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle3")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle3"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     os.mkdir(os.path.join(base_dir, "generated_dir"))
 
@@ -948,14 +948,14 @@ def test_pack_tgz_empty_enabled(tt_cmd, tmpdir):
     assert rc == 1
 
 
-def test_pack_tgz_links_to_binaries(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle4")
+def test_pack_tgz_links_to_binaries(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle4")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle4"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "tgz"],
@@ -985,10 +985,10 @@ def test_pack_tgz_links_to_binaries(tt_cmd, tmpdir):
     os.remove(package_file)
 
 
-def test_pack_incorrect_pack_type(tt_cmd, tmpdir):
-    tmpdir = os.path.join(tmpdir, "bundle1")
+def test_pack_incorrect_pack_type(tt_cmd, tmp_path):
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
@@ -997,20 +997,20 @@ def test_pack_incorrect_pack_type(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "de"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert expected_output in output
 
 
-def test_pack_nonexistent_modules_directory(tt_cmd, tmpdir):
+def test_pack_nonexistent_modules_directory(tt_cmd, tmp_path):
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle5"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "-V", "pack", "tgz"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
 
     assert "Skip copying modules from" in output
     assert rc == 0
@@ -1083,7 +1083,7 @@ def verify_rpmdeb_package_content(pkg_dir):
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_deb(tt_cmd, tmpdir):
+def test_pack_deb(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1091,26 +1091,26 @@ def test_pack_deb(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, "pack", "deb"]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1_0.1.0.0-1_" + get_arch() + ".deb"
     package_file = os.path.join(base_dir, package_file_name)
     assert os.path.isfile(package_file)
 
-    unpacked_pkg_dir = os.path.join(tmpdir, 'unpacked')
+    unpacked_pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(unpacked_pkg_dir)
 
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
@@ -1160,7 +1160,7 @@ def test_pack_deb(tt_cmd, tmpdir):
 
 
 @pytest.mark.docker
-def test_pack_deb_single_app(tt_cmd, tmpdir):
+def test_pack_deb_single_app(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1168,26 +1168,26 @@ def test_pack_deb_single_app(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "single_app")
+    tmp_path = os.path.join(tmp_path, "single_app")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "single_app"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, "pack", "deb"]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "single_app_0.1.0.0-1_" + get_arch() + ".deb"
     package_file = os.path.join(base_dir, package_file_name)
     assert os.path.isfile(package_file)
 
-    unpacked_pkg_dir = os.path.join(tmpdir, 'unpacked')
+    unpacked_pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(unpacked_pkg_dir)
 
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
@@ -1210,11 +1210,11 @@ def test_pack_deb_single_app(tt_cmd, tmpdir):
     app_systemd_template = file.read()
     file.close()
 
-    with open(os.path.join(tmpdir, 'instantiated_unit.txt'), "w") as f:
+    with open(os.path.join(tmp_path, 'instantiated_unit.txt'), "w") as f:
         f.write(app_systemd_template.format(app='single_app@%i', args='single_app:%i',
                                             bundle='single_app'))
 
-    assert filecmp.cmp(os.path.join(tmpdir, 'instantiated_unit.txt'),
+    assert filecmp.cmp(os.path.join(tmp_path, 'instantiated_unit.txt'),
                        os.path.join(unpacked_pkg_dir, "usr/lib/systemd/system/single_app@.service"),
                        False)
 
@@ -1229,7 +1229,7 @@ def test_pack_deb_single_app(tt_cmd, tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_rpm(tt_cmd, tmpdir):
+def test_pack_rpm(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1237,26 +1237,26 @@ def test_pack_rpm(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, "pack", "rpm"]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1-0.1.0.0-1." + get_arch() + ".rpm"
     package_file = os.path.join(base_dir, package_file_name)
     assert os.path.isfile(package_file)
 
-    unpacked_pkg_dir = os.path.join(tmpdir, 'unpacked')
+    unpacked_pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(unpacked_pkg_dir)
 
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
@@ -1305,7 +1305,7 @@ def test_pack_rpm(tt_cmd, tmpdir):
 
 
 @pytest.mark.docker
-def test_pack_rpm_single_app(tt_cmd, tmpdir):
+def test_pack_rpm_single_app(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1313,26 +1313,26 @@ def test_pack_rpm_single_app(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "single_app")
+    tmp_path = os.path.join(tmp_path, "single_app")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "single_app"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, "pack", "rpm"]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "single_app-0.1.0.0-1." + get_arch() + ".rpm"
     package_file = os.path.join(base_dir, package_file_name)
     assert os.path.isfile(package_file)
 
-    unpacked_pkg_dir = os.path.join(tmpdir, 'unpacked')
+    unpacked_pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(unpacked_pkg_dir)
 
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
@@ -1360,11 +1360,11 @@ def test_pack_rpm_single_app(tt_cmd, tmpdir):
     app_systemd_template = file.read()
     file.close()
 
-    with open(os.path.join(tmpdir, 'instantiated_unit.txt'), "w") as f:
+    with open(os.path.join(tmp_path, 'instantiated_unit.txt'), "w") as f:
         f.write(app_systemd_template.format(app='single_app@%i', args='single_app:%i',
                                             bundle='single_app'))
 
-    assert filecmp.cmp(os.path.join(tmpdir, 'instantiated_unit.txt'),
+    assert filecmp.cmp(os.path.join(tmp_path, 'instantiated_unit.txt'),
                        os.path.join(unpacked_pkg_dir, "usr/lib/systemd/system/single_app@.service"),
                        False)
 
@@ -1378,7 +1378,7 @@ def test_pack_rpm_single_app(tt_cmd, tmpdir):
 
 
 @pytest.mark.slow
-def test_pack_rpm_use_docker(tt_cmd, tmpdir):
+def test_pack_rpm_use_docker(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1386,17 +1386,17 @@ def test_pack_rpm_use_docker(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "rpm", "--use-docker"],
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1-0.1.0.0-1." + get_arch() + ".rpm"
@@ -1423,7 +1423,7 @@ def test_pack_rpm_use_docker(tt_cmd, tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_deb_use_docker_tnt_version(tt_cmd, tmpdir):
+def test_pack_deb_use_docker_tnt_version(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1431,17 +1431,17 @@ def test_pack_deb_use_docker_tnt_version(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "deb", "--use-docker", "--tarantool-version", "2.7.3"],
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1_0.1.0.0-1_" + get_arch() + ".deb"
@@ -1463,7 +1463,7 @@ def test_pack_deb_use_docker_tnt_version(tt_cmd, tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_rpm_use_docker_wrong_version_format(tt_cmd, tmpdir):
+def test_pack_rpm_use_docker_wrong_version_format(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1471,25 +1471,25 @@ def test_pack_rpm_use_docker_wrong_version_format(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "rpm", "--use-docker", "--tarantool-version",
             "cool.tarantool.version"],
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 1
 
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_rpm_use_docker_wrong_version(tt_cmd, tmpdir):
+def test_pack_rpm_use_docker_wrong_version(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1497,24 +1497,24 @@ def test_pack_rpm_use_docker_wrong_version(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "rpm", "--use-docker", "--tarantool-version",
             "1.239.239"],
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
 
     assert rc == 1
 
 
 @pytest.mark.slow
-def test_pack_deb_use_docker(tt_cmd, tmpdir):
+def test_pack_deb_use_docker(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1522,17 +1522,17 @@ def test_pack_deb_use_docker(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "pack", "deb", "--use-docker"],
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1_0.1.0.0-1_" + get_arch() + ".deb"
@@ -1562,7 +1562,7 @@ def test_pack_deb_use_docker(tt_cmd, tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.docker
-def test_pack_rpm_with_pre_and_post_inst(tt_cmd, tmpdir):
+def test_pack_rpm_with_pre_and_post_inst(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1570,25 +1570,25 @@ def test_pack_rpm_with_pre_and_post_inst(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "bundle1")
+    tmp_path = os.path.join(tmp_path, "bundle1")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
-    with open(os.path.join(tmpdir, "preinst.sh"), "w") as pre_inst:
+    with open(os.path.join(tmp_path, "preinst.sh"), "w") as pre_inst:
         pre_inst.write("echo 'hello'")
-    with open(os.path.join(tmpdir, "postinst.sh"), "w") as post_inst:
+    with open(os.path.join(tmp_path, "postinst.sh"), "w") as post_inst:
         post_inst.write("echo 'bye'")
 
-    cmd = [tt_cmd, "pack", "rpm", "--preinst", os.path.join(tmpdir, "preinst.sh"),
-           "--postinst", os.path.join(tmpdir, "postinst.sh")]
+    cmd = [tt_cmd, "pack", "rpm", "--preinst", os.path.join(tmp_path, "preinst.sh"),
+           "--postinst", os.path.join(tmp_path, "postinst.sh")]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "bundle1-0.1.0.0-1." + get_arch() + ".rpm"
@@ -1614,7 +1614,7 @@ echo 'bye'
 """ in output
 
 
-def test_pack_systemd_params_default_file(tt_cmd, tmpdir):
+def test_pack_systemd_params_default_file(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1622,19 +1622,19 @@ def test_pack_systemd_params_default_file(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, "systemd_params")
+    tmp_path = os.path.join(tmp_path, "systemd_params")
     shutil.copytree(os.path.join(os.path.dirname(__file__), "test_bundles", "systemd_params"),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, "pack", "rpm"]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = "systemd_params-0.1.0.0-1." + get_arch() + ".rpm"
@@ -1642,7 +1642,7 @@ def test_pack_systemd_params_default_file(tt_cmd, tmpdir):
     assert os.path.isfile(package_file)
 
     # Unpack rpm package.
-    pkg_dir = os.path.join(tmpdir, 'unpacked')
+    pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(pkg_dir)
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
                                              '{0}:/usr/src/'.format(base_dir),
@@ -1674,7 +1674,7 @@ def test_pack_systemd_params_default_file(tt_cmd, tmpdir):
         assert 'Environment=TARANTOOL_WORKDIR=/tmp/workdir' in buf
 
 
-def test_pack_systemd_params_params_file_set(tt_cmd, tmpdir):
+def test_pack_systemd_params_params_file_set(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1682,20 +1682,20 @@ def test_pack_systemd_params_params_file_set(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, 'systemd_params')
+    tmp_path = os.path.join(tmp_path, 'systemd_params')
     shutil.copytree(os.path.join(os.path.dirname(__file__), 'test_bundles', 'systemd_params'),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    base_dir = tmpdir
+    base_dir = tmp_path
 
     cmd = [tt_cmd, 'pack', 'rpm', '--unit-params-file',
            os.path.join(os.path.dirname(__file__), 'test_bundles', 'systemd_params', 'params.yml')]
 
     rc, output = run_command_and_get_output(
         cmd,
-        cwd=base_dir, env=dict(os.environ, PWD=tmpdir))
+        cwd=base_dir, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     package_file_name = 'systemd_params-0.1.0.0-1.' + get_arch() + '.rpm'
@@ -1703,7 +1703,7 @@ def test_pack_systemd_params_params_file_set(tt_cmd, tmpdir):
     assert os.path.isfile(package_file)
 
     # Unpack rpm package.
-    pkg_dir = os.path.join(tmpdir, 'unpacked')
+    pkg_dir = os.path.join(tmp_path, 'unpacked')
     os.mkdir(pkg_dir)
     rc, output = run_command_and_get_output(['docker', 'run', '--rm', '-v',
                                              '{0}:/usr/src/'.format(base_dir),
@@ -1736,7 +1736,7 @@ def test_pack_systemd_params_params_file_set(tt_cmd, tmpdir):
         assert 'Environment=TARANTOOL_WORKDIR=/tmp/workdir' in buf
 
 
-def test_pack_systemd_params_missing_params_file(tt_cmd, tmpdir):
+def test_pack_systemd_params_missing_params_file(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1744,24 +1744,24 @@ def test_pack_systemd_params_missing_params_file(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, 'systemd_params')
+    tmp_path = os.path.join(tmp_path, 'systemd_params')
     shutil.copytree(os.path.join(os.path.dirname(__file__), 'test_bundles', 'systemd_params'),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
     cmd = [tt_cmd, 'pack', 'rpm', '--unit-params-file', 'missing_params.yml']
 
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc != 0
     assert 'no such file or directory' in output
 
     package_file_name = 'systemd_params-0.1.0.0-1.' + get_arch() + '.rpm'
-    package_file = os.path.join(tmpdir, package_file_name)
+    package_file = os.path.join(tmp_path, package_file_name)
     assert not os.path.exists(package_file)
 
 
-def test_pack_systemd_params_params_file_bad_format(tt_cmd, tmpdir):
+def test_pack_systemd_params_params_file_bad_format(tt_cmd, tmp_path):
     if shutil.which('docker') is None:
         pytest.skip("docker is not installed in this system")
 
@@ -1769,38 +1769,38 @@ def test_pack_systemd_params_params_file_bad_format(tt_cmd, tmpdir):
     rc, _ = run_command_and_get_output(['docker', 'ps'])
     assert rc == 0
 
-    tmpdir = os.path.join(tmpdir, 'systemd_params')
+    tmp_path = os.path.join(tmp_path, 'systemd_params')
     shutil.copytree(os.path.join(os.path.dirname(__file__), 'test_bundles', 'systemd_params'),
-                    tmpdir, symlinks=True, ignore=None,
+                    tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, ignore_dangling_symlinks=True,
                     dirs_exist_ok=True)
 
-    with open(os.path.join(tmpdir, 'bad_params.yml'), 'w') as f:
+    with open(os.path.join(tmp_path, 'bad_params.yml'), 'w') as f:
         f.write('''FdLimit: 'string'
 ''')
 
     cmd = [tt_cmd, 'pack', 'rpm', '--unit-params-file', 'bad_params.yml']
 
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc != 0
     assert 'failed to decode systemd unit params' in output
 
     package_file_name = 'systemd_params-0.1.0.0-1.' + get_arch() + '.rpm'
-    package_file = os.path.join(tmpdir, package_file_name)
+    package_file = os.path.join(tmp_path, package_file_name)
     assert not os.path.exists(package_file)
 
 
 @pytest.mark.notarantool
 @pytest.mark.slow
 @pytest.mark.skipif(shutil.which("tarantool") is not None, reason="tarantool found in PATH")
-def test_pack_app_local_tarantool(tt_cmd, tmpdir_with_tarantool, tmpdir):
-    shutil.copytree(tmpdir_with_tarantool, tmpdir, symlinks=True, ignore=None,
+def test_pack_app_local_tarantool(tt_cmd, tmpdir_with_tarantool, tmp_path):
+    shutil.copytree(tmpdir_with_tarantool, tmp_path, symlinks=True, ignore=None,
                     copy_function=shutil.copy2, dirs_exist_ok=True)
 
     build_cmd = [tt_cmd, "create", "cartridge", "--name", "app", "--non-interactive"]
     tt_process = subprocess.Popen(
         build_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -1808,13 +1808,13 @@ def test_pack_app_local_tarantool(tt_cmd, tmpdir_with_tarantool, tmpdir):
     tt_process.wait()
     assert tt_process.returncode == 0
 
-    app_dir = os.path.join(tmpdir, "app")
+    app_dir = os.path.join(tmp_path, "app")
     assert os.path.exists(app_dir)
 
     build_cmd = [tt_cmd, "pack", "tgz"]
     tt_process = subprocess.Popen(
         build_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True

--- a/test/integration/play/test_play.py
+++ b/test/integration/play/test_play.py
@@ -11,36 +11,36 @@ INSTANCE_NAME = "remote_instance_cfg.lua"
 
 
 @pytest.fixture
-def test_instance(request, tmpdir):
+def test_instance(request, tmp_path):
     dir = os.path.dirname(__file__)
     test_app_path = os.path.join(dir, "test_file")
     lua_utils_path = os.path.join(dir, "..", "..")
-    inst = TarantoolTestInstance(INSTANCE_NAME, test_app_path, lua_utils_path, tmpdir)
+    inst = TarantoolTestInstance(INSTANCE_NAME, test_app_path, lua_utils_path, tmp_path)
     inst.start()
     request.addfinalizer(lambda: inst.stop())
     return inst
 
 
-def test_play_unset_arg(tt_cmd, tmpdir):
+def test_play_unset_arg(tt_cmd, tmp_path):
     # Testing with unset uri and .xlog or .snap file.
     cmd = [tt_cmd, "play"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 1
     assert re.search(r"required to specify an URI and at least one .xlog or .snap file", output)
 
 
-def test_play_non_existent_uri(tt_cmd, tmpdir):
+def test_play_non_existent_uri(tt_cmd, tmp_path):
     # Testing with non-existent uri.
     cmd = [tt_cmd, "play", "127.0.0.1:0", "_"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 1
     assert re.search(r"no connection to the host", output)
 
 
-def test_play_non_existent_file(tt_cmd, tmpdir, test_instance):
+def test_play_non_existent_file(tt_cmd, tmp_path, test_instance):
     # Run play with non-existent file.
     cmd = [tt_cmd, "play", "127.0.0.1:" + test_instance.port, "path-to-non-existent-file"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 1
     assert re.search(r"No such file or directory", output)
 
@@ -69,7 +69,7 @@ def test_play_test_remote_instance(tt_cmd, test_instance):
     pytest.param({"env": {"TT_CLI_USERNAME": "fry"}}),
     pytest.param({"uri": "test_user:4"}),
 ])
-def test_play_wrong_creds(tt_cmd, tmpdir, opts, test_instance):
+def test_play_wrong_creds(tt_cmd, tmp_path, opts, test_instance):
     # Play .xlog file to the remote instance.
     uri = "127.0.0.1:" + test_instance.port
     if "uri" in opts:
@@ -82,7 +82,7 @@ def test_play_wrong_creds(tt_cmd, tmpdir, opts, test_instance):
     if "flags" in opts:
         cmd.extend(opts["flags"])
 
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir, env=env)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path, env=env)
     assert rc != 0
 
 
@@ -95,7 +95,7 @@ def test_play_wrong_creds(tt_cmd, tmpdir, opts, test_instance):
     }}),
     pytest.param({"uri": "test_user:secret"}),
 ])
-def test_play_creds(tt_cmd, tmpdir, opts, test_instance):
+def test_play_creds(tt_cmd, tmp_path, opts, test_instance):
     # Play .xlog file to the remote instance.
     uri = "127.0.0.1:" + test_instance.port
     if "uri" in opts:
@@ -108,5 +108,5 @@ def test_play_creds(tt_cmd, tmpdir, opts, test_instance):
     if "flags" in opts:
         cmd.extend(opts["flags"])
 
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir, env=env)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path, env=env)
     assert rc == 0

--- a/test/integration/replicaset/test_replicaset_vshard.py
+++ b/test/integration/replicaset/test_replicaset_vshard.py
@@ -8,7 +8,7 @@ from cartridge_helper import (cartridge_name, cartridge_password,
                               cartridge_username)
 from replicaset_helpers import eval_on_instance, parse_status, stop_application
 
-from utils import (create_tt_config, get_tarantool_version, get_tmpdir,
+from utils import (create_tt_config, get_tarantool_version,
                    run_command_and_get_output, wait_event, wait_file)
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
@@ -154,8 +154,8 @@ def test_vshard_bootstrap_cconfig_vshard_not_installed(tt_cmd, tmpdir_with_cfg):
 
 
 @pytest.fixture(scope="session")
-def vshard_tt_env_session(request, tt_cmd):
-    tmpdir = get_tmpdir(request)
+def vshard_tt_env_session(tt_cmd, tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("vshard_tt_env_session")
     create_tt_config(tmpdir, "")
 
     # Install vshard.
@@ -172,7 +172,7 @@ vshard_cconfig_app_name = "test_vshard_app"
 @pytest.fixture
 def vshard_cconfig_app_tt_env(request, tt_cmd, vshard_tt_env_session):
     tmpdir = vshard_tt_env_session
-    app_path = os.path.join(tmpdir, vshard_cconfig_app_name)
+    app_path = tmpdir / vshard_cconfig_app_name
 
     # Copy application.
     shutil.copytree(os.path.join(os.path.dirname(__file__), vshard_cconfig_app_name), app_path)

--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -78,10 +78,10 @@ def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
         app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], [])
 
 
-def test_restart_no_args(tt_cmd, tmpdir):
+def test_restart_no_args(tt_cmd, tmp_path):
     test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_app")
 
-    test_app_path = os.path.join(tmpdir, "multi_app")
+    test_app_path = os.path.join(tmp_path, "multi_app")
     shutil.copytree(test_app_path_src, test_app_path)
 
     start_output = app_cmd(tt_cmd, test_app_path, ["start"], [])

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -14,36 +14,36 @@ from utils import config_name, create_tt_config, run_command_and_get_output
 # ##### #
 
 
-def test_rocks_module(tt_cmd, tmpdir):
-    create_tt_config(tmpdir, tmpdir)
+def test_rocks_module(tt_cmd, tmp_path):
+    create_tt_config(tmp_path, tmp_path)
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "help"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert re.search("^Usage: tt rocks", output)
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "search", "queue"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "Rockspecs and source rocks:\n" in output
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "install", "queue"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert os.path.isfile(f'{tmpdir}/.rocks/share/tarantool/queue/init.lua')
+    assert os.path.isfile(f'{tmp_path}/.rocks/share/tarantool/queue/init.lua')
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "doc", "queue", "--list"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "Documentation files for queue" in output
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "pack", "queue"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert re.search("Packed: .*queue-.*[.]rock", output)
     rock_file = output.split("Packed: ")[1].strip()
@@ -51,7 +51,7 @@ def test_rocks_module(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "unpack", rock_file],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
 
     rock_dir = ""
@@ -64,113 +64,113 @@ def test_rocks_module(tt_cmd, tmpdir):
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "remove", "queue"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "Removal successful.\n" in output
 
     test_app_path = os.path.join(os.path.dirname(__file__), "files", "testapp-scm-1.rockspec")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "make", "testapp-scm-1.rockspec"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "testapp scm-1 is now installed" in output
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "--verbose", "list"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "fs.current_dir()\n" in output
 
 
-def test_rocks_admin_module(tt_cmd, tmpdir):
-    repo_path = os.path.join(tmpdir, "rocks_repo")
+def test_rocks_admin_module(tt_cmd, tmp_path):
+    repo_path = os.path.join(tmp_path, "rocks_repo")
     os.mkdir(repo_path)
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "admin", "make_manifest", repo_path],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert os.path.isfile(f'{tmpdir}/rocks_repo/index.html')
-    assert os.path.isfile(f'{tmpdir}/rocks_repo/manifest')
+    assert os.path.isfile(f'{tmp_path}/rocks_repo/index.html')
+    assert os.path.isfile(f'{tmp_path}/rocks_repo/manifest')
 
     test_app_path = os.path.join(os.path.dirname(__file__), "files", "testapp-scm-1.rockspec")
-    shutil.copy(test_app_path, tmpdir)
+    shutil.copy(test_app_path, tmp_path)
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "admin", "add", "testapp-scm-1.rockspec", "--server", repo_path],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert os.path.isfile(f'{tmpdir}/rocks_repo/testapp-scm-1.rockspec')
+    assert os.path.isfile(f'{tmp_path}/rocks_repo/testapp-scm-1.rockspec')
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "admin", "remove", "testapp-scm-1.rockspec", "--server", repo_path],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert not os.path.exists(f'{tmpdir}/rocks_repo/testapp-scm-1.rockspec')
+    assert not os.path.exists(f'{tmp_path}/rocks_repo/testapp-scm-1.rockspec')
 
 
-def test_rocks_install_remote(tt_cmd, tmpdir):
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+def test_rocks_install_remote(tt_cmd, tmp_path):
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   rocks: "repo"''')
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "install", "stat"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "Installing http://rocks.tarantool.org/stat" in output
 
 
-def test_rocks_install_local(tt_cmd, tmpdir):
+def test_rocks_install_local(tt_cmd, tmp_path):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")
 
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   rocks: "repo"''')
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
-                    os.path.join(tmpdir, "repo"))
+                    os.path.join(tmp_path, "repo"))
 
     # Disable network with unshare.
     rc, output = run_command_and_get_output(
             ["unshare", "-r", "-n", tt_cmd, "rocks", "install", "stat"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert f"Installing {tmpdir}/repo/stat-0.3.2-1.all.rock" in output
+    assert f"Installing {tmp_path}/repo/stat-0.3.2-1.all.rock" in output
 
 
-def test_rocks_install_local_if_network_is_up(tt_cmd, tmpdir):
+def test_rocks_install_local_if_network_is_up(tt_cmd, tmp_path):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")
 
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   rocks: "repo"''')
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
-                    os.path.join(tmpdir, "repo"))
+                    os.path.join(tmp_path, "repo"))
 
     rc, output = run_command_and_get_output(
         [tt_cmd, "rocks", "--only-server=repo", "install", "stat"],
-        cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+        cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
     assert "Installing repo/stat-0.3.2-1.all.rock" in output
-    assert "stat 0.3.2-1 is now installed in " + os.path.join(tmpdir, ".rocks") in output
+    assert "stat 0.3.2-1 is now installed in " + os.path.join(tmp_path, ".rocks") in output
 
 
-def test_rocks_install_local_specific_version(tt_cmd, tmpdir):
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+def test_rocks_install_local_specific_version(tt_cmd, tmp_path):
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   rocks: "repo"''')
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
-                    os.path.join(tmpdir, "repo"))
+                    os.path.join(tmp_path, "repo"))
 
     rc, output = run_command_and_get_output(
             [tt_cmd, "rocks", "install", "stat", "0.3.1-1"],
-            cwd=tmpdir, env=dict(os.environ, PWD=tmpdir))
+            cwd=tmp_path, env=dict(os.environ, PWD=tmp_path))
     assert rc == 0
-    assert f"Installing {tmpdir}/repo/stat-0.3.1-1.all.rock" in output
+    assert f"Installing {tmp_path}/repo/stat-0.3.1-1.all.rock" in output
 
 
 @pytest.mark.notarantool
@@ -178,7 +178,7 @@ def test_rocks_install_local_specific_version(tt_cmd, tmpdir):
 def test_rock_install_without_system_tarantool(tt_cmd, tmpdir_with_tarantool):
     rocks_cmd = [tt_cmd, "rocks", "install", "mysql", "2.1.3-1"]
     pwd = os.environ.get("PWD")
-    os.environ["PWD"] = tmpdir_with_tarantool
+    os.environ["PWD"] = tmpdir_with_tarantool.as_posix()
     tt_process = subprocess.Popen(
         rocks_cmd,
         cwd=tmpdir_with_tarantool,
@@ -194,51 +194,51 @@ def test_rock_install_without_system_tarantool(tt_cmd, tmpdir_with_tarantool):
                                        ".rocks", "lib", "tarantool", "mysql"))
 
 
-def test_rocks_install_from_dir_with_no_repo(tt_cmd, tmpdir):
+def test_rocks_install_from_dir_with_no_repo(tt_cmd, tmp_path):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")
 
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   rocks: "repo"''')
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
-                    os.path.join(tmpdir, "repo"))
+                    os.path.join(tmp_path, "repo"))
 
-    os.mkdir(os.path.join(tmpdir, "subdir"))
+    os.mkdir(os.path.join(tmp_path, "subdir"))
 
     # Disable network with unshare.
     rc, output = run_command_and_get_output(
             ["unshare", "-r", "-n", tt_cmd, "-c", "../tt.yaml", "rocks", "install", "stat"],
-            cwd=os.path.join(tmpdir, "subdir"),
-            env=dict(os.environ, PWD=os.path.join(tmpdir, "subdir")))
+            cwd=os.path.join(tmp_path, "subdir"),
+            env=dict(os.environ, PWD=os.path.join(tmp_path, "subdir")))
     assert rc == 0
     print(output)
-    assert f"Installing {tmpdir}/repo/stat-0.3.2-1.all.rock" in output
-    assert "stat 0.3.2-1 is now installed in " + os.path.join(tmpdir, "subdir", ".rocks") in output
-    assert os.path.exists(os.path.join(tmpdir, "subdir", ".rocks"))
+    assert f"Installing {tmp_path}/repo/stat-0.3.2-1.all.rock" in output
+    assert f"stat 0.3.2-1 is now installed in {tmp_path / 'subdir' / '.rocks'}" in output
+    assert os.path.exists(os.path.join(tmp_path, "subdir", ".rocks"))
 
 
-def test_rocks_install_from_env_var_repo(tt_cmd, tmpdir):
+def test_rocks_install_from_env_var_repo(tt_cmd, tmp_path):
     if platform.system() == "Darwin":
         pytest.skip("/set platform is unsupported")
 
-    with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+    with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
         tnt_env_file.write('''repo:
   distfiles: "distfiles"''')
 
     shutil.copytree(os.path.join(os.path.dirname(__file__), "repo"),
-                    os.path.join(tmpdir, "repo"))
+                    os.path.join(tmp_path, "repo"))
 
-    os.mkdir(os.path.join(tmpdir, "subdir"))
+    os.mkdir(os.path.join(tmp_path, "subdir"))
 
     # Without env and network. Must fail.
     rc, output = run_command_and_get_output(
         ["unshare", "-r", "-n", tt_cmd, "-c", "../tt.yaml", "rocks", "install", "stat"],
-        cwd=os.path.join(tmpdir, "subdir"),
+        cwd=os.path.join(tmp_path, "subdir"),
         env=dict(
             os.environ,
-            PWD=os.path.join(tmpdir, "subdir")))
+            PWD=os.path.join(tmp_path, "subdir")))
 
     assert rc == 1
     assert "Error: No results matching query" in output
@@ -246,23 +246,23 @@ def test_rocks_install_from_env_var_repo(tt_cmd, tmpdir):
     # Tets with env set, no network.
     rc, output = run_command_and_get_output(
             ["unshare", "-r", "-n", tt_cmd, "-c", "../tt.yaml", "rocks", "install", "stat"],
-            cwd=os.path.join(tmpdir, "subdir"),
+            cwd=tmp_path / "subdir",
             env=dict(
                 os.environ,
-                PWD=os.path.join(tmpdir, "subdir"),
-                TT_CLI_REPO_ROCKS=f'{tmpdir}/repo'))  # Env var for rock repo directory.
+                PWD=os.path.join(tmp_path, "subdir"),
+                TT_CLI_REPO_ROCKS=f'{tmp_path}/repo'))  # Env var for rock repo directory.
     assert rc == 0
     print(output)
-    assert f"Installing {tmpdir}/repo/stat-0.3.2-1.all.rock" in output
-    assert "stat 0.3.2-1 is now installed in " + os.path.join(tmpdir, "subdir", ".rocks") in output
-    assert os.path.exists(os.path.join(tmpdir, "subdir", ".rocks"))
+    assert f"Installing {tmp_path}/repo/stat-0.3.2-1.all.rock" in output
+    assert f"stat 0.3.2-1 is now installed in {tmp_path / 'subdir' / '.rocks'}" in output
+    assert os.path.exists(os.path.join(tmp_path, "subdir", ".rocks"))
 
 
 @pytest.mark.notarantool
 @pytest.mark.skipif(shutil.which("tarantool") is not None, reason="tarantool found in PATH")
 def test_rock_install_with_non_system_tarantool_in_path(tt_cmd, tmpdir_with_tarantool):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, config_name), "w") as tnt_env_file:
+    with tempfile.TemporaryDirectory() as tmp_path:
+        with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
             tnt_env_file.write('''repo:
   distfiles: "distfiles"''')
 
@@ -270,10 +270,10 @@ def test_rock_install_with_non_system_tarantool_in_path(tt_cmd, tmpdir_with_tara
         rocks_cmd = [tt_cmd, "rocks", "install", "crud", "1.1.1-1"]
         rc, output = run_command_and_get_output(
             rocks_cmd,
-            cwd=tmpdir,
+            cwd=tmp_path,
             env=dict(
                 os.environ,
-                PWD=tmpdir,
+                PWD=tmp_path,
                 PATH=os.path.join(tmpdir_with_tarantool, 'bin') + ':' + os.environ['PATH']))
 
         assert rc == 1  # Tarantool headers are not found.
@@ -283,14 +283,14 @@ def test_rock_install_with_non_system_tarantool_in_path(tt_cmd, tmpdir_with_tara
         rocks_cmd = [tt_cmd, "rocks", "install", "crud", "1.1.1-1"]
         rc, output = run_command_and_get_output(
             rocks_cmd,
-            cwd=tmpdir,
+            cwd=tmp_path,
             env=dict(
                 os.environ,
-                PWD=tmpdir,
+                PWD=tmp_path,
                 PATH=os.path.join(tmpdir_with_tarantool, 'bin') + ':' + os.environ['PATH'],
                 TT_CLI_TARANTOOL_PREFIX=os.path.join(tmpdir_with_tarantool, 'include')))
 
         assert rc == 0
         assert 'crud 1.1.1-1 is now installed' in output
 
-        assert os.path.exists(os.path.join(tmpdir, ".rocks", "share", "tarantool", "crud"))
+        assert os.path.exists(os.path.join(tmp_path, ".rocks", "share", "tarantool", "crud"))

--- a/test/integration/search/test_search.py
+++ b/test/integration/search/test_search.py
@@ -6,33 +6,33 @@ import pytest
 from utils import config_name, run_command_and_get_output
 
 
-def test_version_cmd(tt_cmd, tmpdir):
+def test_version_cmd(tt_cmd, tmp_path):
     cmd = [tt_cmd, "search", "tarantool"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Available versions of tarantool:", output)
 
     cmd = [tt_cmd, "search", "tt"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Available versions of tt:", output)
 
     cmd = [tt_cmd, "search", "git"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Search for available versions for the program", output)
 
     cmd = [tt_cmd, "search"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Search for available versions for the program", output)
 
 
 @pytest.mark.slow
-def test_version_cmd_local(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_version_cmd_local(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
     # Create test config
-    distfilesPath = os.path.join(tmpdir, "distfiles")
+    distfilesPath = os.path.join(tmp_path, "distfiles")
     os.mkdir(distfilesPath)
     with open(configPath, 'w') as f:
         f.write('tt:\n  app:\n')
@@ -40,29 +40,29 @@ def test_version_cmd_local(tt_cmd, tmpdir):
     cmd_download_tarantool = ["git", "clone",
                               "https://github.com/tarantool/tarantool.git",
                               os.path.join(distfilesPath, "tarantool")]
-    rc, _ = run_command_and_get_output(cmd_download_tarantool, cwd=tmpdir)
+    rc, _ = run_command_and_get_output(cmd_download_tarantool, cwd=tmp_path)
     assert rc == 0
     cmd_download_tt = ["git", "clone",
                        "https://github.com/tarantool/tt",
                        os.path.join(distfilesPath, "tt")]
-    rc, _ = run_command_and_get_output(cmd_download_tt, cwd=tmpdir)
+    rc, _ = run_command_and_get_output(cmd_download_tt, cwd=tmp_path)
     assert rc == 0
     cmd = [tt_cmd, "search", "--local-repo", "tarantool"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Available versions of tarantool:", output)
 
     cmd = [tt_cmd, "search", "--local-repo", "tt"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Available versions of tt:", output)
 
     cmd = [tt_cmd, "search", "--local-repo", "git"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Search for available versions for the program", output)
 
     cmd = [tt_cmd, "search", "--local-repo"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.search(r"Search for available versions for the program", output)

--- a/test/integration/ttbuild/test_build.py
+++ b/test/integration/ttbuild/test_build.py
@@ -219,11 +219,11 @@ def test_build_spec_file_set(tt_cmd, tmpdir_with_cfg):
 
 
 @pytest.mark.parametrize("flag", [None, "-V"])
-def test_build_app_by_name(tt_cmd, tmpdir, flag):
+def test_build_app_by_name(tt_cmd, tmp_path, flag):
     init_cmd = [tt_cmd, "init"]
     tt_process = subprocess.Popen(
         init_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -231,18 +231,18 @@ def test_build_app_by_name(tt_cmd, tmpdir, flag):
     tt_process.wait()
     assert tt_process.returncode == 0
 
-    os.mkdir(os.path.join(tmpdir, "appdir"))
+    os.mkdir(os.path.join(tmp_path, "appdir"))
     app_dir = shutil.copytree(os.path.join(os.path.dirname(__file__), "apps/app1"),
-                              os.path.join(tmpdir, "appdir", "app1"))
+                              os.path.join(tmp_path, "appdir", "app1"))
 
-    os.symlink("../appdir/app1", os.path.join(tmpdir, "instances.enabled", "app1"), True)
+    os.symlink("../appdir/app1", os.path.join(tmp_path, "instances.enabled", "app1"), True)
     build_cmd = [tt_cmd]
     if flag:
         build_cmd.append(flag)
     build_cmd.extend(["build", "app1"])
     tt_process = subprocess.Popen(
         build_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -9,8 +9,8 @@ import pytest
 from utils import config_name, is_valid_tarantool_installed
 
 
-def test_uninstall_tt(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_uninstall_tt(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir:\n    inc_dir:\n')
@@ -19,19 +19,19 @@ def test_uninstall_tt(tt_cmd, tmpdir):
         # Do not test uninstall through installing tt. Because installed tt will be invoked by
         # current tt. As a result the test will run for the installed tt and not the current.
         # Creating fake tarantool instead.
-        os.mkdir(os.path.join(tmpdir, "bin"))
-        with open(os.path.join(tmpdir, "bin", "tarantool_master"), 'w') as f:
+        os.mkdir(os.path.join(tmp_path, "bin"))
+        with open(os.path.join(tmp_path, "bin", "tarantool_master"), 'w') as f:
             f.write('''#!/bin/sh
                     echo "hello"''')
-        os.chmod(os.path.join(tmpdir, "bin", "tarantool_master"), 0o775)
-        os.symlink("./tarantool_master", os.path.join(tmpdir, "bin", "tarantool"))
-        os.makedirs(os.path.join(tmpdir, "include", "include", "tarantool_master"))
-        os.symlink("./tarantool_master", os.path.join(tmpdir, "include", "include", "tarantool"))
+        os.chmod(os.path.join(tmp_path, "bin", "tarantool_master"), 0o775)
+        os.symlink("./tarantool_master", os.path.join(tmp_path, "bin", "tarantool"))
+        os.makedirs(os.path.join(tmp_path, "include", "include", "tarantool_master"))
+        os.symlink("./tarantool_master", os.path.join(tmp_path, "include", "include", "tarantool"))
 
         uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", *prog]
         uninstall_process = subprocess.Popen(
             uninstall_cmd,
-            cwd=tmpdir,
+            cwd=tmp_path,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             text=True
@@ -42,14 +42,14 @@ def test_uninstall_tt(tt_cmd, tmpdir):
         assert "Removing headers..." in uninstall_output[1]
         assert "tarantool=master is uninstalled" in uninstall_output[2]
 
-        assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool_master"))
-        assert not os.path.exists(os.path.join(tmpdir, "bin", "tarantool"))
-        assert not os.path.exists(os.path.join(tmpdir, "include", "include", "tarantool_master"))
-        os.rmdir(os.path.join(tmpdir, "bin"))
+        assert not os.path.exists(os.path.join(tmp_path, "bin", "tarantool_master"))
+        assert not os.path.exists(os.path.join(tmp_path, "bin", "tarantool"))
+        assert not os.path.exists(os.path.join(tmp_path, "include", "include", "tarantool_master"))
+        os.rmdir(os.path.join(tmp_path, "bin"))
 
 
-def test_uninstall_default_many(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_uninstall_default_many(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir:\n    inc_dir:\n')
@@ -57,20 +57,20 @@ def test_uninstall_default_many(tt_cmd, tmpdir):
     # Do not test uninstall through installing tt. Because installed tt will be invoked by
     # current tt. As a result the test will run for the installed tt and not the current.
     # Creating fake tarantool instead.
-    os.mkdir(os.path.join(tmpdir, "bin"))
-    with open(os.path.join(tmpdir, "bin", "tarantool_master"), 'w') as f:
+    os.mkdir(os.path.join(tmp_path, "bin"))
+    with open(os.path.join(tmp_path, "bin", "tarantool_master"), 'w') as f:
         f.write('''#!/bin/sh
                 echo "hello"''')
-    with open(os.path.join(tmpdir, "bin", "tarantool_123"), 'w') as f:
+    with open(os.path.join(tmp_path, "bin", "tarantool_123"), 'w') as f:
         f.write('''#!/bin/sh
                 echo "hello"''')
-    os.chmod(os.path.join(tmpdir, "bin", "tarantool_master"), 0o775)
-    os.symlink("./tarantool_master", os.path.join(tmpdir, "bin", "tarantool"))
+    os.chmod(os.path.join(tmp_path, "bin", "tarantool_master"), 0o775)
+    os.symlink("./tarantool_master", os.path.join(tmp_path, "bin", "tarantool"))
 
     uninstall_cmd = [tt_cmd,  "--cfg", configPath, "uninstall", "tarantool"]
     uninstall_process = subprocess.Popen(
         uninstall_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -83,19 +83,19 @@ def test_uninstall_default_many(tt_cmd, tmpdir):
     assert expected in uninstall_output[1]
 
 
-def test_uninstall_missing(tt_cmd, tmpdir):
-    configPath = os.path.join(tmpdir, config_name)
+def test_uninstall_missing(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
     # Create test config.
     with open(configPath, 'w') as f:
         f.write('tt:\n  env:\n    bin_dir:\n    inc_dir:\n')
     # Create bin directory.
-    os.mkdir(os.path.join(tmpdir, "bin"))
-    os.mkdir(os.path.join(tmpdir, "include"))
+    os.mkdir(os.path.join(tmp_path, "bin"))
+    os.mkdir(os.path.join(tmp_path, "include"))
     # Remove not installed program.
     uninstall_cmd = [tt_cmd, "uninstall", "tt", "1.2.3"]
     uninstall_process = subprocess.Popen(
         uninstall_cmd,
-        cwd=tmpdir,
+        cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True
@@ -124,12 +124,12 @@ def test_uninstall_foreign_program(tt_cmd, tmpdir_with_cfg):
 
 
 @pytest.mark.parametrize("is_symlink_broken", [False, True])
-def test_uninstall_tarantool_dev_installed(tt_cmd, tmpdir, is_symlink_broken):
+def test_uninstall_tarantool_dev_installed(tt_cmd, tmp_path, is_symlink_broken):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__),
                                  "testdata/tarantool_dev")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     tt_dir = "installed"
     if is_symlink_broken:
@@ -165,12 +165,12 @@ def test_uninstall_tarantool_dev_installed(tt_cmd, tmpdir, is_symlink_broken):
         assert os.path.exists(os.path.join(testdata_path, tt_dir, "tarantool_inc"))
 
 
-def test_uninstall_tarantool_dev_not_installed(tt_cmd, tmpdir):
+def test_uninstall_tarantool_dev_not_installed(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__),
                                  "testdata/tarantool_dev")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     tt_dir = "not_installed"
     uninstall_cmd = [
@@ -198,12 +198,12 @@ def test_uninstall_tarantool_dev_not_installed(tt_cmd, tmpdir):
     )
 
 
-def test_uninstall_tarantool_switch(tt_cmd, tmpdir):
+def test_uninstall_tarantool_switch(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__),
                                  "testdata/uninstall_switch")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     uninstall_cmd = [
         tt_cmd,
@@ -230,12 +230,12 @@ def test_uninstall_tarantool_switch(tt_cmd, tmpdir):
     )
 
 
-def test_uninstall_tarantool_switch_hash(tt_cmd, tmpdir):
+def test_uninstall_tarantool_switch_hash(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__),
                                  "testdata/uninstall_switch_hash")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     uninstall_cmd = [
         tt_cmd,
@@ -264,12 +264,12 @@ def test_uninstall_tarantool_switch_hash(tt_cmd, tmpdir):
 
 # No symlink changes should be made if the symlink was pointing
 # to some other version.
-def test_uninstall_tarantool_no_switch(tt_cmd, tmpdir):
+def test_uninstall_tarantool_no_switch(tt_cmd, tmp_path):
     # Copy test files.
     testdata_path = os.path.join(os.path.dirname(__file__),
                                  "testdata/uninstall_switch")
-    shutil.copytree(testdata_path, os.path.join(tmpdir, "testdata"), True)
-    testdata_path = os.path.join(tmpdir, "testdata")
+    shutil.copytree(testdata_path, os.path.join(tmp_path, "testdata"), True)
+    testdata_path = os.path.join(tmp_path, "testdata")
 
     binary_path = os.path.join(testdata_path, "bin", "tarantool")
     include_path = os.path.join(testdata_path, "inc", "include", "tarantool")

--- a/test/integration/version/test_version.py
+++ b/test/integration/version/test_version.py
@@ -3,23 +3,23 @@ import re
 from utils import run_command_and_get_output
 
 
-def test_version_cmd(tt_cmd, tmpdir):
+def test_version_cmd(tt_cmd, tmp_path):
     cmd = [tt_cmd, "-I", "version"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert len(re.findall(r"(\s\d+.\d+.\d+,|\s<unknown>,)", output)) == 1
 
     cmd = [tt_cmd, "-I", "version", "--short"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>)", output)
 
     cmd = [tt_cmd, "-I", "version", "--commit"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>).\w+", output)
 
     cmd = [tt_cmd, "-I", "version", "--commit", "--short"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmpdir)
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>).\w+", output)

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -9,3 +9,6 @@ markers =
 
 # Max test duration is 15 minutes.
 timeout = 900
+
+# Disable legacy paths.
+addopts = -p no:legacypath

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-pytest==6.2.5
+pytest==8.2.2
 tarantool==0.7.1
 requests==2.31.0
 flake8==6.1.0

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,10 @@ import re
 import shutil
 import socket
 import subprocess
-import tempfile
 import time
 
 import netifaces
 import psutil
-import py
 import tarantool
 import yaml
 
@@ -23,12 +21,6 @@ pid_file = "tt.pid"
 log_file = "tt.log"
 initial_snap = "00000000000000000000.snap"
 initial_xlog = "00000000000000000000.xlog"
-
-
-def get_tmpdir(request):
-    tmpdir = py.path.local(tempfile.mkdtemp())
-    request.addfinalizer(lambda: tmpdir.remove(rec=1))
-    return str(tmpdir)
 
 
 def run_command_and_get_output(


### PR DESCRIPTION
- use tmp_path pytest fixture over tmpdir
- pytest provides convenient api for working with temporary directories. Replase `get_tmpdir` with tmp_path* functions.