### PR TITLE
tt: add command `tt upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt replicaset upgrade`: command to upgrade the schema on a Tarantool cluster.
+  * `-r (--replicaset)`: specify the replicaset name(s) to upgrade.
+  * `-t (--timeout)`: timeout for waiting the LSN synchronization (in seconds) (default 5).
+
 ### Changed
 
 ### Fixed

--- a/cli/replicaset/cmd/lua/upgrade.lua
+++ b/cli/replicaset/cmd/lua/upgrade.lua
@@ -1,0 +1,10 @@
+local ok, err = pcall(box.schema.upgrade)
+if ok then
+   ok, err = pcall(box.snapshot)
+end
+
+return {
+        lsn = box.info.lsn,
+        iid = box.info.id,
+        err = (not ok) and tostring(err) or nil,
+}

--- a/cli/replicaset/cmd/upgrade.go
+++ b/cli/replicaset/cmd/upgrade.go
@@ -1,0 +1,268 @@
+package replicasetcmd
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/replicaset"
+	"github.com/tarantool/tt/cli/running"
+)
+
+// UpgradeOpts contains options used for the upgrade process.
+type UpgradeOpts struct {
+	// List of replicaset names specified by the user for the upgrade.
+	ChosenReplicasetAliases []string
+	// Timeout period (in seconds) for waiting on LSN synchronization.
+	LsnTimeout int
+}
+
+type instanceMeta struct {
+	run  running.InstanceCtx
+	conn connector.Connector
+}
+
+//go:embed lua/upgrade.lua
+var upgradeMasterLua string
+
+type syncInfo struct {
+	LSN uint64  `mapstructure:"lsn"`
+	IID uint32  `mapstructure:"iid"`
+	Err *string `mapstructure:"err"`
+}
+
+// filterReplicasetsByAliases filters the given replicaset list by chosen aliases and
+// returns chosen replicasets. If a non-existent alias is found, it returns an error.
+func filterReplicasetsByAliases(replicasets replicaset.Replicasets,
+	chosenReplicasetAliases []string) ([]replicaset.Replicaset, error) {
+	// If no aliases are provided, return all replicasets.
+	if len(chosenReplicasetAliases) == 0 {
+		return replicasets.Replicasets, nil
+	}
+
+	// Create a map for fast lookup of replicasets by alias.
+	replicasetMap := make(map[string]replicaset.Replicaset)
+	for _, rs := range replicasets.Replicasets {
+		replicasetMap[rs.Alias] = rs
+	}
+
+	var chosenReplicasets []replicaset.Replicaset
+	for _, alias := range chosenReplicasetAliases {
+		rs, exists := replicasetMap[alias]
+		if !exists {
+			return nil, fmt.Errorf("replicaset with alias %q doesn't exist", alias)
+		}
+		chosenReplicasets = append(chosenReplicasets, rs)
+	}
+
+	return chosenReplicasets, nil
+}
+
+// Upgrade upgrades tarantool schema.
+func Upgrade(discoveryCtx DiscoveryCtx, opts UpgradeOpts) error {
+	replicasets, err := getReplicasets(discoveryCtx)
+	if err != nil {
+		return err
+	}
+
+	replicasets = fillAliases(replicasets)
+	replicasetsToUpgrade, err := filterReplicasetsByAliases(replicasets,
+		opts.ChosenReplicasetAliases)
+	if err != nil {
+		return err
+	}
+
+	return internalUpgrade(replicasetsToUpgrade, opts.LsnTimeout)
+}
+
+func internalUpgrade(replicasets []replicaset.Replicaset, lsnTimeout int) error {
+	for _, replicaset := range replicasets {
+		err := upgradeReplicaset(replicaset, lsnTimeout)
+		if err != nil {
+			fmt.Printf("• %s: error\n", replicaset.Alias)
+			return fmt.Errorf("replicaset %s: %w", replicaset.Alias, err)
+		}
+		fmt.Printf("• %s: ok\n", replicaset.Alias)
+	}
+	return nil
+}
+
+func closeConnectors(master *instanceMeta, replicas []instanceMeta) {
+	if master != nil {
+		master.conn.Close()
+	}
+	for _, replica := range replicas {
+		replica.conn.Close()
+	}
+}
+
+func getInstanceConnector(instance replicaset.Instance) (connector.Connector, error) {
+	run := instance.InstanceCtx
+	fullInstanceName := running.GetAppInstanceName(run)
+	if fullInstanceName == "" {
+		fullInstanceName = instance.Alias
+	}
+	if fullInstanceName == "" {
+		fullInstanceName = "unknown"
+	}
+
+	// Try to connect via unix socket.
+	conn, err := connector.Connect(connector.ConnectOpts{
+		Network: "unix",
+		Address: run.ConsoleSocket,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("instance %s failed to connect via UNIX socket "+
+			": %w", fullInstanceName, err)
+	}
+	return conn, nil
+}
+
+func collectRWROInfo(replset replicaset.Replicaset) (*instanceMeta, []instanceMeta,
+	error) {
+	var master *instanceMeta = nil
+	var replicas []instanceMeta
+	for _, instance := range replset.Instances {
+		run := instance.InstanceCtx
+		fullInstanceName := running.GetAppInstanceName(run)
+		conn, err := getInstanceConnector(instance)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if instance.Mode == replicaset.ModeUnknown {
+			closeConnectors(master, replicas)
+			return nil, nil, fmt.Errorf(
+				"can't determine RO/RW mode on instance: %s", fullInstanceName)
+		}
+
+		isRW := instance.Mode.String() == "rw"
+
+		if isRW && master != nil {
+			closeConnectors(master, replicas)
+			return nil, nil, fmt.Errorf("%s and %s are both masters",
+				running.GetAppInstanceName((*master).run), fullInstanceName)
+		} else if isRW {
+			master = &instanceMeta{run, conn}
+		} else {
+			replicas = append(replicas, instanceMeta{run, conn})
+		}
+	}
+	return master, replicas, nil
+}
+
+func waitLSN(conn connector.Connector, masterIID uint32, masterLSN uint64, lsnTimeout int) error {
+	var lastError error
+	query := fmt.Sprintf("return box.info.vclock[%d]", masterIID)
+
+	deadline := time.Now().Add(time.Duration(lsnTimeout) * time.Second)
+	for {
+		res, err := conn.Eval(query, []any{}, connector.RequestOpts{})
+		if err != nil {
+			lastError = fmt.Errorf("failed to evaluate LSN query: %w", err)
+		} else if len(res) == 0 {
+			lastError = errors.New("empty result from LSN query")
+		} else {
+			var lsn uint64
+			if err := mapstructure.Decode(res[0], &lsn); err != nil {
+				lastError = fmt.Errorf("failed to decode LSN: %w", err)
+			} else if lsn >= masterLSN {
+				return nil
+			} else {
+				lastError = fmt.Errorf("current LSN %d is behind required "+
+					"master LSN %d", lsn, masterLSN)
+			}
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return lastError
+}
+
+func upgradeMaster(master *instanceMeta) (syncInfo, error) {
+	var upgradeInfo syncInfo
+	fullMasterName := running.GetAppInstanceName(master.run)
+	res, err := master.conn.Eval(upgradeMasterLua, []any{}, connector.RequestOpts{})
+	if err != nil {
+		return upgradeInfo, fmt.Errorf(
+			"failed to execute upgrade script on master instance - %s: %w",
+			fullMasterName, err)
+	}
+
+	if err := mapstructure.Decode(res[0], &upgradeInfo); err != nil {
+		return upgradeInfo, fmt.Errorf(
+			"failed to decode response from master instance - %s: %w",
+			fullMasterName, err)
+	}
+
+	if upgradeInfo.Err != nil {
+		return upgradeInfo, fmt.Errorf(
+			"master instance upgrade failed - %s: %w",
+			fullMasterName, err)
+	}
+	return upgradeInfo, nil
+}
+
+func snapshot(instance *instanceMeta) error {
+	res, err := instance.conn.Eval("return box.snapshot()", []any{},
+		connector.RequestOpts{})
+	if err != nil {
+		return fmt.Errorf("failed to execute snapshot on replica: %w", err)
+	}
+	if len(res) == 0 {
+		return fmt.Errorf("snapshot command on %s returned an empty result, "+
+			"'ok' expected", running.GetAppInstanceName(instance.run))
+	}
+
+	if result, ok := res[0].(string); !ok || result != "ok" {
+		return fmt.Errorf("snapshot command on %s returned unexpected result: '%v', "+
+			"'ok' expected", running.GetAppInstanceName(instance.run), res[0])
+	}
+	return nil
+}
+
+func upgradeReplicaset(replicaset replicaset.Replicaset, lsnTimeout int) error {
+	master, replicas, err := collectRWROInfo(replicaset)
+	if err != nil {
+		return err
+	}
+
+	defer closeConnectors(master, replicas)
+
+	// Upgrade master instance, collect LSN and IID from master instance.
+	upgradeInfo, err := upgradeMaster(master)
+	if err != nil {
+		return err
+	}
+
+	// Upgrade replica instances.
+	masterLSN := upgradeInfo.LSN
+	masterIID := upgradeInfo.IID
+
+	for _, replica := range replicas {
+		fullReplicaName := running.GetAppInstanceName(replica.run)
+		err := waitLSN(replica.conn, masterIID, masterLSN, lsnTimeout)
+		if err != nil {
+			return fmt.Errorf("can't ensure that upgrade operations performed on %s "+
+				"are replicated to %s to perform snapshotting on it: error "+
+				"waiting LSN %d in vclock component %d: %w",
+				running.GetAppInstanceName(master.run), fullReplicaName,
+				masterLSN, masterIID, err)
+		}
+		err = snapshot(&replica)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/integration/replicaset/single-t2-app/init.lua
+++ b/test/integration/replicaset/single-t2-app/init.lua
@@ -1,0 +1,11 @@
+local fiber = require('fiber')
+local fio = require('fio')
+
+box.cfg({})
+
+fh = fio.open('ready', {'O_WRONLY', 'O_CREAT'}, tonumber('644',8))
+fh:close()
+
+while true do
+    fiber.sleep(5)
+end

--- a/test/integration/replicaset/single-t2-app/tt.yaml
+++ b/test/integration/replicaset/single-t2-app/tt.yaml
@@ -1,0 +1,9 @@
+env:
+  instances_enabled: .
+
+default:
+  app:
+    dir: .
+    file: init.lua
+    memtx_dir: ./
+    wal_dir: ./

--- a/test/integration/replicaset/test_replicaset_upgrade.py
+++ b/test/integration/replicaset/test_replicaset_upgrade.py
@@ -1,0 +1,194 @@
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+from replicaset_helpers import stop_application
+from vshard_cluster import VshardCluster
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, _ = get_tarantool_version()
+
+
+def run_command_on_instance(tt_cmd, tmpdir, full_inst_name, cmd):
+    con_cmd = [tt_cmd, "connect", full_inst_name, "-f", "-"]
+    instance_process = subprocess.Popen(
+        con_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+    instance_process.stdin.writelines([cmd])
+    instance_process.stdin.close()
+    output = instance_process.stdout.read()
+    return output
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3, reason="skip centralized config test for Tarantool < 3"
+)
+def test_upgrade_multi_master(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    app_name = "test_ccluster_app"
+    app_path = os.path.join(tmpdir, app_name)
+    shutil.copytree(os.path.join(os.path.dirname(__file__), app_name), app_path)
+    try:
+        # Start a cluster.
+        start_cmd = [tt_cmd, "start", app_name]
+        rc, out = run_command_and_get_output(start_cmd, cwd=tmpdir)
+        assert rc == 0
+
+        for i in range(1, 6):
+            file = wait_file(
+                os.path.join(tmpdir, app_name), f"ready-instance-00{i}", []
+            )
+            assert file != ""
+
+        status_cmd = [tt_cmd, "replicaset", "upgrade", app_name]
+
+        rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+        assert rc == 1
+        assert "replicaset-002: error" in out and "are both masters" in out
+
+    finally:
+        stop_application(tt_cmd, app_name, tmpdir, [])
+
+
+def test_upgrade_t2_app_dummy_replicaset(tt_cmd):
+    app_name = "single-t2-app"
+    test_app_path_src = os.path.join(os.path.dirname(__file__), app_name)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_app_path = os.path.join(tmpdir, app_name)
+        shutil.copytree(test_app_path_src, test_app_path)
+        memtx_dir = os.path.join(test_app_path, "var", "lib", app_name)
+        os.makedirs(memtx_dir, exist_ok=True)
+
+        try:
+            start_cmd = [tt_cmd, "start", app_name]
+            rc, out = run_command_and_get_output(start_cmd, cwd=test_app_path)
+            assert rc == 0
+
+            file = wait_file(test_app_path, "ready", [])
+            assert file != ""
+
+            # Downgrade schema.
+            out = run_command_on_instance(
+                tt_cmd,
+                test_app_path,
+                app_name,
+                "box.schema.downgrade('2.8.2') box.snapshot()",
+            )
+
+            upgrade_cmd = [tt_cmd, "replicaset", "upgrade", app_name, "--custom"]
+            rc, out = run_command_and_get_output(upgrade_cmd, cwd=test_app_path)
+            assert rc == 0
+            # Out is `• <uuid>: ok` because the instance has no name.
+            assert "ok" in out
+        finally:
+            stop_application(tt_cmd, app_name, test_app_path, [])
+
+
+@pytest.mark.skipif(tarantool_major_version < 3,
+                    reason="skip test with cluster config for Tarantool < 3")
+def test_upgrade_downgraded_cluster_replicasets(tt_cmd, tmp_path):
+    app_name = "vshard_app"
+    replicasets = {
+        "router-001": ["router-001-a"],
+        "storage-001": ["storage-001-a", "storage-001-b"],
+        "storage-002": ["storage-002-a", "storage-002-b"],
+    }
+    app = VshardCluster(tt_cmd, tmp_path, app_name)
+    try:
+        app.build()
+        app.start()
+        cmd_master = '''box.space._schema:run_triggers(false)
+box.space._schema:delete('replicaset_name')
+box.space._schema:run_triggers(true)
+
+box.space._cluster:run_triggers(false)
+box.atomic(function()
+    for _, tuple in box.space._cluster:pairs() do
+        pcall(box.space._cluster.update, box.space._cluster, {tuple.id}, {{'#', 'name', 1}})
+    end
+end)
+box.space._cluster:run_triggers(true)
+box.schema.downgrade('2.11.1')
+box.snapshot()
+        '''
+
+        # Downgrade cluster.
+        for _, replicaset in replicasets.items():
+            for replica in replicaset:
+                out = run_command_on_instance(
+                    tt_cmd,
+                    tmp_path,
+                    f"{app_name}:{replica}",
+                    "box.cfg{force_recovery=true} return box.cfg.force_recovery"
+                )
+                assert "true" in out
+
+        for _, replicaset in replicasets.items():
+            _ = run_command_on_instance(
+                tt_cmd,
+                tmp_path,
+                f"{app_name}:{replicaset[0]}",
+                cmd_master
+            )
+
+        for _, replicaset in replicasets.items():
+            if len(replicaset) == 2:
+                _ = run_command_on_instance(
+                    tt_cmd,
+                    tmp_path,
+                    f"{app_name}:{replicaset[1]}",
+                    "box.snapshot()"
+                )
+
+        for _, replicaset in replicasets.items():
+            for replica in replicaset:
+                out = run_command_on_instance(
+                    tt_cmd,
+                    tmp_path,
+                    f"{app_name}:{replica}",
+                    "box.cfg{force_recovery=false} return box.cfg.force_recovery"
+                )
+                assert "false" in out
+
+        # Can't create data (old schema).
+        out = run_command_on_instance(
+            tt_cmd,
+            tmp_path,
+            f"{app_name}:storage-001-a",
+            "box.schema.space.create('example_space')"
+        )
+        assert "error: Your schema version is 2.11.1" in out
+
+        # For some reason, the storage-002 replica set is having problems with
+        # replication after downgrade. For now check only replicaset storage-001.
+        upgrade_cmd = [tt_cmd, "replicaset", "upgrade", app_name, "-t=15"]
+        rc, out = run_command_and_get_output(upgrade_cmd, cwd=tmp_path)
+
+        assert rc == 0
+
+        upgrade_out = out.strip().split("\n")
+        assert len(upgrade_out) == len(replicasets)
+
+        for i in range(len(replicasets)):
+            assert "ok" in upgrade_out[i]
+
+        # Create data (new schema).
+        out = run_command_on_instance(
+            tt_cmd,
+            tmp_path,
+            f"{app_name}:storage-001-a",
+            "box.schema.space.create('example_space')"
+        )
+        assert "name: example_space" in out
+
+    finally:
+        app.stop()


### PR DESCRIPTION
### `tt upgrade` command steps:
- For each replicaset:
  - On the master instance:
    1. Execute the following commands sequentially:
       ```lua
       box.schema.upgrade()
       box.snapshot()
       ```
  - On each replica:
    1. Wait until the replica applies all transactions produced by `box.schema.upgrade()` on the master by comparing the vector clocks (vclock).
    2. Once synchronization is confirmed, execute the following command on the replica:
       ```lua
       box.snapshot()
       ```

> If any errors occur during the upgrade process, the process will stop and an error report will be generated.

-----

The replica is waiting for synchronization for `Timeout` seconds. The default value for `Timeout` is 5 seconds, but you can specify it manually using the `--timeout` option.
```bash
$tt upgrade [<APP_NAME>] --timeout 10
```

You can also specify which replicaset(s) to upgrade by using the `--replicaset` option.
```bash
$tt upgrade [<APP_NAME>] --replicaset <RS_NAME_1> -r <RS_NAME_2> ...
```