### PR TITLE
aeon: load system CAs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `tt aeon`: did not use system CAs by default.
+
 ## [2.7.0] - 2025-01-22
 
 The release introduces an experimental support of console for AeonDB and


### PR DESCRIPTION
System certificates must be used unless the user specifies a custom one.

Closes #1049