### PR TITLE
cd: add Ubuntu Noble

### DIFF
--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -29,6 +29,7 @@ var targetDistros = []Distro{
 	{OS: "ubuntu", Dist: "bionic"}, // 18.04
 	{OS: "ubuntu", Dist: "focal"},  // 20.04
 	{OS: "ubuntu", Dist: "jammy"},  // 22.04
+	{OS: "ubuntu", Dist: "noble"},  // 24.04
 
 	{OS: "debian", Dist: "stretch"},  // 9
 	{OS: "debian", Dist: "buster"},   // 10


### PR DESCRIPTION
We have a `tt` package in the `linux-deb/static` repository and it is suitable for Ubuntu Noble as well. However, sometimes it is convenient to have the same focal/jammy/noble setup, where the `ubuntu/${codename}` repository is enabled.