### PR TITLE
status: added output sort

### DIFF
--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -51,6 +51,7 @@ func Status(runningCtx running.RunningCtx, opts StatusOpts) error {
 		}
 		ts.AppendRow(row)
 	}
+	ts.SortBy([]table.SortBy{{Name: "INSTANCE", Mode: table.Asc}})
 
 	if opts.Pretty {
 		ts.SetStyle(table.StyleRounded)


### PR DESCRIPTION
Output of `tt status` was not sorted by instance name, so added sorting in ascending order.

Closes [911](https://github.com/tarantool/tt/issues/911)