### PR TITLE
run: fix confusing error message for tt run

### DIFF
--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -1,6 +1,7 @@
 package running
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -150,6 +151,9 @@ func (inst *baseInstance) StopWithSignal(waitTimeout time.Duration, usedSignal o
 func (inst *baseInstance) Run(opts RunOpts) error {
 	f, err := inst.integrityCtx.Repository.Read(inst.tarantoolPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New("tarantool executable is not found")
+		}
 		return err
 	}
 	f.Close()


### PR DESCRIPTION
If tarantool executable is not found, `tt run` prints "open : no such file or directory" error, which is confusing. Make the error message more clear.

Closes #966