### PR TITLE
ci: fix macos tests

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -207,12 +207,6 @@ jobs:
           ETCD_TT_BIN=${ETCD_PATH}etcd;
           pkill -SIGINT -f ${ETCD_TT_BIN} || true
 
-      - name: Kill tarantool, if it was left
-        if: always()
-        run: |
-          TARANTOOL_BIN=${GITHUB_WORKSPACE}/bin/tarantool;
-          pkill -SIGINT -f ${TARANTOOL_BIN} || true
-
   # ee suffix means that the job runs ee integration tests.
   full-ci-macOS-ee:
     if: |

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -201,8 +201,10 @@ jobs:
       - name: Run unit tests
         run: mage unitfull
 
+      # We need to override TMPDIR here because of the very long path in macOS tests
+      # which causes a very long socket path error.
       - name: Integration tests
-        run: mage integrationfull
+        run: TMPDIR=/tmp mage integrationfull
 
       # Etcd can be still running after integration tests when:
       # 1. pytest recieve SIGALRM (can be caused by pytest-timeout plugin)

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -191,6 +191,13 @@ jobs:
         run: |
           echo "TT_CLI_TARANTOOL_PREFIX=${GITHUB_WORKSPACE}/include/" >> $GITHUB_ENV
 
+      # Sometimes CI on macOS terminates with a “docker daemon not running” error.
+      # To prevent this we set the path to the docker socket directly.
+      - name: Prepare Docker
+        run: |
+          echo "DOCKER_HOST=unix:///${HOME}/.docker/run/docker.sock" >> $GITHUB_ENV
+          docker context use default
+
       - name: Run unit tests
         run: mage unitfull
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,6 +187,13 @@ jobs:
         run: |
           echo "TT_CLI_TARANTOOL_PREFIX=${GITHUB_WORKSPACE}/include/" >> $GITHUB_ENV
 
+      # Sometimes CI on macOS terminates with a “docker daemon not running” error.
+      # To prevent this we set the path to the docker socket directly.
+      - name: Prepare Docker
+        run: |
+          echo "DOCKER_HOST=unix:///${HOME}/.docker/run/docker.sock" >> $GITHUB_ENV
+          docker context use default
+
       - name: Unit tests
         run: mage unit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,8 +197,10 @@ jobs:
       - name: Unit tests
         run: mage unit
 
+      # We need to override TMPDIR here because of the very long path in macOS tests
+      # which causes a very long socket path error.
       - name: Run integration tests
-        run: mage integration
+        run: TMPDIR=/tmp mage integration
 
       # Etcd can be still running after integration tests when:
       # 1. pytest recieve SIGALRM (can be caused by pytest-timeout plugin)

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -328,9 +328,9 @@ func runTestMain(m *testing.M) int {
 		WorkDir:      workDir,
 		User:         opts.User,
 		Pass:         opts.Pass,
-		WaitStart:    time.Second,
+		WaitStart:    5 * time.Second,
 		ConnectRetry: 5,
-		RetryTimeout: 200 * time.Millisecond,
+		RetryTimeout: 100 * time.Millisecond,
 	})
 	defer test_helpers.StopTarantoolWithCleanup(inst)
 	if err != nil {

--- a/cli/replicaset/integration_test.go
+++ b/cli/replicaset/integration_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const workDir = "work_dir"
-const server = "127.0.0.1:3013"
+const server = "127.0.0.1:3015"
 const console = workDir + "/" + "console.control"
 
 var opts = tarantool.Opts{
@@ -166,7 +166,7 @@ func (e *instanceEvalerMock) Eval(instance running.InstanceCtx,
 	require.NotNil(e.T, evaler)
 	data, err := evaler.Eval("return box.cfg.listen", []any{}, connector.RequestOpts{})
 	require.NoError(e.T, err)
-	require.Equal(e.T, []any{"127.0.0.1:3013"}, data)
+	require.Equal(e.T, []any{"127.0.0.1:3015"}, data)
 
 	return e.Done, e.Error
 }
@@ -551,9 +551,9 @@ func runTestMain(m *testing.M) int {
 		WorkDir:      workDir,
 		User:         opts.User,
 		Pass:         opts.Pass,
-		WaitStart:    time.Second,
+		WaitStart:    5 * time.Second,
 		ConnectRetry: 5,
-		RetryTimeout: 200 * time.Millisecond,
+		RetryTimeout: 100 * time.Millisecond,
 	})
 	defer test_helpers.StopTarantoolWithCleanup(inst)
 	if err != nil {


### PR DESCRIPTION
This PR fixes CI problems appeared in jobs on machine with `macOS`. There are problems provided below that was fixed.

> There was a problem on macOS pipeline that integration tests written on Go fail sometimes with an `connection refused` error. An instance of Tarantool was unable to start with the specified configuration.
>
>After the patch start options such as `WaitStart`, `ConnectionRetry` and `RetryTimeout` were increased to have enough time for Tarantool startup.

> Sometimes CI on macos fails with an error "docker daemon not running".
>
> To avoid it after the patch docker socket is provided in the github env directly.

>The test `test_t3_instance_names_no_config` always fails because of very long path in tmpdir. This test requires socket path with fexed length, otherwise it can cause socket path buffer overflow.
>
>After the patch tmpdir was overwritten to the shorter one.

Closes #931 
Closes #912