### PR TITLE
help: display external commands only in top level help

### DIFF
--- a/cli/cmd/external.go
+++ b/cli/cmd/external.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/modules"
 )
@@ -50,8 +49,7 @@ func configureNonExistentCmd(rootCmd *cobra.Command,
 
 	externalCmdPath := rootCmd.Name() + " " + externalCmd
 	if _, found := (*modulesInfo)[externalCmdPath]; found {
-		rootCmd.AddCommand(newExternalCommand(modulesInfo, externalCmd,
-			externalCmdPath))
+		rootCmd.AddCommand(newExternalCmd(externalCmd))
 	}
 }
 
@@ -65,20 +63,14 @@ func externalCmdHelpFunc(cmd *cobra.Command, args []string) {
 	cmd.Print(helpMsg)
 }
 
-// newExternalCommand returns a pointer to a new external
+// newExternalCmd returns a pointer to a new external
 // command that will call modules.RunCmd.
-func newExternalCommand(modulesInfo *modules.ModulesInfo,
-	cmdName, cmdPath string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: cmdName,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdCtx.Cli.ForceInternal = false
-			if err := modules.RunCmd(&cmdCtx, cmdPath, modulesInfo, nil, args); err != nil {
-				log.Fatalf(err.Error())
-			}
-		},
+func newExternalCmd(cmdName string) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:                cmdName,
+		Run:                RunModuleFunc(nil),
+		DisableFlagParsing: true,
 	}
-	cmd.DisableFlagParsing = true
 	cmd.SetHelpFunc(externalCmdHelpFunc)
 	return cmd
 }

--- a/cli/cmd/external.go
+++ b/cli/cmd/external.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"github.com/tarantool/tt/cli/modules"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// ExternalCmd configures external commands.
+func configureExternalCmd(rootCmd *cobra.Command,
+	modulesInfo *modules.ModulesInfo, forceInternal bool, args []string) {
+	configureExistsCmd(rootCmd, modulesInfo, forceInternal)
+	configureNonExistentCmd(rootCmd, modulesInfo, args)
+}
+
+// configureExistsCmd configures an external commands
+// that have internal implementation.
+func configureExistsCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo,
+	forceInternal bool) {
+	for _, cmd := range rootCmd.Commands() {
+		if _, found := (*modulesInfo)[cmd.CommandPath()]; found {
+			cmd.DisableFlagParsing = !forceInternal
+		}
+	}
+}
+
+// configureNonExistentCmd configures an external command that
+// has no internal implementation within the Tarantool CLI.
+func configureNonExistentCmd(rootCmd *cobra.Command,
+	modulesInfo *modules.ModulesInfo, args []string) {
+	// Since the user can pass flags, to determine the name of
+	// an external command we have to take the first non-flag argument.
+	externalCmd := args[0]
+	for _, name := range args {
+		if !strings.HasPrefix(name, "-") && name != "help" {
+			externalCmd = name
+			break
+		}
+	}
+
+	// We avoid overwriting existing commands - we should add a command only
+	// if it doesn't have an internal implementation in Tarantool CLI.
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == externalCmd {
+			return
+		}
+	}
+
+	helpCmd := util.GetHelpCommand(rootCmd)
+	externalCmdPath := rootCmd.Name() + " " + externalCmd
+	if _, found := (*modulesInfo)[externalCmdPath]; found {
+		rootCmd.AddCommand(newExternalCommand(modulesInfo, externalCmd,
+			externalCmdPath, nil))
+		helpCmd.AddCommand(newExternalCommand(modulesInfo, externalCmd, externalCmdPath,
+			[]string{"--help"}))
+	}
+}
+
+// newExternalCommand returns a pointer to a new external
+// command that will call modules.RunCmd.
+func newExternalCommand(modulesInfo *modules.ModulesInfo,
+	cmdName, cmdPath string, addArgs []string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: cmdName,
+		Run: func(cmd *cobra.Command, args []string) {
+			if addArgs != nil {
+				args = append(args, addArgs...)
+			}
+
+			cmdCtx.Cli.ForceInternal = false
+			if err := modules.RunCmd(&cmdCtx, cmdPath, modulesInfo, nil, args); err != nil {
+				log.Fatalf(err.Error())
+			}
+		},
+	}
+
+	cmd.DisableFlagParsing = true
+	return cmd
+}

