### PR TITLE
test: fix stop without prompt

### DIFF
--- a/test/integration/replicaset/test_replicaset_roles_remove.py
+++ b/test/integration/replicaset/test_replicaset_roles_remove.py
@@ -198,7 +198,7 @@ def test_replicaset_cconfig_roles_remove(
         start_application(tt_cmd, tmpdir_with_cfg, app_name, instances)
 
         if stop_instance:
-            stop_cmd = [tt_cmd, "stop", f"{app_name}:{stop_instance}"]
+            stop_cmd = [tt_cmd, "stop", "-y", f"{app_name}:{stop_instance}"]
             rc, _ = run_command_and_get_output(stop_cmd, cwd=tmpdir_with_cfg)
             assert rc == 0
 


### PR DESCRIPTION
Since `stop` command needs confirmation by default, new tests was failed waiting indefinitely for confirmation.

After the patch `stop` is executed with `-y` flag to ignore the confirmation request.

Follow up #916