### PR TITLE
ci: fix Python version for tests

### DIFF
--- a/.github/actions/prepare-ce-test-env/action.yml
+++ b/.github/actions/prepare-ce-test-env/action.yml
@@ -24,6 +24,11 @@ runs:
       with:
         go-version: '${{ env.GO_VERSION }}'
 
+    - name: Setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '${{ env.PYTHON_VERSION }}'
+
     - name: Setup Mage
       run: |
         git clone https://github.com/magefile/mage
@@ -40,8 +45,7 @@ runs:
         build-essential ninja-build \
         lua5.1 luarocks lcov \
         ruby-dev liblz4-dev  autoconf \
-        automake \
-        libtool python3-pytest python3-psutil pip
+        automake libtool
         sudo luarocks install luacheck 0.26.1
         sudo gem install coveralls-lcov
         sudo pip3 install tarantool

--- a/.github/actions/prepare-ee-test-env/action.yml
+++ b/.github/actions/prepare-ee-test-env/action.yml
@@ -30,6 +30,11 @@ runs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '${{ env.PYTHON_VERSION }}'
+
       - name: Setup Mage
         run: |
           git clone https://github.com/magefile/mage


### PR DESCRIPTION
Fixed CI environment setup with required Python version.

Follows up #727