--- a/cli/cmd/external.go
+++ b/cli/cmd/external.go
@@ -1,17 +1,20 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/modules"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	commandGroupExternal = &cobra.Group{ID: "External"}
 )
 
 // ExternalCmd configures external commands.
-func configureExternalCmd(rootCmd *cobra.Command,
-	modulesInfo *modules.ModulesInfo, forceInternal bool, args []string) {
+func configureExternalCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo,
+	forceInternal bool) {
 	configureExistsCmd(rootCmd, modulesInfo, forceInternal)
-	configureNonExistentCmd(rootCmd, modulesInfo, args)
+	configureNonExistentCmd(rootCmd, modulesInfo)
 }
 
 // configureExistsCmd configures an external commands
@@ -21,35 +24,32 @@ func configureExistsCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo
 	for _, cmd := range rootCmd.Commands() {
 		if _, found := (*modulesInfo)[cmd.CommandPath()]; found {
 			cmd.DisableFlagParsing = !forceInternal
+			cmd.GroupID = "|" + commandGroupExternal.ID
 		}
 	}
 }
 
 // configureNonExistentCmd configures an external command that
 // has no internal implementation within the Tarantool CLI.
-func configureNonExistentCmd(rootCmd *cobra.Command,
-	modulesInfo *modules.ModulesInfo, args []string) {
-	// Since the user can pass flags, to determine the name of
-	// an external command we have to take the first non-flag argument.
-	externalCmd := args[0]
-	for _, name := range args {
-		if !strings.HasPrefix(name, "-") && name != "help" {
-			externalCmd = name
-			break
-		}
-	}
+func configureNonExistentCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo) {
+	hasExternalCmd := false
 
-	// We avoid overwriting existing commands - we should add a command only
-	// if it doesn't have an internal implementation in Tarantool CLI.
+	// Prepare list of internal command names.
+	internalCmdNames := []string{"help"}
 	for _, cmd := range rootCmd.Commands() {
-		if cmd.Name() == externalCmd {
-			return
+		internalCmdNames = append(internalCmdNames, cmd.Name())
+	}
+
+	// Add external command only if it doesn't have an internal implementation in Tarantool CLI.
+	for name, manifest := range *modulesInfo {
+		if !slices.Contains(internalCmdNames, name) {
+			rootCmd.AddCommand(newExternalCmd(name, manifest))
+			hasExternalCmd = true
 		}
 	}
 
-	externalCmdPath := rootCmd.Name() + " " + externalCmd
-	if _, found := (*modulesInfo)[externalCmdPath]; found {
-		rootCmd.AddCommand(newExternalCmd(externalCmd))
+	if hasExternalCmd {
+		rootCmd.AddGroup(commandGroupExternal)
 	}
 }
 
@@ -65,11 +65,18 @@ func externalCmdHelpFunc(cmd *cobra.Command, args []string) {
 
 // newExternalCmd returns a pointer to a new external
 // command that will call modules.RunCmd.
-func newExternalCmd(cmdName string) *cobra.Command {
+func newExternalCmd(cmdName string, manifest modules.Manifest) *cobra.Command {
+	desc, err := modules.GetExternalModuleDescription(manifest)
+	if err != nil {
+		desc = "description is absent"
+	}
+
 	var cmd = &cobra.Command{
 		Use:                cmdName,
+		Short:              desc,
 		Run:                RunModuleFunc(nil),
 		DisableFlagParsing: true,
+		GroupID:            commandGroupExternal.ID,
 	}
 	cmd.SetHelpFunc(externalCmdHelpFunc)
 	return cmd

--- a/cli/cmd/external.go
+++ b/cli/cmd/external.go
@@ -6,7 +6,6 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/modules"
-	"github.com/tarantool/tt/cli/util"
 )
 
 // ExternalCmd configures external commands.
@@ -49,34 +48,37 @@ func configureNonExistentCmd(rootCmd *cobra.Command,
 		}
 	}
 
-	helpCmd := util.GetHelpCommand(rootCmd)
 	externalCmdPath := rootCmd.Name() + " " + externalCmd
 	if _, found := (*modulesInfo)[externalCmdPath]; found {
 		rootCmd.AddCommand(newExternalCommand(modulesInfo, externalCmd,
-			externalCmdPath, nil))
-		helpCmd.AddCommand(newExternalCommand(modulesInfo, externalCmd, externalCmdPath,
-			[]string{"--help"}))
+			externalCmdPath))
 	}
+}
+
+func externalCmdHelpFunc(cmd *cobra.Command, args []string) {
+	module := modulesInfo[cmd.CommandPath()]
+	helpMsg, err := modules.GetExternalModuleHelp(module.Main)
+	if err != nil {
+		cmd.PrintErr(err)
+		return
+	}
+	cmd.Print(helpMsg)
 }
 
 // newExternalCommand returns a pointer to a new external
 // command that will call modules.RunCmd.
 func newExternalCommand(modulesInfo *modules.ModulesInfo,
-	cmdName, cmdPath string, addArgs []string) *cobra.Command {
+	cmdName, cmdPath string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: cmdName,
 		Run: func(cmd *cobra.Command, args []string) {
-			if addArgs != nil {
-				args = append(args, addArgs...)
-			}
-
 			cmdCtx.Cli.ForceInternal = false
 			if err := modules.RunCmd(&cmdCtx, cmdPath, modulesInfo, nil, args); err != nil {
 				log.Fatalf(err.Error())
 			}
 		},
 	}
