### PR TITLE
start: fix start Tarantool 3 with encrypted etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `tt log -f` crash on removing log directory.
 - `tt connect` crash due to an empty response.
+- `tt start` error on start Tarantool 3 with encrypted etcd.
 
 ### Changed
 

--- a/lib/cluster/cluster.go
+++ b/lib/cluster/cluster.go
@@ -129,7 +129,7 @@ type ClusterConfig struct {
 			Prefix    string   `yaml:"prefix"`
 			Ssl       struct {
 				KeyFile    string `yaml:"ssl_key"`
-				CertFile   string `yaml:"cert_file"`
+				CertFile   string `yaml:"ssl_cert"`
 				CaPath     string `yaml:"ca_path"`
 				CaFile     string `yaml:"ca_file"`
 				VerifyPeer bool   `yaml:"verify_peer"`

--- a/lib/cluster/cluster_test.go
+++ b/lib/cluster/cluster_test.go
@@ -141,7 +141,7 @@ func TestMakeClusterConfig_settings(t *testing.T) {
 		expected.Config.Etcd.Prefix)
 	config.Set([]string{"config", "etcd", "ssl", "ssl_key"},
 		expected.Config.Etcd.Ssl.KeyFile)
-	config.Set([]string{"config", "etcd", "ssl", "cert_file"},
+	config.Set([]string{"config", "etcd", "ssl", "ssl_cert"},
 		expected.Config.Etcd.Ssl.CertFile)
 	config.Set([]string{"config", "etcd", "ssl", "ca_path"},
 		expected.Config.Etcd.Ssl.CaPath)


### PR DESCRIPTION
This patch fixes an incorrect SSL certificate parameter name.

Closes #938