### PR TITLE
ci: add step with killing tarantool after tests

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -206,6 +206,12 @@ jobs:
           ETCD_TT_BIN=${ETCD_PATH}etcd;
           pkill -SIGINT -f ${ETCD_TT_BIN} || true
 
+      - name: Kill tarantool, if it was left
+        if: always()
+        run: |
+          TARANTOOL_BIN=${GITHUB_WORKSPACE}/bin/tarantool;
+          pkill -SIGINT -f ${TARANTOOL_BIN} || true
+
   # ee suffix means that the job runs ee integration tests.
   full-ci-macOS-ee:
     if: |


### PR DESCRIPTION
There were still tarantool processes running after all tests were completed. After the patch all not killed instances of tarantool will be killed in CI pipeline.