### PR TITLE
uninstall: fix uninstalling  if no symlink in bin_dir

### DIFF
--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -61,19 +61,29 @@ func remove(program string, programVersion string, directory string,
 	} else if err != nil {
 		return false, fmt.Errorf("there was some problem locating %s", path)
 	}
-	// Get path where symlink point.
-	resolvedPath, err := util.ResolveSymlink(linkPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to resolve symlink %s: %s", linkPath, err)
-	}
+
 	var isSymlinkRemoved bool
-	// Remove symlink if it points to program.
-	if strings.Contains(resolvedPath, fileName) {
-		err = os.Remove(linkPath)
-		if err != nil {
-			return false, err
+
+	_, err = os.Lstat(linkPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("failed to access %q: %s", linkPath, err)
 		}
-		isSymlinkRemoved = true
+		isSymlinkRemoved = false
+	} else {
+		// Get path where symlink point.
+		resolvedPath, err := util.ResolveSymlink(linkPath)
+		if err != nil {
+			return false, fmt.Errorf("failed to resolve symlink %q: %s", linkPath, err)
+		}
+
+		// Remove symlink if it points to program.
+		if strings.Contains(resolvedPath, fileName) {
+			if err = os.Remove(linkPath); err != nil {
+				return false, err
+			}
+			isSymlinkRemoved = true
+		}
 	}
 	err = os.RemoveAll(path)
 	if err != nil {

--- a/test/integration/uninstall/test_uninstall.py
+++ b/test/integration/uninstall/test_uninstall.py
@@ -348,3 +348,23 @@ def test_uninstall_tt_missing_version_character(
     assert os.path.isfile(os.path.join(tmp_path, "tt_" +
                           "v" if "v" not in version_to_uninstall else "" +
                                        version_to_uninstall)) is False
+
+
+def test_uninstall_tt_missing_symlink(tt_cmd, tmp_path):
+    configPath = os.path.join(tmp_path, config_name)
+    # Create test config.
+    with open(configPath, 'w') as f:
+        f.write(f'env:\n bin_dir: {tmp_path}\n inc_dir:\n')
+
+    shutil.copy(tt_cmd, os.path.join(tmp_path, "tt_94ba971"))
+
+    symlink_path = os.path.join(tmp_path, 'tt')
+    assert not os.path.exists(symlink_path)
+
+    uninstall_cmd = [tt_cmd, "uninstall", "tt", "94ba971"]
+    uninstall_rc, uninstall_output = run_command_and_get_output(uninstall_cmd, cwd=tmp_path)
+
+    assert uninstall_rc == 0
+    assert "tt=94ba971 is uninstalled." in uninstall_output
+
+    assert os.path.exists(os.path.join(tmp_path, "tt_" + "94ba971") is False)


### PR DESCRIPTION
tt uninstall does not work if there is no symbolic link in bin_dir, so a check for the presence of a symbolic link has been added.

Closes: [900](https://github.com/tarantool/tt/issues/900)