### PR TITLE
modules: tt.yaml modules/directory support list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   time format.
 - `tt connect`: add new `--evaler` option to support for customizing the way
   user input is processed.
+- `tt.yaml`: allows to specify a list of modules directories.
 
 ### Changed
 

--- a/cli/cfg/dump_test.go
+++ b/cli/cfg/dump_test.go
@@ -93,7 +93,8 @@ env:
   restart_on_failure: false
   tarantoolctl_layout: false
 modules:
-  directory: /root/modules
+  directory:
+  - /root/modules
 app:
   run_dir: var/run
   log_dir: var/log
@@ -129,7 +130,8 @@ env:
   restart_on_failure: false
   tarantoolctl_layout: false
 modules:
-  directory: %[1]s/my_modules
+  directory:
+  - %[1]s/my_modules
 app:
   run_dir: var/run
   log_dir: var/log
@@ -166,7 +168,8 @@ env:
   restart_on_failure: false
   tarantoolctl_layout: false
 modules:
-  directory: /root/modules
+  directory:
+  - /root/modules
 app:
   run_dir: var/run
   log_dir: var/log

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -21,11 +21,15 @@ package config
 //  ee:
 //    credential_path: path
 
+// FieldStringArrayType a custom type used with mapstructure's hook to accept values
+// as a single string as well as a list of strings.
+type FieldStringArrayType []string
+
 // ModuleOpts is used to store all module options.
 type ModulesOpts struct {
-	// Directory is a path to directory where the external modules
+	// Directories is a list of paths to directories where the external modules
 	// are stored.
-	Directory string
+	Directories FieldStringArrayType `mapstructure:"directory" yaml:"directory"`
 }
 
 // EEOpts is used to store tarantool-ee options.

--- a/cli/configure/testdata/modules_cfg/tt-modules1.yaml
+++ b/cli/configure/testdata/modules_cfg/tt-modules1.yaml
@@ -1,0 +1,3 @@
+# Config with single string with relative path to modules directory.
+modules:
+  directory: modules-dir

--- a/cli/configure/testdata/modules_cfg/tt-modules2.yml
+++ b/cli/configure/testdata/modules_cfg/tt-modules2.yml
@@ -1,0 +1,4 @@
+# Config with single list entry of relative path to modules directory.
+modules:
+  directory:
+  - modules-dir

--- a/cli/configure/testdata/modules_cfg/tt-modules3.yaml
+++ b/cli/configure/testdata/modules_cfg/tt-modules3.yaml
@@ -1,0 +1,6 @@
+# Multiple directory items.
+modules:
+  directory:
+    - modules-dir
+    - /ext/path/modules
+    - local_modules

--- a/cli/configure/testdata/modules_cfg/tt-modules4.yml
+++ b/cli/configure/testdata/modules_cfg/tt-modules4.yml
@@ -1,0 +1,3 @@
+# Empty config value, to use default.
+modules:
+  directory:

--- a/cli/configure/testdata/modules_cfg/tt-modules5.yaml
+++ b/cli/configure/testdata/modules_cfg/tt-modules5.yaml
@@ -1,0 +1,3 @@
+# Config with single string with absolute path to modules directory.
+modules:
+  directory: /ext/path/modules

