### PR TITLE
ci: fix publish on arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,9 @@ jobs:
 
       # These scripts will be picked up while building packages with goreleaser.
       - name: Generate ZSH and Bash completion scripts
+        env:
+          CGO_LDFLAGS: "-L${{ env.GITHUB_WORKSPACE }}/openssl/lib64"
+          CGO_CFLAGS: "-I${{ env.GITHUB_WORKSPACE }}/openssl/include"
         run: |
           mage build
           ./tt completion bash > tt-completion.bash
@@ -100,6 +103,10 @@ jobs:
 
       # These scripts will be picked up while building packages with goreleaser.
       - name: Generate ZSH and Bash completion scripts
+        env:
+          TT_CLI_BUILD_SSL: 'static'
+          CGO_LDFLAGS: "-L/opt/openssl/lib"
+          CGO_CFLAGS: "-I/opt/openssl/include"
         run: |
           mage build
           ./tt completion bash > tt-completion.bash


### PR DESCRIPTION
Since we don't support a build without OpenSSL it is required always to specify paths to the compiled OpenSSL to build a tt with it.