### PR TITLE
tt status: print detailed alerts for instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt status`: display `config`, `box`, and `replication upstream` statuses.
+  * `--details`: display detailed reports of errors and warnings from instances.
 - `tt stop` confirmation prompt. `-y` option is added to accept stop without prompting.
 - `tt cluster replicaset roles add`: command to add roles in config scope provided by flags.
 - `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with cluster

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -17,6 +17,21 @@ func NewStatusCmd() *cobra.Command {
 	var statusCmd = &cobra.Command{
 		Use:   "status [<APP_NAME> | <APP_NAME:INSTANCE_NAME>]",
 		Short: "Status of the tarantool instance(s)",
+		Long: `The 'status' command provides information about the status of Tarantool instances.
+
+Columns:
+- INSTANCE: The name of the Tarantool instance.
+- STATUS: The current status of the instance:
+	- RUNNING: The instance is up and running.
+	- NOT RUNNING: The instance is not running.
+	- ERROR: The process has terminated unexpectedly.
+- PID: The watchdog process PID.
+- MODE: The mode of the instance, indicating its read/write status:
+	- RO: The instance is in read-only mode.
+	- RW: The instance is in read-write mode.
+- CONFIG: The config info status (for Tarantool 3+).
+- BOX: The box info status.
+- UPSTREAM: The replication upstream status.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdCtx.CommandName = cmd.Name()
 			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
@@ -35,6 +50,7 @@ func NewStatusCmd() *cobra.Command {
 	}
 
 	statusCmd.Flags().BoolVarP(&opts.Pretty, "pretty", "p", false, "pretty-print table")
+	statusCmd.Flags().BoolVarP(&opts.Details, "details", "d", false, "print detailed alerts.")
 
 	return statusCmd
 }

--- a/cli/status/lua/instance_state.lua
+++ b/cli/status/lua/instance_state.lua
@@ -1,0 +1,76 @@
+local ok, config = pcall(require, 'config')
+
+-- Default configuration in case the Tarantool 3.x config module is unavailable.
+local config_info_full = {
+    status = "uninitialized",
+    alerts = {},
+}
+
+-- The type check for 'config.info' ensures that we are working with the correct
+-- Tarantool 3.x config module. This is necessary because another module,
+-- 'moonlibs/config', shares the same name.
+if ok and config ~= nil and type(config) == "table" and type(config.info) == "function" then
+    config_info_full = config:info()
+end
+
+local config_info = {
+    status = config_info_full.status,
+    alerts = {}
+}
+
+-- This loop extracts only the 'type' and 'message' fields from each alert,
+-- discarding any additional fields that might be present in the config.alerts.
+-- We only need the type of the error and its message for the status report,
+-- as other fields are considered extra and unnecessary for our purposes.
+for _, alert in ipairs(config_info_full.alerts) do
+    table.insert(config_info.alerts, {
+        type = alert.type,
+        message = alert.message
+    })
+end
+
+local ok, box_replication = pcall(function() return box.info.replication end)
+if not ok or box_replication == nil then
+    box_replication = {}
+end
+
+-- We collect information only for instances that have an upstream,
+-- as this field is necessary for subsequent error reporting
+local replication_info = {}
+for _, instance in pairs(box_replication) do
+    if instance.upstream ~= nil then
+        table.insert(replication_info, {
+            uuid = instance.uuid,
+            name = instance.name,
+            upstream = instance.upstream and {
+                status = instance.upstream.status or "--",
+                message = instance.upstream.message
+            }
+        })
+    end
+end
+
+local ok, read_only = pcall(function() return box.info.ro end)
+if ok then
+    read_only = read_only and "RO" or "RW"
+else
+    read_only = "RO"
+end
+
+local ok, box_status = pcall(function() return box.info.status end)
+if not ok then
+    box_status = "N/A"
+end
+
+local ok, uuid = pcall(function() return box.info.uuid end)
+if not ok then
+    uuid = "00000000-0000-0000-0000-000000000000"
+end
+
+return {
+    replication_info = replication_info,
+    config_info = config_info,
+    read_only = read_only,
+    box_status = box_status,
+    uuid = uuid,
+}

--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -1,58 +1,248 @@
 package status
 
 import (
+	_ "embed"
+	"fmt"
 	"os"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/mitchellh/mapstructure"
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/running"
 )
 
+//go:embed lua/instance_state.lua
+var instanceInfoLuaScript string
+
+var defaultModuleStatus = "--"
+
+func filterComments(script string) string {
+	var filteredLines []string
+	lines := strings.Split(script, "\n")
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmedLine, "--") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+	return strings.Join(filteredLines, "\n")
+}
+
 // StatusOpts contains options for tt status.
 type StatusOpts struct {
 	// Option for pretty-formatted table output.
 	Pretty bool
+	// Option for detailed alerts output for each instance, such as warnings and errors.
+	Details bool
+}
+
+type alert struct {
+	Type    string `mapstructure:"type"`
+	Message string `mapstructure:"message"`
+}
+
+type configInfo struct {
+	Status string  `mapstructure:"status"`
+	Alerts []alert `mapstructure:"alerts"`
+}
+
+type upstream struct {
+	Status  string `mapstructure:"status"`
+	Message string `mapstructure:"message"`
+}
+
+type replicationInfo struct {
+	UUID     string   `mapstructure:"uuid"`
+	Name     *string  `mapstructure:"name"`
+	Upstream upstream `mapstructure:"upstream"`
+}
+
+type instanceState struct {
+	ReplicationInfo []replicationInfo `mapstructure:"replication_info"`
+	ConfigInfo      configInfo        `mapstructure:"config_info"`
+	ReadOnly        string            `mapstructure:"read_only"`
+	BoxStatus       string            `mapstructure:"box_status"`
+	UUID            string            `mapstructure:"uuid"`
+}
+
+func newInstanceStatusMap() map[string]interface{} {
+	return map[string]interface{}{
+		"STATUS":   "",
+		"PID":      nil,
+		"MODE":     "",
+		"CONFIG":   defaultModuleStatus,
+		"BOX":      defaultModuleStatus,
+		"UPSTREAM": defaultModuleStatus,
+	}
+}
+
+var instances = map[string]map[string]interface{}{}
+var instancesAlerts = map[string][]string{}
+var uuid2name = map[string]string{}
+
+var printYellow = color.New(color.FgYellow).SprintFunc()
+var printRed = color.New(color.FgRed).SprintFunc()
+
+func processReplicationInfo(fullInstanceName string, instanceState instanceState) {
+	for _, repl := range instanceState.ReplicationInfo {
+		fullInstanceUpstreamName, ok := uuid2name[repl.UUID]
+		// Use repl.Name if available, otherwise fallback to repl.UUID
+		if !ok {
+			if repl.Name != nil {
+				fullInstanceUpstreamName = *repl.Name
+			} else {
+				fullInstanceUpstreamName = repl.UUID
+			}
+		}
+		if repl.Upstream.Status == "follow" || len(repl.Upstream.Message) == 0 {
+			continue
+		}
+		instances[fullInstanceName]["UPSTREAM"] = repl.Upstream.Status
+
+		var upstreamInstanceDesc string
+		if ok || repl.Name != nil {
+			upstreamInstanceDesc = fmt.Sprintf("instance with name %q",
+				fullInstanceUpstreamName)
+		} else {
+			upstreamInstanceDesc = fmt.Sprintf("instance with UUID %s",
+				fullInstanceUpstreamName)
+		}
+		instancesAlerts[fullInstanceName] = append(instancesAlerts[fullInstanceName],
+			printYellow(fmt.Sprintf(
+				"[upstream][warning]: replication from %s is in %q status: %q",
+				upstreamInstanceDesc, repl.Upstream.Status,
+				repl.Upstream.Message)))
+	}
+}
+
+func processConfigInfo(fullInstanceName string, instanceState instanceState) {
+	if len(instanceState.ConfigInfo.Alerts) == 0 {
+		return
+	}
+	for _, alert := range instanceState.ConfigInfo.Alerts {
+		msg := ""
+		if alert.Type == "error" {
+			msg = printRed(fmt.Sprintf("[config][error]: %s", alert.Message))
+		} else {
+			msg = printYellow(fmt.Sprintf("[config][warning]: %s", alert.Message))
+		}
+		instancesAlerts[fullInstanceName] = append(instancesAlerts[fullInstanceName], msg)
+	}
 }
 
 // Status writes the status as a table.
 func Status(runningCtx running.RunningCtx, opts StatusOpts) error {
 	ts := table.NewWriter()
 	ts.SetOutputMirror(os.Stdout)
-	ts.AppendHeader(table.Row{"INSTANCE", "STATUS", "PID", "MODE"})
+	ts.AppendHeader(
+		table.Row{"INSTANCE", "STATUS", "PID", "MODE", "CONFIG", "BOX", "UPSTREAM"})
+
+	instanceRawState := map[string]instanceState{}
 
 	for _, run := range runningCtx.Instances {
-		row := []interface{}{}
 		fullInstanceName := running.GetAppInstanceName(run)
 		procStatus := running.Status(&run)
+		instances[fullInstanceName] = newInstanceStatusMap()
+		instances[fullInstanceName]["STATUS"] = procStatus.ColorSprint(procStatus.Status)
 
-		row = append(row, fullInstanceName)
-		row = append(row, procStatus.ColorSprint(procStatus.Status))
 		if procStatus.Code == process_utils.ProcessRunningCode {
-			row = append(row, procStatus.PID)
+			instances[fullInstanceName]["PID"] = procStatus.PID
 		}
 
 		conn, err := connector.Connect(connector.ConnectOpts{
 			Network: "unix",
 			Address: run.ConsoleSocket,
 		})
-		if err == nil {
-			res, err := conn.Eval("return (type(box.cfg) == 'function') or box.info.ro",
-				[]any{}, connector.RequestOpts{})
-			if err == nil && len(res) != 0 {
-				mode := res[0].(bool)
-				mode_str := "RO"
-				if !mode {
-					mode_str = "RW"
-				}
-				row = append(row, mode_str)
-			}
+
+		if err != nil && procStatus.Code == process_utils.ProcessRunningCode {
+			instancesAlerts[fullInstanceName] = append(
+				instancesAlerts[fullInstanceName],
+				printRed(fmt.Sprintf(
+					"Error while connecting to instance %s via socket %s: %v",
+					fullInstanceName, run.ConsoleSocket, err)))
+			continue
+		} else if err != nil {
+			continue
 		}
+
+		var instanceState instanceState
+		res, err := conn.Eval(filterComments(instanceInfoLuaScript), []any{},
+			connector.RequestOpts{})
+
+		if err != nil {
+			instancesAlerts[fullInstanceName] = append(
+				instancesAlerts[fullInstanceName],
+				printRed(fmt.Sprintf(
+					"Error while executing Lua script on instance %s: %v",
+					fullInstanceName, err)))
+			continue
+		}
+
+		if len(res) == 0 {
+			instancesAlerts[fullInstanceName] = append(
+				instancesAlerts[fullInstanceName],
+				printRed(fmt.Sprintf(
+					"No data returned from Lua script on instance %s",
+					fullInstanceName)))
+			continue
+		}
+
+		err = mapstructure.Decode(res[0], &instanceState)
+		if err != nil {
+			instancesAlerts[fullInstanceName] = append(
+				instancesAlerts[fullInstanceName],
+				printRed(fmt.Sprintf("Error while decoding data from "+
+					"instance %s: %v", fullInstanceName, err)))
+			continue
+		}
+
+		// Since Tarantool 2.x doesn't support instance names, only UUIDs are available.
+		// To make the alerts more readable, we map the UUIDs to instance names.
+		uuid2name[instanceState.UUID] = fullInstanceName
+
+		instanceRawState[fullInstanceName] = instanceState
+		instances[fullInstanceName]["MODE"] = instanceState.ReadOnly
+		instances[fullInstanceName]["CONFIG"] = instanceState.ConfigInfo.Status
+		instances[fullInstanceName]["BOX"] = instanceState.BoxStatus
+	}
+
+	// Alert handling placed later because we need to know the mapping of instance UUIDs
+	// to their names for a more user-friendly output.
+	for fullInstanceName, instanceState := range instanceRawState {
+		processReplicationInfo(fullInstanceName, instanceState)
+		processConfigInfo(fullInstanceName, instanceState)
+	}
+
+	for instName, instData := range instances {
+		row := []interface{}{}
+		row = append(row, instName)
+		row = append(row, instData["STATUS"])
+		if instData["PID"] == nil {
+			ts.AppendRow(row)
+			continue
+		}
+		row = append(row, instData["PID"])
+		row = append(row, instData["MODE"])
+		row = append(row, instData["CONFIG"])
+		row = append(row, instData["BOX"])
+		row = append(row, instData["UPSTREAM"])
 		ts.AppendRow(row)
 	}
 	ts.SortBy([]table.SortBy{{Name: "INSTANCE", Mode: table.Asc}})
 
+	if opts.Details {
+		for instance, alerts := range instancesAlerts {
+			fmt.Printf("Alerts for %s:\n", instance)
+			for _, alert := range alerts {
+				fmt.Printf("  • %s\n", alert)
+			}
+			fmt.Println()
+		}
+	}
 	if opts.Pretty {
 		ts.SetStyle(table.StyleRounded)
 	} else {
@@ -67,5 +257,18 @@ func Status(runningCtx running.RunningCtx, opts StatusOpts) error {
 		{Number: 4, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
 	})
 	ts.Render()
+
+	if !opts.Details {
+		msg := "\nThe status of some instances requires attention.\n" +
+			"Please rerun the command with the --details flag to see " +
+			"more information"
+		for _, alerts := range instancesAlerts {
+			if len(alerts) > 0 {
+				fmt.Println(msg)
+				break
+			}
+		}
+	}
+
 	return nil
 }

--- a/test/integration/status/single_app/init.lua
+++ b/test/integration/status/single_app/init.lua
@@ -1,0 +1,11 @@
+local log = require('log')
+
+box.cfg{listen=3303}
+box.schema.user.grant('guest', 'super')
+
+box.session.on_connect(function()
+        log.error("Connected")
+end)
+box.session.on_disconnect(function()
+        log.error("Disconnected")
+end)

--- a/test/integration/status/test_custom_app/init.lua
+++ b/test/integration/status/test_custom_app/init.lua
@@ -1,0 +1,11 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+box.cfg({})
+
+fh = fio.open('ready', {'O_WRONLY', 'O_CREAT'}, tonumber('644',8))
+fh:close()
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/status/test_status.py
+++ b/test/integration/status/test_status.py
@@ -1,0 +1,325 @@
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+
+import pytest
+import tarantool
+
+from utils import (control_socket, extract_status, get_tarantool_version,
+                   pid_file, run_command_and_get_output, run_path, wait_file)
+
+tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+
+def start_application(cmd, workdir, app_name, instances):
+    instance_process = subprocess.Popen(
+        cmd,
+        cwd=workdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True
+    )
+    start_output = instance_process.stdout.read()
+    for inst in instances:
+        assert f"Starting an instance [{app_name}:{inst}]" in start_output
+
+
+def stop_application(tt_cmd, app_name, workdir):
+    stop_cmd = [tt_cmd, "stop", app_name, "-y"]
+    stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=workdir)
+    assert stop_rc == 0
+
+
+def break_config(path):
+    with open(path, "a") as config:
+        config.write("invalid_field: invalid_value\n")
+
+
+def run_command_on_instance(tt_cmd, tmpdir, full_inst_name, cmd):
+    con_cmd = [tt_cmd, "connect", full_inst_name, "-f", "-"]
+    instance_process = subprocess.Popen(
+        con_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True
+    )
+    instance_process.stdin.writelines([cmd])
+    instance_process.stdin.close()
+    output = instance_process.stdout.read()
+    return output
+
+
+def wait_instance_status(tt_cmd, tmpdir, full_inst_name, status, port=None, timeout=10):
+    if status == "config":
+        cmd = "return require('config'):info().status"
+        expected_statuses = ["ready", "check_warnings"]
+    elif status == "box":
+        cmd = "return box.info.status"
+        expected_statuses = ["running"]
+    else:
+        raise RuntimeError(f"Not supported status to check: {status}")
+
+    conn = None
+    end_time = time.time() + timeout
+    while True:
+        try:
+            if port:
+                # if socket file doesn't exist use connection by ip:port
+                if not conn:
+                    conn = tarantool.Connection(host="localhost", port=port)
+                res = conn.eval(cmd)[0]
+            else:
+                res = run_command_on_instance(
+                    tt_cmd,
+                    tmpdir,
+                    full_inst_name,
+                    cmd
+                )
+
+            if any(expected_status in res for expected_status in expected_statuses):
+                if conn:
+                    conn.close()
+                return True
+        except tarantool.error.Error:
+            pass
+        if time.time() > end_time:
+            print(f"[{full_inst_name}]: {status} wait timed out after {timeout} seconds.")
+            return False
+        time.sleep(1)
+
+
+@pytest.mark.skipif(tarantool_major_version < 3,
+                    reason="skip cluster instances test for Tarantool < 3")
+def test_t3_instance_names_with_config(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "small_cluster_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), f"../running/{app_name}"), app_path)
+
+    run_dir = os.path.join(tmpdir, app_name, run_path)
+    instances = ['storage-master', 'storage-replica']
+    try:
+        # Start an instance.
+        start_cmd = [tt_cmd, "start", app_name]
+        start_application(start_cmd, tmpdir, app_name, instances)
+
+        # Check status.
+        for inst in instances:
+            file = wait_file(os.path.join(run_dir, inst), 'tarantool.pid', [])
+            assert file != ""
+            file = wait_file(os.path.join(run_dir, inst), control_socket, [])
+            assert file != ""
+
+        status_cmd = [tt_cmd, "status", app_name]
+        status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+        assert status_rc == 0
+        status_info = extract_status(status_out)
+        for inst in instances:
+            assert status_info[app_name+":"+inst]["STATUS"] == "RUNNING"
+            assert os.path.exists(os.path.join(tmpdir, app_name, "var", "lib", inst))
+            assert os.path.exists(os.path.join(tmpdir, app_name, "var", "log", inst, "tt.log"))
+            assert not os.path.exists(os.path.join(tmpdir, app_name, "var", "log", inst,
+                                                   "tarantool.log"))
+
+        full_master_inst_name = f"{app_name}:{instances[0]}"
+
+        # Wait for the configuration setup to complete
+        assert wait_instance_status(tt_cmd, tmpdir, full_master_inst_name, "config")
+
+        # Break the configuration by modifying the config.yaml file
+        config_path = os.path.join(app_path, "config.yaml")
+        break_config(config_path)
+
+        # Reload the configuration on the instance
+        reload_cmd = "require('config'):reload()"
+        res = run_command_on_instance(tt_cmd, tmpdir, full_master_inst_name, reload_cmd)
+
+        # Check if the expected error message is present in the response
+        error_message = "[cluster_config] Unexpected field \"invalid_field\""
+        assert error_message in res
+
+        status_cmd = [tt_cmd, "status", full_master_inst_name, "--details"]
+        status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+        assert status_rc == 0
+
+        status_table = status_out[status_out.find("INSTANCE"):]
+        status_info = extract_status(status_table)
+
+        assert status_info[full_master_inst_name]["STATUS"] == "RUNNING"
+        assert status_info[full_master_inst_name]["MODE"] == "RW"
+        assert status_info[full_master_inst_name]["CONFIG"] == "check_errors"
+        assert status_info[full_master_inst_name]["BOX"] == "running"
+
+        # We cannot be certain that the instance bootstrap has completed.
+        assert status_info[full_master_inst_name]["UPSTREAM"] in ["--", "loading"]
+        assert f"[config][error]: {error_message}" in status_out
+    finally:
+        stop_application(tt_cmd, app_name, tmpdir)
+
+
+@pytest.mark.skipif(tarantool_major_version < 3,
+                    reason="skip cluster instances test for Tarantool < 3")
+def test_t3_instance_names_no_config(tt_cmd):
+    test_app_path_src = os.path.join(os.path.dirname(__file__), "../running/multi_inst_app")
+    instances = ["router", "master", "replica", "stateboard"]
+
+    # Default temporary directory may have very long path. This can cause socket path buffer
+    # overflow. Create our own temporary directory.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_app_path = os.path.join(tmpdir, "app")
+        shutil.copytree(test_app_path_src, test_app_path)
+
+        for subdir in ["", "app"]:
+            if subdir != "":
+                os.mkdir(os.path.join(test_app_path, "app"))
+            try:
+                # Start an instance.
+                start_cmd = [tt_cmd, "start", "app"]
+                instance_process = subprocess.Popen(
+                    start_cmd,
+                    cwd=test_app_path,
+                    stderr=subprocess.STDOUT,
+                    stdout=subprocess.PIPE,
+                    text=True
+                )
+                start_output = instance_process.stdout.readline()
+                assert re.search(
+                    r"Starting an instance \[app:(router|master|replica|stateboard)\]",
+                    start_output
+                )
+
+                # Check status.
+                for instName in instances:
+                    print(os.path.join(test_app_path, "run", "app", instName))
+                    file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
+                    assert file != ""
+
+                status_cmd = [tt_cmd, "status", "app", "--details"]
+                status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
+                assert status_rc == 0
+                status_table = status_out[status_out.find("INSTANCE"):]
+                status_table = extract_status(status_table)
+
+                for instName in instances:
+                    assert status_table[f"app:{instName}"]["STATUS"] == "RUNNING"
+
+                pattern = (
+                    r"Alerts for app:(router|master|replica|stateboard):\s+"
+                    r"• Error while connecting to instance app:\1 via socket "
+                    r".+tarantool\.control: failed to dial: dial unix "
+                    r".+tarantool\.control: connect: no such file or directory"
+                )
+                matches = re.findall(pattern, status_out)
+                assert len(matches) == 4
+
+                # Since we cannot connect to instances because the socket file doesn't exist,
+                # we will verify that the status strings follow this structure:
+                pattern = r"app:(master|replica|router|stateboard)\s+RUNNING\s+\d+\s+--\s+--\s+--"
+                matches = re.findall(pattern, status_out)
+                assert len(matches) == 4
+
+            finally:
+                stop_application(tt_cmd, "app", test_app_path)
+
+
+@pytest.mark.skipif(tarantool_major_version < 3,
+                    reason="skip cluster instances test for Tarantool < 3")
+def test_t3_no_instance_names_no_config(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "single_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+
+    try:
+        start_cmd = [tt_cmd, "start", app_name]
+        instance_process = subprocess.Popen(
+            start_cmd,
+            cwd=app_path,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        start_output = instance_process.stdout.read()
+        assert re.search(
+                    r"Starting an instance \[single_app\]",
+                    start_output
+                )
+        assert wait_instance_status(tt_cmd, app_path, app_name, "box", port=3303)
+        status_cmd = [tt_cmd, "status", app_name]
+        status_rc, status_out = run_command_and_get_output(status_cmd, cwd=app_path)
+        assert status_rc == 0
+        status_out = extract_status(status_out)
+
+        assert status_out[app_name]["STATUS"] == "RUNNING"
+        assert status_out[app_name]["MODE"] == "RW"
+        assert status_out[app_name]["CONFIG"] == "uninitialized"
+        assert status_out[app_name]["BOX"] == "running"
+        assert status_out[app_name]["UPSTREAM"] == "--"
+    finally:
+        stop_application(tt_cmd, app_name, app_path)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip custom test for Tarantool > 2")
+def test_status_custom_app(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_custom_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        # Check for start.
+        file = wait_file(os.path.join(tmpdir, app_name), 'ready', [])
+        assert file != ""
+
+        status_cmd = [tt_cmd, "status"]
+        status_cmd.append("test_custom_app")
+
+        rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+        assert rc == 0
+        status_out = extract_status(out)
+        assert status_out[app_name]["STATUS"] == "RUNNING"
+        assert status_out[app_name]["MODE"] == "RW"
+        assert status_out[app_name]["CONFIG"] == "uninitialized"
+        assert status_out[app_name]["BOX"] == "running"
+        assert status_out[app_name]["UPSTREAM"] == "--"
+    finally:
+        stop_application(tt_cmd, app_name, tmpdir)
+
+
+@pytest.mark.skipif(tarantool_major_version > 2,
+                    reason="skip cartridge test for Tarantool > 2")
+def test_status_cartridge(tt_cmd, cartridge_app):
+    rs_cmd = [tt_cmd, "status"]
+
+    time.sleep(20)
+    rc, out = run_command_and_get_output(rs_cmd, cwd=cartridge_app.workdir)
+    assert rc == 0
+    status_out = extract_status(out)
+
+    instances = {
+        "cartridge_app:router": "RW",
+        "cartridge_app:s1-master": "RW",
+        "cartridge_app:s2-master": "RW",
+        "cartridge_app:s3-master": "RW",
+        "cartridge_app:stateboard": "RW",
+        "cartridge_app:s1-replica": "RO",
+        "cartridge_app:s2-replica-1": "RO",
+        "cartridge_app:s2-replica-2": "RO",
+    }
+
+    for app_name, mode in instances.items():
+        assert status_out[app_name]["STATUS"] == "RUNNING"
+        assert status_out[app_name]["MODE"] == mode
+        assert status_out[app_name]["CONFIG"] == "uninitialized"
+        assert status_out[app_name]["BOX"] == "running"
+        assert status_out[app_name]["UPSTREAM"] == "--"

--- a/test/utils.py
+++ b/test/utils.py
@@ -432,13 +432,15 @@ def extract_status(status_output):
     statuses = status_output.split("\n")
     for i in range(1, len(statuses)-1):
         summary = statuses[i]
+        if not summary:
+            break
         fields = summary.split()
         instance = fields[0]
         info = {}
         if fields[1] == "RUNNING":
             info["STATUS"] = fields[1]
             info["PID"] = int(fields[2])
-            if len(fields) == 4:
+            if len(fields) >= 4:
                 info["MODE"] = fields[3]
         else:
             info["STATUS"] = " ".join(fields[1:])

--- a/test/utils.py
+++ b/test/utils.py
@@ -440,8 +440,10 @@ def extract_status(status_output):
         if fields[1] == "RUNNING":
             info["STATUS"] = fields[1]
             info["PID"] = int(fields[2])
-            if len(fields) >= 4:
-                info["MODE"] = fields[3]
+            keys = ["MODE", "CONFIG", "BOX", "UPSTREAM"]
+            for i, key in enumerate(keys, start=3):
+                if len(fields) > i:
+                    info[key] = fields[i]
         else:
             info["STATUS"] = " ".join(fields[1:])
         result[instance] = info


### PR DESCRIPTION
This patch improves the `tt status` command by displaying all collected errors, warnings, and the current instance status. Instances with warnings or errors will now be highlighted in yellow.

Closes #836