### PR TITLE
replicaset: add tests for tarantool config storage

### DIFF
--- a/test/integration/cluster/test_cluster_demote.py
+++ b/test/integration/cluster/test_cluster_demote.py
@@ -1,7 +1,11 @@
 import pytest
-from etcd_helper import DEFAULT_ETCD_PASSWORD, DEFAULT_ETCD_USERNAME
+from tarantool.connection import os
 
-from utils import run_command_and_get_output
+from utils import (get_fixture_tcs_params, is_tarantool_ee,
+                   is_tarantool_less_3, run_command_and_get_output)
+
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
 
 
 def to_etcd_key(key):
@@ -31,20 +35,41 @@ groups:
 """
 
 
-def test_cluster_demote_single_key(tt_cmd, tmpdir_with_cfg, etcd):
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_demote_single_key(tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
-    etcdcli = etcd.conn()
+    conn = instance.conn()
     key = to_etcd_key("all")
-    etcdcli.put(key, cfg1)
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+    if instance_name == "etcd":
+        conn.put(key, cfg1)
+    else:
+        conn.call("config.storage.put", key, cfg1)
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+    )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
     rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir)
     assert rc == 0
     assert f'Patching the config by the key: "{key}"' in out
 
-    actual, _ = etcdcli.get(key)
-    actual = actual.decode("utf-8")
-    assert actual == """\
+    content = ""
+    if instance_name == "etcd":
+        content, _ = conn.get(key)
+        content = content.decode("utf-8")
+    else:
+        content = conn.call("config.storage.get", key)
+        if len(content) > 0:
+            content = content[0]["data"][0]["value"]
+    assert content == """\
 groups:
   group-001:
     replicasets:
@@ -56,15 +81,40 @@ groups:
 """
 
 
-@pytest.mark.parametrize("key", [None, "b"])
-def test_cluster_demote_many_keys(tt_cmd, tmpdir_with_cfg, etcd, key):
+@pytest.mark.parametrize("instance_name, key", [
+    ("etcd", None),
+    ("etcd", "b"),
+    ("tcs", None),
+    ("tcs", "b"),
+])
+def test_cluster_demote_many_keys(tt_cmd,
+                                  tmpdir_with_cfg,
+                                  key,
+                                  instance_name,
+                                  request,
+                                  fixture_params):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
-    etcdcli = etcd.conn()
+    conn = instance.conn()
     a_key = to_etcd_key("a")
     b_key = to_etcd_key("b")
-    etcdcli.put(a_key, cfg1)
-    etcdcli.put(b_key, cfg2)
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+    if instance_name == "etcd":
+        conn.put(a_key, cfg1)
+        conn.put(b_key, cfg2)
+    else:
+        conn.call("config.storage.put", a_key, cfg1)
+        conn.call("config.storage.put", b_key, cfg2)
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+        )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     if key:
         url = f"{url}&key={key}"
     demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-002"]
@@ -72,13 +122,24 @@ def test_cluster_demote_many_keys(tt_cmd, tmpdir_with_cfg, etcd, key):
     assert rc == 0
     assert f'Patching the config by the key: "{b_key}"' in out
 
-    actual, _ = etcdcli.get(a_key)
-    actual = actual.decode("utf-8")
-    assert actual == cfg1  # Nothing was changed.
+    content = ""
+    if instance_name == "etcd":
+        content, _ = conn.get(a_key)
+        content = content.decode("utf-8")
+    else:
+        content = conn.call("config.storage.get", a_key)
+        if len(content) > 0:
+            content = content[0]["data"][0]["value"]
+    assert content == cfg1  # Nothing was changed.
 
-    actual, _ = etcdcli.get(b_key)
-    actual = actual.decode("utf-8")
-    assert actual == """\
+    if instance_name == "etcd":
+        content, _ = conn.get(b_key)
+        content = content.decode("utf-8")
+    else:
+        content = conn.call("config.storage.get", b_key)
+        if len(content) > 0:
+            content = content[0]["data"][0]["value"]
+    assert content == """\
 groups:
   group-001:
     replicasets:
