### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.5.0] - 2024-10-15
+
+Added a number of subcommands for replicaset roles,
+improved understanding of the version number to install,
+enhanced status display, and added a flag to disable interactivity when
+the application is stopped.
+Implemented a number of fixes to improve stability.
+
+### Added
+
 - `tt status`: display `config`, `box`, and `replication upstream` statuses.
   * `--details`: display detailed reports of errors and warnings from instances.
 - `tt stop` confirmation prompt. `-y` option is added to accept stop without prompting.

--- a/test/integration/running/test_running.py
+++ b/test/integration/running/test_running.py
@@ -871,7 +871,7 @@ def test_kill(tt_cmd, tmpdir_with_cfg, cmd, input):
         process_not_running(watchdog_process)
 
     finally:
-        stop = [tt_cmd, "stop", "test_app"]
+        stop = [tt_cmd, "stop", "--yes", "test_app"]
         run_command_and_get_output(stop, cwd=tmpdir)
 
 
@@ -925,7 +925,7 @@ def test_kill_without_app_name(tt_cmd, tmp_path, cmd, input):
         assert status_out["app2"]["STATUS"] == "NOT RUNNING"
 
     finally:
-        stop = [tt_cmd, "stop"]
+        stop = [tt_cmd, "stop", "--yes"]
         run_command_and_get_output(stop, cwd=test_app_path)
 
 
@@ -965,5 +965,5 @@ def test_start_interactive(tt_cmd, tmp_path):
         assert not (tmp_path / "var" / "log").exists()
 
     finally:
-        run_command_and_get_output([tt_cmd, "stop"], cwd=tmp_path)
+        run_command_and_get_output([tt_cmd, "stop", "--yes"], cwd=tmp_path)
         assert instance_process.wait(5) == 0


### PR DESCRIPTION
Added a number of subcommands for replicaset roles, improved understanding of the version number to install, enhanced status display, and added a flag to disable interactivity when the application is stopped.
Implemented a number of fixes to improve stability.

### Added

- `tt status`: display `config`, `box`, and `replication upstream` statuses.
  * `--details`: display detailed reports of errors and warnings from instances.
- `tt stop` confirmation prompt. `-y` option is added to accept stop without prompting.
- `tt cluster replicaset roles add`: command to add roles in config scope provided by flags.
- `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with cluster config (3.0) or cartridge orchestrator.
- `tt replicaset roles add`: command to add roles in the tarantool replicaset with cluster config (3.0) or cartridge orchestrator.
- `tt replicaset roles remove`: command to remove roles in the tarantool replicaset with cluster config (3.0) or cartridge orchestrator.
- `tt install tt|tarantool <version>` - allow `<version>` be incomplete. So `2.3` will install the the last available release with specified `<major=2>.<minor=3>` in `<version>`.

### Fixed

- Command `\set delimiter [marker]` works correctly and don't hangs `tt` console.
- `tt log -f` crash on removing log directory.
- `tt connect` crash due to an empty response.
- `tt start` error on start Tarantool 3 with encrypted etcd.
- `tt replicaset vshard bootstrap` unable to bootstrap large clusters due to a timeout.
- `tt replicaset vshard bootstrap` timeout was 3s instead of 10s.