### PR TITLE
cluster: add command 'roles remove' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt cluster replicaset roles add`: command to add roles in config scope provided by flags.
+- `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with cluster
+  config (3.0) or cartridge orchestrator.
 
 ### Fixed
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -71,7 +71,7 @@ func getInternalHelpFunc(cmd *cobra.Command, help DefaultHelpFunc) modules.Inter
 				return err
 			}
 
-			cmd.Printf(helpMsg)
+			cmd.Print(helpMsg)
 		}
 
 		return nil

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -132,7 +133,7 @@ func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	if canStart, reason :=
 		running.IsAbleToStartInstances(runningCtx.Instances, cmdCtx); !canStart {
-		return fmt.Errorf(reason)
+		return errors.New(reason)
 	}
 
 	if !watchdog {

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -89,7 +90,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 	} else if ssl {
 		greetingConn.Close()
 		errMsg := "unencrypted connection established, but encryption required"
-		return nil, fmt.Errorf(errMsg)
+		return nil, errors.New(errMsg)
 	}
 
 	// Reset the deadline. From the SetDeadline doc:

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -380,7 +381,7 @@ func getPlainTextEvalResYaml(resBytes []byte) (string, error) {
 			if len(errorStrings) > 0 {
 				errStr, found := errorStrings[0]["error"]
 				if found {
-					return "", fmt.Errorf(errStr)
+					return "", errors.New(errStr)
 				}
 			}
 
@@ -410,7 +411,7 @@ func getPlainTextEvalResLua(resBytes []byte) (string, error) {
 	luaRes := L.Env.RawGetString("res")
 
 	if luaRes.Type() == lua.LTString {
-		return "", fmt.Errorf(lua.LVAsString(luaRes))
+		return "", errors.New(lua.LVAsString(luaRes))
 	}
 
 	encodedDataLV := L.GetTable(luaRes, lua.LString("data_enc"))

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -42,7 +43,7 @@ func (handler *DaemonHandler) callCommand(ttCmd *command) (string, error) {
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {
-		err = fmt.Errorf(fmt.Sprint(err) + ": " + stderr.String())
+		err = errors.New(fmt.Sprint(err) + ": " + stderr.String())
 	}
 
 	return stdout.String() + stderr.String(), err

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bufio"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -376,7 +377,7 @@ func programDependenciesInstalled(program string) error {
 			}
 		}
 		errMsg.WriteString("Usage: tt install -f if you already have those packages installed")
-		return fmt.Errorf(errMsg.String())
+		return errors.New(errMsg.String())
 	}
 	return nil
 }