@@ -90,76 +151,147 @@ groups:
 """
 
 
-def test_cluster_demote_no_auth(tt_cmd, tmpdir_with_cfg, etcd):
+@pytest.mark.parametrize("instance_name, err_msg", [
+    ("etcd", "⨯ failed to collect cluster config: " +
+             "failed to fetch data from etcd: etcdserver: user name is empty"),
+    ("tcs", "⨯ failed to collect cluster config: failed to fetch data from tarantool:" +
+            " Execute access to function 'config.storage.get' is denied for user 'guest'")
+])
+def test_cluster_demote_no_auth(tt_cmd,
+                                tmpdir_with_cfg,
+                                instance_name,
+                                fixture_params,
+                                request,
+                                err_msg):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
 
     try:
-        etcd.enable_auth()
-        url = f"{etcd.endpoint}/prefix?timeout=5"
+        if instance_name == "etcd":
+            instance.enable_auth()
+        url = f"{instance.endpoint}/prefix?timeout=5"
         demote_cmd = [tt_cmd, "cluster", "rs", "demote", url, "instance-002"]
         rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir)
         assert rc != 0
-        expected = (r"   ⨯ failed to collect cluster config: " +
-                    "failed to fetch data from etcd: etcdserver: user name is empty")
-        assert expected in out
+        assert err_msg in out
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()
 
 
-def test_cluster_demote_bad_auth(tt_cmd, tmpdir_with_cfg, etcd):
+@pytest.mark.parametrize("instance_name, err_msg", [
+    ("etcd", "failed to connect to etcd: " +
+             "etcdserver: authentication failed, invalid user ID or password"),
+    ("tcs", "failed to establish a connection to tarantool or etcd:" +
+            " failed to connect to tarantool: failed to authenticate:")
+])
+def test_cluster_demote_bad_auth(tt_cmd,
+                                 tmpdir_with_cfg,
+                                 instance_name,
+                                 err_msg,
+                                 fixture_params,
+                                 request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
 
     try:
-        etcd.enable_auth()
-        url = f"http://invalid_user:invalid_pass@{etcd.host}:{etcd.port}/prefix?timeout=5"
+        if instance_name == "etcd":
+            instance.enable_auth()
+        url = f"http://invalid_user:invalid_pass@{instance.host}:{instance.port}/prefix?timeout=5"
         demote_cmd = [tt_cmd, "cluster", "rs", "demote", url, "instance-002"]
         rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir)
         assert rc != 0
-        expected = (r"failed to connect to etcd: " +
-                    "etcdserver: authentication failed, invalid user ID or password")
-        assert expected in out
+        # expected = (r"failed to connect to etcd: " +
+        #             "etcdserver: authentication failed, invalid user ID or password")
+        assert err_msg in out
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()
 
 
-@pytest.mark.parametrize("auth", ["url", "flag", "env"])
-def test_cluster_demote_auth(tt_cmd, tmpdir_with_cfg, etcd, auth):
+@pytest.mark.parametrize("instance_name, auth", [
+    ("etcd", "url"),
+    ("etcd", "flag"),
+    ("etcd", "env"),
+    ("tcs", "url"),
+    ("tcs", "flag"),
+    ("tcs", "env"),
+])
+def test_cluster_demote_auth(tt_cmd, tmpdir_with_cfg, instance_name, auth, fixture_params, request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
-    etcdcli = etcd.conn()
+    conn = instance.conn()
     key = to_etcd_key("all")
-    etcdcli.put(key, cfg1)
+    if instance_name == "etcd":
+        conn.put(key, cfg1)
+    else:
+        conn.call("config.storage.put", key, cfg1)
     try:
-        etcd.enable_auth()
+        if instance_name == "etcd":
+            instance.enable_auth()
 
         if auth == "url":
             env = None
             url = (
-                f"http://{DEFAULT_ETCD_USERNAME}:{DEFAULT_ETCD_PASSWORD}@"
-                f"{etcd.host}:{etcd.port}/prefix?timeout=5"
+                f"http://{instance.connection_username}:{instance.connection_password}@"
+                f"{instance.host}:{instance.port}/prefix?timeout=5"
             )
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
         elif auth == "flag":
             env = None
-            url = f"{etcd.endpoint}/prefix?timeout=5"
+            url = f"{instance.endpoint}/prefix?timeout=5"
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f",
-                          "-u", DEFAULT_ETCD_USERNAME,
-                          "-p", DEFAULT_ETCD_PASSWORD,
+                          "-u", instance.connection_username,
+                          "-p", instance.connection_password,
                           url, "instance-001"]
         elif auth == "env":
-            env = {"TT_CLI_ETCD_USERNAME": DEFAULT_ETCD_USERNAME,
-                   "TT_CLI_ETCD_PASSWORD": DEFAULT_ETCD_PASSWORD}
-            url = f"{etcd.endpoint}/prefix?timeout=5"
+            env = {
+                (
+                    "TT_CLI_ETCD_USERNAME"
+                    if instance_name == "etcd"
+                    else "TT_CLI_USERNAME"
+                ): instance.connection_username,
+                (
+                    "TT_CLI_ETCD_PASSWORD"
+                    if instance_name == "etcd"
+                    else "TT_CLI_PASSWORD"
+                ): instance.connection_password,
+            }
+            url = f"{instance.endpoint}/prefix?timeout=5"
             demote_cmd = [tt_cmd, "cluster", "rs", "demote", "-f", url, "instance-001"]
 
         rc, out = run_command_and_get_output(demote_cmd, cwd=tmpdir, env=env)
         assert rc == 0
         assert f'Patching the config by the key: "{key}"' in out
 
-        etcd.disable_auth()
-        etcdcli = etcd.conn()
-        actual, _ = etcdcli.get(to_etcd_key("all"))
-        actual = actual.decode("utf-8")
-        assert actual == """\
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+        conn = instance.conn()
+        content = ""
+        if instance_name == "etcd":
+            content, _ = conn.get(key)
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", key)
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert content == """\
 groups:
   group-001:
     replicasets:
@@ -171,4 +303,5 @@ groups:
 """
 
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()

