### PR TITLE
test: add tests for tcs cluster publish/show

### DIFF
--- a/test/etcd_helper.py
+++ b/test/etcd_helper.py
@@ -3,17 +3,21 @@ import subprocess
 
 import etcd3
 
-etcd_username = "root"
-etcd_password = "password"
+DEFAULT_ETCD_USERNAME = "root"
+DEFAULT_ETCD_PASSWORD = "password"
 
 
 class EtcdInstance():
-    def __init__(self, host, port, workdir):
+    def __init__(self, host, port, workdir,
+                 username=DEFAULT_ETCD_USERNAME,
+                 password=DEFAULT_ETCD_PASSWORD):
         self.host = host
         self.port = port
         self.workdir = workdir
         self.endpoint = f"http://{self.host}:{self.port}"
         self.popen = None
+        self.connection_username = username
+        self.connection_password = password
 
     def start(self):
         popen = subprocess.Popen(
@@ -57,11 +61,11 @@ class EtcdInstance():
         # authentication enabled in latest python versions. So we need a separate steps
         # to upload/fetch data to/from etcd via the client.
         try:
-            subprocess.run(["etcdctl", "user", "add", etcd_username,
-                           f"--new-user-password={etcd_password}",
+            subprocess.run(["etcdctl", "user", "add", self.connection_username,
+                           f"--new-user-password={self.connection_password}",
                             f"--endpoints={self.endpoint}"])
             subprocess.run(["etcdctl", "auth", "enable",
-                           f"--user={etcd_username}:{etcd_password}",
+                           f"--user={self.connection_username}:{self.connection_password}",
                             f"--endpoints={self.endpoint}"])
         except Exception as ex:
             self.stop()
@@ -69,5 +73,5 @@ class EtcdInstance():
 
     def disable_auth(self):
         subprocess.run(["etcdctl", "auth", "disable",
-                        f"--user={etcd_username}:{etcd_password}",
+                        f"--user={self.connection_username}:{self.connection_password}",
                         f"--endpoints={self.endpoint}"])

--- a/test/integration/cluster/test_cluster_demote.py
+++ b/test/integration/cluster/test_cluster_demote.py
@@ -1,5 +1,5 @@
 import pytest
-from etcd_helper import etcd_password, etcd_username
+from etcd_helper import DEFAULT_ETCD_PASSWORD, DEFAULT_ETCD_USERNAME
 
 from utils import run_command_and_get_output
 
@@ -133,18 +133,21 @@ def test_cluster_demote_auth(tt_cmd, tmpdir_with_cfg, etcd, auth):
 
         if auth == "url":
             env = None
-            url = f"http://{etcd_username}:{etcd_password}@{etcd.host}:{etcd.port}/prefix?timeout=5"
+            url = (
+                f"http://{DEFAULT_ETCD_USERNAME}:{DEFAULT_ETCD_PASSWORD}@"
+                f"{etcd.host}:{etcd.port}/prefix?timeout=5"
+            )
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
         elif auth == "flag":
             env = None
             url = f"{etcd.endpoint}/prefix?timeout=5"
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f",
-                          "-u", etcd_username,
-                          "-p", etcd_password,
+                          "-u", DEFAULT_ETCD_USERNAME,
+                          "-p", DEFAULT_ETCD_PASSWORD,
                           url, "instance-001"]
         elif auth == "env":
-            env = {"TT_CLI_ETCD_USERNAME": etcd_username,
-                   "TT_CLI_ETCD_PASSWORD": etcd_password}
+            env = {"TT_CLI_ETCD_USERNAME": DEFAULT_ETCD_USERNAME,
+                   "TT_CLI_ETCD_PASSWORD": DEFAULT_ETCD_PASSWORD}
             url = f"{etcd.endpoint}/prefix?timeout=5"
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
 

--- a/test/integration/cluster/test_cluster_promote.py
+++ b/test/integration/cluster/test_cluster_promote.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from etcd_helper import etcd_password, etcd_username
+from etcd_helper import DEFAULT_ETCD_PASSWORD, DEFAULT_ETCD_USERNAME
 
 from utils import read_kv, run_command_and_get_output
 
@@ -257,18 +257,21 @@ def test_cluster_promote_auth(tt_cmd, etcd, tmpdir_with_cfg, auth):
 
         if auth == "url":
             env = None
-            url = f"http://{etcd_username}:{etcd_password}@{etcd.host}:{etcd.port}/prefix?timeout=5"
+            url = (
+                f"http://{DEFAULT_ETCD_USERNAME}:{DEFAULT_ETCD_PASSWORD}@"
+                f"{etcd.host}:{etcd.port}/prefix?timeout=5"
+            )
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
         elif auth == "flag":
             env = None
             url = f"{etcd.endpoint}/prefix?timeout=5"
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f",
-                           "-u", etcd_username,
-                           "-p", etcd_password,
+                           "-u", DEFAULT_ETCD_USERNAME,
+                           "-p", DEFAULT_ETCD_PASSWORD,
                            url, "instance-002"]
         elif auth == "env":
-            env = {"TT_CLI_ETCD_USERNAME": etcd_username,
-                   "TT_CLI_ETCD_PASSWORD": etcd_password}
+            env = {"TT_CLI_ETCD_USERNAME": DEFAULT_ETCD_USERNAME,
+                   "TT_CLI_ETCD_PASSWORD": DEFAULT_ETCD_PASSWORD}
             url = f"{etcd.endpoint}/prefix?timeout=5"
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
 

--- a/test/integration/cluster/test_tcs_app/config.yaml
+++ b/test/integration/cluster/test_tcs_app/config.yaml
@@ -1,0 +1,37 @@
+credentials:
+  users:
+    replicator:
+      password: 'topsecret'
+      roles: [replication]
+    client:
+      password: 'secret'
+      privileges:
+        - permissions: [execute]
+          universe: true
+        - permissions: [read, write]
+          spaces: [config_storage, config_storage_meta]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+
+replication:
+  failover: election
+
+database:
+  use_mvcc_engine: true
+
+groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        roles: [config.storage]
+        roles_cfg:
+          config_storage:
+            status_check_interval: 3
+        instances:
+          instance-001:
+            iproto:
+              listen: 
+              - uri: '127.0.0.1:3303'

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -9,7 +9,8 @@ import psutil
 import pytest
 
 from utils import (control_socket, create_tt_config, get_tarantool_version,
-                   kill_procs, run_command_and_get_output, run_path, wait_file)
+                   is_tarantool_ee, kill_procs, run_command_and_get_output,
+                   run_path, wait_file)
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
 BINARY_PORT_NAME = "tarantool.sock"
