### PR TITLE
test: turn on integration tests for modules

### DIFF
--- a/cli/init/init.go
+++ b/cli/init/init.go
@@ -172,7 +172,6 @@ func generateTtEnv(configPath string, sourceCfg configData) error {
 		cfg.Env.BinDir,
 		cfg.Repo.Install,
 	}
-	// FIXME: Need select only internal directories https://github.com/tarantool/tt/issues/1014
 	directoriesToCreate = append(directoriesToCreate, cfg.Modules.Directories...)
 	for _, templatesPathOpts := range cfg.Templates {
 		directoriesToCreate = append(directoriesToCreate, templatesPathOpts.Path)

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -1,5 +1,3 @@
-// FIXME: Create new tests https://github.com/tarantool/tt/issues/1039
-
 package modules_test
 
 import (

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -227,7 +227,7 @@ func copyEnvModules(bundleEnvPath string, packCtx *PackCtx, cliOpts, newOpts *co
 			if files, _ := dir.Readdir(1); len(files) == 0 {
 				return // No modules.
 			}
-			// FIXME: Add working with a list https://github.com/tarantool/tt/issues/1014
+			// FIXME: Add working with a list https://jira.vk.team/browse/TNTP-2506
 			if err := copy.Copy(directory,
 				util.JoinPaths(bundleEnvPath, newOpts.Modules.Directories[0])); err != nil {
 				log.Warnf("Failed to copy modules from %q: %s", directory, err)

--- a/test/integration/help/test_help.py
+++ b/test/integration/help/test_help.py
@@ -29,8 +29,8 @@ def test_help_internal_module(tt_cmd, tmp_path):
 
 
 def test_external_help_module(tt_cmd, tmp_path):
-    create_tt_config(tmp_path, tmp_path.as_posix())
-    module_message = create_external_module("help", tmp_path)
+    create_tt_config(tmp_path, "modules")
+    module_message = create_external_module("help", tmp_path / "modules")
 
     rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmp_path)
     assert rc == 0
@@ -52,31 +52,43 @@ def test_external_help_module(tt_cmd, tmp_path):
         assert "help\tDescription for external module help" in output
 
 
-def test_internal_help_with_external_module(tt_cmd, tmp_path):
-    create_tt_config(tmp_path, tmp_path.as_posix())
-    module_message = create_external_module("version", tmp_path)
-
+def test_internal_help_list_external_commands(tt_cmd, tmp_path):
     # No external help module, but external version module.
     # List of available external commands should be displayed.
+    create_tt_config(tmp_path, "modules")
+    create_external_module("version", tmp_path / "modules")
     rc, output = run_command_and_get_output([tt_cmd, "help"], cwd=tmp_path)
     assert rc == 0
+    assert "EXTERNAL COMMANDS" in output
     assert "version\tDescription for external module version" in output
 
-    # In this case, the external module version should be called with the --help flag.
+
+def test_call_help_for_external_override_module(tt_cmd, tmp_path):
+    # In this case, the external module 'version' should be called with the --help flag.
+    create_tt_config(tmp_path, "modules")
+    create_external_module("version", tmp_path / "modules")
     rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmp_path)
     assert rc == 0
     assert "Help for external version module\nList of passed args: --help\n" == output
 
-    create_external_module("abc", tmp_path)
+
+def test_call_help_for_external_custom_module(tt_cmd, tmp_path):
+    # In this case, the external module version should be called with the --help flag.
+    create_tt_config(tmp_path, "modules")
+    create_external_module("abc", tmp_path / "modules")
     # External modules without internal implementation.
     rc, output = run_command_and_get_output([tt_cmd, "help", "abc"], cwd=tmp_path)
     assert rc == 0
     assert "Help for external abc module\nList of passed args: --help\n" == output
 
+
+def test_external_help_module_with_args(tt_cmd, tmp_path):
     # If the external module help and version exist at the same time,
     # then the external module help should be called with the <version>
     # argument. For example, execute "path/to/external/help version" command.
-    module_message = create_external_module("help", tmp_path)
+    create_tt_config(tmp_path, "modules")
+    create_external_module("version", tmp_path / "modules")
+    module_message = create_external_module("help", tmp_path / "modules")
     rc, output = run_command_and_get_output([tt_cmd, "help", "version"], cwd=tmp_path)
     assert rc == 0
     assert f"{module_message}\nList of passed args: version\n" == output

--- a/test/integration/modules/test_modules_list.py
+++ b/test/integration/modules/test_modules_list.py
@@ -1,0 +1,165 @@
+from utils import (create_external_module, create_tt_config,
+                   run_command_and_get_output)
+
+
+def test_show_available_modules(tt_cmd, tmp_path):
+    """
+    Run 'tt' without args should show available external commands.
+    """
+    modules = ("ext_cmd1", "ext_cmd2", "ext_cmd3")
+    create_tt_config(tmp_path, "modules")
+
+    for module in modules:
+        create_external_module(module, tmp_path / "modules")
+
+    rc, output = run_command_and_get_output(tt_cmd, cwd=tmp_path)
+    assert rc == 0
+    assert "EXTERNAL COMMANDS" in output
+    for module in modules:
+        assert f"{module}\tDescription for external module {module}\n" in output
+
+
+def test_show_available_modules_with_env(tt_cmd, tmp_path):
+    """
+    Run 'tt' without args should show available external commands.
+    While some modules declared with environment variable TT_CLI_MODULES_PATH.
+    """
+    ext_modules = ("ext_cmd1", "ext_cmd2", "ext_cmd3")
+    int_modules = ("int_cmd1", "int_cmd2", "int_cmd3")
+    cfg_dir = tmp_path / "tt"
+    create_tt_config(cfg_dir, "modules")
+
+    for module in int_modules:
+        create_external_module(module, cfg_dir / "modules")
+    for module in ext_modules:
+        create_external_module(module, tmp_path / "ext_modules")
+
+    rc, output = run_command_and_get_output(
+        tt_cmd, cwd=cfg_dir, env={"TT_CLI_MODULES_PATH": str(tmp_path / "ext_modules")}
+    )
+    assert rc == 0
+    assert "EXTERNAL COMMANDS" in output
+    for module in int_modules + ext_modules:
+        assert f"{module}\tDescription for external module {module}\n" in output
+
+
+def test_show_available_multiple_modules(tt_cmd, tmp_path):
+    """
+    'tt.yaml' has multiple modules directories, with custom names, not "modules".
+    """
+    modules1 = ("cmd1", "cmd2", "cmd3")
+    modules2 = ("mod1", "mod2", "mod3")
+    create_tt_config(tmp_path, ["extra_cmd", "plugins"])
+
+    for module in modules1:
+        create_external_module(module, tmp_path / "extra_cmd")
+    for module in modules2:
+        create_external_module(module, tmp_path / "plugins")
+
+    rc, output = run_command_and_get_output(tt_cmd, cwd=tmp_path)
+    assert rc == 0
+    assert "EXTERNAL COMMANDS" in output
+    for module in modules1 + modules2:
+        assert f"{module}\tDescription for external module {module}\n" in output
+
+
+def test_show_available_multiple_modules_env(tt_cmd, tmp_path):
+    """
+    Run 'tt' without configured environment.
+    TT_CLI_MODULES_PATH has multiple modules directories.
+    """
+    modules1 = ("cmd1", "cmd2", "cmd3")
+    modules2 = ("mod1", "mod2", "mod3")
+
+    for module in modules1:
+        create_external_module(module, tmp_path / "extra_cmd")
+    for module in modules2:
+        create_external_module(module, tmp_path / "plugins")
+
+    rc, output = run_command_and_get_output(
+        tt_cmd,
+        env={"TT_CLI_MODULES_PATH": f"{tmp_path / 'extra_cmd'}:{tmp_path / 'plugins'}"},
+    )
+    assert rc == 0
+    assert "EXTERNAL COMMANDS" in output
+    for module in modules1 + modules2:
+        assert f"{module}\tDescription for external module {module}\n" in output
+
+
+def test_list_available_modules(tt_cmd, tmp_path):
+    """
+    Run 'tt modules list' - produce sorted list of available external modules.
+    """
+    modules = ("002_cmd", "004_cmd", "003_cmd", "001_cmd")
+    create_tt_config(tmp_path, "modules")
+
+    for module in modules:
+        create_external_module(module, tmp_path / "modules")
+
+    cmd = (tt_cmd, "modules", "list")
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    assert rc == 0
+    expected = ""
+    for module in sorted(modules):
+        expected += f"{module} - Description for external module {module}\n"
+    assert expected == output
+
+
+def test_list_available_modules_version(tt_cmd, tmp_path):
+    """
+    Run 'tt modules list --version' - produce sorted list of available
+    external modules with version info.
+    """
+    modules = ("002_cmd", "004_cmd", "003_cmd", "001_cmd")
+    create_tt_config(tmp_path, "modules")
+
+    for module in modules:
+        create_external_module(module, tmp_path / "modules")
+
+    cmd = (tt_cmd, "modules", "list", "--version")
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    assert rc == 0
+    expected = ""
+    for module in sorted(modules):
+        expected += f"0.0.1\t{module} - Description for external module {module}\n"
+    assert expected == output
+
+
+def test_list_available_modules_path(tt_cmd, tmp_path):
+    """
+    Run 'tt modules list --path' - produce sorted list of available
+    external modules with path up to executable entry point instead description.
+    """
+    modules = ("002_cmd", "004_cmd", "003_cmd", "001_cmd")
+    create_tt_config(tmp_path, "modules")
+
+    for module in modules:
+        create_external_module(module, tmp_path / "modules")
+
+    cmd = (tt_cmd, "modules", "list", "--path")
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    assert rc == 0
+    expected = ""
+    for module in sorted(modules):
+        expected += f"{module} - { tmp_path / 'modules' / module / 'main'}\n"
+    assert expected == output
+
+
+def test_list_available_modules_version_and_path(tt_cmd, tmp_path):
+    """
+    Run 'tt modules list --version --path' - produce sorted list of available
+    external modules with with version info and path up to executable entry point.
+    """
+    modules = ("002_cmd", "004_cmd", "003_cmd", "001_cmd")
+    create_tt_config(tmp_path, "modules")
+
+    for module in modules:
+        create_external_module(module, tmp_path / "modules")
+
+    cmd = (tt_cmd, "modules", "list", "--version", "--path")
+    rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
+    assert rc == 0
+    expected = ""
+    for module in sorted(modules):
+        expected += f"0.0.1\t{module} - { tmp_path / 'modules' / module / 'main'}\n"
+    assert expected == output

--- a/test/integration/version/test_version.py
+++ b/test/integration/version/test_version.py
@@ -30,6 +30,6 @@ def test_version_cmd(tt_cmd, tmp_path):
 
 
 def test_version_internal_over_external(tt_cmd, tmp_path):
-    utils.create_external_module("version", tmp_path)
-    utils.create_tt_config(tmp_path, tmp_path)
+    utils.create_external_module("version", tmp_path / "modules")
+    utils.create_tt_config(tmp_path, "modules")
     check_internal_version_cmd(tt_cmd, tmp_path)

--- a/test/module.py.tt
+++ b/test/module.py.tt
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from sys import argv as ARGV
+
+parser = ArgumentParser(description="Help for external {module_name} module", add_help=False)
+parser.add_argument("--help", action="store_true", help="Show this help message and exit")
+parser.add_argument("--description", action="store_true", help="Show short description")
+parser.add_argument("--version", action="store_true", help="Show module version")
+args, extra_args = parser.parse_known_args()
+
+if args.help:
+    print("Help for external {module_name} module")
+else:
+    if args.version:
+        print("version: 0.0.1")
+    if args.description:
+        print("help: Description for external module {module_name}")
+
+if not (args.version or args.description or args.help):
+    print("{module_message}")
+print("List of passed args:", *ARGV[1:])


### PR DESCRIPTION
Restore working integration tests for external modules.

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Tests (see [documentation][go-testing] for a testing package)

Closes #TNTP-1809

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
