### PR TITLE
pack: fix packing rpm if only one of --pre/postinst option specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Arguments of an internal command are not parsed if it is forced over its existent
   external counterpart.
 - aeon: fix SSL paths configuration for aeon connection.
+- `tt pack rpm`: failed to pack if only one of `--preinst`/`--postinst` options is specified.
 
 ## [2.8.1] - 2025-03-10
 

--- a/cli/pack/rpm_header.go
+++ b/cli/pack/rpm_header.go
@@ -106,7 +106,7 @@ func addPreAndPostInstallScriptsRPM(rpmHeader *rpmTagSetType,
 	}
 
 	postInstScript := postInstScriptContent
-	if preInst != "" {
+	if postInst != "" {
 		userPostInstBytes, err := os.ReadFile(postInst)
 		if err != nil {
 			return fmt.Errorf("error reading postinst file %q: %s", postInst, err)


### PR DESCRIPTION
I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1143

@TarantoolBot
Title: Fix packing rpm if only one of --pre/postinst option is specified

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
