### PR TITLE
pack: fix artifacts directories owner:group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sorted by name order of columns for `table` and `ttable` formats.
 - `tt switch tt`: does not work with `x.x.x` version format.
 - `tt install tt` returns expected exit status code on unsuccessful dependency check.
+- `tt pack`: failed to start instances using systemctl due to `permissions denied`.
 
 ### Changed
 

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -786,13 +786,13 @@ func updatePermissions(baseDir string) func(path string, entry fs.DirEntry, err 
 func createArtifactsDirs(pkgDataDir string, packCtx *PackCtx) error {
 	for _, dirToCreate := range []string{configure.VarDataPath, configure.VarLogPath,
 		configure.VarRunPath} {
-		artifactEnvDir := filepath.Join(pkgDataDir, dirToCreate, "tarantool", packCtx.Name)
+		artifactEnvDir := filepath.Join(pkgDataDir, dirToCreate, "tarantool")
 		if err := os.MkdirAll(artifactEnvDir, dirPermissions); err != nil {
 			return fmt.Errorf("cannot create %q: %s", artifactEnvDir, err)
 		}
 	}
 	for _, dir := range [...]string{"lib", "log", "run"} {
-		packCtx.RpmDeb.pkgFilesInfo[fmt.Sprintf("var/%s/tarantool/%s", dir, packCtx.Name)] =
+		packCtx.RpmDeb.pkgFilesInfo[fmt.Sprintf("var/%s/tarantool", dir)] =
 			packFileInfo{"tarantool", "tarantool"}
 	}
 	return nil

--- a/cli/pack/rpm_const.go
+++ b/cli/pack/rpm_const.go
@@ -103,7 +103,6 @@ var (
 		"usr/lib/tmpfiles.d":     struct{}{},
 		"var":                    struct{}{},
 		"var/lib":                struct{}{},
-		"var/lib/tarantool":      struct{}{},
 		"var/run":                struct{}{},
 		"var/log":                struct{}{},
 		"etc":                    struct{}{},


### PR DESCRIPTION
systemctl start fails for the instances packed by `tt pack` due to permissions error. `/var/<dir>/tarantool` has root:root owner:group which does not allows `tt` to check sub-directories. Set tarantool:tarantool permissions for `/var/<dir>/tarantool` directories. Do not create sub-dirs by default, they will be created on first start.