### PR TITLE
lint: golangci-lint version lock

### DIFF
--- a/.github/actions/static-code-check/action.yml
+++ b/.github/actions/static-code-check/action.yml
@@ -35,6 +35,7 @@ runs:
       - name: Go Linter
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.62.2
           args: --config=golangci-lint.yml --out-${NO_FUTURE}format colored-line-number
           skip-cache: true
 


### PR DESCRIPTION
This patch locks `golangci-lint` version at 1.62.2.

Closes #1079