### PR TITLE
install: fix impossibility of reinstalling master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   an application directory.
 - `tt replicaset bootstrap`: command to bootstrap a Cartridge cluster or an instance.
 - `tt rs rebootstrap`: re-bootstraps an instance.
+- `-s (--self)` flag to execute `tt` itself and don't search for other `tt`s in bin_dir
+  provided in config.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt install tt` returns expected exit status code on unsuccessful dependency check.
 - `tt pack`: failed to start instances using systemctl due to `permissions denied`.
 - `tt uninstall tt`: does not work with `x.y.z` version format.
+- Ability to update a latest version of `master` tarantool and tt with `tt install`.
 
 ### Changed
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -151,6 +151,8 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		false, "Verbose output")
 	rootCmd.Flags().BoolVarP(&cmdCtx.Cli.IsSelfExec, "self", "s",
 		false, "Skip searching for other tt versions to run")
+	rootCmd.Flags().BoolVarP(&cmdCtx.Cli.NoPrompt, "no-prompt", "",
+		false, "Skip cli interaction using default behavior")
 
 	integrity.RegisterIntegrityCheckFlag(rootCmd.Flags(), &cmdCtx.Cli.IntegrityCheck)
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -149,6 +149,8 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		"", "Path to configuration file")
 	rootCmd.Flags().BoolVarP(&cmdCtx.Cli.Verbose, "verbose", "V",
 		false, "Verbose output")
+	rootCmd.Flags().BoolVarP(&cmdCtx.Cli.IsSelfExec, "self", "s",
+		false, "Skip searching for other tt versions to run")
 
 	integrity.RegisterIntegrityCheckFlag(rootCmd.Flags(), &cmdCtx.Cli.IntegrityCheck)
 

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -85,4 +85,6 @@ type CliCtx struct {
 	TarantoolCli TarantoolCli
 	// IntegrityCheck is a public key used for integrity check.
 	IntegrityCheck string
+  // This flag disables searching of other tt versions to run instead of the current one.
+	IsSelfExec bool
 }

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -85,6 +85,8 @@ type CliCtx struct {
 	TarantoolCli TarantoolCli
 	// IntegrityCheck is a public key used for integrity check.
 	IntegrityCheck string
-  // This flag disables searching of other tt versions to run instead of the current one.
+	// This flag disables searching of other tt versions to run instead of the current one.
 	IsSelfExec bool
+	// NoPrompt flag needs to skip cli interaction using default behavior.
+	NoPrompt bool
 }

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 	"github.com/tarantool/tt/lib/integrity"
 )
@@ -61,6 +62,26 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	return tntCli.version, nil
 }
 
+// GetTtVersion returns version of Tt provided by its executable path.
+func GetTtVersion(pathToBin string) (version.Version, error) {
+	if !util.IsRegularFile(pathToBin) {
+		return version.Version{}, fmt.Errorf("file %q not found", pathToBin)
+	}
+
+	output, err := exec.Command(pathToBin, "--self", "version",
+		"--commit").Output()
+	if err != nil {
+		return version.Version{}, fmt.Errorf("failed to get tt version: %s", err)
+	}
+
+	ttVersion, err := version.ParseTt(string(output))
+	if err != nil {
+		return version.Version{}, err
+	}
+
+	return ttVersion, nil
+}
+
 // CliCtx - CLI context. Contains flags passed when starting
 // Tarantool CLI and some other parameters.
 type CliCtx struct {
@@ -85,7 +106,8 @@ type CliCtx struct {
 	TarantoolCli TarantoolCli
 	// IntegrityCheck is a public key used for integrity check.
 	IntegrityCheck string
-	// This flag disables searching of other tt versions to run instead of the current one.
+	// This flag disables searching of other tt versions to run
+	// instead of the current one.
 	IsSelfExec bool
 	// NoPrompt flag needs to skip cli interaction using default behavior.
 	NoPrompt bool

--- a/cli/cmdcontext/cmdcontext_test.go
+++ b/cli/cmdcontext/cmdcontext_test.go
@@ -1,6 +1,7 @@
 package cmdcontext
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,4 +79,80 @@ exit 1`),
 	tntVersion, err = tntCli.GetVersion()
 	assert.ErrorContains(t, err, "failed to get tarantool version: exit status 1")
 	assert.Equal(t, version.Version{}, tntVersion)
+}
+
+func TestTtCli_GetVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	type testCase struct {
+		name           string
+		versionToCheck string
+		expectedVer    version.Version
+		isErr          bool
+		expectedErrMsg string
+	}
+
+	cases := []testCase{
+		{
+			name:           "basic",
+			versionToCheck: "2.3.1.f7cc1de\n",
+			expectedVer: version.Version{
+				Major: 2,
+				Minor: 3,
+				Patch: 1,
+				Hash:  "f7cc1de",
+				Str:   "2.3.1.f7cc1de",
+			},
+			isErr:          false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "parse error",
+			versionToCheck: "2.w.1.f7cc1de",
+			expectedVer:    version.Version{},
+			isErr:          true,
+			expectedErrMsg: `strconv.ParseUint: parsing "w": invalid syntax`,
+		},
+		{
+			name:           "no dots in version",
+			versionToCheck: "2131f7cc1de",
+			expectedVer:    version.Version{},
+			isErr:          true,
+			expectedErrMsg: fmt.Sprintf(`failed to parse version "2131f7cc1de\n":` +
+				` format is not valid`),
+		},
+		{
+			name:           "version does not match",
+			versionToCheck: "2.1.3.1.f7cc1de",
+			expectedVer:    version.Version{},
+			isErr:          true,
+			expectedErrMsg: fmt.Sprintf(`the version of "2.1.3.1" does not match` +
+				` <major>.<minor>.<patch> format`),
+		},
+		{
+			name:           "hash does not match",
+			versionToCheck: "2.1.3.f7cc1de_",
+			expectedVer:    version.Version{},
+			isErr:          true,
+			expectedErrMsg: `hash "f7cc1de_" has a wrong format`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := os.WriteFile(filepath.Join(tmpDir, "tt.sh"),
+				[]byte(fmt.Sprintf(`#!/bin/bash
+    echo "%s"`, tc.versionToCheck)),
+				0755)
+			require.NoError(t, err)
+
+			ttVersion, err := GetTtVersion(filepath.Join(tmpDir, "tt.sh"))
+			if tc.isErr {
+				require.EqualError(t, err, tc.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedVer, ttVersion)
+		})
+	}
 }

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -549,9 +549,12 @@ func configureLocalCli(cmdCtx *cmdcontext.CmdCtx) error {
 		return err
 	}
 
-	localCli, err := detectLocalTt(cliOpts)
-	if err != nil {
-		return err
+	var localCli string
+	if !cmdCtx.Cli.IsSelfExec {
+		localCli, err = detectLocalTt(cliOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	// We have to use the absolute path to the current binary "tt" for


### PR DESCRIPTION
Fix impossibility of reinstalling latest version of master. Add additional checking if current binary file with the latest version. Also add to 'fixed' in CHANGELOG file and write integration test for it.

Closes #690