-
 	cmd.DisableFlagParsing = true
+	cmd.SetHelpFunc(externalCmdHelpFunc)
 	return cmd
 }

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -2,80 +2,50 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/util"
 )
 
-// DefaultHelpFunc is a type of the standard built-in
-// cobra implementation of the help function.
-type DefaultHelpFunc func(*cobra.Command, []string)
-
-// configureHelpCommand configures our own help module
-// so that it can be external as well.
-// If the help is called for an external module
-// (for example `tt help version`), we try to get the help from it.
-func configureHelpCommand(cmdCtx *cmdcontext.CmdCtx, rootCmd *cobra.Command) error {
+func configureHelpCommand(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo) error {
 	// Add information about external modules into help template.
-	rootCmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, getExternalCommandsString(&modulesInfo)))
-	defaultHelp := rootCmd.HelpFunc()
+	rootCmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, getExternalCommandsString(modulesInfo)))
 
-	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		cmdCtx.CommandName = cmd.Name()
-		if len(os.Args) == 1 || util.Find(args, "-h") != -1 || util.Find(args, "--help") != -1 {
-			defaultHelp(cmd, nil)
-			return
+	internalHelpModule := func(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+		fmt.Printf("internalHelpModule: cmdCtx.CommandName=%s\n", cmdCtx.CommandName)
+		fmt.Printf("internalHelpModule: args: %v\n", args)
+		if len(args) == 0 {
+			rootCmd.Help()
+			return nil
 		}
 
-		args = modules.GetDefaultCmdArgs("help")
-		err := modules.RunCmd(cmdCtx, "tt help", &modulesInfo,
-			getInternalHelpFunc(cmd, defaultHelp), args)
+		cmd, _, err := rootCmd.Find(args)
+		fmt.Printf("internalHelpModule: cmd.Name=%s\n", cmd.Name())
+		fmt.Printf("internalHelpModule: cmd.CommandPath=%s\n", cmd.CommandPath())
 		if err != nil {
-			log.Fatalf(err.Error())
+			return err
 		}
-	})
+
+		cmd.Help()
+		return nil
+	}
+
+	helpCmd := &cobra.Command{
+		Use:   "help [command]",
+		Short: "Help about any command",
+		Run:   RunModuleFunc(internalHelpModule),
+	}
 
 	// Add valid arguments for completion.
