### PR TITLE
github: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,8 @@ What has been done? Why? What problem is being solved?
 
 I didn't forget about (remove if it is not applicable):
 
-- [ ] Well-written commits
-      (see [documentation][how-to-write-commit] how to write a commit message)
-- [ ] Don't forget about TarantoolBot in a commit message
-      (see [example][tarantoolbot-example])
+- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
+- [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
 - [ ] Tests (see [documentation][go-testing] for a testing package)
 - [ ] Changelog (see [documentation][keepachangelog] for changelog format)
 - [ ] Documentation (see [documentation][go-doc] for documentation style guide)


### PR DESCRIPTION
Currently the line breaks in the list don't look good.

See the problem below:

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Well-written commits
      (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message
      (see [example][tarantoolbot-example])
- [ ] Tests (see [documentation][go-testing] for a testing package)
- [ ] Changelog (see [documentation][keepachangelog] for changelog format)
- [ ] Documentation (see [documentation][go-doc] for documentation style guide)

Related issues:

Related to #XXX

Part of #XXX

Closes #XXX

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
