### PR TITLE
ci: add release tag validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,20 @@ env:
   GO_VERSION: '1.22.11'
 
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 'master'
+          fetch-depth: 0
+
+      - name: Validation
+        run: git branch -r --contains ${{ github.ref }} | grep "origin/master"
+
   create-packages-linux:
+    needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +91,7 @@ jobs:
           path: dist
 
   create-packages-linux-arm64:
+    needs: validate-tag
     runs-on: graviton
     strategy:
       fail-fast: false
@@ -128,6 +142,7 @@ jobs:
           path: dist
 
   create-packages-macos:
+    needs: validate-tag
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
@@ -265,7 +280,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-s3:
-    needs: [create-packages-linux, create-packages-linux-arm64]
+    needs: [validate-tag, create-packages-linux, create-packages-linux-arm64]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     steps:


### PR DESCRIPTION
Special job was added to avoid publishing release with a tag that is not visible from the master branch. Such a tag produces `tt` that displays incorrect version information with `tt version`

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Closes #TNTP-1826

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
