### PR TITLE
modules: add command to list modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt aeon connect` added tests for connect file/app.
+- `tt modules list` added command to show available modules.
+  If support extra flags:
+  * `--version` - to show information about version.
+  * `--path` - to show module executables.
+
+- `tt aeon connect` added tests for connect file/app.
 - `tt pack `: support `.packignore` file to specify files that should not be included
   in package (works the same as `.gitignore`).
 - `tt tcm start`: add the tcm command.

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/rocks"
 )
 
@@ -34,12 +33,7 @@ func RootShellCompletionCommands(cmd *cobra.Command, args []string,
 ) ([]string, cobra.ShellCompDirective) {
 	var commands []string
 	for name, manifest := range modulesInfo {
-		description, err := modules.GetExternalModuleDescription(manifest)
-		if err != nil {
-			description = "Failed to get description"
-		}
-
-		commands = append(commands, fmt.Sprintf("%s\t%s", name, description))
+		commands = append(commands, fmt.Sprintf("%s\t%s", name, manifest.Help))
 	}
 
 	return commands, cobra.ShellCompDirectiveDefault

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -78,18 +78,13 @@ func getInternalHelpFunc(cmd *cobra.Command, help DefaultHelpFunc) modules.Inter
 	}
 }
 
-// getExternalCommandString returns a pretty string
+// getExternalCommandsString returns a pretty string
 // of descriptions for external modules.
 func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
 	str := ""
-	for path, manifest := range *modulesInfo {
-		helpMsg, err := modules.GetExternalModuleDescription(manifest)
-		if err != nil {
-			helpMsg = "description is absent"
-		}
-
-		name := strings.Split(path, " ")[1]
-		str = fmt.Sprintf("%s  %s\t%s\n", str, name, helpMsg)
+	for _, path := range sortExternalModules() {
+		mf := (*modulesInfo)[path]
+		str += fmt.Sprintf("  %s\t%s\n", mf.Name, mf.Help)
 	}
 
 	if str != "" {
@@ -100,8 +95,7 @@ func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
 	return ""
 }
 
-var (
-	usageTemplate = util.Bold("USAGE") + `
+var usageTemplate = util.Bold("USAGE") + `
 {{- if (and .Runnable .HasAvailableInheritedFlags)}}
   {{.UseLine}}
 {{end -}}
@@ -130,7 +124,7 @@ var (
 {{end}}
 {{end -}}
 
-{{- if not .HasAvailableInheritedFlags}} %s
+{{- if not .HasParent}} %s
 {{end -}}
 
 {{- if .HasAvailableLocalFlags}}` + util.Bold("\nFLAGS") + `
@@ -149,4 +143,3 @@ var (
 Use "{{.CommandPath}} <command> --help" for more information about a command.
 {{end -}}
 `
-)

--- a/cli/cmd/modules.go
+++ b/cli/cmd/modules.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	showVersion bool
+	showPath    bool
+)
+
+// newModulesListCmd creates a new `modules list` subcommand.
+func newModulesListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List available modules",
+		Run: func(cmd *cobra.Command, args []string) {
+			searchCtx.ProgramName = cmd.Name()
+			err := modules.RunCmd(&cmdCtx, cmd.CommandPath(), &modulesInfo,
+				internalModulesList, args)
+			util.HandleCmdErr(cmd, err)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show modules version")
+	cmd.Flags().BoolVarP(&showPath, "path", "p", false,
+		"Show modules path instead of description")
+
+	return cmd
+}
+
+// NewModulesCmd creates a new `modules` command.
+func NewModulesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "modules",
+		Short: "Manage tt cli modules",
+	}
+	cmd.AddCommand(
+		newModulesListCmd(),
+	)
+	return cmd
+}
+
+// sortExternalModules returns a sorted list of external modules.
+func sortExternalModules() []string {
+	keys := make([]string, 0, len(modulesInfo))
+	for k := range modulesInfo {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// internalModulesList produce list all available external modules.
+func internalModulesList(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	for _, path := range sortExternalModules() {
+		m := modulesInfo[path]
+
+		if showVersion {
+			fmt.Printf("%-5s\t", m.Version)
+		}
+		fmt.Printf("%s - ", m.Name)
+
+		if showPath {
+			fmt.Print(m.Main)
+		} else {
+			fmt.Print(m.Help)
+		}
+
+		fmt.Print("\n")
+	}
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -212,6 +212,7 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		NewEnableCmd(),
 		NewAeonCmd(),
 		NewTcmCmd(),
+		NewModulesCmd(),
 	)
 	if err := injectCmds(rootCmd); err != nil {
 		panic(err.Error())

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -45,12 +45,16 @@ func TestGetModulesInfo(t *testing.T) {
 			modules: []string{"testdata/modules1"},
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
+					Name:    "ext_mod",
 					Main:    "testdata/modules1/ext_mod/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root simple": modules.Manifest{
-					Main: "testdata/modules1/simple/main",
+					Name:    "simple",
+					Main:    "testdata/modules1/simple/main",
+					Help:    "Description for simple module",
+					Version: "v0.0.1",
 				},
 			},
 		},
@@ -60,17 +64,22 @@ func TestGetModulesInfo(t *testing.T) {
 			env_modules: "testdata/modules1:testdata/modules2",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
+					Name:    "ext_mod",
 					Main:    "testdata/modules1/ext_mod/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root ext_mod2": modules.Manifest{
+					Name:    "ext_mod2",
 					Main:    "testdata/modules2/ext_mod2/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root simple": modules.Manifest{
-					Main: "testdata/modules1/simple/main",
+					Name:    "simple",
+					Main:    "testdata/modules1/simple/main",
+					Help:    "Description for simple module",
+					Version: "v0.0.1",
 				},
 			},
 		},
@@ -80,12 +89,16 @@ func TestGetModulesInfo(t *testing.T) {
 			env_modules: "testdata/modules1",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
+					Name:    "ext_mod",
 					Main:    "testdata/modules1/ext_mod/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root simple": modules.Manifest{
-					Main: "testdata/modules1/simple/main",
+					Name:    "simple",
+					Main:    "testdata/modules1/simple/main",
+					Help:    "Description for simple module",
+					Version: "v0.0.1",
 				},
 			},
 		},
@@ -96,17 +109,22 @@ func TestGetModulesInfo(t *testing.T) {
 			env_modules: "testdata/modules2",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
+					Name:    "ext_mod",
 					Main:    "testdata/modules1/ext_mod/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root ext_mod2": modules.Manifest{
+					Name:    "ext_mod2",
 					Main:    "testdata/modules2/ext_mod2/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root simple": modules.Manifest{
-					Main: "testdata/modules1/simple/main",
+					Name:    "simple",
+					Main:    "testdata/modules1/simple/main",
+					Help:    "Description for simple module",
+					Version: "v0.0.1",
 				},
 			},
 		},
@@ -117,12 +135,16 @@ func TestGetModulesInfo(t *testing.T) {
 			env_modules: "testdata/modules1",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
+					Name:    "ext_mod",
 					Main:    "testdata/modules1/ext_mod/command.sh",
 					Help:    "Help for the ext_mod module",
 					Version: "1.2.3",
 				},
 				"root simple": modules.Manifest{
-					Main: "testdata/modules1/simple/main",
+					Name:    "simple",
+					Main:    "testdata/modules1/simple/main",
+					Help:    "Description for simple module",
+					Version: "v0.0.1",
 				},
 			},
 			log: []string{"Ignore duplicate module"},