-	helpCmd := util.GetHelpCommand(rootCmd)
-	for name := range modulesInfo {
+	for name := range *modulesInfo {
 		helpCmd.ValidArgs = append(helpCmd.ValidArgs, name)
 	}
 
+	rootCmd.SetHelpCommand(helpCmd)
 	return nil
-}
-
-// getInternalHelpFunc returns a internal implementation of help module.
-func getInternalHelpFunc(cmd *cobra.Command, help DefaultHelpFunc) modules.InternalFunc {
-	return func(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-		switch manifest, found := modulesInfo[cmd.CommandPath()]; {
-		// Cases when we have to run the "default" help:
-		// - `tt help` and no external help module.
-		// 	It looks strange: if we type the command `tt help`,
-		// 	the call to cmd.Name() returns `tt` and I don’t know
-		// 	what is the reason. If there is an external help module,
-		// 	then we also cannot be here (see the code below) and it
-		// 	is enough to check cmd.Name() == "tt".
-		// - `tt help -I`
-		// - `tt --help`, `tt -h` or `tt` (look code above).
-		case cmd.Name() == "tt", !found:
-			help(cmd, nil)
-		// We make a call to the external module (if it exists) with the `--help` flag.
-		default:
-			helpMsg, err := modules.GetExternalModuleHelp(manifest.Main)
-			if err != nil {
-				return err
-			}
-
-			cmd.Print(helpMsg)
-		}
-
-		return nil
-	}
 }
 
 // getExternalCommandString returns a pretty string

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,19 +11,21 @@ import (
 
 func configureHelpCommand(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo) error {
 	// Add information about external modules into help template.
-	rootCmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, getExternalCommandsString(modulesInfo)))
+	cobra.AddTemplateFunc("title", util.Bold)
+	cobra.AddTemplateFunc("split", strings.Split)
+	rootCmd.SetUsageTemplate(usageTemplate)
 
 	internalHelpModule := func(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-		fmt.Printf("internalHelpModule: cmdCtx.CommandName=%s\n", cmdCtx.CommandName)
-		fmt.Printf("internalHelpModule: args: %v\n", args)
+		// fmt.Printf("internalHelpModule: cmdCtx.CommandName=%s\n", cmdCtx.CommandName)
+		// fmt.Printf("internalHelpModule: args: %v\n", args)
 		if len(args) == 0 {
 			rootCmd.Help()
 			return nil
 		}
 
 		cmd, _, err := rootCmd.Find(args)
-		fmt.Printf("internalHelpModule: cmd.Name=%s\n", cmd.Name())
-		fmt.Printf("internalHelpModule: cmd.CommandPath=%s\n", cmd.CommandPath())
+		// fmt.Printf("internalHelpModule: cmd.Name=%s\n", cmd.Name())
+		// fmt.Printf("internalHelpModule: cmd.CommandPath=%s\n", cmd.CommandPath())
 		if err != nil {
 			return err
 		}
@@ -48,75 +49,66 @@ func configureHelpCommand(rootCmd *cobra.Command, modulesInfo *modules.ModulesIn
 	return nil
 }
 
-// getExternalCommandString returns a pretty string
-// of descriptions for external modules.
-func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
-	str := ""
-	for path, manifest := range *modulesInfo {
-		helpMsg, err := modules.GetExternalModuleDescription(manifest)
-		if err != nil {
-			helpMsg = "description is absent"
-		}
-
-		name := strings.Split(path, " ")[1]
-		str = fmt.Sprintf("%s  %s\t%s\n", str, name, helpMsg)
-	}
-
-	if str != "" {
-		str = util.Bold("\nEXTERNAL COMMANDS\n") + str
-		return strings.Trim(str, "\n")
-	}
-
-	return ""
-}
-
 var (
-	usageTemplate = util.Bold("USAGE") + `
+	usageTemplate = `{{title "USAGE"}}
 {{- if (and .Runnable .HasAvailableInheritedFlags)}}
   {{.UseLine}}
 {{end -}}
 
 {{- if .HasAvailableSubCommands}}
   {{.CommandPath}} [flags] <command> [command flags]
-{{end -}}
-
-{{if not .HasAvailableSubCommands}}
-{{- if .Runnable}}
+{{- else if .Runnable}}
   {{.UseLine}}
-{{end -}}
-{{end}}
+{{- end}}
+{{- if gt (len .Aliases) 0}}
 
-{{- if gt (len .Aliases) 0}}` + util.Bold("\nALIASES") + `
+{{title "ALIASES"}}
   {{.NameAndAliases}}
-{{end -}}
-
-{{if .HasAvailableSubCommands}}` + util.Bold("\nCOMMANDS") + `
-{{- range .Commands}}
-
-{{- if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}
-{{- end -}}
-
-{{end}}
-{{end -}}
-
-{{- if not .HasAvailableInheritedFlags}} %s
-{{end -}}
-
-{{- if .HasAvailableLocalFlags}}` + util.Bold("\nFLAGS") + `
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
-{{end -}}
-
-{{- if .HasAvailableInheritedFlags}}` + util.Bold("\nGLOBAL FLAGS") + `
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
-{{end -}}
-
-{{- if .HasExample}}` + util.Bold("\nEXAMPLES") + `
-  {{.Example}}
-{{end -}}
-
+{{- end}}
 {{- if .HasAvailableSubCommands}}
+
+{{title "COMMANDS"}}
+{{- range .Commands}}
+{{- if or .IsAvailableCommand (eq .Name "help")}}
+{{- if eq .GroupID ""}}
+  {{rpad .Name .NamePadding }} {{.Short}}
+{{- else if ne .GroupID "External"}}
+  {{rpad .Name .NamePadding }} {{index (split .Short "|") 0}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- if gt (len .Groups) 0}}
+
+{{title "EXTERNAL COMMANDS"}}
+{{- range .Commands}}
+{{- if or .IsAvailableCommand (eq .Name "help")}}
+{{- if eq .GroupID "External"}}
+  {{rpad .Name .NamePadding }} {{.Short}}
+{{- else if ne .GroupID ""}}
+  {{rpad .Name .NamePadding }} {{index (split .Short "|") 1}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- if .HasAvailableLocalFlags}}
+
+{{title "FLAGS"}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- end}}
+{{- if .HasAvailableInheritedFlags}}
+
+{{title "GLOBAL FLAGS"}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- end}}
+{{- if .HasExample}}
+
+{{title "EXAMPLES"}}
+  {{.Example}}
+{{- end}}
+{{- if .HasAvailableSubCommands}}
+
 Use "{{.CommandPath}} <command> --help" for more information about a command.