@@ -152,19 +153,6 @@ def is_tuple_format_supported(tt_cmd, tmpdir):
     ok, major, minor, patch = get_version(tt_cmd, tmpdir)
     assert ok
     return major > 3 or (major == 3 and minor >= 2)
-
-
-def is_tarantool_ee():
-    cmd = ["tarantool", "--version"]
-    instance_process = subprocess.run(
-        cmd,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True
-    )
-    if instance_process.returncode == 0:
-        return "Tarantool Enterprise" in instance_process.stdout
-    return False
 
 
 def is_tarantool_major_one():

--- a/test/integration/play/test_play.py
+++ b/test/integration/play/test_play.py
@@ -16,7 +16,7 @@ def test_instance(request, tmp_path):
     test_app_path = os.path.join(dir, "test_file")
     lua_utils_path = os.path.join(dir, "..", "..")
     inst = TarantoolTestInstance(INSTANCE_NAME, test_app_path, lua_utils_path, tmp_path)
-    inst.start()
+    inst.start(use_lua=True)
     request.addfinalizer(lambda: inst.stop())
     return inst
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -209,14 +209,22 @@ class TarantoolTestInstance:
         # Copy the instance config files to the run pytest tmpdir directory.
         shutil.copytree(instance_cfg_file_dir, tmpdir, dirs_exist_ok=True)
         # Copy the lua module with the auxiliary functions required by the instance config file.
-        shutil.copy(os.path.join(path_to_lua_utils, "utils.lua"), tmpdir)
+        if os.path.isfile(os.path.join(path_to_lua_utils, "utils.lua")):
+            shutil.copy(os.path.join(path_to_lua_utils, "utils.lua"), tmpdir)
 
         self._tmpdir = tmpdir
         self._instance_cfg_file_name = instance_cfg_file_name
 
-    def start(self, connection_test=True,
-              connection_test_user='guest',
-              connection_test_password=None):
+    def start(
+        self,
+        connection_test=True,
+        connection_test_user="guest",
+        connection_test_password=None,
+        instance_name=None,
+        instance_port="",
+        instance_host="localhost",
+        use_lua=False,
+    ):
         """Starts tarantool test instance and init self.port attribute.
 
         Args:
@@ -224,6 +232,13 @@ class TarantoolTestInstance:
             made to connect to the test instance within a three second deadline. (default is True)
         connection_test_user (str): username for the connection attempt. (default is 'guest')
         connection_test_password (str): password for the connection attempt. (default is None)
+        instance_name (str): name of instance will be started. (default is None)
+        instance_port (str): port which will try to connect to instance. If check is successful,
+            set it into class field. (default is empty string)
+        instance_host (str): host which will try to connect to instance. If check is successful,
+            set it into class field. (default is empty string)
+        use_lua (bool): needs to specify if we want to start tarantool with lua configuration
+            even if tarantool major version more than 3. (default is false)
 
         Raises:
             RuntimeError:
@@ -234,21 +249,45 @@ class TarantoolTestInstance:
                 instance within three seconds deadline after port bound (an attempt to connect is
                 made if there is an option connection_test=True that is present by default).
         """
