### PR TITLE
Fix tt log follow segmentation fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `tt log -f` crash on removing log directory.
+
 ### Changed
 
 ## [2.4.0] - 2024-08-07

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,7 +44,7 @@ def tt_cmd(tmp_path_factory):
 
     build_env = os.environ.copy()
     build_env["TTEXE"] = tt_path
-    build_env["TT_CLI_BUILD_SSL"] = "static"
+    build_env.setdefault("TT_CLI_BUILD_SSL", "static")
 
     process = subprocess.run(["mage", "-v", "build"], cwd=tt_base_path, env=build_env)
     assert process.returncode == 0, "Failed to build Tarantool CLI executable"

--- a/test/integration/log/test_log.py
+++ b/test/integration/log/test_log.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import time
 
@@ -253,3 +254,25 @@ def test_log_output_default_follow_want_zero_last(tt_cmd, mock_env_dir):
     assert 'app0:inst1' not in output
     assert 'app0:inst2' not in output
     assert 'app1:inst0' not in output
+
+
+def test_log__dir_removed_after_follow(tt_cmd, mock_env_dir):
+    cmd = [tt_cmd, 'log', '-f']
+    process = subprocess.Popen(
+        cmd,
+        cwd=mock_env_dir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    wait_for_lines_in_output(process.stdout,
+                             ['app0:inst0: line 19', 'app1:inst2: line 19',
+                              'app0:inst1: line 19', 'app1:inst1: line 19'])
+
+    var_dir = os.path.join(mock_env_dir, 'ie', 'app0', 'var')
+    assert os.path.exists(var_dir)
+    shutil.rmtree(var_dir)
+
+    assert process.wait(2) == 0
+    assert "Failed to detect creation of" in process.stdout.read()


### PR DESCRIPTION
- `tt log -f` crashes if the log directory is removed:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe6dbf9]
```
Perform graceful shutdown in case of inability to continue following the log.

- Provide a way to disable static openssl linking for tests.