--- a/test/integration/cluster/test_cluster_expel.py
+++ b/test/integration/cluster/test_cluster_expel.py
@@ -1,4 +1,11 @@
-from utils import run_command_and_get_output
+import pytest
+from tarantool.connection import os
+
+from utils import (get_fixture_tcs_params, is_tarantool_ee,
+                   is_tarantool_less_3, run_command_and_get_output)
+
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
 
 
 def to_etcd_key(key):
@@ -25,30 +32,71 @@ groups:
 """
 
 
-def test_cluster_expel_no_instance(tt_cmd, etcd, tmpdir_with_cfg):
-    etcdcli = etcd.conn()
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_expel_no_instance(tt_cmd, tmpdir_with_cfg, instance_name, fixture_params, request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+
+    conn = instance.conn()
     tmpdir = tmpdir_with_cfg
-    etcdcli.put(to_etcd_key("all"), cfg)
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+
+    key = to_etcd_key("all")
+    if instance_name == "etcd":
+        conn.put(key, cfg)
+    else:
+        conn.call("config.storage.put", key, cfg)
+
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+        )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-003"]
     rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc != 0
     assert 'instance "instance-003" not found in the cluster configuration' in out
 
 
-def test_cluster_expel_single_key(tt_cmd, etcd, tmpdir_with_cfg):
-    etcdcli = etcd.conn()
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_expel_single_key(tt_cmd, tmpdir_with_cfg, instance_name, fixture_params, request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+    conn = instance.conn()
     tmpdir = tmpdir_with_cfg
     key = to_etcd_key("all")
-    etcdcli.put(key, cfg)
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+    if instance_name == "etcd":
+        conn.put(key, cfg)
+    else:
+        conn.call("config.storage.put", key, cfg)
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+        )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     cmd = [tt_cmd, "cluster", "rs", "expel", "-f", url, "instance-002"]
     rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
     assert rc == 0
     assert f'Patching the config by the key: "{key}"' in out
 
-    actual, _ = etcdcli.get(key)
-    assert actual.decode("utf-8") == """\
+    if instance_name == "etcd":
+        content, _ = conn.get(key)
+        content = content.decode("utf-8")
+    else:
+        content = conn.call("config.storage.get", key)
+        if len(content) > 0:
+            content = content[0]["data"][0]["value"]
+
+    assert content == """\
 groups:
   group-1:
     replicasets:

--- a/test/integration/cluster/test_cluster_promote.py
+++ b/test/integration/cluster/test_cluster_promote.py
@@ -1,78 +1,165 @@
 import os
 
 import pytest
-from etcd_helper import DEFAULT_ETCD_PASSWORD, DEFAULT_ETCD_USERNAME
 
-from utils import read_kv, run_command_and_get_output
+from utils import (get_fixture_tcs_params, is_tarantool_ee,
+                   is_tarantool_less_3, read_kv, run_command_and_get_output)
+
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
 
 
 def to_etcd_key(key):
     return f"/prefix/config/{key}"
 
 
-@pytest.mark.parametrize("data_dir, err_text", [
+@pytest.mark.parametrize("instance_name, data_dir, err_text", [
     pytest.param(
+        "etcd",
         "off_default",
         None,
         id="failover = off; default",
     ),
     pytest.param(
+        "etcd",
         "off_multi",
         None,
         id="failover = off; multi",
     ),
     pytest.param(
+        "etcd",
         "off_explicit",
         None,
         id="failover = off; explicit",
     ),
     pytest.param(
+        "etcd",
         "off_no_diff",
         None,
         id="failover = off; nothing changes",
     ),
     pytest.param(
+        "etcd",
         "manual_no_leader",
         None,
         id="failover = maual; no leader",
     ),
     pytest.param(
+        "etcd",
         "manual",
         None,
         id="failover = manual; leader is set"
     ),
     pytest.param(
+        "etcd",
         "election",
         'unsupported failover: "election", supported: "manual", "off"',
         id="failover = election",
     ),
     pytest.param(
+        "etcd",
         "unknown",
         'unknown failover, supported: "manual", "off"',
         id="unknown failover",
     ),
     pytest.param(
+        "etcd",
         "no_instance",
         'instance "instance-002" not found in the cluster configuration',
         id="unknown instance",
     ),
     pytest.param(
+        "etcd",
+        "many_replicasets",
+        None,
+        id="many replicasets",
+    ),
+    pytest.param(
+        "tcs",
+        "off_default",
+        None,
+        id="failover = off; default",
+    ),
+    pytest.param(
+        "tcs",
+        "off_multi",
+        None,
+        id="failover = off; multi",
+    ),
+    pytest.param(
+        "tcs",
+        "off_explicit",
+        None,
+        id="failover = off; explicit",
+    ),
+    pytest.param(
+        "tcs",
+        "off_no_diff",
+        None,
+        id="failover = off; nothing changes",
+    ),
+    pytest.param(
+        "tcs",
+        "manual_no_leader",
+        None,
+        id="failover = maual; no leader",
+    ),
+    pytest.param(
+        "tcs",
+        "manual",
+        None,
+        id="failover = manual; leader is set"
+    ),
+    pytest.param(
+        "tcs",
+        "election",
+        'unsupported failover: "election", supported: "manual", "off"',
+        id="failover = election",
+    ),
+    pytest.param(
+        "tcs",
+        "unknown",
+        'unknown failover, supported: "manual", "off"',
+        id="unknown failover",
+    ),
+    pytest.param(
+        "tcs",
+        "no_instance",
+        'instance "instance-002" not found in the cluster configuration',
+        id="unknown instance",
+    ),
+    pytest.param(
+        "tcs",
         "many_replicasets",
         None,
         id="many replicasets",
     )
 ])
 def test_cluster_promote_single_key(
-    tt_cmd, etcd, tmpdir_with_cfg, data_dir, err_text,
+    tt_cmd, tmpdir_with_cfg, data_dir, err_text, instance_name, fixture_params, request
 ):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     test_data_dir = os.path.join(os.path.dirname(__file__), "testdata", "promote",
                                  "single_key", data_dir)
     kv = read_kv(test_data_dir)
     init_cfg = kv["init"]
     tmpdir = tmpdir_with_cfg
-    etcdcli = etcd.conn()
-    etcdcli.put("/prefix/config/all", init_cfg)
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+    conn = instance.conn()
+    if instance_name == "etcd":
+        conn.put("/prefix/config/all", init_cfg)
+    else:
+        conn.call("config.storage.put", "/prefix/config/all", init_cfg)
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+        )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
     rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir)
 
@@ -84,44 +171,92 @@ def test_cluster_promote_single_key(
     assert 'Patching the config by the key: "/prefix/config/all"' in out
 
     expected = kv["expected"]
-    actual, _ = etcdcli.get("/prefix/config/all")
-    assert expected == actual.decode("utf-8")
+    content = ""
+    if instance_name == "etcd":
+        content, _ = conn.get("/prefix/config/all")
+        content = content.decode("utf-8")
+    else:
+        content = conn.call("config.storage.get", "/prefix/config/all")
+        if len(content) > 0:
+            content = content[0]["data"][0]["value"]
+    assert content == expected
 
 
-@pytest.mark.parametrize("data_dir, exp_key, err_text", [
+@pytest.mark.parametrize("instance_name, data_dir, exp_key, err_text", [
     pytest.param(
+        "etcd",
         "off_lexi_order",
         "a",
         None,
         id="failover = off; lexi order",
     ),
     pytest.param(
+        "etcd",
         "off_priority_order",
         "c",
         None,
         id="failover = off; priority order",
     ),
     pytest.param(
+        "etcd",
         "manual_priority_order",
         "b",
         None,
         id="failover = manual; priority order",
     ),
     pytest.param(
+        "etcd",
         "no_instance",
         None,
         'instance "instance-002" not found in the cluster configuration',
         id="instance not found among keys",
-    )
+    ),
+    pytest.param(
+        "tcs",
+        "off_lexi_order",
+        "a",
+        None,
+        id="failover = off; lexi order",
+    ),
+    pytest.param(
+        "tcs",
+        "off_priority_order",
+        "c",
+        None,
+        id="failover = off; priority order",
+    ),
+    pytest.param(
+        "tcs",
+        "manual_priority_order",
+        "b",
+        None,
+        id="failover = manual; priority order",
+    ),
+    pytest.param(
+        "tcs",
+        "no_instance",
+        None,
+        'instance "instance-002" not found in the cluster configuration',
+        id="instance not found among keys",
+    ),
 ])
 def test_cluster_promote_many_keys(
-    tt_cmd, etcd,
+    tt_cmd,
     tmpdir_with_cfg,
     data_dir,
     exp_key,
     err_text,
+    instance_name,
+    fixture_params,
+    request
 ):
-    etcdcli = etcd.conn()
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+    conn = instance.conn()
     tmpdir = tmpdir_with_cfg
     test_data_dir = os.path.join(os.path.dirname(__file__), "testdata", "promote",
                                  "many_keys", data_dir)
@@ -129,14 +264,22 @@ def test_cluster_promote_many_keys(
     exp_config = None
     for k, v in kvs.items():
         if k != "expected":
-            etcdcli.put(to_etcd_key(k), v)
+            if instance_name == "etcd":
+                conn.put(to_etcd_key(k), v)
+            else:
+                conn.call("config.storage.put", to_etcd_key(k), v)
         else:
             exp_config = v
     if not err_text:
         assert exp_config
         del kvs["expected"]
 
-    url = f"{etcd.endpoint}/prefix?timeout=5"
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+        )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?timeout=5"
     promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
 
     rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir)
@@ -153,12 +296,29 @@ def test_cluster_promote_many_keys(
     expected_kv[exp_key] = exp_config
 
     for k, v in expected_kv.items():
-        actual, _ = etcdcli.get(to_etcd_key(k))
-        assert v == actual.decode("utf-8")
+        if instance_name == "etcd":
+            content, _ = conn.get(to_etcd_key(k))
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", to_etcd_key(k))
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert content == v
 
 
-def test_cluster_promote_key_specified(tt_cmd, etcd, tmpdir_with_cfg):
-    etcdcli = etcd.conn()
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_promote_key_specified(tt_cmd,
+                                       tmpdir_with_cfg,
+                                       instance_name,
+                                       fixture_params,
+                                       request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+    conn = instance.conn()
     tmpdir = tmpdir_with_cfg
     test_data_dir = os.path.join(os.path.dirname(__file__), "testdata", "promote",
                                  "many_keys", "key_specified")
@@ -166,13 +326,21 @@ def test_cluster_promote_key_specified(tt_cmd, etcd, tmpdir_with_cfg):
     exp_config = None
     for k, v in kvs.items():
         if k != "expected":
-            etcdcli.put(to_etcd_key(k), v)
+            if instance_name == "etcd":
+                conn.put(to_etcd_key(k), v)
+            else:
+                conn.call("config.storage.put", to_etcd_key(k), v)
         else:
             exp_config = v
     assert exp_config
     del kvs["expected"]
 
-    url = f"{etcd.endpoint}/prefix?key=b&timeout=5"
+    creds = (
+            f"{instance.connection_username}:{instance.connection_password}@"
+            if instance_name == "tcs"
+            else ""
+    )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix?key=b&timeout=5"
     promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
 
     rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir)
@@ -187,40 +355,81 @@ def test_cluster_promote_key_specified(tt_cmd, etcd, tmpdir_with_cfg):
     expected_kv["b"] = exp_config
 
     for k, v in expected_kv.items():
-        actual, _ = etcdcli.get(to_etcd_key(k))
-        assert v == actual.decode("utf-8")
+        content = ""
+        if instance_name == "etcd":
+            content, _ = conn.get(to_etcd_key(k))
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", to_etcd_key(k))
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert content == v
 
 
-def test_cluster_promote_no_auth(tt_cmd, etcd, tmpdir_with_cfg):
+@pytest.mark.parametrize("instance_name, err_msg", [
+    ("etcd", "⨯ failed to collect cluster config: " +
+             "failed to fetch data from etcd: etcdserver: user name is empty"),
+    ("tcs", "⨯ failed to collect cluster config: failed to fetch data from tarantool:" +
+            " Execute access to function 'config.storage.get' is denied for user 'guest'")
+])
+def test_cluster_promote_no_auth(tt_cmd,
+                                 tmpdir_with_cfg,
+                                 instance_name,
+                                 err_msg,
+                                 fixture_params,
+                                 request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
 
     try:
-        etcd.enable_auth()
-        url = f"{etcd.endpoint}/prefix?timeout=5"
+        if instance_name == "etcd":
+            instance.enable_auth()
+        url = f"{instance.endpoint}/prefix?timeout=5"
         promote_cmd = [tt_cmd, "cluster", "rs", "promote", url, "instance-002"]
         rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir)
         assert rc != 0
-        expected = (r"   ⨯ failed to collect cluster config: " +
-                    "failed to fetch data from etcd: etcdserver: user name is empty")
-        assert expected in out
+        assert err_msg in out
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()
 
 
-def test_cluster_promote_bad_auth(tt_cmd, etcd, tmpdir_with_cfg):
+@pytest.mark.parametrize("instance_name, err_msg", [
+    ("etcd", "failed to connect to etcd: " +
+             "etcdserver: authentication failed, invalid user ID or password"),
+    ("tcs", "failed to establish a connection to tarantool or etcd:" +
+            " failed to connect to tarantool: failed to authenticate:")
+])
+def test_cluster_promote_bad_auth(tt_cmd,
+                                  tmpdir_with_cfg,
+                                  instance_name,
+                                  err_msg,
+                                  fixture_params,
+                                  request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
 
     try:
-        etcd.enable_auth()
-        url = f"http://invalid_user:invalid_pass@{etcd.host}:{etcd.port}/prefix?timeout=5"
+        if instance_name == "etcd":
+            instance.enable_auth()
+        url = f"http://invalid_user:invalid_pass@{instance.host}:{instance.port}/prefix?timeout=5"
         promote_cmd = [tt_cmd, "cluster", "rs", "promote", url, "instance-002"]
         rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir)
         assert rc != 0
-        expected = (r"failed to connect to etcd: " +
-                    "etcdserver: authentication failed, invalid user ID or password")
-        assert expected in out
+        assert err_msg in out
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()
 
 
 test_auth_cfg_init = """\
