### PR TITLE
stop:added confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt stop` confirmation prompt. `-y` option is added to accept stop without prompting.
 - `tt cluster replicaset roles add`: command to add roles in config scope provided by flags.
 - `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with cluster
   config (3.0) or cartridge orchestrator.

--- a/test/cartridge_helper.py
+++ b/test/cartridge_helper.py
@@ -210,13 +210,13 @@ class CartridgeApp:
         assert re.search(r"Failover configured successfully", out)
 
     def stop(self):
-        cmd = [self.tt_cmd, "stop", cartridge_name]
+        cmd = [self.tt_cmd, "stop", "-y", cartridge_name]
         rc, _ = run_command_and_get_output(cmd, cwd=self.workdir)
         assert rc == 0
 
     def stop_inst(self, name):
         assert name in self.instances, "instance is offline"
-        cmd = [self.tt_cmd, "stop", f"{cartridge_name}:{name}"]
+        cmd = [self.tt_cmd, "stop", "-y", f"{cartridge_name}:{name}"]
         rc, _ = run_command_and_get_output(cmd, cwd=self.workdir)
         self.instances.remove(name)
         assert rc == 0

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -763,7 +763,7 @@ def test_create_app_from_builtin_cartridge_template_with_dst_specified(tt_cmd, t
         assert status_info[key]["STATUS"] == "RUNNING"
 
     # Stop the cartridge app.
-    stop_cmd = [tt_cmd, "stop", "app1"]
+    stop_cmd = [tt_cmd, "stop", "-y", "app1"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"The Instance app1:\w+ \(PID = \d+\) has been terminated.", stop_out)
@@ -907,7 +907,7 @@ def test_create_app_from_builtin_vshard_cluster_template(tt_cmd, tmp_path):
             print(inst, f.read())
 
     # Stop the vhsard_cluster app.
-    stop_cmd = [tt_cmd, "stop", "app1"]
+    stop_cmd = [tt_cmd, "stop", "--yes", "app1"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert stop_rc == 0
     for inst in instances:

--- a/test/integration/daemon/test_daemon.py
+++ b/test/integration/daemon/test_daemon.py
@@ -218,7 +218,7 @@ def test_daemon_http_requests(tt_cmd, tmpdir_with_cfg):
     status_info = utils.extract_status(response.json()["res"])
     assert status_info["test_app"]["STATUS"] == "RUNNING"
 
-    body = {"command_name": "stop", "params": ["test_app"]}
+    body = {"command_name": "stop", "params": ["-y", "test_app"]}
     response = requests.post(default_url, json=body)
     assert response.status_code == 200
     assert re.search(r"The Instance test_app \(PID = \d+\) has been terminated.",
@@ -291,7 +291,7 @@ def test_daemon_http_requests_with_cfg(tt_cmd, tmpdir_with_cfg):
     assert response.status_code == 200
     status_info = utils.extract_status(response.json()["res"])
     assert status_info["test_app"]["STATUS"] == "RUNNING"
-    body = {"command_name": "stop", "params": ["test_app"]}
+    body = {"command_name": "stop", "params": ["-y", "test_app"]}
     response = requests.post(url, json=body)
     assert response.status_code == 200
     assert re.search(r"The Instance test_app \(PID = \d+\) has been terminated.",

--- a/test/integration/replicaset/replicaset_helpers.py
+++ b/test/integration/replicaset/replicaset_helpers.py
@@ -21,7 +21,7 @@ def start_application(tt_cmd, workdir, app_name, instances):
 
 
 def stop_application(tt_cmd, app_name, workdir, instances, force=False):
-    stop_cmd = [tt_cmd, "stop", app_name]
+    stop_cmd = [tt_cmd, "stop", "-y", app_name]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=workdir)
     assert stop_rc == 0
 

--- a/test/integration/replicaset/test_replicaset_bootstrap.py
+++ b/test/integration/replicaset/test_replicaset_bootstrap.py
@@ -68,7 +68,7 @@ def test_bootstrap_custom_app(tt_cmd, tmpdir_with_cfg, flag):
         expected = '⨯ bootstrap is not supported for an application by "custom" orchestrator'
         assert expected in out
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
 
@@ -95,7 +95,7 @@ def test_bootstrap_instance_no_replicaset_specified(tt_cmd, tmpdir_with_cfg):
         assert rc != 0
         assert "⨯ the replicaset must be specified to bootstrap an instance" in out
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
 
@@ -123,7 +123,7 @@ def test_bootstrap_app_replicaset_specified(tt_cmd, tmpdir_with_cfg):
         expected = "⨯ the replicaset can not be specified in the case of application bootstrapping"
         assert expected in out
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
 
@@ -237,7 +237,7 @@ def test_replicaset_bootstrap_cartridge_new_instance(tt_cmd, cartridge_app):
         assert re.search(expected, out)
     finally:
         # Get rid of the tested instance.
-        stop_cmd = [tt_cmd, "stop", f"{cartridge_name}:new_inst"]
+        stop_cmd = [tt_cmd, "stop", "-y", f"{cartridge_name}:new_inst"]
         rc, out = run_command_and_get_output(stop_cmd, cwd=cartridge_app.workdir)
         with open(instances_yml_path, "w") as f:
             f.write(old_instances_yml)

--- a/test/integration/replicaset/test_replicaset_demote.py
+++ b/test/integration/replicaset/test_replicaset_demote.py
@@ -28,7 +28,7 @@ def test_demote_cconfig_failover_off(tt_cmd, tmpdir_with_cfg, force):
         start_application(tt_cmd, tmpdir, app_name, instances)
         if force:
             # Stop an instance.
-            stop_cmd = [tt_cmd, "stop", f"{app_name}:off-failover-2"]
+            stop_cmd = [tt_cmd, "stop", "-y", f"{app_name}:off-failover-2"]
             rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
             instances.remove("off-failover-2")
             assert rc == 0
@@ -161,7 +161,7 @@ def test_demote_cconfig_errors(
             box_ctl_promote(tt_cmd, app_name, "election-failover-1", tmpdir)
 
         if stop_inst:
-            stop_cmd = [tt_cmd, "stop", f"{app_name}:{stop_inst}"]
+            stop_cmd = [tt_cmd, "stop", "-y", f"{app_name}:{stop_inst}"]
             rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
             assert rc == 0
             instances.remove(stop_inst)

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -80,7 +80,7 @@ Replicasets state: bootstrapped
    ⨯ expel is not supported for an application by "custom" orchestrator
 """, out)
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
 
@@ -211,6 +211,6 @@ Replicasets state: bootstrapped
 """ == out
 
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0

--- a/test/integration/replicaset/test_replicaset_promote.py
+++ b/test/integration/replicaset/test_replicaset_promote.py
@@ -150,7 +150,7 @@ def test_promote_cconfig_failovers(
             box_ctl_promote(tt_cmd, app_name, "election-failover-1", tmpdir)
 
         if stop_inst:
-            stop_cmd = [tt_cmd, "stop", f"{app_name}:{stop_inst}"]
+            stop_cmd = [tt_cmd, "stop", "-y", f"{app_name}:{stop_inst}"]
             rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
             assert rc == 0
 

--- a/test/integration/replicaset/test_replicaset_rebootstrap.py
+++ b/test/integration/replicaset/test_replicaset_rebootstrap.py
@@ -109,7 +109,7 @@ s2:''')
             assert oldSnapName != os.path.basename(snaps[0])
 
     finally:
-        run_command_and_get_output([tt_cmd, "stop"], cwd=tmp_path)
+        run_command_and_get_output([tt_cmd, "stop", "-y"], cwd=tmp_path)
 
 
 @pytest.mark.skipif(tarantool_major_version < 3,

--- a/test/integration/replicaset/test_replicaset_roles_add.py
+++ b/test/integration/replicaset/test_replicaset_roles_add.py
@@ -162,7 +162,7 @@ def test_replicaset_cconfig_roles_add(
         start_application(tt_cmd, tmpdir_with_cfg, app_name, instances)
 
         if stop_instance:
-            stop_cmd = [tt_cmd, "stop", f"{app_name}:{stop_instance}"]
+            stop_cmd = [tt_cmd, "stop", "-y", f"{app_name}:{stop_instance}"]
             rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
             assert rc == 0
         if is_add_role:

--- a/test/integration/replicaset/test_replicaset_vshard.py
+++ b/test/integration/replicaset/test_replicaset_vshard.py
@@ -81,7 +81,7 @@ Replicasets state: bootstrapped
    ⨯ bootstrap vshard is not supported for an application by "custom" orchestrator
 """, out)
     finally:
-        stop_cmd = [tt_cmd, "stop", app_name]
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
         rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir)
         assert rc == 0
 

--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -48,7 +48,7 @@ def test_restart(tt_cmd, tmpdir_with_cfg):
                          pid_file, []) != ""
 
     finally:
-        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], [])
+        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], ["y\n"])
 
 
 def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
@@ -75,7 +75,7 @@ def test_restart_with_auto_yes(tt_cmd, tmpdir_with_cfg):
                          pid_file, []) != ""
 
     finally:
-        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], [])
+        app_cmd(tt_cmd, tmpdir_with_cfg, ["stop", app_name], ["y\n"])
 
 
 def test_restart_no_args(tt_cmd, tmp_path):
@@ -93,4 +93,4 @@ def test_restart_no_args(tt_cmd, tmp_path):
         assert "Confirm restart of all instances [y/n]" in restart_output[0]
 
     finally:
-        app_cmd(tt_cmd, test_app_path, ["stop"], [])
+        app_cmd(tt_cmd, test_app_path, ["stop"], ["y\n"])

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -52,7 +52,7 @@ def test_running_base_functionality(tt_cmd, tmpdir_with_cfg):
     assert status_info["test_app"]["MODE"] == "RO"
 
     # Stop the Instance.
-    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
     assert stop_rc == 0
     assert re.search(r"The Instance test_app \(PID = \d+\) has been terminated.", stop_out)
@@ -117,7 +117,7 @@ def test_restart(tt_cmd, tmpdir_with_cfg):
     assert status_out["test_app"]["STATUS"] == "RUNNING"
 
     # Stop the new Instance.
-    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
     assert stop_rc == 0
     assert re.search(r"The Instance test_app \(PID = \d+\) has been terminated.", stop_out)
@@ -165,7 +165,7 @@ def test_logrotate(tt_cmd, tmpdir_with_cfg):
         assert "reopened" in f.read()
 
     # Stop the Instance.
-    stop_cmd = [tt_cmd, "stop", "test_env_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_env_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
     assert stop_rc == 0
     assert re.search(r"The Instance test_env_app \(PID = \d+\) has been terminated.", stop_out)
@@ -222,7 +222,7 @@ def test_clean(tt_cmd, tmpdir_with_cfg):
     assert re.search(r"instance `test_data_app` must be stopped", clean_out)
 
     # Stop the Instance.
-    stop_cmd = [tt_cmd, "stop", "test_data_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_data_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
     assert stop_rc == 0
     assert re.search(r"The Instance test_data_app \(PID = \d+\) has been terminated\.", stop_out)
@@ -282,7 +282,7 @@ def test_running_base_functionality_working_dir_app(tt_cmd):
                 assert status_out[f"app:{instName}"]["STATUS"] == "RUNNING"
 
             # Stop the application.
-            stop_cmd = [tt_cmd, "stop", "app"]
+            stop_cmd = [tt_cmd, "stop", "-y", "app"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert stop_rc == 0
             assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
@@ -334,7 +334,7 @@ def test_running_base_functionality_working_dir_app_no_app_name(tt_cmd):
                 assert status_out[f"app:{instName}"]["STATUS"] == "RUNNING"
 
             # Stop the application.
-            stop_cmd = [tt_cmd, "stop"]
+            stop_cmd = [tt_cmd, "stop", "-y"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert stop_rc == 0
             assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
@@ -384,7 +384,7 @@ def test_running_instance_from_multi_inst_app(tt_cmd):
             assert status_out[f"app:{inst}"]["STATUS"] == "NOT RUNNING"
 
         # Stop the Instance.
-        stop_cmd = [tt_cmd, "stop", "app:router"]
+        stop_cmd = [tt_cmd, "stop", "-y", "app:router"]
         stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
         assert stop_rc == 0
         assert re.search(r"The Instance app:router \(PID = \d+\) has been terminated.", stop_out)
@@ -562,7 +562,7 @@ def test_no_args_usage(tt_cmd):
             assert re.search(r"app2: logs has been rotated. PID: \d+.", status_out)
 
             # Stop all applications.
-            stop_cmd = [tt_cmd, "stop"]
+            stop_cmd = [tt_cmd, "stop", "-y"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert stop_rc == 0
             assert re.search(r"The Instance app1:(router|master|replica) \(PID = \d+\) "
@@ -603,7 +603,7 @@ def test_running_env_variables(tt_cmd, tmpdir_with_cfg):
     assert status_out["test_env_app"]["STATUS"] == "RUNNING"
 
     # Stop the Instance.
-    stop_cmd = [tt_cmd, "stop", "test_env_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_env_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmpdir)
     assert stop_rc == 0
     assert re.search(r"The Instance test_env_app \(PID = \d+\) has been terminated.", stop_out)
@@ -661,7 +661,7 @@ def test_running_tarantoolctl_layout(tt_cmd, tmp_path):
     assert status_out["test_app"]["STATUS"] == "RUNNING"
 
     # Stop the Instance.
-    stop_cmd = [tt_cmd, "stop", "test_app"]
+    stop_cmd = [tt_cmd, "stop", "-y", "test_app"]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=tmp_path)
     assert status_rc == 0
     assert re.search(r"The Instance test_app \(PID = \d+\) has been terminated.", stop_out)
@@ -710,7 +710,7 @@ def test_running_start(tt_cmd):
             for instName in instances:
                 assert status_out[f'app:{instName}']["STATUS"] == "RUNNING"
 
-            status_cmd = [tt_cmd, "stop", "app:router"]
+            status_cmd = [tt_cmd, "stop", "-y", "app:router"]
             status_rc, stop_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
             assert status_rc == 0
             assert re.search(r"The Instance app:router \(PID = \d+\) "
@@ -751,7 +751,7 @@ def test_running_start(tt_cmd):
                 assert status_out[f'app:{instName}']["STATUS"] == "RUNNING"
 
             # Stop all applications.
-            stop_cmd = [tt_cmd, "stop"]
+            stop_cmd = [tt_cmd, "stop", "-y"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_app_path)
             assert status_rc == 0
             assert re.search(r"The Instance app:(router|master|replica|stateboard) \(PID = \d+\) "
@@ -814,7 +814,7 @@ def test_running_instance_from_multi_inst_app_no_init_script(tt_cmd):
                 assert status_out[f"mi_app:{inst}"]["STATUS"] == "RUNNING"
 
             # Stop the Instance.
-            stop_cmd = [tt_cmd, "stop", "mi_app"]
+            stop_cmd = [tt_cmd, "stop", "-y", "mi_app"]
             stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=test_env_path)
             assert stop_rc == 0
             assert re.search(r"The Instance mi_app:router \(PID = \d+\) has been terminated.",

--- a/test/integration/running/test_running_cluster.py
+++ b/test/integration/running/test_running_cluster.py
@@ -26,7 +26,7 @@ def start_application(cmd, workdir, app_name, instances):
 
 
 def stop_application(tt_cmd, app_name, workdir, instances):
-    stop_cmd = [tt_cmd, "stop", app_name]
+    stop_cmd = [tt_cmd, "stop", "-y", app_name]
     stop_rc, stop_out = run_command_and_get_output(stop_cmd, cwd=workdir)
     assert stop_rc == 0
 

--- a/test/integration/stop/multi_app
+++ b/test/integration/stop/multi_app
@@ -1,0 +1,1 @@
+../running/multi_app

--- a/test/integration/stop/test_app.lua
+++ b/test/integration/stop/test_app.lua
@@ -1,0 +1,7 @@
+local fiber = require('fiber')
+
+box.cfg({})
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/stop/test_stop.py
+++ b/test/integration/stop/test_stop.py
@@ -1,0 +1,128 @@
+import os
+import shutil
+
+from utils import pid_file, run_command_and_get_output, run_path, wait_file
+
+
+def test_stop(tt_cmd, tmpdir_with_cfg):
+    shutil.copy(os.path.join(os.path.dirname(__file__), "test_app.lua"), tmpdir_with_cfg)
+    app_name = "test_app"
+    start_cmd = [tt_cmd, "start", app_name]
+    rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir_with_cfg)
+    assert "Starting an instance" in out
+    assert wait_file(os.path.join(tmpdir_with_cfg, app_name, run_path, app_name),
+                     pid_file, []) != ""
+
+    try:
+        # Test confirmed stop.
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg, input="y\n")
+        assert f"Confirm stop of '{app_name}' [y/n]" in out
+        assert "has been terminated" in out
+        app_path = os.path.join(tmpdir_with_cfg, app_name, run_path, app_name, pid_file)
+        assert not os.path.exists(app_path)
+
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir_with_cfg)
+        assert rc == 0
+        assert "Starting an instance" in out
+        assert wait_file(os.path.join(tmpdir_with_cfg, app_name, run_path, app_name),
+                         pid_file, []) != ""
+
+        # Test cancelled stop.
+        stop_cmd = [tt_cmd, "stop", app_name]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg, input="n\n")
+        assert rc == 0
+        assert f"Confirm stop of '{app_name}' [y/n]" in out
+        assert "Stop is cancelled" in out
+        assert os.path.exists(app_path)
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
+        run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+
+
+def test_stop_with_auto_yes(tt_cmd, tmpdir_with_cfg):
+    shutil.copy(os.path.join(os.path.dirname(__file__), "test_app.lua"), tmpdir_with_cfg)
+    app_name = "test_app"
+    start_cmd = [tt_cmd, "start", app_name]
+    rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 0
+    assert "Starting an instance" in out
+    assert wait_file(os.path.join(tmpdir_with_cfg, app_name, run_path, app_name),
+                     pid_file, []) != ""
+
+    try:
+        # Test auto-stop with -y flag.
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+        assert rc == 0
+        assert f"Confirm stop of '{app_name}' [y/n]" not in out
+        assert "has been terminated" in out
+        app_path = os.path.join(tmpdir_with_cfg, app_name, run_path, app_name, pid_file)
+        assert not os.path.exists(app_path)
+
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir_with_cfg)
+        assert rc == 0
+        assert "Starting an instance" in out
+        assert wait_file(os.path.join(tmpdir_with_cfg, app_name, run_path, app_name),
+                         pid_file, []) != ""
+
+        # Test auto-stop with --yes flag.
+        stop_cmd = [tt_cmd, "stop", "--yes", app_name]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+        assert rc == 0
+        assert f"Confirm stop of '{app_name}' [y/n]" not in out
+        assert "has been terminated" in out
+        assert not os.path.exists(app_path)
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
+        run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+
+
+def test_stop_no_args(tt_cmd, tmp_path):
+    app_name = "multi_app"
+    test_app_path_src = os.path.join(os.path.dirname(__file__), app_name)
+    test_app_path = os.path.join(tmp_path, app_name)
+    shutil.copytree(test_app_path_src, test_app_path)
+
+    start_cmd = [tt_cmd, "start"]
+    rc, out = run_command_and_get_output(start_cmd, cwd=test_app_path)
+    assert rc == 0
+    assert "Starting an instance" in out
+
+    try:
+        # Test confirmed stop of all instances.
+        stop_cmd = [tt_cmd, "stop"]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=test_app_path, input="y\n")
+        assert "Confirm stop of all instances [y/n]" in out
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", "-y"]
+        run_command_and_get_output(stop_cmd, cwd=test_app_path)
+
+
+def test_stop_no_prompt(tt_cmd, tmpdir_with_cfg):
+    shutil.copy(os.path.join(os.path.dirname(__file__), "test_app.lua"), tmpdir_with_cfg)
+    app_name = "test_app"
+    start_cmd = [tt_cmd, "start", app_name]
+    rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir_with_cfg)
+    assert rc == 0
+    assert "Starting an instance" in out
+    assert wait_file(os.path.join(tmpdir_with_cfg, app_name, run_path, app_name),
+                     pid_file, []) != ""
+
+    try:
+        # Test stop with tt --no-prompt flag.
+        stop_cmd = [tt_cmd, "--no-prompt", "stop", app_name]
+        rc, out = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
+        assert f"Confirm stop of '{app_name}' [y/n]" not in out
+        assert "has been terminated" in out
+        app_path = os.path.join(tmpdir_with_cfg, app_name, run_path, app_name, pid_file)
+        assert not os.path.exists(app_path)
+
+    finally:
+        stop_cmd = [tt_cmd, "stop", "-y", app_name]
+        run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)

--- a/test/vshard_cluster.py
+++ b/test/vshard_cluster.py
@@ -62,7 +62,7 @@ class VshardCluster:
         if inst is not None:
             stop_arg = stop_arg + ":" + inst
 
-        cmd = [self.tt_cmd, "stop", stop_arg]
+        cmd = [self.tt_cmd, "stop", "-y", stop_arg]
         rc, _ = run_command_and_get_output(cmd, cwd=self.env_dir)
         assert rc == 0
 


### PR DESCRIPTION
Since the **stop** command is dangerous and can be harmful if executed accidentally, it was necessary to add a user confirmation for its execution to improve security.  
To use auto-confirm, you must pass the -y / --yes option, like this: `tt stop -y` or you can use `--no-prompt` option to skip interactions.