### PR TITLE
cli: add integrity-check-period flag in global context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Do not create Dockerfile.* in application's directory.
-- Updated `luarocks` to `v3.10.0`.
 
 ## [2.3.1] - 2024-06-13
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -155,6 +155,7 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		false, "Skip cli interaction using default behavior")
 
 	integrity.RegisterIntegrityCheckFlag(rootCmd.Flags(), &cmdCtx.Cli.IntegrityCheck)
+	integrity.RegisterIntegrityCheckPeriodFlag(rootCmd.Flags(), &cmdCtx.Cli.IntegrityCheckPeriod)
 
 	rootCmd.Flags().SetInterspersed(false)
 

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -106,6 +106,8 @@ type CliCtx struct {
 	TarantoolCli TarantoolCli
 	// IntegrityCheck is a public key used for integrity check.
 	IntegrityCheck string
+	// IntegrityCheckPeriod is an period during which the integrity check is reproduced.
+	IntegrityCheckPeriod int
 	// This flag disables searching of other tt versions to run
 	// instead of the current one.
 	IsSelfExec bool

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -352,6 +352,13 @@ func ValidateCliOpts(cliCtx *cmdcontext.CliCtx) error {
 				"you can specify only one of -S(--system), -c(--cfg) and 'TT_CLI_CFG' options")
 		}
 	}
+	if len(cliCtx.IntegrityCheck) == 0 && cliCtx.IntegrityCheckPeriod != 0 {
+		return fmt.Errorf("need to specify public key in --integrity-check to " +
+			"use --integrity-check-period")
+	}
+	if cliCtx.IntegrityCheckPeriod < 0 {
+		return fmt.Errorf("--integrity-check-period must take non-negative value")
+	}
 	return nil
 }
 

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -177,7 +177,6 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) err
 	rocks_preload := map[string]string{
 		"extra.wrapper":                    extra_path + "wrapper.lua",
 		"luarocks.core.hardcoded":          extra_path + "hardcoded.lua",
-		"luarocks.vendor.dkjson":           rocks_path + "luarocks/vendor/dkjson.lua",
 		"luarocks.core.util":               rocks_path + "luarocks/core/util.lua",
 		"luarocks.core.persist":            rocks_path + "luarocks/core/persist.lua",
 		"luarocks.core.sysdetect":          rocks_path + "luarocks/core/sysdetect.lua",

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -277,7 +277,7 @@ def test_rock_install_with_non_system_tarantool_in_path(tt_cmd, tmpdir_with_tara
                 PATH=os.path.join(tmpdir_with_tarantool, 'bin') + ':' + os.environ['PATH']))
 
         assert rc == 1  # Tarantool headers are not found.
-        assert re.search("Could not find header file for TARANTOOL", output)
+        assert re.search("Error: Failed finding Lua header files", output)
 
         # Set env var to find tarantool headers.
         rocks_cmd = [tt_cmd, "rocks", "install", "crud", "1.1.1-1"]


### PR DESCRIPTION
It was impossible to provide integrity check period in `tt restart`. After the patch flag "--integrity-check-period" is locating in the global cli context.

Part of https://github.com/tarantool/tt-ee/issues/203