### PR TITLE
ci: fix failed tests with tarantool 3.2.0

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         sdk-version:
           - "2.11.2-0-r609.linux.x86_64"
-          - "3.0.0-0-gf58f7d82a-r23.linux.x86_64"
+          - "3.2.0-0-r40.linux.x86_64"
       fail-fast: false
     steps:
         # `ref` as merge request is needed for pull_request_target because this
@@ -278,7 +278,7 @@ jobs:
       matrix:
         sdk-version:
           - "2.11.2-0-r609.linux.x86_64"
-          - "3.0.0-0-gf58f7d82a-r23.linux.x86_64"
+          - "3.2.0-0-r40.linux.x86_64"
       fail-fast: false
     steps:
       # `ref` as merge request is needed for pull_request_target because this

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         sdk-version:
           - "2.11.2-0-r609.linux.x86_64"
-          - "3.0.0-0-gf58f7d82a-r23.linux.x86_64"
+          - "3.2.0-0-r40.linux.x86_64"
       fail-fast: false
     steps:
         # `ref` as merge request is needed for pull_request_target because this

--- a/cli/running/process_controller.go
+++ b/cli/running/process_controller.go
@@ -102,17 +102,21 @@ func (pc *processController) StopWithSignal(waitTimeout time.Duration, stopSigna
 	// Terminate the process at any cost.
 	select {
 	case <-time.After(waitTimeout):
-		// Send "SIGKILL" signal
-		if err := pc.Cmd.Process.Kill(); err != nil {
-			return fmt.Errorf("failed to send SIGKILL to instance: %s", err)
-		} else {
-			// Wait for the process to terminate.
-			<-waitDone
-			return nil
+		if pc.IsAlive() {
+			// Send "SIGKILL" signal if process is still alive.
+			if err := pc.Cmd.Process.Kill(); err != nil {
+				return fmt.Errorf("failed to send SIGKILL to instance: %s", err)
+			} else {
+				// Wait for the process to terminate.
+				<-waitDone
+				return nil
+			}
 		}
 	case err := <-waitDone:
 		return err
 	}
+
+	return nil
 }
 
 // GetPid returns process PID.

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -95,13 +95,15 @@ func TestInstanceLogger(t *testing.T) {
 	assert := assert.New(t)
 
 	reader, writer := io.Pipe()
-	defer writer.Close()
-	defer reader.Close()
 	logger := ttlog.NewCustomLogger(writer, "", 0)
 	consoleSock := ""
 	inst := startTestInstance(t, context.Background(), "log_check_test_app", consoleSock, "",
 		logger)
-	t.Cleanup(func() { cleanupTestInstance(t, inst) })
+	t.Cleanup(func() {
+		defer reader.Close()
+		defer writer.Close()
+		cleanupTestInstance(t, inst)
+	})
 
 	msg := "Check Log.\n"
 	msgLen := int64(len(msg))

--- a/test/integration/rocks/test_rocks.py
+++ b/test/integration/rocks/test_rocks.py
@@ -176,7 +176,7 @@ def test_rocks_install_local_specific_version(tt_cmd, tmp_path):
 @pytest.mark.notarantool
 @pytest.mark.skipif(shutil.which("tarantool") is not None, reason="tarantool found in PATH")
 def test_rock_install_without_system_tarantool(tt_cmd, tmpdir_with_tarantool):
-    rocks_cmd = [tt_cmd, "rocks", "install", "mysql", "2.1.3-1"]
+    rocks_cmd = [tt_cmd, "rocks", "install", "pg", "2.0.1"]
     pwd = os.environ.get("PWD")
     os.environ["PWD"] = tmpdir_with_tarantool.as_posix()
     tt_process = subprocess.Popen(
@@ -191,7 +191,7 @@ def test_rock_install_without_system_tarantool(tt_cmd, tmpdir_with_tarantool):
     assert tt_process.returncode == 0
 
     assert os.path.exists(os.path.join(tmpdir_with_tarantool,
-                                       ".rocks", "lib", "tarantool", "mysql"))
+                                       ".rocks", "lib", "tarantool", "pg"))
 
 
 def test_rocks_install_from_dir_with_no_repo(tt_cmd, tmp_path):


### PR DESCRIPTION
There are a few failed tests with replacing tarantool sdk version in CI workflow from 3.0.0 into 3.2.0.

After the patch all failed tests related with the upgrade was fixed.

Part of https://github.com/tarantool/tt/issues/931