### PR TITLE
modules: find module with TT_CLI_MODULES_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt.yaml`: allows to specify a list of modules directories.
+- Environment variable TT_CLI_MODULES_PATH can be used to specify
+  an extra path with modules.
 
 ### Changed
 

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -1,3 +1,5 @@
+// FIXME: Create new tests https://github.com/tarantool/tt/issues/1039
+
 package modules
 
 import (


### PR DESCRIPTION
Closes #1013 

@TarantoolBot document
Title: Use environment variable to find modules.

The TT_CLI_MODULES_PATH environment variable specifies a list of
module's paths separated by a colon “:”.
It can be set externally from tt and must contain a list of
folders where modules are located.
The logic of working with this variable is similar to the PATH
system variable.

Lists of modules are combined into one common list:

- The modules declared in the configuration file tt.yaml come first
- then the modules defined via the environment variable are added.
Any duplicates must be removed, while maintaining the original
order of module declarations.

**Usage example**
Set variable:
```sh
export TT_CLI_MODULES_PATH=/ext/path/modules:${TT_CLI_MODULES_PATH}
```
