### PR TITLE
rocks: fix wrong interpreter after install

### DIFF
--- a/cli/rocks/extra/hardcoded.lua
+++ b/cli/rocks/extra/hardcoded.lua
@@ -54,4 +54,5 @@ return {
         include = "include",
     },
     LOCAL_BY_DEFAULT = true,
+    FORCE_HARDCODED = true,
 }

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -177,6 +177,7 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) err
 	rocks_preload := map[string]string{
 		"extra.wrapper":                    extra_path + "wrapper.lua",
 		"luarocks.core.hardcoded":          extra_path + "hardcoded.lua",
+		"luarocks.vendor.dkjson":           rocks_path + "luarocks/vendor/dkjson.lua",
 		"luarocks.core.util":               rocks_path + "luarocks/core/util.lua",
 		"luarocks.core.persist":            rocks_path + "luarocks/core/persist.lua",
 		"luarocks.core.sysdetect":          rocks_path + "luarocks/core/sysdetect.lua",

--- a/test/utils.py
+++ b/test/utils.py
@@ -68,6 +68,27 @@ def create_tt_config(config_path, modules_path):
     return config_path
 
 
+def create_lua_config(tmp_path):
+    config_file = tmp_path / 'config-5.1.lua'
+    with open(config_file, "w") as f:
+        f.write('''-- LuaRocks configuration
+    rocks_trees = {
+       { name = "user", root = home .. "/.luarocks" };
+       { name = "system", root = "/usr" };
+    }
+    variables = {
+       LUA_DIR = "/usr";
+       LUA_INCDIR = "/usr/include/lua5.1";
+       LUA_BINDIR = "/usr/bin";
+       LUA_VERSION = "5.1";
+       LUA = "/usr/bin/lua5.1";
+       IS_LUA_CONFIG_USED = true
+    }
+    ''')
+
+    return config_file
+
+
 def create_external_module(module_name, directory):
     module_message = f"\"Hello, I'm {module_name} external module!\""
     with open(os.path.join(directory, f"{module_name}.sh"), "w") as f:


### PR DESCRIPTION
Updated luarocks dependency to 3.10.
And there were a problem - rocks used Lua as an interpreter instead of Tarantool if it found users config. So now rocks  always uses tarantool as an interpreter
Closes #919 