### PR TITLE
build: add go_tarantool_msgpack_v5 build tag

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -195,7 +195,7 @@ func appendLdFlags(flags ...string) optsUpdater {
 
 // appendTags appends tags.
 func appendTags(args []string) ([]string, error) {
-	tags := []string{"netgo", "osusergo"}
+	tags := []string{"netgo", "osusergo", "go_tarantool_msgpack_v5"}
 
 	buildType := os.Getenv(buildTypeEnv)
 	switch BuildType(buildType) {


### PR DESCRIPTION
The tag enables usage of `msgpack/v5` libreary instead of `msgpack.v2`. It fixes decoding errors with msgpack extension types at the go-tarantool connector.

Part of https://github.com/tarantool/tt-ee/issues/151