### PR TITLE
feat: added support for new {{ metricsPort }} construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt aeon connect`: add connection from the `app:insance_name`.
+- Added support for the `{{ metricsPort }}` construct in Go text templates.
+  This new function allows template users to generate a monitoring port value
+  directly within their templates, providing more flexibility and simplifying
+  configuration management.
 
 ### Changed
 

--- a/cli/templates/internal/engines/builtin_funcs.go
+++ b/cli/templates/internal/engines/builtin_funcs.go
@@ -6,18 +6,25 @@ import (
 
 // genState describes template generation state.
 type genState struct {
-	port int
+	port, metricsPort int
 }
 
 // newGenState creates genState.
 func newGenState() *genState {
-	return &genState{port: 3301}
+	return &genState{port: 3301, metricsPort: 8081}
 }
 
 // genPort generates port.
 func (state *genState) genPort() int {
 	ret := state.port
 	state.port++
+	return ret
+}
+
+// genMetricsPort generates metrics port.
+func (state *genState) genMetricsPort() int {
+	ret := state.metricsPort
+	state.metricsPort++
 	return ret
 }
 

--- a/cli/templates/internal/engines/builtin_funcs_test.go
+++ b/cli/templates/internal/engines/builtin_funcs_test.go
@@ -13,6 +13,12 @@ func TestGenPort(t *testing.T) {
 	require.Equal(t, state.genPort(), 3302)
 }
 
+func TestGenMetricsPort(t *testing.T) {
+	state := newGenState()
+	require.Equal(t, state.genMetricsPort(), 8081)
+	require.Equal(t, state.genMetricsPort(), 8082)
+}
+
 func TestGenReplicasets(t *testing.T) {
 	replicasets, err := genReplicasets("name", 4, 3)
 	require.NoError(t, err)

--- a/cli/templates/internal/engines/go_text_engine.go
+++ b/cli/templates/internal/engines/go_text_engine.go
@@ -17,6 +17,7 @@ func makeTemplate(name string) *template.Template {
 	state := newGenState()
 	funcMap := template.FuncMap{
 		"port":        state.genPort,
+		"metricsPort": state.genMetricsPort,
 		"replicasets": genReplicasets,
 		"atoi":        strconv.Atoi,
 	}

--- a/cli/templates/internal/engines/go_text_engine_test.go
+++ b/cli/templates/internal/engines/go_text_engine_test.go
@@ -93,6 +93,12 @@ func TestTextRendering(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedText, actualText)
 
+	templateText = "{{metricsPort}}"
+	expectedText = "8081"
+	actualText, err = engine.RenderText(templateText, nil)
+	require.NoError(t, err)
+	assert.Equal(t, expectedText, actualText)
+
 	templateText = `{{range replicasets "name" 1 1}}` +
 		"Hi, {{.Name}}! Your instances: {{ range .InstNames }}{{.}}{{end}}{{end}}"
 	expectedText = "Hi, name-001! Your instances: name-001-a"


### PR DESCRIPTION
The configuration template generation functionality has been extended:

- Previously, the `{{ port }}` construct was available for generating cluster configuration files with different ports.
- A new construct, `{{ metricsPort }}`, has been added for generating the port of the metrics/metrics-export-role module.

This allows for more flexible configuration of ports for instances.

Based on PR: https://github.com/tarantool/tt/pull/1107