### PR TITLE
connect: fix Lua parse error handling - return instead of ignoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `tt aeon`: did not use system CAs by default.
+- `tt connect`: return Lua parse error.
 
 ## [2.7.0] - 2025-01-22
 

--- a/cli/connect/internal/luabody/eval_func_body.lua
+++ b/cli/connect/internal/luabody/eval_func_body.lua
@@ -23,7 +23,7 @@ if not fun then
     fun, errmsg = loadstring(cmd)
 end
 if not fun then
-    return yaml.encode({box.NULL})
+    return yaml.encode({ {error = errmsg} })
 end
 {{ end }}
 


### PR DESCRIPTION
close #1064

solution emulation on version 2.7.0 by evaler

```
echo "hello)" | tt connect --evaler '_, errmsg = loadstring(cmd); box.error(box.error.PROC_LUA,  errmsg)' $TARANTOOL_CONSOLE_URI
---
- error: '[string "hello)"]:1: ''='' expected near '')'''
...
```