@@ -246,43 +455,85 @@ groups:
 """
 
 
-@pytest.mark.parametrize('auth', ["url", "flag", "env"])
-def test_cluster_promote_auth(tt_cmd, etcd, tmpdir_with_cfg, auth):
+@pytest.mark.parametrize("instance_name, auth", [
+    ("etcd", "url"),
+    ("etcd", "flag"),
+    ("etcd", "env"),
+    ("tcs", "url"),
+    ("tcs", "flag"),
+    ("tcs", "env"),
+])
+def test_cluster_promote_auth(tt_cmd,
+                              tmpdir_with_cfg,
+                              instance_name,
+                              auth,
+                              fixture_params,
+                              request):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
     tmpdir = tmpdir_with_cfg
-    etcdcli = etcd.conn()
+    conn = instance.conn()
     key = to_etcd_key("all")
-    etcdcli.put(key, test_auth_cfg_init)
+    if instance_name == "etcd":
+        conn.put(key, test_auth_cfg_init)
+    else:
+        conn.call("config.storage.put", key, test_auth_cfg_init)
     try:
-        etcd.enable_auth()
+        if instance_name == "etcd":
+            instance.enable_auth()
 
         if auth == "url":
             env = None
             url = (
-                f"http://{DEFAULT_ETCD_USERNAME}:{DEFAULT_ETCD_PASSWORD}@"
-                f"{etcd.host}:{etcd.port}/prefix?timeout=5"
+                f"http://{instance.connection_username}:{instance.connection_password}@"
+                f"{instance.host}:{instance.port}/prefix?timeout=5"
             )
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
         elif auth == "flag":
             env = None
-            url = f"{etcd.endpoint}/prefix?timeout=5"
+            url = f"{instance.endpoint}/prefix?timeout=5"
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f",
-                           "-u", DEFAULT_ETCD_USERNAME,
-                           "-p", DEFAULT_ETCD_PASSWORD,
+                           "-u", instance.connection_username,
+                           "-p", instance.connection_password,
                            url, "instance-002"]
         elif auth == "env":
-            env = {"TT_CLI_ETCD_USERNAME": DEFAULT_ETCD_USERNAME,
-                   "TT_CLI_ETCD_PASSWORD": DEFAULT_ETCD_PASSWORD}
-            url = f"{etcd.endpoint}/prefix?timeout=5"
+            env = {
+                (
+                    "TT_CLI_ETCD_USERNAME"
+                    if instance_name == "etcd"
+                    else "TT_CLI_USERNAME"
+                ): instance.connection_username,
+                (
+                    "TT_CLI_ETCD_PASSWORD"
+                    if instance_name == "etcd"
+                    else "TT_CLI_PASSWORD"
+                ): instance.connection_password,
+            }
+            url = f"{instance.endpoint}/prefix?timeout=5"
             promote_cmd = [tt_cmd, "cluster", "rs", "promote", "-f", url, "instance-002"]
 
         rc, out = run_command_and_get_output(promote_cmd, cwd=tmpdir, env=env)
         assert rc == 0
         assert f'Patching the config by the key: "{key}"' in out
 
-        etcd.disable_auth()
-        etcdcli = etcd.conn()
-        actual, _ = etcdcli.get(to_etcd_key("all"))
-        assert test_auth_cfg_expected == actual.decode("utf-8")
+        if instance_name == "etcd":
+            instance.disable_auth()
+        conn = instance.conn()
+
+        content = ""
+        if instance_name == "etcd":
+            content, _ = conn.get(to_etcd_key("all"))
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", key)
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert test_auth_cfg_expected == content
 
     finally:
-        etcd.disable_auth()
+        if instance_name == "etcd":
+            instance.disable_auth()

--- a/test/integration/cluster/test_cluster_publish.py
+++ b/test/integration/cluster/test_cluster_publish.py
@@ -4,18 +4,10 @@ import subprocess
 
 import pytest
 
-import utils
+from utils import get_fixture_tcs_params, is_tarantool_ee, is_tarantool_less_3
 
-fixture_tcs_params = {
-    "path_to_cfg_dir": os.path.join(os.path.dirname(
-                                    os.path.abspath(__file__)), "test_tcs_app"),
-    "connection_test": True,
-    "connection_test_user": "client",
-    "connection_test_password": "secret",
-    "instance_name": "instance-001",
-    "instance_host": "localhost",
-    "instance_port": "3303",
-}
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
 
 
 def copy_app(tmpdir, app_name):
@@ -654,7 +646,7 @@ def test_cluster_publish_config_no_auth(
     instance_name, tt_cmd, tmpdir_with_cfg, request, expected_err_msg, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -695,7 +687,7 @@ def test_cluster_publish_config_bad_auth(
     tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -744,7 +736,7 @@ def test_cluster_publish_cluster(tt_cmd,
                                  request,
                                  fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -833,7 +825,7 @@ def test_cluster_publish_cluster(tt_cmd,
 @pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
 def test_cluster_publish_instance(tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -903,7 +895,7 @@ def test_cluster_publish_instance(tt_cmd, tmpdir_with_cfg, instance_name, reques
 @pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
 def test_cluster_publish_key(tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -979,7 +971,7 @@ def test_cluster_publish_instance_not_exist(
     tt_cmd, tmpdir_with_cfg, specify_replicaset, instance_name, request, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v

--- a/test/integration/cluster/test_cluster_show.py
+++ b/test/integration/cluster/test_cluster_show.py
@@ -439,9 +439,7 @@ def test_cluster_show_config_cluster(
         if instance_name == "etcd":
             conn.put("/prefix/config/all", config)
         else:
-            conn.insert(
-                space_name="config_storage", values=["/prefix/config/all", config, 2]
-            )
+            conn.call("config.storage.put", "/prefix/config/all", config)
 
         if auth and instance_name == "etcd":
             instance.enable_auth()
@@ -530,9 +528,7 @@ def test_cluster_show_config_instance(tt_cmd,
     if instance_name == "etcd":
         conn.put("/prefix/config/", config)
     else:
-        conn.insert(
-            space_name="config_storage", values=["/prefix/config/all", config, 2]
-        )
+        conn.call("config.storage.put", "/prefix/config/all", config)
     creds = (
         f"{instance.connection_username}:{instance.connection_password}@"
         if instance_name == "tcs"
@@ -577,10 +573,7 @@ def test_cluster_show_config_key(tt_cmd, tmpdir_with_cfg, instance_name, request
     if instance_name == "etcd":
         conn.put("/prefix/config/anykey", valid_cluster_cfg)
     else:
-        conn.insert(
-            space_name="config_storage",
-            values=["/prefix/config/anykey", valid_cluster_cfg, 2],
-        )
+        conn.call("config.storage.put", "/prefix/config/anykey", valid_cluster_cfg)
     creds = (
         f"{instance.connection_username}:{instance.connection_password}@"
         if instance_name == "tcs"
@@ -622,10 +615,7 @@ def test_cluster_show_config_key_instance(
     if instance_name == "etcd":
         conn.put("/prefix/config/anykey", valid_cluster_cfg)
     else:
-        conn.insert(
-            space_name="config_storage",
-            values=["/prefix/config/anykey", valid_cluster_cfg, 2],
-        )
+        conn.call("config.storage.put", "/prefix/config/anykey", valid_cluster_cfg)
     creds = (
         f"{instance.connection_username}:{instance.connection_password}@"
         if instance_name == "tcs"
@@ -676,9 +666,9 @@ group-001:
         instances:
 """
     if instance_name == "etcd":