--- a/cli/replicaset/cartridge.go
+++ b/cli/replicaset/cartridge.go
@@ -2,6 +2,7 @@ package replicaset
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -721,7 +722,7 @@ func getCartridgeVersion(evaler connector.Evaler) (string, error) {
 		return "", fmt.Errorf(errPrefix+"%w", err)
 	}
 	if len(ret) != 1 {
-		return "", fmt.Errorf(errPrefix + "unexpected response length")
+		return "", errors.New(errPrefix + "unexpected response length")
 	}
 	version, ok := ret[0].(string)
 	if !ok {

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -62,6 +62,14 @@ type CConfigInstance struct {
 	evaler connector.Evaler
 }
 
+// patchRoleTarget describes a content to patch a config.
+type patchRoleTarget struct {
+	// path is a destination to a patch target in config.
+	path []string
+	// roleNames are roles to add by path in config.
+	roleNames []string
+}
+
 // NewCConfigInstance create a new CConfigInstance object for the evaler.
 func NewCConfigInstance(evaler connector.Evaler) *CConfigInstance {
 	inst := &CConfigInstance{
@@ -853,10 +861,12 @@ func patchCConfigElectionMode(config *libcluster.Config,
 	return config, nil
 }
 
-func patchCConfigAddRole(config *libcluster.Config, path []string,
-	roleNames []string) (*libcluster.Config, error) {
-	if err := config.Set(path, roleNames); err != nil {
-		return nil, err
+func patchCConfigEditRole(config *libcluster.Config,
+	prt []patchRoleTarget) (*libcluster.Config, error) {
+	for _, p := range prt {
+		if err := config.Set(p.path, p.roleNames); err != nil {
+			return nil, err
+		}
 	}
 	return config, nil
 }

--- a/cli/replicaset/roles.go
+++ b/cli/replicaset/roles.go
@@ -1,18 +1,44 @@
 package replicaset
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
-// RolesAddCtx describes a context for adding roles.
-type RolesAddCtx struct {
-	// InstName is an instance name in which add role.
+// ChangeRoleFunc is a function type for addition or removing a role.
+type ChangeRoleFunc func([]string, string) ([]string, error)
+
+// AddRole is a function that implements addition of role.
+func AddRole(roles []string, r string) ([]string, error) {
+	if len(roles) > 0 && slices.Index(roles, r) != -1 {
+		return []string{}, fmt.Errorf("role %q already exists", r)
+	}
+	return append(roles, r), nil
+}
+
+// RemoveRole is a function that implements removing of role.
+func RemoveRole(roles []string, r string) ([]string, error) {
+	idx := slices.Index(roles, r)
+	if idx == -1 {
+		return []string{}, fmt.Errorf("role %q not found", r)
+	}
+	if len(roles) == 1 {
+		return []string{}, nil
+	}
+	return append(roles[:idx], roles[idx+1:]...), nil
+}
+
+// RolesChangeCtx describes a context for adding/removing roles.
+type RolesChangeCtx struct {
+	// InstName is an instance name in which add/remove role.
 	InstName string
-	// GroupName is an instance name in which add role.
+	// GroupName is an instance name in which add/remove role.
 	GroupName string
-	// ReplicasetName is an instance name in which add role.
+	// ReplicasetName is an instance name in which add/remove role.
 	ReplicasetName string
-	// IsGlobal is an boolean value if role needs to add in global scope.
+	// IsGlobal is an boolean value if role needs to add/remove in global scope.
 	IsGlobal bool
-	// RoleName is a role name which needs to add into config.
+	// RoleName is a role name which needs to add/remove into config.
 	RoleName string
 	// Force is true when promoting can skip
 	// some non-critical checks.

--- a/cli/replicaset/roles_test.go
+++ b/cli/replicaset/roles_test.go
@@ -1,0 +1,59 @@
+package replicaset_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/replicaset"
+)
+
+func TestRoles_AddRole(t *testing.T) {
+	cases := []struct {
+		name      string
+		roles     []string
+		roleToAdd string
+		expected  []string
+		errMsg    string
+	}{
+		{"ok", []string{"role"}, "other_role", []string{"role", "other_role"}, ""},
+		{"already exists", []string{"role"}, "role", []string{}, "role \"role\" already exists"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := replicaset.AddRole(tc.roles, tc.roleToAdd)
+			if tc.errMsg != "" {
+				require.EqualError(t, err, tc.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, res, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRoles_RemoveRole(t *testing.T) {
+	cases := []struct {
+		name         string
+		roles        []string
+		roleToRemove string
+		expected     []string
+		errMsg       string
+	}{
+		{"ok one role", []string{"role"}, "role", []string{}, ""},
+		{"ok many roles", []string{"role_1", "role_2"}, "role_1", []string{"role_2"}, ""},
+		{"not found", []string{"role"}, "other_role", []string{}, "role \"other_role\" not found"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := replicaset.RemoveRole(tc.roles, tc.roleToRemove)
+			if tc.errMsg != "" {
+				require.EqualError(t, err, tc.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, res, tc.expected)
+			}
+		})
+	}
+}

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -858,12 +858,12 @@ func Status(run *InstanceCtx) process_utils.ProcessState {
 func Logrotate(run *InstanceCtx) (string, error) {
 	pid, err := process_utils.GetPIDFromFile(run.PIDFile)
 	if err != nil {
-		return "", fmt.Errorf(instStateStopped.String())
+		return "", errors.New(instStateStopped.String())
 	}
 
 	alive, err := process_utils.IsProcessAlive(pid)
 	if !alive {
-		return "", fmt.Errorf(instStateDead.String())
+		return "", errors.New(instStateDead.String())
 	}
 
 	if err := syscall.Kill(pid, syscall.Signal(syscall.SIGHUP)); err != nil {
@@ -883,7 +883,7 @@ func Check(cmdCtx *cmdcontext.CmdCtx, run *InstanceCtx) error {
 	cmd := exec.Command(cmdCtx.Cli.TarantoolCli.Executable, "-e", checkSyntax)
 	cmd.Stderr = &errbuff
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf(errbuff.String())
+		return errors.New(errbuff.String())
 	}
 
 	return nil


### PR DESCRIPTION
@TarantoolBot document
Title: `tt cluster rs roles remove` removes role in config scope provided by flags.

This patch introduces new command for the cluster replicaset module:

```
tt cluster replicaset roles remove <URI> <ROLE_NAME> [flags]
```

URI is a target configuration source (etcd/tcs). ROLE_NAME is a role removing from a Tarantool config storage. It is necessary to provide flag with destination in config for role removing. It can be one or more destinations.

Command supports following flags:
- Flags for the destination of role removing:
  - `--global (-G)` for a global scope to remove a role;
  - `--instance (-i) string` for an application name target to specify
    an instance to remove a role;
  - `--replicaset (-r) string` for an application name target to specify
    a replicaset to remove a role;
  - `--group (-g) string` for an application name target to specify a group.
- Common flag to interact with config storages (etcd / tarantool config
  storage):
  - `--force (-f)` to skip selecting a key for patching;
  - `--username (-u)` is a username (used as etcd/tarantool config
    storage credentials);
  - `--password (-p)` is a password (used as etcd/tarantool config
    storage credentials).

Closes https://github.com/tarantool/tt/issues/917