### PR TITLE
replicaset: add command 'roles remove'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   config (3.0) or cartridge orchestrator.
 - `tt replicaset roles add`: command to add roles in the tarantool replicaset with
  cluster config (3.0) or cartridge orchestrator.
+- `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with
+ cluster config (3.0) or cartridge orchestrator.
 
 ### Fixed
 

--- a/cli/cluster/cmd/replicaset.go
+++ b/cli/cluster/cmd/replicaset.go
@@ -301,7 +301,7 @@ type RolesChangeCtx struct {
 }
 
 // ChangeRole adds/removes a role by patching the cluster config.
-func ChangeRole(uri *url.URL, ctx RolesChangeCtx, changeRoleFunc replicaset.ChangeRoleFunc) error {
+func ChangeRole(uri *url.URL, ctx RolesChangeCtx, action replicaset.RolesChangerAction) error {
 	opts, err := ParseUriOpts(uri)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", uri, err)
@@ -327,7 +327,7 @@ func ChangeRole(uri *url.URL, ctx RolesChangeCtx, changeRoleFunc replicaset.Chan
 		IsGlobal:       ctx.IsGlobal,
 		RoleName:       ctx.RoleName,
 		Force:          ctx.Force,
-	}, changeRoleFunc)
+	}, action)
 	if err == nil {
 		log.Info("Done.")
 	}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -575,7 +575,7 @@ func internalClusterReplicasetRolesAddModule(cmdCtx *cmdcontext.CmdCtx, args []s
 	}
 
 	rolesChangeCtx.RoleName = args[1]
-	return clustercmd.ChangeRole(uri, rolesChangeCtx, replicaset.AddRole)
+	return clustercmd.ChangeRole(uri, rolesChangeCtx, replicaset.RolesAdder{})
 }
 
 // internalClusterReplicasetRolesRemoveModule is a "cluster replicaset roles remove" command.
@@ -597,7 +597,7 @@ func internalClusterReplicasetRolesRemoveModule(cmdCtx *cmdcontext.CmdCtx, args 
 	}
 
 	rolesChangeCtx.RoleName = args[1]
-	return clustercmd.ChangeRole(uri, rolesChangeCtx, replicaset.RemoveRole)
+	return clustercmd.ChangeRole(uri, rolesChangeCtx, replicaset.RolesRemover{})
 }
 
 // internalClusterFailoverSwitchModule is as "cluster failover switch" command

--- a/cli/replicaset/cartridge_test.go
+++ b/cli/replicaset/cartridge_test.go
@@ -19,14 +19,14 @@ var _ replicaset.Demoter = &replicaset.CartridgeInstance{}
 var _ replicaset.Expeller = &replicaset.CartridgeInstance{}
 var _ replicaset.VShardBootstrapper = &replicaset.CartridgeInstance{}
 var _ replicaset.Bootstrapper = &replicaset.CartridgeInstance{}
-var _ replicaset.RolesAdder = &replicaset.CartridgeInstance{}
+var _ replicaset.RolesChanger = &replicaset.CartridgeInstance{}
 
 var _ replicaset.Discoverer = &replicaset.CartridgeApplication{}
 var _ replicaset.Promoter = &replicaset.CartridgeApplication{}
 var _ replicaset.Demoter = &replicaset.CartridgeApplication{}
 var _ replicaset.Expeller = &replicaset.CartridgeApplication{}
 var _ replicaset.Bootstrapper = &replicaset.CartridgeApplication{}
-var _ replicaset.RolesAdder = &replicaset.CartridgeApplication{}
+var _ replicaset.RolesChanger = &replicaset.CartridgeApplication{}
 
 func TestCartridgeApplication_Demote(t *testing.T) {
 	app := replicaset.NewCartridgeApplication(running.RunningCtx{})
@@ -978,9 +978,32 @@ func TestCartridgeInstance_Expel(t *testing.T) {
 		`expel is not supported for a single instance by "cartridge" orchestrator`)
 }
 
-func TestCartridgeInstance_RolesAdd(t *testing.T) {
+func TestCartridgeInstance_RolesChange(t *testing.T) {
+	cases := []struct {
+		name         string
+		changeAction replicaset.RolesChangerAction
+		errMsg       string
+	}{
+		{
+			name:         "roles add",
+			changeAction: replicaset.RolesAdder{},
+			errMsg: "roles add is not supported for a single instance by" +
+				` "cartridge" orchestrator`,
+		},
+		{
+			name:         "roles remove",
+			changeAction: replicaset.RolesRemover{},
+			errMsg: "roles remove is not supported for a single instance by" +
+				` "cartridge" orchestrator`,
+		},
+	}
+
 	inst := replicaset.NewCartridgeInstance(nil)
-	err := inst.RolesAdd(replicaset.RolesChangeCtx{})
-	assert.EqualError(t, err,
-		`roles add is not supported for a single instance by "cartridge" orchestrator`)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := inst.RolesChange(replicaset.RolesChangeCtx{}, tc.changeAction)
+			assert.EqualError(t, err, tc.errMsg)
+		})
+	}
 }

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -22,7 +22,7 @@ type replicasetOrchestrator interface {
 	replicaset.Expeller
 	replicaset.VShardBootstrapper
 	replicaset.Bootstrapper
-	replicaset.RolesAdder
+	replicaset.RolesChanger
 }
 
 // makeApplicationOrchestrator creates an orchestrator for the application.

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -213,9 +213,9 @@ func (c *CConfigSource) Expel(ctx ExpelCtx) error {
 	)
 }
 
-// ChangeRole patches a config to add role to a config.
-func (c *CConfigSource) ChangeRole(ctx RolesChangeCtx, changeRoleFunc ChangeRoleFunc) error {
-	return c.patchConfigWithRoles(ctx, getCConfigRolesPath, changeRoleFunc, patchCConfigEditRole)
+// ChangeRole patches a config with addition/removing role.
+func (c *CConfigSource) ChangeRole(ctx RolesChangeCtx, action RolesChangerAction) error {
+	return c.patchConfigWithRoles(ctx, getCConfigRolesPath, action.Change, patchCConfigEditRole)
 }
 
 // getCConfigRolesPath returns a path and it's minimum interesting depth

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -120,12 +120,12 @@ func TestCConfigSource_collect_config_error(t *testing.T) {
 		},
 		{
 			func(source *replicaset.CConfigSource) error {
-				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.AddRole)
+				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RolesAdder{})
 			},
 		},
 		{
 			func(source *replicaset.CConfigSource) error {
-				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RemoveRole)
+				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RolesRemover{})
 			},
 		},
 	}
@@ -281,7 +281,7 @@ func TestCConfigSource_passes_force(t *testing.T) {
 		{
 			func(source *replicaset.CConfigSource) error {
 				return source.ChangeRole(replicaset.RolesChangeCtx{InstName: instName, Force: true},
-					replicaset.AddRole)
+					replicaset.RolesAdder{})
 			},
 		},
 	}
@@ -330,7 +330,7 @@ func TestCConfigSource_publish_error(t *testing.T) {
 		{
 			func(source *replicaset.CConfigSource) error {
 				return source.ChangeRole(replicaset.RolesChangeCtx{InstName: instName},
-					replicaset.AddRole)
+					replicaset.RolesAdder{})
 			},
 		},
 	}
@@ -379,7 +379,7 @@ func TestCConfigSource_keypick_error(t *testing.T) {
 		{
 			func(source *replicaset.CConfigSource) error {
 				return source.ChangeRole(replicaset.RolesChangeCtx{InstName: instName},
-					replicaset.AddRole)
+					replicaset.RolesAdder{})
 			},
 		},
 	}
@@ -421,12 +421,12 @@ func TestCConfigSource_Promote_invalid_config(t *testing.T) {
 		},
 		{
 			func(source *replicaset.CConfigSource) error {
-				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.AddRole)
+				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RolesAdder{})
 			},
 		},
 		{
 			func(source *replicaset.CConfigSource) error {
-				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RemoveRole)
+				return source.ChangeRole(replicaset.RolesChangeCtx{}, replicaset.RolesRemover{})
 			},
 		},
 	}
@@ -936,7 +936,7 @@ roles:
 			publisher := newOnceMockDataPublisher(nil)
 			source := replicaset.NewCConfigSource(collector, publisher, picker)
 
-			err := source.ChangeRole(tc.rolesChangeCtx, replicaset.AddRole)
+			err := source.ChangeRole(tc.rolesChangeCtx, replicaset.RolesAdder{})
 			if tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {
@@ -1122,7 +1122,7 @@ roles: []
 			publisher := newOnceMockDataPublisher(nil)
 			source := replicaset.NewCConfigSource(collector, publisher, picker)
 
-			err := source.ChangeRole(tc.rolesChangeCtx, replicaset.RemoveRole)
+			err := source.ChangeRole(tc.rolesChangeCtx, replicaset.RolesRemover{})
 			if tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -93,9 +93,9 @@ func (c *CustomInstance) Bootstrap(BootstrapCtx) error {
 	return newErrBootstrapByInstanceNotSupported(OrchestratorCustom)
 }
 
-// RolesAdd is not supported for a single instance by the Custom orchestrator.
-func (c *CustomInstance) RolesAdd(RolesChangeCtx) error {
-	return newErrRolesAddByInstanceNotSupported(OrchestratorCustom)
+// RolesChange is not supported for a single instance by the Custom orchestrator.
+func (c *CustomInstance) RolesChange(_ RolesChangeCtx, action RolesChangerAction) error {
+	return newErrRolesChangeByInstanceNotSupported(OrchestratorCustom, action)
 }
 
 // CustomApplication is an application with a custom orchestrator.
@@ -167,9 +167,10 @@ func (c *CustomApplication) Bootstrap(BootstrapCtx) error {
 	return newErrBootstrapByAppNotSupported(OrchestratorCustom)
 }
 
-// RolesAdd is not supported for an application by the Custom orchestrator.
-func (c *CustomApplication) RolesAdd(RolesChangeCtx) error {
-	return newErrRolesAddByAppNotSupported(OrchestratorCustom)
+// RolesChange is not supported for an application by the Custom orchestrator.
+func (c *CustomApplication) RolesChange(_ RolesChangeCtx,
+	action RolesChangerAction) error {
+	return newErrRolesChangeByAppNotSupported(OrchestratorCustom, action)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/roles_test.go
+++ b/cli/replicaset/roles_test.go
@@ -21,7 +21,11 @@ func TestRoles_AddRole(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := replicaset.AddRole(tc.roles, tc.roleToAdd)
+			adder := replicaset.RolesAdder{}
+
+			require.Equal(t, adder.Action(), replicaset.AddAction)
+
+			res, err := adder.Change(tc.roles, tc.roleToAdd)
 			if tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {
@@ -47,7 +51,11 @@ func TestRoles_RemoveRole(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := replicaset.RemoveRole(tc.roles, tc.roleToRemove)
+			remover := replicaset.RolesRemover{}
+
+			require.Equal(t, remover.Action(), replicaset.RemoveAction)
+
+			res, err := remover.Change(tc.roles, tc.roleToRemove)
 			if tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -680,7 +680,7 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 	var err error
 
 	if len(args) > 1 && cmdCtx.CommandName != "run" && cmdCtx.CommandName != "connect" &&
-		cmdCtx.CommandName != "add" {
+		cmdCtx.CommandName != "add" && cmdCtx.CommandName != "remove" {
 		return util.NewArgError("currently, you can specify only one instance at a time")
 	}
 

--- a/test/cartridge_helper.py
+++ b/test/cartridge_helper.py
@@ -16,11 +16,12 @@ cartridge_password = "secret-cluster-cookie"
 instances = ["router",
              "s1-master", "s1-replica",
              "s2-master", "s2-replica-1", "s2-replica-2",
-             "stateboard"]
+             "stateboard",
+             "s3-master"]
 
 
 def get_instances_cfg():
-    ports = find_ports(13)
+    ports = find_ports(15)
     cfg = {
         f"{cartridge_name}.router": {
             "advertise_uri": f"localhost:{ports[0]}",
@@ -50,6 +51,10 @@ def get_instances_cfg():
             "listen": f"localhost:{ports[12]}",
             "password": "passwd",
         },
+        f"{cartridge_name}.s3-master": {
+            "advertise_uri": f"localhost:{ports[13]}",
+            "http_port": ports[14],
+        },
     }
     return cfg
 
@@ -74,6 +79,13 @@ replicasets_cfg = {
         "all_rw": False,
         "vshard_group": "default"
     },
+    "s-3": {
+        "instances": ["s3-master"],
+        "roles": ["app.roles.custom"],
+        "weight": 1,
+        "all_rw": False,
+        "vshard_group": "default"
+    }
 }
 
 

--- a/test/integration/replicaset/test_replicaset_bootstrap.py
+++ b/test/integration/replicaset/test_replicaset_bootstrap.py
@@ -153,6 +153,13 @@ def test_replicaset_bootstrap_cartridge_app_second_bootstrap(tt_cmd, cartridge_a
             "all_rw": False,
             "vshard_group": "default"
         },
+        "s-3": {
+            "instances": ["s3-master"],
+            "roles": ["app.roles.custom"],
+            "weight": 1,
+            "all_rw": False,
+            "vshard_group": "default"
+        }
     }
     with open(os.path.join(cartridge_app.workdir, cartridge_name, "replicasets.yml"), "w") as f:
         f.write(yaml.dump(replicasets_cfg))


### PR DESCRIPTION
@TarantoolBot document
Title: `tt replicaset roles remove` removes roles in the tarantool replicaset
with cluster config (3.0) or cartridge orchestrator.

This patch introduces new command for the replicaset module.

```
$ tt rs roles remove [--cartridge|--config|--custom] [-f] [--timeout secs]
    <APP_NAME:INSTANCE_NAME> <ROLE_NAME> [flags]
```

It is possible to provide `cartridge`, `config` or `custom` flag to explicitly state which orchestrator to use. ROLE_NAME is a role to remove from local cluster config in case of `cluster config` orchestrator and directly from all instances of replicaset in case of `cartridge` orchestrator. Command supports `cartridge` and `cluster config` orchestrators only for the entire application. INSTANCE_NAME works only for `cluster config` to provide instance  ame to remove role from.

There are flags supported by this command:
- `--global (-G)` for a global scope to add a role (only for `cluster config`
  orchestrator);
- `--instance (-i) string` for an application name target to specify
  an instance to add a role;
- `--replicaset (-r) string` for an application name target to specify
  a replicaset to add a role;
- `--group (-g) string` for an application name target to specify a group
  to specify a group to add a role (only for `cluster config`);
- `--force (-f)` skips instances not found locally in `cluster
  config` orchestrator.

Closes https://github.com/tarantool/tt/issues/916