-        conn.put("/prefix/config/", config)
+        conn.put("/prefix/config/all", config)
     else:
-        conn.insert(space_name="config_storage", values=["/prefix/config/", config, 2])
+        conn.call("config.storage.put", "/prefix/config/all", config)
     creds = (
         f"{instance.connection_username}:{instance.connection_password}@"
         if instance_name == "tcs"

--- a/test/integration/cluster/test_cluster_show.py
+++ b/test/integration/cluster/test_cluster_show.py
@@ -3,9 +3,11 @@ import shutil
 import subprocess
 
 import pytest
-from test_cluster_publish import fixture_tcs_params
 
-import utils
+from utils import get_fixture_tcs_params, is_tarantool_ee, is_tarantool_less_3
+
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
 
 
 def copy_app(tmpdir, app_name):
@@ -240,7 +242,7 @@ def test_cluster_show_config_no_prefix(
     tt_cmd, tmpdir_with_cfg, instance_name, request, storage_name, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -281,7 +283,7 @@ def test_cluster_show_config_no_key(
     tt_cmd, tmpdir_with_cfg, instance_name, request, storage_name, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -334,7 +336,7 @@ def test_cluster_show_config_no_auth(
     tt_cmd, tmpdir_with_cfg, instance_name, request, err_msg, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -366,7 +368,7 @@ def test_cluster_show_config_bad_auth(tt_cmd,
                                       request,
                                       fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -414,7 +416,7 @@ def test_cluster_show_config_cluster(
     tt_cmd, tmpdir_with_cfg, auth, instance_name, request, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -505,7 +507,7 @@ def test_cluster_show_config_instance(tt_cmd,
                                       request,
                                       fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -564,7 +566,7 @@ iproto:
 @pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
 def test_cluster_show_config_key(tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -609,7 +611,7 @@ def test_cluster_show_config_key_instance(
     tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v
@@ -659,7 +661,7 @@ def test_cluster_show_config_no_instance(
     tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params
 ):
     if instance_name == "tcs":
-        if utils.is_tarantool_less_3() or not utils.is_tarantool_ee():
+        if is_tarantool_less_3() or not is_tarantool_ee():
             pytest.skip()
         for k, v in fixture_tcs_params.items():
             fixture_params[k] = v

--- a/test/utils.py
+++ b/test/utils.py
@@ -24,6 +24,23 @@ initial_snap = "00000000000000000000.snap"
 initial_xlog = "00000000000000000000.xlog"
 
 
+def get_fixture_tcs_params(path_to_cfg, connection_test=True,
+                           connection_test_user="client",
+                           connection_test_password="secret",
+                           instance_name="instance-001",
+                           instance_host="localhost",
+                           instance_port="3303"):
+    return {
+        "path_to_cfg_dir": path_to_cfg,
+        "connection_test": connection_test,
+        "connection_test_user": connection_test_user,
+        "connection_test_password": connection_test_password,
+        "instance_name": instance_name,
+        "instance_host": instance_host,
+        "instance_port": instance_port,
+    }
+
+
 def run_command_and_get_output(
     cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, input=None, cwd=None, env=None
 ):


### PR DESCRIPTION
There were integration tests for `tt cluster replicaset` only for `etcd` and weren't for Tarantool Config Storage.

Due to the same interface tests have been parametrised to do the same business logic for different storages.

Closes #879