### PR TITLE
Release 2.8.1

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = */rocks/third_party,*/cartridge/third_party,tarantool-static-build.patch,./cli/cluster/paths.go
+skip = go.sum,**/third_party,tarantool-*,mage
 count =
 quiet-level = 3
 ignore-words-list = fo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.8.1] - 2025-03-10
+
+### Added
+
 - `tt aeon connect`: add connection from the `app:insance_name`.
 - Added support for the `{{ metricsPort }}` construct in Go text templates.
   This new function allows template users to generate a monitoring port value

--- a/lib/dial/dial_test.go
+++ b/lib/dial/dial_test.go
@@ -38,14 +38,14 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name: "deafult",
+			name: "default",
 			opts: Opts{
 				Transport: "",
 			},
 			expected: tarantool.NetDialer{},
 		},
 		{
-			name: "deafult_but_key_is_set",
+			name: "default_but_key_is_set",
 			opts: Opts{
 				SslKeyFile: "any.key",
 				Transport:  "",

--- a/magefile.go
+++ b/magefile.go
@@ -445,7 +445,7 @@ func IntegrationNoTarantool() error {
 func Codespell() error {
 	fmt.Println("Running codespell tests...")
 
-	return sh.RunV("codespell", packagePath, "test", "README.md", "doc", "CHANGELOG.md")
+	return sh.RunV("codespell", ".")
 }
 
 // Run all tests together, excluding slow and unit integration tests.

--- a/test/integration/cluster/test_cluster_promote.py
+++ b/test/integration/cluster/test_cluster_promote.py
@@ -42,7 +42,7 @@ def to_etcd_key(key):
         "etcd",
         "manual_no_leader",
         None,
-        id="failover = maual; no leader",
+        id="failover = manual; no leader",
     ),
     pytest.param(
         "etcd",
@@ -102,7 +102,7 @@ def to_etcd_key(key):
         "tcs",
         "manual_no_leader",
         None,
-        id="failover = maual; no leader",
+        id="failover = manual; no leader",
     ),
     pytest.param(
         "tcs",

--- a/test/integration/replicaset/test_replicaset_expel.py
+++ b/test/integration/replicaset/test_replicaset_expel.py
@@ -113,7 +113,7 @@ Replicasets state: bootstrapped
 """
     status_unexpelled = status_expelled + "    • s2-replica localhost:3305 read\n"
 
-    # Wait for the configurated state.
+    # Wait for the configured state.
     for _ in range(100):
         rs_cmd = [tt_cmd, "replicaset", "status", f"{cartridge_name}:s2-master"]
         rs_rc, rs_out = run_command_and_get_output(rs_cmd, cwd=cartridge_app.workdir)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ flake8-unused-arguments==0.0.6
 flake8-isort==6.1.0
 psutil==5.7.0
 pyyaml==6.0.1
-codespell==2.2.5
+codespell==2.4.1
 netifaces==0.11.0
 etcd3==0.12.0
 protobuf==3.20.3


### PR DESCRIPTION
The release introduces minor changes in stabilization of `tt connect`
command. Expanded possibility to connect to `aeon` base.
Improvement in the work of templates.

### Added

- `tt aeon connect`: add connection from the `app:instance_name`.
- Added support for the `{{ metricsPort }}` construct in Go text templates.
  This new function allows template users to generate a monitoring port value
  directly within their templates, providing more flexibility and simplifying
  configuration management.

### Changed

- `tt connect`: allow to disconnect with `Ctrl+C` or `Ctrl+\` if script execution hung.

### Fixed

- `tt connect`: return Lua parse error.
- `tt connect`: panic on render empty table.
- `tt` can be built without linking to OpenSSL.
