### PR TITLE
Fix arguments parsing if internal command is forced over external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Arguments of an internal command are not parsed if it is forced over its existent
+  external counterpart.
+
 ## [2.8.1] - 2025-03-10
 
 The release introduces minor changes in stabilization of `tt connect`

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -314,7 +314,7 @@ func InitRoot() {
 	// External commands must be configured in a special way.
 	// This is necessary, for example, so that we can pass arguments to these commands.
 	if len(os.Args) > 1 {
-		configure.ExternalCmd(rootCmd, &cmdCtx, &modulesInfo, os.Args[1:])
+		configure.ExternalCmd(rootCmd, &cmdCtx, &modulesInfo, cmdCtx.Cli.ForceInternal, os.Args[1:])
 	}
 
 	// Configure help command.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -438,17 +438,18 @@ func Cli(cmdCtx *cmdcontext.CmdCtx) error {
 
 // ExternalCmd configures external commands.
 func ExternalCmd(rootCmd *cobra.Command, cmdCtx *cmdcontext.CmdCtx,
-	modulesInfo *modules.ModulesInfo, args []string) {
-	configureExistsCmd(rootCmd, modulesInfo)
+	modulesInfo *modules.ModulesInfo, forceInternal bool, args []string) {
+	configureExistsCmd(rootCmd, modulesInfo, forceInternal)
 	configureNonExistentCmd(rootCmd, cmdCtx, modulesInfo, args)
 }
 
 // configureExistsCmd configures an external commands
 // that have internal implementation.
-func configureExistsCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo) {
+func configureExistsCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo,
+	forceInternal bool) {
 	for _, cmd := range rootCmd.Commands() {
 		if _, found := (*modulesInfo)[cmd.CommandPath()]; found {
-			cmd.DisableFlagParsing = true
+			cmd.DisableFlagParsing = !forceInternal
 		}
 	}
 }

--- a/test/integration/version/test_version.py
+++ b/test/integration/version/test_version.py
@@ -12,7 +12,7 @@ def check_internal_version_cmd(tt_cmd, tmp_path):
     cmd = [tt_cmd, "-I", "version", "--short"]
     rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
-    assert re.match(r"(\d+.\d+.\d+|<unknown>)", output)
+    assert re.match(r"(\d+.\d+.\d+|<unknown>)$", output)
 
     cmd = [tt_cmd, "-I", "version", "--commit"]
     rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)

--- a/test/integration/version/test_version.py
+++ b/test/integration/version/test_version.py
@@ -1,25 +1,35 @@
 import re
 
-from utils import run_command_and_get_output
+import utils
 
 
-def test_version_cmd(tt_cmd, tmp_path):
+def check_internal_version_cmd(tt_cmd, tmp_path):
     cmd = [tt_cmd, "-I", "version"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert len(re.findall(r"(\s\d+.\d+.\d+,|\s<unknown>,)", output)) == 1
 
     cmd = [tt_cmd, "-I", "version", "--short"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>)", output)
 
     cmd = [tt_cmd, "-I", "version", "--commit"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>).\w+", output)
 
     cmd = [tt_cmd, "-I", "version", "--commit", "--short"]
-    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    rc, output = utils.run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     assert re.match(r"(\d+.\d+.\d+|<unknown>).\w+", output)
+
+
+def test_version_cmd(tt_cmd, tmp_path):
+    check_internal_version_cmd(tt_cmd, tmp_path)
+
+
+def test_version_internal_over_external(tt_cmd, tmp_path):
+    utils.create_external_module("version", tmp_path)
+    utils.create_tt_config(tmp_path, tmp_path)
+    check_internal_version_cmd(tt_cmd, tmp_path)


### PR DESCRIPTION
Arguments of an internal command are not parsed if it is forced over its existent external counterpart.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1134 

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