-{{end -}}
+{{- end}}
 `
 )

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -318,7 +318,7 @@ func InitRoot() {
 	}
 
 	// Configure help command.
-	err = configureHelpCommand(&cmdCtx, rootCmd)
+	err = configureHelpCommand(rootCmd, &modulesInfo)
 	if err != nil {
 		log.Fatalf("Failed to set up help command: %s", err)
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -313,9 +313,7 @@ func InitRoot() {
 
 	// External commands must be configured in a special way.
 	// This is necessary, for example, so that we can pass arguments to these commands.
-	if len(os.Args) > 1 {
-		configureExternalCmd(rootCmd, &modulesInfo, cmdCtx.Cli.ForceInternal, os.Args[1:])
-	}
+	configureExternalCmd(rootCmd, &modulesInfo, cmdCtx.Cli.ForceInternal)
 
 	// Configure help command.
 	err = configureHelpCommand(rootCmd, &modulesInfo)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -314,7 +314,7 @@ func InitRoot() {
 	// External commands must be configured in a special way.
 	// This is necessary, for example, so that we can pass arguments to these commands.
 	if len(os.Args) > 1 {
-		configure.ExternalCmd(rootCmd, &cmdCtx, &modulesInfo, cmdCtx.Cli.ForceInternal, os.Args[1:])
+		configureExternalCmd(rootCmd, &modulesInfo, cmdCtx.Cli.ForceInternal, os.Args[1:])
 	}
 
 	// Configure help command.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -6,15 +6,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"syscall"
 
 	"github.com/apex/log"
 	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
-	"github.com/tarantool/tt/cli/modules"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/lib/integrity"
 )
@@ -434,78 +431,6 @@ func Cli(cmdCtx *cmdcontext.CmdCtx) error {
 
 	// No flags specified.
 	return configureDefaultCli(cmdCtx)
-}
-
-// ExternalCmd configures external commands.
-func ExternalCmd(rootCmd *cobra.Command, cmdCtx *cmdcontext.CmdCtx,
-	modulesInfo *modules.ModulesInfo, forceInternal bool, args []string) {
-	configureExistsCmd(rootCmd, modulesInfo, forceInternal)
-	configureNonExistentCmd(rootCmd, cmdCtx, modulesInfo, args)
-}
-
-// configureExistsCmd configures an external commands
-// that have internal implementation.
-func configureExistsCmd(rootCmd *cobra.Command, modulesInfo *modules.ModulesInfo,
-	forceInternal bool) {
-	for _, cmd := range rootCmd.Commands() {
-		if _, found := (*modulesInfo)[cmd.CommandPath()]; found {
-			cmd.DisableFlagParsing = !forceInternal
-		}
-	}
-}
-
-// configureNonExistentCmd configures an external command that
-// has no internal implementation within the Tarantool CLI.
-func configureNonExistentCmd(rootCmd *cobra.Command, cmdCtx *cmdcontext.CmdCtx,
-	modulesInfo *modules.ModulesInfo, args []string) {
-	// Since the user can pass flags, to determine the name of
-	// an external command we have to take the first non-flag argument.
-	externalCmd := args[0]
-	for _, name := range args {
-		if !strings.HasPrefix(name, "-") && name != "help" {
-			externalCmd = name
-			break
-		}
-	}
-
-	// We avoid overwriting existing commands - we should add a command only
-	// if it doesn't have an internal implementation in Tarantool CLI.
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Name() == externalCmd {
-			return
-		}
-	}
-
-	helpCmd := util.GetHelpCommand(rootCmd)
-	externalCmdPath := rootCmd.Name() + " " + externalCmd
-	if _, found := (*modulesInfo)[externalCmdPath]; found {
-		rootCmd.AddCommand(newExternalCommand(cmdCtx, modulesInfo, externalCmd,
-			externalCmdPath, nil))
-		helpCmd.AddCommand(newExternalCommand(cmdCtx, modulesInfo, externalCmd, externalCmdPath,
-			[]string{"--help"}))
-	}
-}
-
-// newExternalCommand returns a pointer to a new external
-// command that will call modules.RunCmd.
-func newExternalCommand(cmdCtx *cmdcontext.CmdCtx, modulesInfo *modules.ModulesInfo,
-	cmdName, cmdPath string, addArgs []string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: cmdName,
-		Run: func(cmd *cobra.Command, args []string) {
-			if addArgs != nil {
-				args = append(args, addArgs...)
-			}
-
-			cmdCtx.Cli.ForceInternal = false
-			if err := modules.RunCmd(cmdCtx, cmdPath, modulesInfo, nil, args); err != nil {
-				log.Fatalf(err.Error())
-			}
-		},
-	}
-
-	cmd.DisableFlagParsing = true
-	return cmd
 }
 
 // detectLocalTarantool searches for available Tarantool executable.


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about:

- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [ ] Tests (see [documentation][go-testing] for a testing package)
- [ ] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1136

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
