### PR TITLE
install: add the ability to flexibly define the version

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -10,7 +10,8 @@ on:
     types: [labeled]
 
 env:
-  GO_VERSION: '>=1.21.5'
+  # Note: Use exactly match version of tool, to avoid unexpected issues with test on CI.
+  GO_VERSION: '1.21.13'
   PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '>=1.21.5'
+  # Note: Use exactly match version of tool, to avoid unexpected issues with test on CI.
+  GO_VERSION: '1.21.13'
 
 jobs:
   create-packages-linux:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,8 @@ on:
     types: [labeled]
 
 env:
-  GO_VERSION: '>=1.21.5'
+  # Note: Use exactly match version of tool, to avoid unexpected issues with test on CI.
+  GO_VERSION: '1.21.13'
   PYTHON_VERSION: '3.10'
 
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '>=1.21.5'
+  # Note: Use exactly match version of tool, to avoid unexpected issues with test on CI.
+  GO_VERSION: '1.21.13'
 
 jobs:
   update:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  cluster config (3.0) or cartridge orchestrator.
 - `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with
  cluster config (3.0) or cartridge orchestrator.
+- `tt install tt|tarantool <version>` - allow <version> be incomplete. So `2.3` will install
+ the the last available release with specified <major=2>.<minor=3> in <version>.
 
 ### Fixed
 

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -24,6 +24,8 @@ const (
 		search.ProgramCe + "|" +
 		search.ProgramEe + ")"
 	verRegexp = "(?P<ver>.*)"
+
+	MajorMinorPatchRegexp = `^[0-9]+\.[0-9]+\.[0-9]+`
 )
 
 var errNotInstalled = errors.New("program is not installed")
@@ -157,7 +159,7 @@ func getAllTtVersionFormats(programName, ttVersion string) ([]string, error) {
 	if programName == search.ProgramTt {
 		// Need to determine if we have x.y.z format in tt uninstall argument
 		// to make sure we add version prefix.
-		versionMatches, err := regexp.Match(install.MajorMinorPatchRegexp, []byte(ttVersion))
+		versionMatches, err := regexp.Match(MajorMinorPatchRegexp, []byte(ttVersion))
 		if err != nil {
 			return versionsToDelete, err
 		}

--- a/cli/uninstall/uninstall_test.go
+++ b/cli/uninstall/uninstall_test.go
@@ -189,7 +189,7 @@ func TestGetAllVersionFormats(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ttVersions, err := getAllTtVersionFormats(tc.programName, tc.ttVersion)
 			assert.NoError(t, err)
-			assert.Equal(t, ttVersions, tc.expectedVersions)
+			assert.Equal(t, tc.expectedVersions, ttVersions)
 		})
 	}
 }

--- a/cli/version/version_match.go
+++ b/cli/version/version_match.go
@@ -1,0 +1,175 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/tarantool/tt/cli/util"
+)
+
+type requiredField uint8
+type requiredFields []requiredField
+
+const (
+	// Values according order of Fields in regex from `matchVersionParts()`.
+	requiredFieldBuildName requiredField = iota
+	requiredFieldMajor
+	requiredFieldMinor
+	requiredFieldPatch
+	requiredFieldReleaseType
+	requiredFieldReleaseNum
+	requiredFieldAdditional
+	requiredFieldHash
+	requiredFieldRevision
+
+	countOfRequiredFields
+)
+
+// NotFoundError is sentinel error for case when required version not found.
+type NotFoundError struct {
+	expected string
+}
+
+// Error implements the [error] interface.
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("not matched with: %q", e.expected)
+}
+
+// exploreMatchVersion examines the given string and retrieves the version components,
+// that define the rules for checking for version consistency.
+func exploreMatchVersion(verStr string) (Version, requiredFields, error) {
+	var version Version
+	fields := make(requiredFields, 0, countOfRequiredFields)
+
+	matches, err := matchVersionParts(verStr, false)
+	if err != nil {
+		return version, fields, err
+	}
+
+	version.BuildName = matches["buildname"]
+	if version.BuildName != "" {
+		fields = append(fields, requiredFieldBuildName)
+	}
+
+	if matches["major"] != "" {
+		if version.Major, err = util.AtoiUint64(matches["major"]); err != nil {
+			return version, fields, fmt.Errorf("can't parse Major: %w", err)
+		}
+		fields = append(fields, requiredFieldMajor)
+	}
+
+	if matches["minor"] != "" {
+		if matches["major"] == "" {
+			return version, fields, fmt.Errorf("minor version requires major to be specified")
+		}
+		if version.Minor, err = util.AtoiUint64(matches["minor"]); err != nil {
+			return version, fields, fmt.Errorf("can't parse Minor: %w", err)
+		}
+		fields = append(fields, requiredFieldMinor)
+	}
+
+	if matches["patch"] != "" {
+		if matches["minor"] == "" {
+			return version, fields, fmt.Errorf("patch version requires minor to be specified")
+		}
+		if version.Patch, err = util.AtoiUint64(matches["patch"]); err != nil {
+			return version, fields, fmt.Errorf("can't parse Patch version: %w", err)
+		}
+		fields = append(fields, requiredFieldPatch)
+	}
+
+	if matches["release"] != "" {
+		version.Release, err = newRelease(matches["release"], matches["releaseNum"])
+		if err != nil {
+			return version, fields, fmt.Errorf("can't parse Release: %w", err)
+		}
+		fields = append(fields, requiredFieldReleaseType)
+		if matches["releaseNum"] != "" {
+			fields = append(fields, requiredFieldReleaseNum)
+		}
+	} else if len(fields) > 0 {
+		// By default require 'release' version.
+		version.Release.Type = TypeRelease
+		fields = append(fields, requiredFieldReleaseType)
+	}
+
+	if matches["additional"] != "" {
+		if version.Additional, err = util.AtoiUint64(matches["additional"]); err != nil {
+			return version, fields, fmt.Errorf("can't parse Additional: %w", err)
+		}
+		fields = append(fields, requiredFieldAdditional)
+	}
+
+	version.Hash = matches["hash"]
+	if version.Hash != "" {
+		fields = append(fields, requiredFieldHash)
+	}
+
+	if matches["revision"] != "" {
+		if version.Revision, err = util.AtoiUint64(matches["revision"]); err != nil {
+			return version, fields, fmt.Errorf("can't parse Revision: %w", err)
+		}
+		fields = append(fields, requiredFieldRevision)
+	}
+
+	version.Str = verStr
+
+	return version, fields, nil
+}
+
+// compareVersions compares with two Version according list of fields.
+//
+// Return `true` if all required version components the same.
+func compareVersions(ref Version, other Version, fields requiredFields) bool {
+	for _, m := range fields {
+		isMatch := false
+		switch m {
+		case requiredFieldBuildName:
+			isMatch = ref.BuildName == other.BuildName
+		case requiredFieldMajor:
+			isMatch = ref.Major == other.Major
+		case requiredFieldMinor:
+			isMatch = ref.Minor == other.Minor
+		case requiredFieldPatch:
+			isMatch = ref.Patch == other.Patch
+		case requiredFieldReleaseType:
+			isMatch = ref.Release.Type == other.Release.Type
+		case requiredFieldReleaseNum:
+			isMatch = ref.Release.Num == other.Release.Num
+		case requiredFieldAdditional:
+			isMatch = ref.Additional == other.Additional
+		case requiredFieldHash:
+			isMatch = ref.Hash == other.Hash
+		case requiredFieldRevision:
+			isMatch = ref.Revision == other.Revision
+		}
+		if !isMatch {
+			return false
+		}
+	}
+	return true
+}
+
+// IsVersion checks is string looks like version.
+// If isStrict is true, then version <major.minor.patch> components are required.
+func IsVersion(version string, isStrict bool) bool {
+	re := createVersionRegexp(isStrict)
+	return re.MatchString(version)
+}
+
+// MatchVersion takes as input an ascending sorted list of versions.
+// In which it finds the latest version matching the search mask.
+//
+// Return string of found version or `NotFoundVersion` with error if just not found.
+func MatchVersion(expected string, sortedVersions []Version) (string, error) {
+	reference, fields, err := exploreMatchVersion(expected)
+	if err != nil {
+		return "", err
+	}
+	for i := len(sortedVersions) - 1; i >= 0; i-- {
+		ver := sortedVersions[i]
+		if compareVersions(reference, ver, fields) {
+			return ver.Str, nil
+		}
+	}
+	return "", NotFoundError{expected}
+}

--- a/cli/version/version_match_test.go
+++ b/cli/version/version_match_test.go
@@ -1,0 +1,162 @@
+package version_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/version"
+)
+
+func parseVersions(t *testing.T, verStr []string) []version.Version {
+	t.Helper()
+	versions := make([]version.Version, 0, len(verStr))
+	for _, v := range verStr {
+		ver, err := version.Parse(v)
+		require.NoError(t, err)
+		versions = append(versions, ver)
+	}
+	return versions
+}
+
+func TestMatchVersion(t *testing.T) {
+	sortedVersions := parseVersions(t, []string{
+		"1.10.14",
+		"1.10.15",
+		"v2.8.1",
+		"v2.8.2",
+		"v2.10.0-beta1",
+		"v2.10.0-beta2",
+		"v2.10.0-rc1",
+		"v2.10.0",
+		"v2.10.2",
+		"v2.10.3",
+		"v2.10.4",
+		"v2.10.5-entrypoint",
+		"v2.10.5",
+		"v2.10.6-entrypoint",
+		"v2.10.6",
+		"v2.10.7-entrypoint",
+		"v2.10.7",
+		"v2.10.8-entrypoint",
+		"v2.10.8",
+		"v2.10.9-entrypoint",
+		"v2.11.0-entrypoint",
+		"v2.11.0-rc1",
+		"v2.11.0-rc2",
+		"v2.11.0",
+		"v2.11.1-entrypoint",
+		"v2.11.1",
+		"v2.11.2-entrypoint",
+		"v2.11.2",
+		"v2.11.3-entrypoint",
+		"v2.11.3",
+		"v2.11.4-entrypoint",
+		"v2.11.4",
+		"v2.11.5-entrypoint",
+		"3.0.0-entrypoint",
+		"3.0.0-alpha1",
+		"3.0.0-alpha2",
+		"3.0.0-alpha3",
+		"3.0.0-beta1",
+		"gc64-3.0.0-1-ga73da88-r123",
+		"3.0.1",
+		"3.0.2",
+		"3.0.3-entrypoint",
+		"3.1.0-entrypoint",
+		"3.1.1-entrypoint",
+		"3.1.2-entrypoint",
+		"3.2.0-entrypoint",
+		"3.2.0",
+		"3.2.1-entrypoint",
+		"3.3.0-entrypoint",
+		"3.3.0",
+	})
+	data := []struct {
+		find     string
+		expected string
+		errMsg   string
+	}{
+		{"1", "1.10.15", ""},
+		{"2", "v2.11.4", ""},
+		{"2.10.6", "v2.10.6", ""},
+		{"v2.10", "v2.10.8", ""},
+		{"2.11.0-rc1", "v2.11.0-rc1", ""},
+		{"2.11-rc", "v2.11.0-rc2", ""},
+		{"2.11", "v2.11.4", ""},
+		{"3.0.0-alpha2", "3.0.0-alpha2", ""},
+		{"3.003", "3.3.0", ""},
+		{"gc64-3", "gc64-3.0.0-1-ga73da88-r123", ""},
+		{"3.0-1", "gc64-3.0.0-1-ga73da88-r123", ""},
+		{"3.0-r123", "gc64-3.0.0-1-ga73da88-r123", ""},
+		{"v-ga73da88", "gc64-3.0.0-1-ga73da88-r123", ""},
+
+		{"1234.5678.90", "", `not matched with: "1234.5678.90"`},
+		{"1.1", "", `not matched with: "1.1"`},
+		{"3.1-0", "", `not matched with: "3.1-0"`},
+		{"V1", "", "failed to parse version"},
+		{"18446744073709551616", "", "can't parse Major"},
+		{"1.18446744073709551616", "", "can't parse Minor"},
+		{"0.1.18446744073709551616", "", "can't parse Patch"},
+		{"1.2.3-rc18446744073709551616", "", "bad release number format"},
+		{"1.2.3-18446744073709551616", "", "can't parse Additional"},
+		{"1.2.3-r18446744073709551616", "", "can't parse Revision"},
+		{".2.3", "", "minor version requires major to be specified"},
+	}
+
+	for i, v := range data {
+		t.Run(fmt.Sprintf("[%d] find %s", i, v.find), func(t *testing.T) {
+			found, err := version.MatchVersion(v.find, sortedVersions)
+			if v.errMsg != "" {
+				require.ErrorContains(t, err, v.errMsg,
+					"Found version: '%s' -> '%s'", v.find, found)
+			} else {
+				require.NoError(t, err, "Found version: '%s' -> '%s'", v.find, found)
+			}
+			if v.expected != "" {
+				require.Equal(t, v.expected, found)
+			}
+		})
+	}
+}
+
+func TestMatchVersion_NotFoundError(t *testing.T) {
+	data := []string{
+		"",
+		"1234.5678.90",
+	}
+	for i, v := range data {
+		t.Run(fmt.Sprintf("[%d] find %s", i, v), func(t *testing.T) {
+			var errNotFound version.NotFoundError
+			_, err := version.MatchVersion(v, []version.Version{})
+			require.True(t, errors.As(err, &errNotFound))
+			require.Equal(t, fmt.Sprintf("not matched with: %q", v), err.Error())
+		})
+	}
+}
+
+func TestIsVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		strict  bool
+		want    bool
+	}{
+		{"1.2.3", true, true},
+		{"1.2", false, true},
+		{"2.11.0-rc1", true, true},
+		{"2.11-rc1", true, false},
+		{"2-rc1", false, true},
+		{"v1-ga73da88", false, true},
+		{"gc64-3.0.0-1-ga73da88-r123", false, true},
+		{"gc64-3.0.0-1-ga73da88-r123", true, true},
+		{"1,2,3", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := version.IsVersion(tt.version, tt.strict); got != tt.want {
+				t.Errorf("IsVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarantool/tt
 
-go 1.20
+go 1.21
 
 require (
 	github.com/adam-hanna/arrayOperations v0.2.6


### PR DESCRIPTION
Allow specify version like:
 - 2.11 - Chooses last release patch for specified major.minor set
 - 3 - get last available release version with required major==3
 - 2.11-rc - will select in major.minor version with last release candidate mark
 And many other combination matched with version regular expression.

Closes #737