### PR TITLE
ci: hotfix to avoid cmake warning

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,3 +13,7 @@ protobuf==3.20.3
 importlib-metadata<4.3
 pytest-timeout==2.2.0
 retry==0.9.2
+# HOTFIX: Workaround to avoid cmake warning that appears after upgrading cmake on CI runners.
+# The warning occurs during CI tests in 'checks' repo and finally leads to CI failure.
+# REMOVE IT as soon as proper fixes are applied to 'checks' and all dependent repos.
+cmake==3.15.3


### PR DESCRIPTION
After upgrading cmake on CI runners it starts to generate warning during CI tests that finally leads to CI failure.
This patch applies quick fix that uses cmake of an older version to avoid the warning.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Related to #TNTP-1918

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