--- a/cli/init/init.go
+++ b/cli/init/init.go
@@ -168,11 +168,12 @@ func generateTtEnv(configPath string, sourceCfg configData) error {
 
 	directoriesToCreate := []string{
 		cfg.Env.InstancesEnabled,
-		cfg.Modules.Directory,
 		cfg.Env.IncludeDir,
 		cfg.Env.BinDir,
 		cfg.Repo.Install,
 	}
+	// FIXME: Need select only internal directories https://github.com/tarantool/tt/issues/1014
+	directoriesToCreate = append(directoriesToCreate, cfg.Modules.Directories...)
 	for _, templatesPathOpts := range cfg.Templates {
 		directoriesToCreate = append(directoriesToCreate, templatesPathOpts.Path)
 	}

--- a/cli/init/init_test.go
+++ b/cli/init/init_test.go
@@ -63,7 +63,7 @@ func checkDefaultEnv(t *testing.T, configName string, instancesEnabled string) {
 	assert.Equal(t, "var/run", cfg.App.RunDir)
 	assert.Equal(t, "var/log", cfg.App.LogDir)
 	assert.Equal(t, "bin", cfg.Env.BinDir)
-	assert.Equal(t, "modules", cfg.Modules.Directory)
+	assert.Equal(t, config.FieldStringArrayType{"modules"}, cfg.Modules.Directories)
 	assert.Equal(t, "distfiles", cfg.Repo.Install)
 	assert.Equal(t, "include", cfg.Env.IncludeDir)
 	assert.Equal(t, "templates", cfg.Templates[0].Path)

--- a/cli/init/templates/tt.yaml.default
+++ b/cli/init/templates/tt.yaml.default
@@ -1,6 +1,6 @@
 modules:
   # Directory where the external modules are stored.
-  directory: {{ .Modules.Directory }}
+  directory: {{ .Modules.Directories }}
 
 env:
   # Restart instance on failure.

--- a/cli/modules/modules.go
+++ b/cli/modules/modules.go
@@ -94,7 +94,8 @@ func getExternalModulesDir(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) (
 	// 1. If a directory field is specified;
 	// 2. Specified path exists;
 	// 3. Path points to not a directory.
-	modulesDir := cliOpts.Modules.Directory
+	// FIXME: Add working with a list https://github.com/tarantool/tt/issues/1014
+	modulesDir := cliOpts.Modules.Directories[0]
 	if info, err := os.Stat(modulesDir); err == nil {
 		// TODO: Add warning in next patches, discussion
 		// what if the file exists, but access is denied, etc.

--- a/cli/pack/common_test.go
+++ b/cli/pack/common_test.go
@@ -243,7 +243,7 @@ func Test_createNewOpts(t *testing.T) {
 					RunDir:   "var/run",
 				},
 				Modules: &config.ModulesOpts{
-					Directory: "modules",
+					Directories: []string{"modules"},
 				},
 				Repo: &config.RepoOpts{
 					Rocks:   "",
@@ -280,7 +280,7 @@ func Test_createNewOpts(t *testing.T) {
 					RunDir:   "var/run",
 				},
 				Modules: &config.ModulesOpts{
-					Directory: "modules",
+					Directories: []string{"modules"},
 				},
 				Repo: &config.RepoOpts{
 					Rocks:   "",
@@ -317,7 +317,7 @@ func Test_createNewOpts(t *testing.T) {
 					RunDir:   "/var/run/tarantool/bundle",
 				},
 				Modules: &config.ModulesOpts{
-					Directory: "modules",
+					Directories: []string{"modules"},
 				},
 				Repo: &config.RepoOpts{
 					Rocks:   "",
@@ -360,7 +360,7 @@ func Test_createNewOpts(t *testing.T) {
 					RunDir:   "var/run",
 				},
 				Modules: &config.ModulesOpts{
-					Directory: "modules",
+					Directories: []string{"modules"},
 				},
 				Repo: &config.RepoOpts{
 					Rocks:   "",

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -802,6 +802,10 @@ func GetYamlFileName(fileName string, mustExist bool) (string, error) {
 		fileBaseName = strings.TrimSuffix(fileName, ".yaml")
 	case ".yml":
 		fileBaseName = strings.TrimSuffix(fileName, ".yml")
+	case ".":
+		fileBaseName = strings.TrimSuffix(fileName, ".")
+	case "":
+		fileBaseName = fileName
 	default:
 		return "", fmt.Errorf("provided file '%s' has no .yaml/.yml extension", fileName)
 	}

--- a/test/integration/cfg/test_dump.py
+++ b/test/integration/cfg/test_dump.py
@@ -30,7 +30,7 @@ def test_cfg_dump_default(tt_cmd, tmp_path):
     assert f"vinyl_dir: {os.path.join('lib', 'vinyl')}" in output
     assert f"log_dir: {os.path.join('./var', 'log')}" in output
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
-    assert f"directory: {os.path.join(tmp_path, 'new_modules')}" in output
+    assert f"modules:\n  directory:\n  - {os.path.join(tmp_path, 'new_modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
     assert f"instances_enabled: {tmp_path}" in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
@@ -110,7 +110,7 @@ def test_cfg_dump_default_no_config(tt_cmd, tmp_path):
     assert f"memtx_dir: {os.path.join('var', 'lib')}" in output
     assert f"log_dir: {os.path.join('var', 'log')}" in output
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
-    assert f"directory: {os.path.join(tmp_path, 'modules')}" in output
+    assert f"modules:\n  directory:\n  - {os.path.join(tmp_path, 'modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
     assert f"instances_enabled: {tmp_path}" in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
@@ -144,7 +144,7 @@ def test_cfg_dump_default_no_config(tt_cmd, tmp_path):
     assert f"memtx_dir: {os.path.join('var', 'lib')}" in output
     assert f"log_dir: {os.path.join('var', 'log')}" in output
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
-    assert f"directory: {os.path.join(tmp_path, 'modules')}" in output
+    assert f"modules:\n  directory:\n  - {os.path.join(tmp_path, 'modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
     assert "instances_enabled: ." in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output

--- a/test/integration/init/test_init.py
+++ b/test/integration/init/test_init.py
@@ -69,7 +69,7 @@ def test_init_missing_configs(tt_cmd, tmp_path):
         assert data_loaded["app"]["memtx_dir"] == "var/lib"
         assert data_loaded["env"]["instances_enabled"] == "instances.enabled"
         assert not data_loaded["env"]["tarantoolctl_layout"]
-        assert data_loaded["modules"]["directory"] == "modules"
+        assert data_loaded["modules"]["directory"] == ["modules"]
         assert data_loaded["env"]["bin_dir"] == "bin"
         assert data_loaded["templates"][0]["path"] == "templates"
         assert data_loaded["repo"]["distfiles"] == "distfiles"


### PR DESCRIPTION
Closes #1012

@TarantoolBot document
Title: Allow multiple directories with modules

The logic of working with configuration file tt.yaml has been updated,
now  modules/directory can be specified both as a single line and
as a list.

**Usage example**
Old behavior:
```yaml
modules:
  directory: modules
```
Possibility to specify a list of directories:
```yaml
modules:
  directory:
  - modules
  - /ext/path/modules
  - other_modules
```

If a relative path is specified, the search is performed in
the subfolders below, relative to the tt.yaml file. If an absolute
path is specified, external modules are searched according to
the specified path.