### PR TITLE
coredump: support options in `pack` subcommand

### DIFF
--- a/.github/actions/prepare-ce-test-env/action.yml
+++ b/.github/actions/prepare-ce-test-env/action.yml
@@ -67,3 +67,8 @@ runs:
         TT_CLI_BUILD_SSL: 'static'
       run: mage build
       shell: bash
+
+    - name: Install test requirements
+      run: |
+        sudo apt -y install gdb
+      shell: bash

--- a/.github/actions/prepare-ee-test-env/action.yml
+++ b/.github/actions/prepare-ee-test-env/action.yml
@@ -91,3 +91,8 @@ runs:
           TT_CLI_BUILD_SSL: 'static'
         run: mage build
         shell: bash
+
+      - name: Install test requirements
+        run: |
+          sudo apt -y install gdb
+        shell: bash

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: sudo systemctl kill mono-xsp4 || true
 
       - name: Integration tests
+        env:
+          TT_ENABLE_COREDUMP_TESTS: '1'
         run: mage integrationfull
 
   full-ci-ce-linux-arm64:
@@ -83,6 +85,8 @@ jobs:
         run: mage unit:fullSkipDocker
 
       - name: Integration tests
+        env:
+          TT_ENABLE_COREDUMP_TESTS: '1'
         run: mage integrationfullskipdocker
 
   full-ci-sdk:
@@ -139,6 +143,8 @@ jobs:
         run: sudo systemctl kill mono-xsp4 || true
 
       - name: Integration tests
+        env:
+          TT_ENABLE_COREDUMP_TESTS: '1'
         run: mage integrationfull
 
   full-ci-macOS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   an extra path with modules.
 - `tt play`: support connection to a target instance by `application` name
   or `application:instance` name.
+- `tt coredump pack`: add options to customize coredump packing:
+  * `-e (--executable)`: specify Tarantool executable path.
+  * `-p (--pid)`: specify PID of the dumped process.
+  * `-t (--time)`: specify time of dump (seconds since the Epoch).
 
 ### Changed
 
 - `tt stop/kill/clean/logrotate`: no longer need:
    * Instances scripts for multi-instance applications.
    * Cluster config for tarantool3-based cluster applications.
-
 - `tt logrotate`: don't exit at non-running instance, just warn and proceed
   with the other instances, like `tt stop` and `tt kill` do.
+- `tt coredump pack`: by default tarantool executable path is obtained from
+  `PATH` instead of using the hardcoded path `/usr/bin/tarantool`.
 
 ### Fixed
 

--- a/cli/cmd/coredump.go
+++ b/cli/cmd/coredump.go
@@ -6,9 +6,17 @@ import (
 	"github.com/tarantool/tt/cli/util"
 )
 
+var (
+	coredumpPackExecutable      string
+	coredumpPackPID             uint
+	coredumpPackTime            string
+	coredumpPackOutputDirectory string
+	coredumpInspectSourceDir    string
+)
+
 // NewCoredumpCmd creates coredump command.
 func NewCoredumpCmd() *cobra.Command {
-	var coredumpCmd = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:   "coredump",
 		Short: "Perform manipulations with the tarantool coredumps",
 	}
@@ -17,12 +25,28 @@ func NewCoredumpCmd() *cobra.Command {
 		Use:   "pack COREDUMP",
 		Short: "pack tarantool coredump into tar.gz archive",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := coredump.Pack(args[0]); err != nil {
+			err := coredump.Pack(args[0],
+				coredumpPackExecutable,
+				coredumpPackOutputDirectory,
+				coredumpPackPID,
+				coredumpPackTime,
+			)
+			if err != nil {
 				util.HandleCmdErr(cmd, err)
 			}
 		},
 		Args: cobra.ExactArgs(1),
 	}
