### PR TITLE
build: add go_tarantool_msgpack_v5 tag to goreleaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Release packages were built using the outdated and buggy MessagePack
+  library.
+
 ## [2.5.0] - 2024-10-15
 
 Added a number of subcommands for replicaset roles,

--- a/goreleaser/.goreleaser_linux.yml
+++ b/goreleaser/.goreleaser_linux.yml
@@ -18,6 +18,7 @@ builds:
       - netgo
       - osusergo
       - openssl_static
+      - go_tarantool_msgpack_v5
 
     ldflags:
       - -linkmode=external -extldflags -static

--- a/goreleaser/.goreleaser_linux_arm64.yml
+++ b/goreleaser/.goreleaser_linux_arm64.yml
@@ -18,6 +18,7 @@ builds:
       - netgo
       - osusergo
       - openssl_static
+      - go_tarantool_msgpack_v5
 
     ldflags:
       - -linkmode=external -extldflags -static

--- a/goreleaser/.goreleaser_macOS.yml
+++ b/goreleaser/.goreleaser_macOS.yml
@@ -18,6 +18,7 @@ builds:
       - netgo
       - osusergo
       - openssl_static
+      - go_tarantool_msgpack_v5
 
     ldflags:
       - -s -w


### PR DESCRIPTION
It is already done for local builds [1], but we forgot to do it for the goreleaser builds on CI.

1. https://github.com/tarantool/tt/pull/891

Part of https://github.com/tarantool/tt-ee/issues/243