### PR TITLE
tt: add support set delimiter in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  cluster config (3.0) or cartridge orchestrator.
 
 ### Fixed
+- Command `\set delimiter [marker]` works correctly and don't hangs `tt` console.
 
 - `tt log -f` crash on removing log directory.
 

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -160,7 +160,7 @@ func (command argSetCmdDecorator) Aliases() []string {
 // Run checks that there is one allowed argument and runs the command.
 func (command argSetCmdDecorator) Run(console *Console,
 	cmd string, args []string) (string, error) {
-	if len(args) != 1 || !find(command.sorted, args[0]) {
+	if len(command.sorted) > 0 && (len(args) != 1 || !find(command.sorted, args[0])) {
 		return "", fmt.Errorf("the command expects one of: %s",
 			strings.Join(command.sorted, ", "))
 	}
@@ -361,6 +361,19 @@ func setTableColumnWidthMaxFunc(console *Console,
 	return "", nil
 }
 
+// setDelimiterMarker apply delimiter to the Console object.
+func setDelimiterMarker(console *Console, cmd string, args []string) (string, error) {
+	switch len(args) {
+	case 0:
+		console.delimiter = ""
+	case 1:
+		console.delimiter = args[0]
+	default:
+		return "", fmt.Errorf("the command expects zero or single argument")
+	}
+	return "", nil
+}
+
 // switchNextFormatFunc switches to a next output format.
 func switchNextFormatFunc(console *Console, cmd string, args []string) (string, error) {
 	console.format = (1 + console.format) % formatter.FormatsAmount
@@ -451,6 +464,14 @@ var cmdInfos = []cmdInfo{
 				[]string{setTableColumnWidthMaxLong},
 				setTableColumnWidthMaxFunc,
 			),
+		),
+	},
+	cmdInfo{
+		Short: setDelimiter + " <marker>",
+		Long:  "set expression delimiter",
+		Cmd: newArgSetCmdDecorator(
+			newBaseCmd([]string{setDelimiter}, setDelimiterMarker),
+			[]string{},
 		),
 	},
 	cmdInfo{

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -65,6 +65,7 @@ type Console struct {
 	executor   func(in string)
 	completer  func(in prompt.Document) []prompt.Suggest
 	validators map[Language]ValidateCloser
+	delimiter  string
 
 	prompt *prompt.Prompt
 }
@@ -197,7 +198,7 @@ func getExecutor(console *Console) func(string) {
 
 		var completed bool
 		validator := console.validators[console.language]
-		console.input, completed = AddStmtPart(console.input, in, validator)
+		console.input, completed = AddStmtPart(console.input, in, console.delimiter, validator)
 		if !completed {
 			console.livePrefixEnabled = true
 			return

--- a/cli/connect/const.go
+++ b/cli/connect/const.go
@@ -19,6 +19,9 @@ const setTableDialect = "\\set table_format"
 // width for tables.
 const setTableColumnWidthMaxLong = "\\set table_column_width"
 
+// setDelimiter set a custom expression delimiter for Tarantool console.
+const setDelimiter = "\\set delimiter"
+
 // setTableColumnWidthMaxShort is a short command to set a maximum columnt
 // width for tables.
 const setTableColumnWidthMaxShort = "\\xw"


### PR DESCRIPTION
The “\set delimiter [marker]” command is handled by the `tt` utility, simulating the behavior of a similar command for the Tarantool console.

Closes #727