### PR TITLE
cluster: add command 'roles add'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `tt cluster replicaset roles add`: command to add roles in config scope provided by flags.
+
+### Fixed
+
+### Changed
+
 ## [2.4.0] - 2024-08-07
 
 ### Added

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -138,7 +138,8 @@ func collectTarantoolConfig(collectors libcluster.CollectorFactory,
 				time.Duration(tarantoolConfig.Timeout*float64(time.Second)))
 			if err != nil {
 				connectionErrors = append(connectionErrors,
-					fmt.Errorf("error when creating a colletor for endpoint %q: %w", opt.addr, err))
+					fmt.Errorf("error when creating a collector for endpoint %q: %w",
+						opt.addr, err))
 				continue
 			}
 

--- a/cli/cluster/cmd/replicaset.go
+++ b/cli/cluster/cmd/replicaset.go
@@ -73,8 +73,7 @@ type PromoteCtx struct {
 }
 
 // pickPatchKey prompts to select a key to patch the config.
-// If force is true, picks the first passed key.
-func pickPatchKey(keys []string, force bool) (int, error) {
+func pickPatchKey(keys []string, force bool, pathMsg string) (int, error) {
 	if len(keys) == 0 {
 		return 0, fmt.Errorf("no keys for the config patching")
 	}
@@ -82,7 +81,11 @@ func pickPatchKey(keys []string, force bool) (int, error) {
 		pos = 0
 		err error
 	)
-	if !force {
+	if !force && len(keys) != 1 {
+		label := "Select a key for the config patching"
+		if len(pathMsg) != 0 {
+			label = fmt.Sprintf("%s for destination path %q", label, pathMsg)
+		}
 		programSelect := promptui.Select{
 			Label:        "Select a key for the config patching",
 			Items:        keys,

--- a/cli/init/init.go
+++ b/cli/init/init.go
@@ -21,7 +21,7 @@ const (
 // InitCtx contains information for tt config creation.
 type InitCtx struct {
 	// SkipConfig - if set, disables cartridge & tarantoolctl config analysis,
-	// so init does not try to get directories information from exitsting config files.
+	// so init does not try to get directories information from existing config files.
 	SkipConfig bool
 	// ForceMode, if set, tt config is re-written without a question.
 	ForceMode bool

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -853,6 +853,14 @@ func patchCConfigElectionMode(config *libcluster.Config,
 	return config, nil
 }
 
+func patchCConfigAddRole(config *libcluster.Config, path []string,
+	roleNames []string) (*libcluster.Config, error) {
+	if err := config.Set(path, roleNames); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
 // getCConfigInstance extracts an instance from the cluster config.
 func getCConfigInstance(
 	config *libcluster.ClusterConfig, instName string) (cconfigInstance, error) {

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	libcluster "github.com/tarantool/tt/lib/cluster"
 )
 
 // KeyPicker picks a key to patch.
-type KeyPicker func(keys []string, force bool) (int, error)
+type KeyPicker func([]string, bool, string) (int, error)
 
 // CConfigSource describes the cluster config source.
 type CConfigSource struct {
@@ -56,12 +57,13 @@ func collectCConfig(
 }
 
 // pickTarget applies keyPicker to the targets slice and returns picked target.
-func (c *CConfigSource) pickTarget(targets []patchTarget, force bool) (patchTarget, error) {
+func (c *CConfigSource) pickTarget(targets []patchTarget, force bool,
+	pathMsg string) (patchTarget, error) {
 	targetKeys := make([]string, 0, len(targets))
 	for _, target := range targets {
 		targetKeys = append(targetKeys, target.key)
 	}
-	dstIndex, err := c.keyPicker(targetKeys, force)
+	dstIndex, err := c.keyPicker(targetKeys, force, pathMsg)
 	if err != nil {
 		return patchTarget{}, err
 	}
@@ -90,7 +92,7 @@ func (c *CConfigSource) patchInstanceConfig(instanceName string, force bool,
 	if err != nil {
 		return err
 	}
-	target, err := c.pickTarget(targets, force)
+	target, err := c.pickTarget(targets, force, strings.Join(path, "/"))
 	if err != nil {
 		return err
 	}

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -213,7 +213,7 @@ func TestCConfigSource_Promote_invalid_failover(t *testing.T) {
 }
 
 func TestCConfigSource_Promote_single_key(t *testing.T) {
-	keyPicker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+	keyPicker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 		require.Equal(t, []string{"all"}, keys)
 		return 0, nil
 	})
@@ -270,7 +270,7 @@ func TestCConfigSource_passes_force(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		keyPicker := replicaset.KeyPicker(func(keys []string, force bool) (int, error) {
+		keyPicker := replicaset.KeyPicker(func(_ []string, force bool, _ string) (int, error) {
 			require.True(t, force)
 			return 0, nil
 		})
@@ -318,7 +318,7 @@ func TestCConfigSource_publish_error(t *testing.T) {
 		collector := newOnceMockDataCollector([]libcluster.Data{
 			{Source: "all", Value: cfg},
 		}, nil)
-		keyPicker := replicaset.KeyPicker(func([]string, bool) (int, error) {
+		keyPicker := replicaset.KeyPicker(func(_ []string, _ bool, _ string) (int, error) {
 			return 0, nil
 		})
 		source := replicaset.NewCConfigSource(collector, publisher, keyPicker)
@@ -361,7 +361,7 @@ func TestCConfigSource_keypick_error(t *testing.T) {
 			{Source: "all", Value: cfg},
 		}, nil)
 		err := fmt.Errorf("it's too late")
-		keyPicker := replicaset.KeyPicker(func([]string, bool) (int, error) {
+		keyPicker := replicaset.KeyPicker(func(_ []string, _ bool, _ string) (int, error) {
 			return 0, err
 		})
 		source := replicaset.NewCConfigSource(collector, publisher, keyPicker)
@@ -429,7 +429,7 @@ func TestCConfigSource_Promote_many_keys(t *testing.T) {
 			}
 			collector := newOnceMockDataCollector(data, nil)
 			publisher := newOnceMockDataPublisher(nil)
-			picker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+			picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 				require.Equal(t, tc.keys, keys)
 				return 0, nil
 			})
@@ -464,7 +464,7 @@ func TestCConfigSource_Promote_many_keys_choose_affects(t *testing.T) {
 		{Source: "a", Value: cfg, Revision: 13},
 		{Source: "b", Value: cfg, Revision: revision},
 	}, nil)
-	picker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+	picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 		require.Equal(t, []string{"a", "b"}, keys)
 		return 1, nil
 	})
@@ -520,7 +520,7 @@ func TestCConfigSource_Promote_mix_failovers(t *testing.T) {
 				{Source: "c", Value: cfg3},
 			}, nil)
 			publisher := newOnceMockDataPublisher(nil)
-			picker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+			picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 				require.Equal(t, []string{tc.key}, keys)
 				return 0, nil
 			})
@@ -582,7 +582,7 @@ func TestCConfigSource_Demote_invalid_failover(t *testing.T) {
 }
 
 func TestCConfigSource_Demote_single_key(t *testing.T) {
-	keyPicker := replicaset.KeyPicker(func(keys []string, force bool) (int, error) {
+	keyPicker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 		require.Equal(t, []string{"all"}, keys)
 		return 0, nil
 	})
@@ -633,7 +633,7 @@ func TestCConfigSource_Demote_many_keys(t *testing.T) {
 			}
 			collector := newOnceMockDataCollector(data, nil)
 			publisher := newOnceMockDataPublisher(nil)
-			picker := replicaset.KeyPicker(func(keys []string, force bool) (int, error) {
+			picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 				require.Equal(t, tc.keys, keys)
 				return 0, nil
 			})
@@ -680,7 +680,7 @@ func TestCConfigSource_Demote_many_keys_choose_affects(t *testing.T) {
 		{Source: "a", Value: cfg, Revision: 13},
 		{Source: "b", Value: cfg, Revision: revision},
 	}, nil)
-	picker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+	picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 		require.Equal(t, []string{"a", "b"}, keys)
 		return 1, nil
 	})
@@ -703,7 +703,7 @@ func TestCConfigSource_Expel_single_key(t *testing.T) {
 	collector := newOnceMockDataCollector([]libcluster.Data{
 		{Source: "a", Value: cfg, Revision: revision},
 	}, nil)
-	picker := replicaset.KeyPicker(func(keys []string, _ bool) (int, error) {
+	picker := replicaset.KeyPicker(func(keys []string, _ bool, _ string) (int, error) {
 		require.Equal(t, []string{"a"}, keys)
 		return 0, nil
 	})

--- a/cli/replicaset/roles.go
+++ b/cli/replicaset/roles.go
@@ -1,0 +1,41 @@
+package replicaset
+
+import "fmt"
+
+// RolesAddCtx describes a context for adding roles.
+type RolesAddCtx struct {
+	// InstName is an instance name in which add role.
+	InstName string
+	// GroupName is an instance name in which add role.
+	GroupName string
+	// ReplicasetName is an instance name in which add role.
+	ReplicasetName string
+	// IsGlobal is an boolean value if role needs to add in global scope.
+	IsGlobal bool
+	// RoleName is a role name which needs to add into config.
+	RoleName string
+	// Force is true when promoting can skip
+	// some non-critical checks.
+	Force bool
+	// Timeout is a timeout for promoting waitings in seconds.
+	// Keep int, because it can be passed to the target instance.
+	Timeout int
+}
+
+// parseRoles is a function to convert roles type 'any'
+// from yaml config. Returns slice of roles and error.
+func parseRoles(value any) ([]string, error) {
+	sliceVal, ok := value.([]interface{})
+	if !ok {
+		return []string{}, fmt.Errorf("%v is not a slice", value)
+	}
+	existingRoles := make([]string, 0, len(sliceVal)+1)
+	for _, v := range sliceVal {
+		vStr, ok := v.(string)
+		if !ok {
+			return []string{}, fmt.Errorf("%v is not a string", v)
+		}
+		existingRoles = append(existingRoles, vStr)
+	}
+	return existingRoles, nil
+}

--- a/test/integration/cluster/test_cluster_roles_add.py
+++ b/test/integration/cluster/test_cluster_roles_add.py
@@ -1,0 +1,337 @@
+import pytest
+from tarantool.connection import os
+
+from utils import (get_fixture_tcs_params, is_tarantool_ee,
+                   is_tarantool_less_3, run_command_and_get_output)
+
+fixture_tcs_params = get_fixture_tcs_params(os.path.join(os.path.dirname(
+                                            os.path.abspath(__file__)), "test_tcs_app"))
+
+
+def to_etcd_key(key):
+    return f"/prefix/config/{key}"
+
+
+valid_cluster_cfg = r"""groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001:
+            iproto:
+              listen: {}
+"""
+
+
+@pytest.mark.parametrize("role_args, err_msg", [
+    (["http://localhost:3303"], "Error: accepts 2 arg(s), received 1"),
+    (["http://localhost:3303", "role"], "need to provide flag(s) with scope roles will added")
+])
+def test_cluster_rs_roles_add_missing_args(tt_cmd, tmpdir_with_cfg, role_args, err_msg):
+    tmpdir = tmpdir_with_cfg
+    cmd = [tt_cmd, "cluster", "rs", "roles", "add"]
+    cmd.extend(role_args)
+    rc, out = run_command_and_get_output(cmd, cwd=tmpdir)
+    assert rc != 0
+    assert err_msg in out
+
+
+@pytest.mark.parametrize(
+    "instance_name, expected_err_msg",
+    [
+        pytest.param(
+            "etcd",
+            r"   ⨯ failed to collect cluster config: failed to fetch" +
+            " data from etcd: etcdserver: user name is empty",
+        ),
+        pytest.param(
+            "tcs",
+            r"⨯ failed to collect cluster config: failed to fetch data" +
+            " from tarantool: Execute access to function 'config.storage.get'" +
+            " is denied for user 'guest'"
+        ),
+    ],
+)
+def test_cluster_rs_roles_add_no_auth(
+    instance_name, tt_cmd, tmpdir_with_cfg, request, expected_err_msg, fixture_params
+):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+
+    if instance_name == "etcd":
+        instance.enable_auth()
+
+    try:
+        roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", "-f",
+                         f"{instance.endpoint}/prefix?timeout=0.1", "role", "-G"]
+        rc, output = run_command_and_get_output(roles_add_cmd, cwd=tmpdir_with_cfg)
+        assert rc == 1
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+    assert expected_err_msg in output
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_rs_roles_add_bad_auth(
+    tt_cmd, tmpdir_with_cfg, instance_name, request, fixture_params
+):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+
+    roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add",
+                     f"http://invalid_user:invalid:pass@{instance.endpoint}/prefix?timeout=0.1",
+                     "role", "-G"]
+    rc, output = run_command_and_get_output(roles_add_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 1
+
+    expected = (r"   ⨯ failed to establish a connection to tarantool or etcd:")
+    assert expected in output
+
+
+@pytest.mark.parametrize("auth, instance_name", [
+    (None, "etcd"),
+    ("url", "etcd"),
+    ("flag", "etcd"),
+    ("env", "etcd"),
+    ("url", "tcs"),
+    ("flag", "tcs"),
+    ("env", "tcs"),
+])
+def test_cluster_rs_roles_add_auth(tt_cmd,
+                                   tmpdir_with_cfg,
+                                   auth,
+                                   instance_name,
+                                   request,
+                                   fixture_params):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+
+    conn = instance.conn()
+    key = to_etcd_key("all")
+    if instance_name == "etcd":
+        conn.put(key, valid_cluster_cfg)
+    else:
+        conn.call("config.storage.put", key, valid_cluster_cfg)
+    try:
+        if instance_name == "etcd" and auth:
+            instance.enable_auth()
+
+        if not auth:
+            env = None
+            url = f"{instance.endpoint}/prefix?timeout=5"
+            roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", "-f",
+                             url, "config.storage", "-G"]
+        if auth == "url":
+            env = None
+            url = (
+                f"http://{instance.connection_username}:{instance.connection_password}@"
+                f"{instance.host}:{instance.port}/prefix?timeout=5"
+            )
+            roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", "-f",
+                             url, "config.storage", "-G"]
+        elif auth == "flag":
+            env = None
+            url = f"{instance.endpoint}/prefix?timeout=5"
+            roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", "-f",
+                             "-u", instance.connection_username,
+                             "-p", instance.connection_password, url, "config.storage", "-G"]
+        elif auth == "env":
+            env = {
+                (
+                    "TT_CLI_ETCD_USERNAME"
+                    if instance_name == "etcd"
+                    else "TT_CLI_USERNAME"
+                ): instance.connection_username,
+                (
+                    "TT_CLI_ETCD_PASSWORD"
+                    if instance_name == "etcd"
+                    else "TT_CLI_PASSWORD"
+                ): instance.connection_password,
+            }
+            url = f"{instance.endpoint}/prefix?timeout=5"
+            roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", "-f",
+                             url, "config.storage", "-G"]
+        rc, out = run_command_and_get_output(roles_add_cmd, cwd=tmpdir_with_cfg, env=env)
+        assert rc == 0
+        assert f'Patching the config by the key: "{key}"' in out
+
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+        conn = instance.conn()
+        content = ""
+        if instance_name == "etcd":
+            content, _ = conn.get(key)
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", key)
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert content == """groups:
+  group-001:
+    replicasets:
+      replicaset-001:
+        instances:
+          instance-001:
+            iproto:
+              listen: {}
+roles:
+  - config.storage
+"""
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+
+@pytest.mark.parametrize("instance_name, flags, cfg, expected_cfg, err_msg", [
+    ("etcd", ["-G"], valid_cluster_cfg, valid_cluster_cfg + """\
+roles:
+  - role
+""", None),
+    ("etcd", ["-g", "group-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+    roles:
+      - role
+""", None),
+    ("etcd", ["-r", "replicaset-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+        roles:
+          - role
+""", None),
+    ("etcd", ["-i", "instance-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+            roles:
+              - role
+""", None),
+    ("etcd", ["-G", "-g", "group-001", "-r", "replicaset-001", "-i", "instance-001"],
+     valid_cluster_cfg, valid_cluster_cfg + """\
+            roles:
+              - role
+        roles:
+          - role
+    roles:
+      - role
+roles:
+  - role
+""", None),
+    ("etcd", ["-G"], valid_cluster_cfg + """\
+roles:
+  - other_role""", valid_cluster_cfg + """\
+roles:
+  - other_role
+  - role
+""", None),
+    ("etcd", ["-g", "group-001"], valid_cluster_cfg + """\
+    roles:
+      - role
+""", "", "role \"role\" already exists in groups/group-001/roles"),
+    ("etcd", ["-g", "invalid_group"], valid_cluster_cfg, "",
+     "cannot find group \"invalid_group\""),
+    ("etcd", ["-r", "invalid_replicaset"], valid_cluster_cfg, "",
+     "cannot find replicaset \"invalid_replicaset\" above group"),
+    ("etcd", ["-i", "invalid_instance"], valid_cluster_cfg, "",
+     "cannot find instance \"invalid_instance\" above group and/or replicaset"),
+    ("tcs", ["-G"], valid_cluster_cfg, valid_cluster_cfg + """\
+roles:
+  - role
+""", None),
+    ("tcs", ["-g", "group-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+    roles:
+      - role
+""", None),
+    ("tcs", ["-r", "replicaset-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+        roles:
+          - role
+""", None),
+    ("tcs", ["-i", "instance-001"], valid_cluster_cfg, valid_cluster_cfg + """\
+            roles:
+              - role
+""", None),
+    ("tcs", ["-G", "-g", "group-001", "-r", "replicaset-001", "-i", "instance-001"],
+     valid_cluster_cfg, valid_cluster_cfg + """\
+            roles:
+              - role
+        roles:
+          - role
+    roles:
+      - role
+roles:
+  - role
+""", None),
+    ("tcs", ["-G"], valid_cluster_cfg + """\
+roles:
+  - other_role""", valid_cluster_cfg + """\
+roles:
+  - other_role
+  - role
+""", None),
+    ("tcs", ["-g", "group-001"], valid_cluster_cfg + """\
+    roles:
+      - role
+""", "", "role \"role\" already exists in groups/group-001/roles"),
+    ("tcs", ["-g", "invalid_group"], valid_cluster_cfg, "",
+     "cannot find group \"invalid_group\""),
+    ("tcs", ["-r", "invalid_replicaset"], valid_cluster_cfg, "",
+     "cannot find replicaset \"invalid_replicaset\" above group"),
+    ("tcs", ["-i", "invalid_instance"], valid_cluster_cfg, "",
+     "cannot find instance \"invalid_instance\" above group and/or replicaset"),
+])
+def test_cluster_rs_roles_add(tt_cmd,
+                              tmpdir_with_cfg,
+                              instance_name,
+                              flags,
+                              cfg,
+                              expected_cfg,
+                              err_msg,
+                              request,
+                              fixture_params):
+    if instance_name == "tcs":
+        if is_tarantool_less_3() or not is_tarantool_ee():
+            pytest.skip()
+        for k, v in fixture_tcs_params.items():
+            fixture_params[k] = v
+    instance = request.getfixturevalue(instance_name)
+
+    conn = instance.conn()
+    key = to_etcd_key("all")
+    if instance_name == "etcd":
+        conn.put(key, cfg)
+    else:
+        conn.call("config.storage.put", key, cfg)
+
+    url = (
+        f"http://{instance.connection_username}:{instance.connection_password}@"
+        f"{instance.host}:{instance.port}/prefix?timeout=5"
+    )
+    roles_add_cmd = [tt_cmd, "cluster", "rs", "roles", "add", url, "role"]
+    roles_add_cmd.extend(flags)
+    rc, output = run_command_and_get_output(roles_add_cmd, cwd=tmpdir_with_cfg)
+
+    if not err_msg:
+        assert rc == 0
+        assert f"Patching the config by the key: \"{key}\"" in output
+
+        conn = instance.conn()
+        content = ""
+        if instance_name == "etcd":
+            content, _ = conn.get(key)
+            content = content.decode("utf-8")
+        else:
+            content = conn.call("config.storage.get", key)
+            if len(content) > 0:
+                content = content[0]["data"][0]["value"]
+        assert content == expected_cfg
+    else:
+        assert rc == 1
+        assert err_msg in output


### PR DESCRIPTION
@TarantoolBot document
Title: `tt cluster rs roles add` adds role in config scope provided by flags.

This patch introduces new command for the cluster replicaset module:

```
tt cluster replicaset roles add <URI> <ROLE_NAME> [flags]
```

URI is a target configuration source (etcd/tcs). ROLE_NAME is a role for adding to a Tarantool config storage. It is necessary to provide flag with destination in config for role addition. It can be one or more roles.

Command supports following flags:
- Flags for the destination of role addition:
  - `--global (-G)` for a global scope to add a role;
  - `--instance (-i) string` for an application name target to specify an instance to add a role;
  - `--replicaset (-r) string` for an application name target to specify a replicaset to add a role;
  - `--group (-g) string` for an application name target to specify a group.
- Common flag to interact with config storages (etcd / tarantool config storage):
  - `--force (-f)` to skip selecting a key for patching;
  - `--username (-u)` is a username (used as etcd/tarantool config storage credentials);
  - `--password (-p)` is a password (used as etcd/tarantool config storage credentials).

Closes #915