### PR TITLE
aeon: fix crash on SQL response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a crash in `tt aeon connect` when processing responses
+  from certain SQL commands.
+
 ## [2.9.1] - 2025-04-15
 
 The release includes minor fixes identified by Svacer and CVE linters.

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -179,11 +180,10 @@ func parseSQLResponse(resp *pb.SQLResponse) any {
 		return resultType{}
 	}
 	res := resultType{
-		names: make([]string, len(resp.TupleFormat.Names)),
+		names: slices.Clone(resp.TupleFormat.Names),
 		rows:  make([]resultRow, len(resp.Tuples)),
 	}
-	for i, n := range resp.TupleFormat.Names {
-		res.names[i] = n
+	for i := range resp.Tuples {
 		res.rows[i] = make([]any, 0, len(resp.TupleFormat.Names))
 	}
 


### PR DESCRIPTION
Fixed a crash in `tt aeon connect` when processing responses from certain SQL commands.

I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Closes #TNTP-2413

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