@@ -140,6 +162,9 @@ func TestGetModulesInfo(t *testing.T) {
 				`Failed to get information about module "no-help": help field is mandatory`,
 				`Failed to get information about module "not-mf": failed to read manifest`,
 				`Failed to get information about module "broken": failed to parse manifest`,
+				`Failed to get information about module "no_version":` +
+					` reply for --version is mandatory for module`,
+				`Failed to get information about module "simple": can't parse module info`,
 			},
 		},
 
@@ -162,9 +187,18 @@ func TestGetModulesInfo(t *testing.T) {
 			modules: []string{"testdata/mod_override"},
 			want: modules.ModulesInfo{
 				"root testCmd": modules.Manifest{
-					Main: "testdata/mod_override/testCmd/main",
+					Name:    "testCmd",
+					Main:    "testdata/mod_override/testCmd/main",
+					Help:    "Description for testCmd module",
+					Version: "v1.2.3",
 				},
 			},
+		},
+		"disabled override ": {
+			config:      "some/config/tt.yaml",
+			env_modules: "testdata/disabled_override",
+			want:        modules.ModulesInfo{},
+			err:         `module "modules" is disabled to override`,
 		},
 	}
 

--- a/cli/modules/testdata/bad_manifest/no_version/main
+++ b/cli/modules/testdata/bad_manifest/no_version/main
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "help: only description reply; no version"

--- a/cli/modules/testdata/bad_manifest/simple/main
+++ b/cli/modules/testdata/bad_manifest/simple/main
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Module without version and description support"

--- a/cli/modules/testdata/disabled_override/modules/main
+++ b/cli/modules/testdata/disabled_override/modules/main
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Try overriding internal modules command"

--- a/cli/modules/testdata/mod_override/testCmd/main
+++ b/cli/modules/testdata/mod_override/testCmd/main
@@ -1,2 +1,22 @@
 #!/bin/sh
+NEED_EXIT=false
+
+for var in "$@"
+do
+	case "$var" in
+		"--description")
+			echo "help: Description for testCmd module"
+			NEED_EXIT=true
+			;;
+		"--version")
+			echo "version: v1.2.3"
+			NEED_EXIT=true
+			;;
+	esac
+done
+
+if $NEED_EXIT; then
+	exit 0
+fi
+
 echo "Hello, simple module!"

--- a/cli/modules/testdata/modules1/simple/main
+++ b/cli/modules/testdata/modules1/simple/main
@@ -1,2 +1,22 @@
 #!/bin/sh
+NEED_EXIT=false
+
+for var in "$@"
+do
+	case "$var" in
+		"--description")
+			echo "help: Description for simple module"
+			NEED_EXIT=true
+			;;
+		"--version")
+			echo "version: v0.0.1"
+			NEED_EXIT=true
+			;;
+	esac
+done
+
+if $NEED_EXIT; then
+	exit 0
+fi
+
 echo "Hello, simple module!"


### PR DESCRIPTION
It's part of `modules` support. Introduce `modules list` sub-command.

I didn't forget about (remove if it is not applicable):

- [x] Well-written commits
      (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message
      (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)
- [x] Documentation (see [documentation][go-doc] for documentation style guide)

Related issues:

Closes #1016
Closes #TNTP-1805


[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
