### PR TITLE
go: bump version to v1.23.8

### DIFF
--- a/lib/connect/go.mod
+++ b/lib/connect/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarantool/tt/lib/connect
 
-go 1.20
+go 1.23.8
 
 require (
 	github.com/pmezard/go-difflib v1.0.0

--- a/lib/integrity/go.mod
+++ b/lib/integrity/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarantool/tt/lib/integrity
 
-go 1.20
+go 1.23.8
 
 require (
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
This patch bumps `go` version for internal packages `lib/connect` and `lib/integrity`.