### PR TITLE
`tt start` interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt rs rebootstrap`: re-bootstraps an instance.
 - `-s (--self)` flag to execute `tt` itself and don't search for other `tt`s in bin_dir
   provided in config.
+- `tt start` interactive mode with `-i` option.
 
 ### Fixed
 

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -16,7 +16,7 @@ import (
 // DaemonHandler is used to communicate with the daemon over HTTP.
 type DaemonHandler struct {
 	cmdPath string
-	logger  *ttlog.Logger
+	logger  ttlog.Logger
 }
 
 // resResult describes a failure during the command execution.
@@ -57,7 +57,7 @@ func NewDaemonHandler(cmdPath string) *DaemonHandler {
 }
 
 // Logger sets logger for DaemonHandler.
-func (handler *DaemonHandler) Logger(logger *ttlog.Logger) *DaemonHandler {
+func (handler *DaemonHandler) Logger(logger ttlog.Logger) *DaemonHandler {
 	handler.logger = logger
 	return handler
 }

--- a/cli/daemon/httpserver.go
+++ b/cli/daemon/httpserver.go
@@ -29,7 +29,7 @@ type HTTPServer struct {
 	// to the HTTP server to shutdown correctly.
 	timeout time.Duration
 	// logger is  a log file the HTTP server will write to.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 }
 
 // listenIP discovers IP address on the specified interface.
@@ -98,7 +98,7 @@ func (httpServer *HTTPServer) Timeout(timeout time.Duration) *HTTPServer {
 }
 
 // SetLogger sets a log file the HTTP server will write to.
-func (httpServer *HTTPServer) SetLogger(logger *ttlog.Logger) {
+func (httpServer *HTTPServer) SetLogger(logger ttlog.Logger) {
 	httpServer.logger = logger
 }
 

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -25,7 +25,7 @@ const (
 type Worker interface {
 	Start(ttPath string)
 	Stop() error
-	SetLogger(logger *ttlog.Logger)
+	SetLogger(logger ttlog.Logger)
 }
 
 // Process describes a running process.
@@ -33,7 +33,7 @@ type Process struct {
 	// logOpts are options to create a logger.
 	logOpts ttlog.LoggerOpts
 	// logger is a log file the process will write to.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	// pidFileName is a path to the process pid file.
 	pidFileName string
 	// cmdPath is a path to the command the process should perform.
@@ -94,7 +94,10 @@ func (process *Process) IsChild() bool {
 // Start starts the process.
 func (process *Process) Start() error {
 	if process.IsChild() {
-		process.logger = ttlog.NewLogger(process.logOpts)
+		var err error
+		if process.logger, err = ttlog.NewFileLogger(process.logOpts); err != nil {
+			return fmt.Errorf("failed to create log: %s", err)
+		}
 
 		if err := process_utils.CreatePIDFile(process.pidFileName); err != nil {
 			return err

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -99,7 +99,7 @@ func (process *Process) Start() error {
 			return fmt.Errorf("failed to create log: %s", err)
 		}
 
-		if err := process_utils.CreatePIDFile(process.pidFileName); err != nil {
+		if err := process_utils.CreatePIDFile(process.pidFileName, os.Getpid()); err != nil {
 			return err
 		}
 

--- a/cli/daemon/test_process/test_process.go
+++ b/cli/daemon/test_process/test_process.go
@@ -9,7 +9,7 @@ import (
 
 // TestWorker represents simple worker.
 type TestWorker struct {
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	done   chan bool
 }
 
@@ -21,7 +21,7 @@ func NewTestWorker() *TestWorker {
 }
 
 // SetLogger sets worker logger.
-func (w *TestWorker) SetLogger(logger *ttlog.Logger) {
+func (w *TestWorker) SetLogger(logger ttlog.Logger) {
 	w.logger = logger
 }
 

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -106,7 +106,7 @@ func CheckPIDFile(pidFileName string) error {
 
 // CreatePIDFile checks that the instance PID file is absent or
 // deprecated and creates a new one. Returns an error on failure.
-func CreatePIDFile(pidFileName string) error {
+func CreatePIDFile(pidFileName string, pid int) error {
 	if err := CheckPIDFile(pidFileName); err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func CreatePIDFile(pidFileName string) error {
 	}
 	defer pidFile.Close()
 
-	if _, err = pidFile.WriteString(strconv.Itoa(os.Getpid())); err != nil {
+	if _, err = pidFile.WriteString(strconv.Itoa(pid)); err != nil {
 		return err
 	}
 

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -1,0 +1,165 @@
+package running
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/tarantool/tt/cli/ttlog"
+	"github.com/tarantool/tt/lib/integrity"
+)
+
+// baseInstance represents a tarantool instance.
+type baseInstance struct {
+	// processController is a child process controller.
+	*processController
+	// logger represents an active logging object.
+	logger ttlog.Logger
+	// tarantoolPath describes the path to the tarantool binary
+	// that will be used to launch the Instance.
+	tarantoolPath string
+	// appPath describes the path to the "init" file of an application.
+	appPath string
+	// appDir is an application directory.
+	appDir string
+	// appName describes the application name (the name of the directory
+	// where the application files are present).
+	appName string
+	// instName describes the instance name.
+	instName string
+	// walDir is a directory where write-ahead log (.xlog) files are stored.
+	walDir string
+	// memtxDir is a directory where memtx stores snapshot (.snap) files.
+	memtxDir string `mapstructure:"memtx_dir" yaml:"memtx_dir"`
+	// vinylDir is a directory where vinyl files or subdirectories will be stored.
+	vinylDir string `mapstructure:"vinyl_dir" yaml:"vinyl_dir"`
+	// consoleSocket is a Unix domain socket to be used as "admin port".
+	consoleSocket string
+	// binaryPort is a Unix socket to be used as "binary port".
+	binaryPort string
+	// logDir is log files location.
+	logDir string
+	// IntegrityCtx contains information necessary to perform integrity checks.
+	integrityCtx integrity.IntegrityCtx
+	// integrityChecks tells whether integrity checks are turned on.
+	integrityChecks bool
+	// stdOut is a standard output writer.
+	stdOut io.Writer
+	// stdErr is a standard error writer.
+	stdErr io.Writer
+}
+
+func newBaseInstance(tarantoolPath string, instanceCtx InstanceCtx,
+	opts ...InstanceOption) baseInstance {
+	baseInst := baseInstance{
+		tarantoolPath: tarantoolPath,
+		appPath:       instanceCtx.InstanceScript,
+		appName:       instanceCtx.AppName,
+		appDir:        instanceCtx.AppDir,
+		instName:      instanceCtx.InstName,
+		consoleSocket: instanceCtx.ConsoleSocket,
+		walDir:        instanceCtx.WalDir,
+		vinylDir:      instanceCtx.VinylDir,
+		memtxDir:      instanceCtx.MemtxDir,
+		logDir:        instanceCtx.LogDir,
+		binaryPort:    instanceCtx.BinaryPort,
+		stdOut:        os.Stdout,
+		stdErr:        os.Stderr,
+	}
+	for _, opt := range opts {
+		opt(&baseInst)
+	}
+	return baseInst
+}
+
+// InstanceOption is a functional option to configure tarantool instance.
+type InstanceOption func(inst *baseInstance) error
+
+// IntegrityOpt sets integrity context.
+func IntegrityOpt(integrityCtx integrity.IntegrityCtx) InstanceOption {
+	return func(inst *baseInstance) error {
+		inst.integrityChecks = true
+		inst.integrityCtx = integrityCtx
+		return nil
+	}
+}
+
+// StdOutOpt sets stdout writer for the child process.
+func StdOutOpt(writer io.Writer) InstanceOption {
+	return func(inst *baseInstance) error {
+		inst.stdOut = writer
+		return nil
+	}
+}
+
+// StdErrOpt sets stderr writer for the child process.
+func StdErrOpt(writer io.Writer) InstanceOption {
+	return func(inst *baseInstance) error {
+		inst.stdErr = writer
+		return nil
+	}
+}
+
+// StdLoggerOpt sets logger for the instance and standard out FDs to logger writer.
+func StdLoggerOpt(logger ttlog.Logger) InstanceOption {
+	return func(inst *baseInstance) error {
+		inst.logger = logger
+		inst.stdOut = logger.Writer()
+		inst.stdErr = logger.Writer()
+		return nil
+	}
+}
+
+// Wait waits for the child process to complete.
+func (inst *baseInstance) Wait() error {
+	if inst.processController == nil {
+		return fmt.Errorf("instance is not started")
+	}
+	return inst.processController.Wait()
+}
+
+// SendSignal sends a signal to tarantool instance.
+func (inst *baseInstance) SendSignal(sig os.Signal) error {
+	if inst.processController == nil {
+		return fmt.Errorf("instance is not started")
+	}
+	return inst.processController.SendSignal(sig)
+}
+
+// IsAlive verifies that the instance is alive by sending a "0" signal.
+func (inst *baseInstance) IsAlive() bool {
+	if inst.processController == nil {
+		return false
+	}
+	return inst.processController.IsAlive()
+}
+
+// StopWithSignal terminates the process with a specific signal.
+func (inst *baseInstance) StopWithSignal(waitTimeout time.Duration, usedSignal os.Signal) error {
+	if inst.processController == nil {
+		return nil
+	}
+	return inst.processController.StopWithSignal(waitTimeout, usedSignal)
+}
+
+// Run runs tarantool instance.
+func (inst *baseInstance) Run(opts RunOpts) error {
+	f, err := inst.integrityCtx.Repository.Read(inst.tarantoolPath)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	newInstanceEnv := os.Environ()
+	args := []string{inst.tarantoolPath}
+	args = append(args, opts.RunArgs...)
+	log.Debugf("Running Tarantool with args: %s", strings.Join(args[1:], " "))
+	execErr := syscall.Exec(inst.tarantoolPath, args, newInstanceEnv)
+	if execErr != nil {
+		return execErr
+	}
+	return nil
+}

--- a/cli/running/cluster_instance.go
+++ b/cli/running/cluster_instance.go
@@ -21,7 +21,7 @@ type clusterInstance struct {
 	// processController is a child process controller.
 	processController *processController
 	// logger represents an active logging object.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	// tarantoolPath describes the path to the tarantool binary
 	// that will be used to launch the Instance.
 	tarantoolPath string
@@ -59,7 +59,7 @@ type clusterInstance struct {
 
 // newClusterInstance creates a clusterInstance.
 func newClusterInstance(tarantoolCli cmdcontext.TarantoolCli, instanceCtx InstanceCtx,
-	logger *ttlog.Logger, integrityCtx integrity.IntegrityCtx,
+	logger ttlog.Logger, integrityCtx integrity.IntegrityCtx,
 	integrityChecks bool) (*clusterInstance, error) {
 	// Check if tarantool binary exists.
 	if _, err := exec.LookPath(tarantoolCli.Executable); err != nil {

--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -1,6 +1,7 @@
 package running
 
 import (
+	"context"
 	"os"
 	"time"
 )
@@ -8,7 +9,7 @@ import (
 // Instance describes a running tarantool instance.
 type Instance interface {
 	// Start starts the Instance with the specified parameters.
-	Start() error
+	Start(context.Context) error
 
 	// Run runs tarantool interpreter.
 	Run(opts RunOpts) error
@@ -30,4 +31,10 @@ type Instance interface {
 
 	// StopWithSignal terminates the process with specific signal.
 	StopWithSignal(waitTimeout time.Duration, usedSignal os.Signal) error
+
+	// GetPid returns instance process PID.
+	GetPid() int
+
+	// ProcessState returns completed process state.
+	ProcessState() *os.ProcessState
 }

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -27,7 +27,7 @@ type scriptInstance struct {
 	// processController is a child process controller.
 	processController *processController
 	// logger represents an active logging object.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	// tarantoolPath describes the path to the tarantool binary
 	// that will be used to launch the Instance.
 	tarantoolPath string
@@ -62,7 +62,7 @@ type scriptInstance struct {
 var instanceLauncher []byte
 
 // newScriptInstance creates an Instance.
-func newScriptInstance(tarantoolPath string, instanceCtx InstanceCtx, logger *ttlog.Logger,
+func newScriptInstance(tarantoolPath string, instanceCtx InstanceCtx, logger ttlog.Logger,
 	integrityCtx integrity.IntegrityCtx, integrityChecks bool) (*scriptInstance, error) {
 	// Check if tarantool binary exists.
 	if _, err := exec.LookPath(tarantoolPath); err != nil {

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -23,7 +23,7 @@ const (
 
 // startTestInstance starts instance for the test.
 func startTestInstance(t *testing.T, app string, consoleSock string, binaryPort string,
-	logger *ttlog.Logger) *scriptInstance {
+	logger ttlog.Logger) *scriptInstance {
 	assert := assert.New(t)
 
 	// Need absolute path to the script, because working dir is changed on start.

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -17,10 +17,10 @@ import (
 // file).
 type Provider interface {
 	// CreateInstance is used to create a new instance on restart.
-	CreateInstance(logger *ttlog.Logger) (Instance, error)
+	CreateInstance(logger ttlog.Logger) (Instance, error)
 	// UpdateLogger updates the logger settings or creates a new logger,
 	// if passed nil.
-	UpdateLogger(logger *ttlog.Logger) (*ttlog.Logger, error)
+	UpdateLogger(logger ttlog.Logger) (ttlog.Logger, error)
 	// IsRestartable checks
 	IsRestartable() (bool, error)
 }
@@ -30,7 +30,7 @@ type Watchdog struct {
 	// instance describes the controlled Instance.
 	instance Instance
 	// logger represents an active logging object.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	// doneBarrier used to indicate the completion of the
 	// signal handling goroutine.
 	doneBarrier sync.WaitGroup
@@ -54,7 +54,7 @@ type Watchdog struct {
 }
 
 // NewWatchdog creates a new instance of Watchdog.
-func NewWatchdog(restartable bool, restartTimeout time.Duration, logger *ttlog.Logger,
+func NewWatchdog(restartable bool, restartTimeout time.Duration, logger ttlog.Logger,
 	provider Provider, preStartAction func() error,
 	integrityCtx integrity.IntegrityCtx, integrityCheckPeriod time.Duration) *Watchdog {
 	wd := Watchdog{
@@ -234,7 +234,7 @@ func (wd *Watchdog) startSignalHandling(ctx context.Context, cancel context.Canc
 						wd.instance.Stop(30 * time.Second)
 					}
 				case syscall.SIGQUIT:
-					wd.logger.Print("(INFO): SIGQUIT received.")
+					wd.logger.Println("(INFO): SIGQUIT received.")
 					wd.stopMutex.Lock()
 					wd.shouldStop = true
 					wd.stopMutex.Unlock()

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -112,7 +112,7 @@ func (wd *Watchdog) Start() error {
 			return nil
 		}
 		// Start the Instance.
-		if err := wd.instance.Start(); err != nil {
+		if err := wd.instance.Start(context.Background()); err != nil {
 			wd.logger.Printf(`(ERROR):  instance start failed: %v.`, err)
 			wd.stopMutex.Unlock()
 			break

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -43,9 +43,7 @@ func (provider *providerTestImpl) CreateInstance(logger ttlog.Logger) (Instance,
 		InstanceScript: provider.appPath,
 		AppDir:         provider.t.TempDir(),
 	},
-		logger, integrity.IntegrityCtx{
-			Repository: &mockRepository{},
-		}, false)
+		StdLoggerOpt(logger))
 }
 
 // UpdateLogger updates the logger settings or creates a new logger, if passed nil.

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -29,7 +29,7 @@ type providerTestImpl struct {
 	// appPath is the path to the application.
 	appPath string
 	// logger describes the logger used by Watchdog.
-	logger *ttlog.Logger
+	logger ttlog.Logger
 	// dataDir used by an Instance.
 	dataDir string
 	// restartable indicates the need to restart the instance in case of a crash.
@@ -38,7 +38,7 @@ type providerTestImpl struct {
 }
 
 // createInstance reads config and creates an Instance.
-func (provider *providerTestImpl) CreateInstance(logger *ttlog.Logger) (Instance, error) {
+func (provider *providerTestImpl) CreateInstance(logger ttlog.Logger) (Instance, error) {
 	return newScriptInstance(provider.tarantool, InstanceCtx{
 		InstanceScript: provider.appPath,
 		AppDir:         provider.t.TempDir(),
@@ -49,7 +49,7 @@ func (provider *providerTestImpl) CreateInstance(logger *ttlog.Logger) (Instance
 }
 
 // UpdateLogger updates the logger settings or creates a new logger, if passed nil.
-func (provider *providerTestImpl) UpdateLogger(logger *ttlog.Logger) (*ttlog.Logger, error) {
+func (provider *providerTestImpl) UpdateLogger(logger ttlog.Logger) (ttlog.Logger, error) {
 	return logger, nil
 }
 

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -1,0 +1,60 @@
+package running
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+
+	"github.com/fatih/color"
+)
+
+var (
+	errorColor     = color.New(color.FgRed, color.Bold)
+	logLevelColors = map[string]*color.Color{
+		"F": errorColor,
+		"!": errorColor,
+		"E": errorColor,
+		"W": color.New(color.FgYellow),
+	}
+
+	logLevelRgx *regexp.Regexp
+)
+
+func init() {
+	logLevelRgx = regexp.MustCompile(" ([F!EW])> ")
+}
+
+type colorizedWriter func(msg []byte) (int, error)
+
+// Write is an io.Writer implementation.
+func (f colorizedWriter) Write(msg []byte) (int, error) {
+	return f(msg)
+}
+
+// NewColorizedPrefixWriter creates a writer which colors the prefix or the whole
+// line depending on its log level.
+func NewColorizedPrefixWriter(writer io.Writer, color color.Color, prefix string) io.Writer {
+	buf := bytes.Buffer{}
+	buf.Grow(1024)
+	return colorizedWriter(func(msg []byte) (int, error) {
+		for _, line := range bytes.Split(msg, []byte{'\n'}) {
+			if len(line) == 0 {
+				continue
+			}
+			buf.Reset()
+
+			if submatch := logLevelRgx.FindSubmatch(line); submatch != nil {
+				color.Fprint(&buf, prefix)
+				logLevelColors[string(submatch[1])].Fprintln(&buf, string(line))
+				writer.Write(buf.Bytes())
+				continue
+			}
+
+			color.Fprint(&buf, prefix)
+			buf.Write(line)
+			buf.WriteByte('\n')
+			writer.Write(buf.Bytes())
+		}
+		return len(msg), nil
+	})
+}

--- a/cli/running/writer_test.go
+++ b/cli/running/writer_test.go
@@ -1,0 +1,27 @@
+package running
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewColorizedPrefixWriter(t *testing.T) {
+	var buf bytes.Buffer
+	wr := NewColorizedPrefixWriter(&buf, *color.New(color.FgGreen), "prefix ")
+	wr.Write([]byte("hello\n"))
+	wr.Write([]byte(" E> world\n"))
+
+	var expected bytes.Buffer
+	clr := color.New(color.FgGreen)
+
+	clr.Fprint(&expected, "prefix ")
+	expected.WriteString("hello\n")
+
+	clr.Fprint(&expected, "prefix ")
+	clr.Add(color.FgRed, color.Bold)
+	clr.Fprint(&expected, " E> world\n")
+	assert.Equal(t, expected.Bytes(), buf.Bytes())
+}

--- a/cli/tail/color.go
+++ b/cli/tail/color.go
@@ -8,11 +8,12 @@ type ColorPicker func() color.Color
 // DefaultColorPicker create a color picker to get a color from a default colors set.
 func DefaultColorPicker() ColorPicker {
 	var colorTable = []color.Color{
-		*color.New(color.FgCyan),
-		*color.New(color.FgGreen),
-		*color.New(color.FgMagenta),
-		*color.New(color.FgYellow),
+		*color.New(color.FgHiBlue),
+		*color.New(color.FgHiCyan),
+		*color.New(color.FgHiMagenta),
 		*color.New(color.FgBlue),
+		*color.New(color.FgCyan),
+		*color.New(color.FgMagenta),
 	}
 
 	i := 0

--- a/cli/ttlog/logger_test.go
+++ b/cli/ttlog/logger_test.go
@@ -15,9 +15,10 @@ func TestLoggerBase(t *testing.T) {
 	fileName := filepath.Join(tmpDir, "test_log")
 
 	// Create logger.
-	opts := LoggerOpts{fileName, "watchdog"}
-	logger := NewLogger(opts)
-	// Write one test message to create a log file.
+	opts := LoggerOpts{fileName, "watchdog "}
+	logger, err := NewFileLogger(opts)
+	require.NoError(t, err)
+	// Write one test message.
 	logger.Println(`Test msg 1`)
 
 	// Check the count of the log files (must be 1).
@@ -47,9 +48,30 @@ func TestLoggerBase(t *testing.T) {
 	assert.Contains(t, contentStr, "watchdog")
 	assert.Contains(t, contentStr, "Test msg 1")
 	assert.Contains(t, contentStr, "Test msg 2")
+	assert.Contains(t, contentStr, "log file has been reopened")
 
 	content, err = os.ReadFile(fileName)
 	require.NoError(t, err)
 	contentStr = string(content)
 	assert.Contains(t, contentStr, "Test msg 3")
+	assert.Contains(t, contentStr, "log file has been reopened")
+}
+
+func TestLoggerNoDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	fileName := filepath.Join(tmpDir, "dir", "subdir", "test.log")
+
+	opts := LoggerOpts{fileName, "watchdog "}
+	logger, err := NewFileLogger(opts)
+	require.NoError(t, err)
+	logger.Println(`Test msg 1`)
+
+	require.FileExists(t, fileName)
+	assert.NoError(t, logger.Close())
+
+	content, err := os.ReadFile(fileName)
+	require.NoError(t, err)
+	contentStr := string(content)
+	assert.Contains(t, contentStr, "watchdog")
+	assert.Contains(t, contentStr, "Test msg 1")
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/dave/jennifer v1.5.0
 	github.com/docker/docker v26.0.0+incompatible
 	github.com/fatih/color v1.13.0
+	github.com/google/uuid v1.4.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/magefile/mage v1.12.1
@@ -18,6 +19,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c
+	github.com/nxadm/tail v1.4.11
 	github.com/otiai10/copy v1.14.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
@@ -28,6 +30,7 @@ require (
 	github.com/tarantool/tt/lib/integrity v0.0.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/yuin/gopher-lua v1.1.1-0.20230219103905-71163b697a8f
+	go.etcd.io/etcd/api/v3 v3.5.12
 	go.etcd.io/etcd/client/pkg/v3 v3.5.12
 	go.etcd.io/etcd/client/v3 v3.5.12
 	go.etcd.io/etcd/tests/v3 v3.5.12
@@ -35,7 +38,6 @@ require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sys v0.17.0
 	golang.org/x/term v0.15.0
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -70,7 +72,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/uuid v1.4.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
@@ -93,7 +94,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -119,7 +119,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.8 // indirect
-	go.etcd.io/etcd/api/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.12 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.12 // indirect
 	go.etcd.io/etcd/raft/v3 v3.5.12 // indirect
@@ -148,6 +147,7 @@ require (
 	google.golang.org/grpc v1.61.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,7 +135,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -191,8 +190,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -339,15 +336,9 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1:YWuSjZCQAPM8UUBLkYUk1e+rZcvWHJmFb6i6rM44Xs8=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/otiai10/copy v1.7.1 h1:SOSQHrLZhfpeL5djcKMDPVdYQbEiNYFNPdmdffR8tXs=
-github.com/otiai10/copy v1.7.1/go.mod h1:hsfX19wcn0UWIHUQ3/4fHuehhk2UyArQ9dVFAn3FczI=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/otiai10/mint v1.4.0 h1:umwcf7gbpEwf7WFzqmWwSv0CzbeMsae2u9ZvpP8j2q4=
-github.com/otiai10/mint v1.4.0/go.mod h1:gifjb2MYOoULtKLqUAEILUG/9KONW6f7YsJ6vQLTlFI=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/integration/log/test_log.py
+++ b/test/integration/log/test_log.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from utils import config_name
+from utils import config_name, wait_for_lines_in_output
 
 
 @pytest.fixture(scope="function")
@@ -187,31 +187,6 @@ def test_log_no_inst(tt_cmd, mock_env_dir):
     output = process.stdout.read()
 
     assert 'app0:inst4: instance(s) not found' in output
-
-
-def wait_for_lines_in_output(stdout, expected_lines):
-    output = ''
-    retries = 10
-    found = 0
-    while True:
-        line = stdout.readline()
-        if line == '':
-            if retries == 0:
-                break
-            time.sleep(0.2)
-            retries -= 1
-        else:
-            retries = 10
-            output += line
-            for expected in expected_lines:
-                if expected in line:
-                    found += 1
-                    break
-
-            if found == len(expected_lines):
-                break
-
-    return output
 
 
 def test_log_output_default_follow(tt_cmd, mock_env_dir):

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import signal
 import subprocess
 import tempfile
 
@@ -12,7 +13,8 @@ from retry import retry
 from utils import (config_name, control_socket, extract_status, initial_snap,
                    initial_xlog, kill_child_process, lib_path, log_file,
                    log_path, pid_file, run_command_and_get_output, run_path,
-                   wait_file, wait_instance_start, wait_instance_stop)
+                   wait_file, wait_for_lines_in_output, wait_instance_start,
+                   wait_instance_stop)
 
 
 def test_running_base_functionality(tt_cmd, tmpdir_with_cfg):
@@ -927,3 +929,43 @@ def test_kill_without_app_name(tt_cmd, tmp_path, cmd, input):
     finally:
         stop = [tt_cmd, "stop"]
         run_command_and_get_output(stop, cwd=test_app_path)
+
+
+def test_start_interactive(tt_cmd, tmp_path):
+    test_app_path_src = os.path.join(os.path.dirname(__file__), "multi_inst_app")
+
+    tmp_path /= "multi_inst_app"
+    shutil.copytree(test_app_path_src, tmp_path)
+
+    start_cmd = [tt_cmd, "start", "-i"]
+    instance_process = subprocess.Popen(
+        start_cmd,
+        cwd=tmp_path,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    try:
+        wait_for_lines_in_output(instance_process.stdout, [
+            "multi_inst_app:router custom init file...",
+            "multi_inst_app:router multi_inst_app:router",
+            "multi_inst_app:master multi_inst_app:master",
+            "multi_inst_app:replica multi_inst_app:replica",
+            "multi_inst_app:stateboard unknown instance",
+        ])
+
+        instance_process.send_signal(signal.SIGTERM)
+
+        wait_for_lines_in_output(instance_process.stdout, [
+            "multi_inst_app:router stopped",
+            "multi_inst_app:master stopped",
+            "multi_inst_app:replica stopped",
+            "multi_inst_app:stateboard stopped",
+        ])
+
+        # Make sure no log dir created.
+        assert not (tmp_path / "var" / "log").exists()
+
+    finally:
+        run_command_and_get_output([tt_cmd, "stop"], cwd=tmp_path)
+        assert instance_process.wait(5) == 0

--- a/test/utils.py
+++ b/test/utils.py
@@ -526,3 +526,27 @@ def wait_string_in_file(file, text):
                     break
             lines = fp.readlines(100)
         assert found
+
+
+def wait_for_lines_in_output(stdout, expected_lines: list):
+    output = ''
+    retries = 10
+    while True:
+        line = stdout.readline()
+        if line == '':
+            if retries == 0:
+                break
+            time.sleep(0.2)
+            retries -= 1
+        else:
+            retries = 10
+            output += line
+            for expected in expected_lines:
+                if expected in line:
+                    expected_lines.remove(expected)
+                    break
+
+            if len(expected_lines) == 0:
+                break
+
+    return output


### PR DESCRIPTION
    This patch adds support for `tt start` interactive mode with
    `-i/--interactive` flag. In this mode `tt` will wait for
    child Tarantool process completions. Standard output will be
    used instead of the default log files. Use Ctrl-C combination
    to stop `tt` and its child Tarantool instances. No watchdog
    processes created.
    
![2024-07-12_14-25](https://github.com/user-attachments/assets/0deb0367-b92c-4456-84df-2c5826ec0d56)