+	packCmd.Flags().StringVarP(&coredumpPackExecutable, "executable", "e", "",
+		"Tarantool executable path")
+	packCmd.Flags().StringVarP(&coredumpPackOutputDirectory, "directory", "d", "",
+		"Directory the resulting archive is created in")
+	packCmd.Flags().StringVarP(&coredumpPackTime, "time", "t", "",
+		"Time of dump, expressed as seconds since the Epoch (1970-01-01 00:00 UTC)")
+	packCmd.Flags().UintVarP(&coredumpPackPID, "pid", "p", 0,
+		"PID of the dumped process, as seen in the PID namespace in which\n"+
+			"the given process resides (see %p in core(5) for more info). This flag\n"+
+			"is to be used when tt is used as kernel.core_pattern pipeline script")
 
 	var unpackCmd = &cobra.Command{
 		Use:   "unpack ARCHIVE",
@@ -35,29 +59,24 @@ func NewCoredumpCmd() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
-	var sourceDir string
 	var inspectCmd = &cobra.Command{
 		Use:   "inspect {ARCHIVE|DIRECTORY}",
 		Short: "inspect tarantool coredump",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := coredump.Inspect(args[0], sourceDir); err != nil {
+			if err := coredump.Inspect(args[0], coredumpInspectSourceDir); err != nil {
 				util.HandleCmdErr(cmd, err)
 			}
 		},
 		Args: cobra.ExactArgs(1),
 	}
-	inspectCmd.Flags().StringVarP(&sourceDir, "sourcedir", "s", "",
+	inspectCmd.Flags().StringVarP(&coredumpInspectSourceDir, "sourcedir", "s", "",
 		"Source directory")
 
-	subCommands := []*cobra.Command{
+	cmd.AddCommand(
 		packCmd,
 		unpackCmd,
 		inspectCmd,
-	}
+	)
 
-	for _, cmd := range subCommands {
-		coredumpCmd.AddCommand(cmd)
-	}
-
-	return coredumpCmd
+	return cmd
 }

--- a/cli/coredump/coredump.go
+++ b/cli/coredump/coredump.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/apex/log"
@@ -24,7 +25,7 @@ const packEmbedPath = "scripts/tarabrt.sh"
 const inspectEmbedPath = "scripts/gdb.sh"
 
 // Pack packs coredump into a tar.gz archive.
-func Pack(corePath string) error {
+func Pack(corePath string, executable string, outputDir string, pid uint, time string) error {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "tt-coredump-*")
 	if err != nil {
 		return fmt.Errorf("cannot create a temporary directory for archiving: %v", err)
@@ -32,6 +33,15 @@ func Pack(corePath string) error {
 	defer os.RemoveAll(tmpDir) // Clean up on function return.
 
 	scriptArgs := []string{"-c", corePath}
+	if executable != "" {
+		scriptArgs = append(scriptArgs, "-e", executable)
+	}
+	if outputDir != "" {
+		scriptArgs = append(scriptArgs, "-d", outputDir)
+	}
+	if pid != 0 {
+		scriptArgs = append(scriptArgs, "-p", strconv.FormatUint(uint64(pid), 10))
+	}
 
 	// Prepare gdb wrapper for packing.
 	inspectPath := filepath.Join(tmpDir, filepath.Base(inspectEmbedPath))

--- a/test/utils.py
+++ b/test/utils.py
@@ -518,10 +518,10 @@ def is_valid_tarantool_installed(
     return True
 
 
-def get_tarantool_version():
+def get_tarantool_version(tarantool_bin="tarantool"):
     try:
         tt_process = subprocess.Popen(
-            ["tarantool", "--version"],
+            [tarantool_bin, "--version"],
             stderr=subprocess.STDOUT, stdout=subprocess.PIPE, text=True
         )
     except FileNotFoundError:


### PR DESCRIPTION
`-e,--executable path`  Tarantool executable path
`-p,--pid pid`   PID of the dumped process
`-t,--time time`  Time of dump (seconds since the Epoch)

Closes #763