### PR TITLE
replicaset: use `vshard bootstrap` timeout as bootstrap timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt log -f` crash on removing log directory.
 - `tt connect` crash due to an empty response.
 - `tt start` error on start Tarantool 3 with encrypted etcd.
+- `tt replicaset vshard bootstrap` unable to bootstrap large clusters due to
+  a timeout.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt start` error on start Tarantool 3 with encrypted etcd.
 - `tt replicaset vshard bootstrap` unable to bootstrap large clusters due to
   a timeout.
+- `tt replicaset vshard bootstrap` timeout was 3s instead of 10s.
 
 ### Changed
 

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -36,6 +36,7 @@ var (
 	replicasetSslCiphers               string
 	replicasetForce                    bool
 	replicasetTimeout                  int
+	replicasetBootstrapTimeout         int
 	replicasetIntegrityPrivateKey      string
 	replicasetBootstrapVshard          bool
 	replicasetCartridgeReplicasetsFile string
@@ -178,8 +179,8 @@ func newBootstrapCmd() *cobra.Command {
 		`file where replicasets configuration is described (default "<APP_DIR>/replicasets.yml")`)
 	cmd.Flags().StringVarP(&replicasetReplicasetName, "replicaset", "",
 		"", "replicaset name for an instance bootstrapping")
-	cmd.Flags().IntVarP(&replicasetTimeout, "timeout", "", replicasetcmd.
-		VShardBootstrapDefaultTimeout, "timeout")
+	cmd.Flags().IntVarP(&replicasetBootstrapTimeout, "timeout", "",
+		replicasetcmd.VShardBootstrapDefaultTimeout, "timeout")
 
 	return cmd
 }
@@ -206,7 +207,7 @@ func newBootstrapVShardCmd() *cobra.Command {
 	addOrchestratorFlags(cmd)
 	addTarantoolConnectFlags(cmd)
 	integrity.RegisterWithIntegrityFlag(cmd.Flags(), &replicasetIntegrityPrivateKey)
-	cmd.Flags().IntVarP(&replicasetTimeout, "timeout", "",
+	cmd.Flags().IntVarP(&replicasetBootstrapTimeout, "timeout", "",
 		replicasetcmd.VShardBootstrapDefaultTimeout, "timeout")
 
 	return cmd
@@ -619,7 +620,7 @@ func internalReplicasetBootstrapVShardModule(cmdCtx *cmdcontext.CmdCtx, args []s
 		Orchestrator:  ctx.Orchestrator,
 		Publishers:    publishers,
 		Collectors:    collectors,
-		Timeout:       replicasetTimeout,
+		Timeout:       replicasetBootstrapTimeout,
 	})
 }
 
@@ -638,7 +639,7 @@ func internalReplicasetBootstrapModule(cmdCtx *cmdcontext.CmdCtx, args []string)
 		ReplicasetsFile: replicasetCartridgeReplicasetsFile,
 		Orchestrator:    ctx.Orchestrator,
 		RunningCtx:      ctx.RunningCtx,
-		Timeout:         replicasetTimeout,
+		Timeout:         replicasetBootstrapTimeout,
 		BootstrapVShard: replicasetBootstrapVshard,
 		Replicaset:      replicasetReplicasetName,
 	}

--- a/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
+++ b/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
@@ -24,7 +24,7 @@ local deadline = fiber.time() + timeout
 local ok, err
 
 while fiber.time() < deadline do
-    ok, err = vshard.router.bootstrap()
+    ok, err = vshard.router.bootstrap({timeout = timeout})
     if ok then
         break
     end


### PR DESCRIPTION
The `--timeout` flag for `tt vshard bootstrap` is now passed as `vshard.router.bootstrap({timeout=...})`. It allows to increase the real bootstrap process timeout.

Closes https://github.com/tarantool/tt-ee/issues/232

I also noticed that the default timeout was 3 seconds instead of 10s expected. Fixed.