### PR TITLE
aeon: fix repo URL for Aeon submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,5 +9,5 @@
 	ignore = dirty
 [submodule "cli/aeon/protos"]
 	path = cli/aeon/protos
-	url = git@github.com:tarantool/aeon-api-protos.git
+	url = https://github.com/tarantool/aeon-api-protos.git
 	branch = master


### PR DESCRIPTION
Use HTTPS instead Git protocol to avoid extra authorization.