### PR TITLE
svacer: fix handle leaks

### DIFF
--- a/cli/pack/deb.go
+++ b/cli/pack/deb.go
@@ -187,6 +187,8 @@ func createDebianBinary(packageDir string) error {
 	if err != nil {
 		return err
 	}
+	defer debBin.Close()
+
 	_, err = debBin.Write([]byte(debianBinaryFileContent))
 	if err != nil {
 		return err


### PR DESCRIPTION
Handle 'debBin' is created at deb.go:186 by calling function 'os.Create' and lost at deb.go:192.