### PR TITLE
uninstall: fix removing tt by version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt switch tt`: does not work with `x.x.x` version format.
 - `tt install tt` returns expected exit status code on unsuccessful dependency check.
 - `tt pack`: failed to start instances using systemctl due to `permissions denied`.
+- `tt uninstall tt`: does not work with `x.y.z` version format.
 
 ### Changed
 

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -68,11 +68,15 @@ var unwindPatch []byte
 //go:embed extra/bump-libunwind-new.patch
 var unwindPatchNew []byte
 
-// defaultDirPermissions is rights used to create folders.
-// 0755 - drwxr-xr-x
-// We need to give permission for all to execute
-// read,write for user and only read for others.
-const defaultDirPermissions = 0755
+const (
+	// defaultDirPermissions is rights used to create folders.
+	// 0755 - drwxr-xr-x
+	// We need to give permission for all to execute
+	// read,write for user and only read for others.
+	defaultDirPermissions = 0755
+
+	MajorMinorPatchRegexp = `^[0-9]+\.[0-9]+\.[0-9]+`
+)
 
 // programGitRepoUrls contains URLs of programs git repositories.
 var programGitRepoUrls = map[string]string{
@@ -494,8 +498,13 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 			if err != nil {
 				return err
 			}
+
+			versionMatches, err := regexp.Match(MajorMinorPatchRegexp, []byte(ttVersion))
+			if err != nil {
+				return err
+			}
 			for _, ver := range versions {
-				if ttVersion == ver.Str || (ttVersion[:1] != "v" && "v"+ttVersion == ver.Str) {
+				if ttVersion == ver.Str || (versionMatches && "v"+ttVersion == ver.Str) {
 					versionFound = true
 					ttVersion = ver.Str
 					break

--- a/cli/uninstall/uninstall_test.go
+++ b/cli/uninstall/uninstall_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/configure"
+	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/version"
 )
 
@@ -140,6 +141,55 @@ func TestSearchLatestVersion(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 			}
+		})
+	}
+}
+
+func TestGetAllVersionFormats(t *testing.T) {
+	type testCase struct {
+		name             string
+		programName      string
+		ttVersion        string
+		expectedVersions []string
+		expectedError    error
+	}
+
+	cases := []testCase{
+		{
+			name:             "without prefix",
+			programName:      search.ProgramTt,
+			ttVersion:        "1.2.3",
+			expectedVersions: []string{"1.2.3", "v1.2.3"},
+			expectedError:    nil,
+		},
+		{
+			name:             "with prefix",
+			programName:      search.ProgramTt,
+			ttVersion:        "v1.2.3",
+			expectedVersions: []string{"v1.2.3"},
+			expectedError:    nil,
+		},
+		{
+			name:             "not tt program",
+			programName:      search.ProgramCe,
+			ttVersion:        "1.2.3",
+			expectedVersions: []string{"1.2.3"},
+			expectedError:    nil,
+		},
+		{
+			name:             "not <major.minor.patch> format",
+			programName:      search.ProgramCe,
+			ttVersion:        "e902206",
+			expectedVersions: []string{"e902206"},
+			expectedError:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ttVersions, err := getAllTtVersionFormats(tc.programName, tc.ttVersion)
+			assert.NoError(t, err)
+			assert.Equal(t, ttVersions, tc.expectedVersions)
 		})
 	}
 }


### PR DESCRIPTION
It was impossible to uninstall tt by version without 'v' prefix using `tt unistall tt 1.2.0` for example because program checks version in binary file with prefix.

After the patch `tt uninstall` checks 'v' prefix before version and if it didn't find, adds for strings matching.

Closes #583