### PR TITLE
tests: fix flacky test_running_base_functionality

### DIFF
--- a/test/integration/running/test_running_cluster.py
+++ b/test/integration/running/test_running_cluster.py
@@ -7,7 +7,8 @@ import pytest
 import yaml
 
 from utils import (control_socket, extract_status, get_tarantool_version,
-                   run_command_and_get_output, run_path, wait_file)
+                   run_command_and_get_output, run_path, wait_file,
+                   wait_pid_disappear)
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
 
@@ -98,6 +99,12 @@ def test_running_base_functionality(tt_cmd, tmpdir_with_cfg):
             text=True
         )
         start_output = instance_process.stdout.read()
+
+        # Need to wait for all instances to stop before start.
+        for inst in instances:
+            # Wait when PID that was fetched on start disappears.
+            wait_pid_disappear(os.path.join(run_dir, inst, 'tarantool.pid'),
+                               pidByInstanceName.get(inst))
 
         for inst in instances:
             assert f"Starting an instance [{app_name}:{inst}]" in start_output

--- a/test/utils.py
+++ b/test/utils.py
@@ -573,3 +573,17 @@ def wait_for_lines_in_output(stdout, expected_lines: list):
                 break
 
     return output
+
+
+@retry(Exception, tries=40, delay=0.5)
+def wait_pid_disappear(file, target_pid):
+    found = True
+    while found:
+        if not os.path.exists(file):
+            found = False
+            break
+        with open(file, "r") as f:
+            if target_pid not in f.readline():
+                found = False
+                break
+    assert not found


### PR DESCRIPTION
The integration test `test_running_cluster::test_running_base_functionality` fails sometimes with an failed assertion of the same PID after restart.

After the patch waiting for instances stop was added to make sure that cluster is down before it will start again and will check for PID.

Closes #972