### PR TITLE
aeon: Fix SSL paths configuration for aeon connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Arguments of an internal command are not parsed if it is forced over its existent
   external counterpart.
+- aeon: fix SSL paths configuration for aeon connection.
 
 ## [2.8.1] - 2025-03-10
 

--- a/cli/cmd/aeon.go
+++ b/cli/cmd/aeon.go
@@ -94,7 +94,12 @@ func aeonConnectValidateArgs(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	case len(args) == 2 && util.IsRegularFile(args[0]):
-		if err := readConfigFilePath(args[0], args[1]); err != nil {
+		configPath, err := filepath.Abs(args[0])
+		if err != nil {
+			return err
+		}
+
+		if err := readConfigFilePath(configPath, args[1]); err != nil {
 			return err
 		}
 	default:
@@ -216,15 +221,15 @@ func readConfigFilePath(configPath string, instance string) error {
 		connectCtx.Transport = aeoncmd.TransportSsl
 		configDir := filepath.Dir(configPath)
 
-		if connectCtx.Ssl.CaFile == "" {
+		if connectCtx.Ssl.CaFile == "" && advertise.Params.CaFile != "" {
 			connectCtx.Ssl.CaFile = util.JoinPaths(configDir, advertise.Params.CaFile)
 		}
 
-		if connectCtx.Ssl.KeyFile == "" {
+		if connectCtx.Ssl.KeyFile == "" && advertise.Params.KeyFile != "" {
 			connectCtx.Ssl.KeyFile = util.JoinPaths(configDir, advertise.Params.KeyFile)
 		}
 
-		if connectCtx.Ssl.CertFile == "" {
+		if connectCtx.Ssl.CertFile == "" && advertise.Params.CertFile != "" {
 			connectCtx.Ssl.CertFile = util.JoinPaths(configDir, advertise.Params.CertFile)
 		}
 	}

--- a/test/integration/aeon/test_aeon.py
+++ b/test/integration/aeon/test_aeon.py
@@ -313,7 +313,7 @@ def test_cli_invalid_ssl_config_file(tt_cmd, tmp_path, aeon_ssl,):
 
     print(f"stderr {tt.stderr}")
 
-    assert "not valid path to a private SSL key file" in tt.stderr
+    assert "Error: not valid path to trusted certificate authorities" in tt.stderr
     assert tt.returncode != 0
 
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [ ] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)
- [ ] Documentation (see [documentation][go-doc] for documentation style guide)

Related issues:

Related to #XXX

Part of #XXX

Closes #XXX

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