-        popen_obj = subprocess.Popen(["tarantool", self._instance_cfg_file_name], cwd=self._tmpdir)
-        file_with_port_path = str(self._tmpdir) + '/' + self._instance_cfg_file_name + '.port'
-
-        # Waiting 3 seconds for instance configure itself and dump bound port to temp file.
-        deadline = time.time() + 3
-        while time.time() < deadline:
-            if os.path.exists(file_with_port_path) and os.path.getsize(file_with_port_path) > 0:
-                break
-            time.sleep(0.1)
+        tnt_start_cmd = []
+        major_version, _ = get_tarantool_version()
+        if major_version < 3 or use_lua:
+            if instance_name != "" and (".yml" in self._instance_cfg_file_name or
+                                        ".yaml" in self._instance_cfg_file_name):
+                raise Exception("instance_name cannot be used with Tarantool version < 3")
+            tnt_start_cmd = ["tarantool", self._instance_cfg_file_name]
         else:
-            raise RuntimeError('Could not find a file with an instance bound port or empty file')
+            tnt_start_cmd = [
+                "tarantool",
+                "--name",
+                instance_name,
+                "--config",
+                self._instance_cfg_file_name,
+            ]
+        popen_obj = subprocess.Popen(tnt_start_cmd, cwd=self._tmpdir)
 
-        # Read bound port of test instance from file in temp pytest directory.
-        with open(file_with_port_path) as file_with_port:
-            instance_port = file_with_port.read()
+        # Search for file with port only if port directly not provided.
+        if len(instance_port) == 0:
+            file_with_port_path = (
+                str(self._tmpdir) + "/" + self._instance_cfg_file_name + ".port"
+            )
+            # Waiting 3 seconds for instance configure itself and dump bound port to temp file.
+            deadline = time.time() + 3
+            while time.time() < deadline:
+                if (
+                    os.path.exists(file_with_port_path)
+                    and os.path.getsize(file_with_port_path) > 0
+                ):
+                    break
+                time.sleep(0.1)
+            else:
+                raise RuntimeError(
+                    "Could not find a file with an instance bound port or empty file"
+                )
+
+            # Read bound port of test instance from file in temp pytest directory.
+            with open(file_with_port_path) as file_with_port:
+                instance_port = file_with_port.read()
 
         # Tries connect to the started instance during 3 seconds deadline with bound port.
         if connection_test:
@@ -266,7 +305,11 @@ class TarantoolTestInstance:
                 raise RuntimeError('Could not connect to the started instance with bound port')
 
         self.popen_obj = popen_obj
+        self.host = instance_host
         self.port = instance_port
+        self.connection_username = connection_test_user
+        self.connection_password = connection_test_password
+        self.endpoint = f"http://{self.host}:{self.port}"
 
     def stop(self):
         """Stops tarantool test instance by SIGKILL signal.
@@ -287,6 +330,20 @@ class TarantoolTestInstance:
                 time.sleep(0.1)
         else:
             raise RuntimeError("PID {} couldn't stop after receiving SIGKILL".format(instance.pid))
+
+    def conn(self):
+        """Connects to self instance set in class."""
+        conn = tarantool.Connection
+        try:
+            conn = tarantool.connect(
+                self.host,
+                int(self.port),
+                user=self.connection_username,
+                password=self.connection_password,
+            )
+        except Exception:
+            raise Exception("cannot connect to instance with provided params")
+        return conn
 
 
 def is_ipv4_type(address):
@@ -434,3 +491,21 @@ def read_kv(dirname):
         with open(os.path.join(dirname, filename), "r") as f:
             kvs[key] = f.read()
     return kvs
+
+
+def is_tarantool_less_3():
+    major_versoin, _ = get_tarantool_version()
+    return True if major_versoin < 3 else False
+
+
+def is_tarantool_ee():
+    cmd = ["tarantool", "--version"]
+    instance_process = subprocess.run(
+        cmd,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    if instance_process.returncode == 0:
+        return "Tarantool Enterprise" in instance_process.stdout
+    return False


### PR DESCRIPTION
There were integration tests for `tt cluster publish/show` only for `etcd` and weren't for Tarantool Config Storage.

Due to the same interface tests have been parametrised to do the same business logic for different storages.

Closes #716