### PR TITLE
ci: restore packages build on master push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,16 @@ env:
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v4
         with:
           ref: 'master'
           fetch-depth: 0
+        if: startsWith(github.ref, 'refs/tags')
 
       - name: Validation
         run: git branch -r --contains ${{ github.ref }} | grep "origin/master"
+        if: startsWith(github.ref, 'refs/tags')
 
   create-packages-linux:
     needs: validate-tag


### PR DESCRIPTION
This patch turns back building of the packages that should be triggered by push event on master branch and that was turned off by mistake with the previous patch.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Related to #TNTP-1826

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
