### PR TITLE
Added TCM packing when executing the tt pack command, also with flags…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `tt pack`: added TCM packing when executing the tt pack command, except for the
+  flag without-binaries in this case TCM will not be in the archive.
+
 - Arguments of an internal command are not parsed if it is forced over its existent
   external counterpart.
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -37,9 +37,10 @@ The supported types are: tgz, deb, rpm`,
 	packCmd.Flags().StringVar(&packCtx.FileName, "filename", packCtx.FileName,
 		"Explicitly set filename of the bundle")
 	packCmd.Flags().BoolVar(&packCtx.WithoutBinaries, "without-binaries",
-		packCtx.WithoutBinaries, "Don't include tarantool and tt binaries to the result package")
+		packCtx.WithoutBinaries, "Don't include tarantool,"+
+			"tt and tcm binaries to the result package")
 	packCmd.Flags().BoolVar(&packCtx.WithBinaries, "with-binaries", packCtx.WithoutBinaries,
-		"Include tarantool and tt binaries to the result package")
+		"Include tarantool, tt and tcm binaries to the result package")
 	packCmd.Flags().BoolVar(&packCtx.CartridgeCompat, "cartridge-compat", false,
 		"Pack cartridge cli compatible archive (only for tgz type)")
 	packCmd.Flags().BoolVar(&packCtx.WithoutModules, "without-modules",

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -275,14 +275,12 @@ func copyBinaries(bundleEnvPath string, packCtx *PackCtx, cmdCtx *cmdcontext.Cmd
 	}
 
 	// Copy tcm.
-	if packCtx.WithBinaries {
-		if cmdCtx.Cli.TcmCli.Executable == "" {
-			log.Warnf("Skip copying tcm binary: not found")
-		} else {
-			if err := util.CopyFileDeep(cmdCtx.Cli.TcmCli.Executable,
-				util.JoinPaths(pkgBin, "tcm")); err != nil {
-				return fmt.Errorf("failed copying tcm: %w", err)
-			}
+	if cmdCtx.Cli.TcmCli.Executable == "" {
+		log.Warnf("Skip copying tcm binary: not found")
+	} else {
+		if err := util.CopyFileDeep(cmdCtx.Cli.TcmCli.Executable,
+			util.JoinPaths(pkgBin, "tcm")); err != nil {
+			return fmt.Errorf("failed copying tcm: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
… (all, with-binaries etc) except for the flag without-binaries in this case TCM will not be in the archive.

Closes: #TNTP-2370

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [ ] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)
- [x] Documentation (see [documentation][go-doc] for documentation style guide)

Related issues:

Related to #XXX

Part of #XXX

Closes #TNTP-2370

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
