### PR TITLE
play: fix cat/play working with directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- In commands `tt cat|play <DIR>` added options `-r`/`--recursive` to
+  allow find WAL files inside nested subdirectories.
 - `tt search tcm` - the command performs a search for tarantool cluster
   manager (TCM) in the customer zone or local `distfiles` directory.
 
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed a crash in `tt aeon connect` when processing responses
   from certain SQL commands.
+- `tt cat|play <DIR>` with directories handles only `.snap` or `.xlog` files.
 
 ## [2.9.1] - 2025-04-15
 

--- a/cli/checkpoint/checkpoint.go
+++ b/cli/checkpoint/checkpoint.go
@@ -20,6 +20,7 @@ type Opts struct {
 	Format     string
 	Replica    []int
 	ShowSystem bool
+	Recursive  bool
 }
 
 // Cat print the contents of .snap/.xlog files.

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
-	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -552,7 +551,6 @@ func RunCommandAndGetOutput(program string, args ...string) (string, error) {
 
 // ExtractTar extracts tar archive.
 func ExtractTar(tarName string) error {
-
 	path, err := filepath.Abs(tarName)
 	if err != nil {
 		return err
@@ -665,7 +663,6 @@ func ExecuteCommandStdin(program string, isVerbose bool, logFile *os.File, workD
 			cmd.Stdout = io.Discard
 			cmd.Stderr = io.Discard
 		}
-
 	}
 	if workDir == "" {
 		workDir, _ = os.Getwd()
@@ -997,45 +994,4 @@ func StringToTimestamp(input string) (string, error) {
 		strconv.FormatInt(int64(tsNanoSec), 10))
 
 	return ts, nil
-}
-
-// CollectWALFiles globs files from args.
-func CollectWALFiles(paths []string) ([]string, error) {
-	collectedFiles := make([]string, 0)
-
-	sortSnapFilesFirst := func(left, right string) int {
-		reSnap := regexp.MustCompile(`\.snap`)
-		reXlog := regexp.MustCompile(`\.xlog`)
-		if reSnap.Match([]byte(left)) && reXlog.Match([]byte(right)) {
-			return -1
-		}
-		if reXlog.Match([]byte(left)) && reSnap.Match([]byte(right)) {
-			return 1
-		}
-		return 0
-	}
-
-	for _, path := range paths {
-		entry, err := os.Stat(path)
-		if err != nil {
-			return nil, err
-		}
-
-		if entry.IsDir() {
-			foundEntries, err := os.ReadDir(path)
-			if err != nil {
-				return nil, err
-			}
-			for _, entry := range foundEntries {
-				collectedFiles = append(collectedFiles, filepath.Join(path, entry.Name()))
-			}
-			slices.SortFunc(collectedFiles, sortSnapFilesFirst)
-
-			continue
-		}
-
-		collectedFiles = append(collectedFiles, path)
-	}
-
-	return collectedFiles, nil
 }

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -798,64 +798,6 @@ func TestStringToTimestamp(t *testing.T) {
 	}
 }
 
-func TestCollectWALFiles(t *testing.T) {
-	srcDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "1.xlog"), []byte{}, 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "2.xlog"), []byte{}, 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "1.snap"), []byte{}, 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "2.snap"), []byte{}, 0644))
-	snap1 := fmt.Sprintf("%s/%s", srcDir, "1.snap")
-	snap2 := fmt.Sprintf("%s/%s", srcDir, "2.snap")
-	xlog1 := fmt.Sprintf("%s/%s", srcDir, "1.xlog")
-	xlog2 := fmt.Sprintf("%s/%s", srcDir, "2.xlog")
-
-	tests := []struct {
-		name           string
-		input          []string
-		output         []string
-		expectedErrMsg string
-	}{
-		{
-			name:   "no_file",
-			input:  []string{},
-			output: []string{},
-		},
-		{
-			name:           "incorrect_file",
-			input:          []string{"file"},
-			expectedErrMsg: "stat file: no such file or directory",
-		},
-		{
-			name:   "one_file",
-			input:  []string{xlog1},
-			output: []string{xlog1},
-		},
-		{
-			name:   "directory",
-			input:  []string{srcDir},
-			output: []string{snap1, snap2, xlog1, xlog2},
-		},
-		{
-			name:   "mix",
-			input:  []string{srcDir, "util_test.go"},
-			output: []string{snap1, snap2, xlog1, xlog2, "util_test.go"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result, err := CollectWALFiles(test.input)
-
-			if test.expectedErrMsg != "" {
-				assert.EqualError(t, err, test.expectedErrMsg)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.output, result)
-			}
-		})
-	}
-}
-
 func TestIsURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cli/util/wal.go
+++ b/cli/util/wal.go
@@ -1,0 +1,142 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/apex/log"
+)
+
+const (
+	snapSuffix = ".snap"
+	xlogSuffix = ".xlog"
+)
+
+// hasExt checks if the file name ends with the given suffix and is longer than the suffix itself.
+func hasExt(f string, s string) bool {
+	return strings.HasSuffix(f, s) && len(f) > len(s)
+}
+
+// isWAL checks if a file name has a .snap or .xlog extension.
+func isWal(f string) bool {
+	return hasExt(f, snapSuffix) || hasExt(f, xlogSuffix)
+}
+
+// sortWalFiles sorts a slice of file paths, ensuring .snap files come before .xlog files.
+// Files of the same type are sorted lexicographically.
+// The sorting happens in place.
+func sortWalFiles(files []string) {
+	slices.SortFunc(files, func(left, right string) int {
+		if hasExt(left, snapSuffix) && hasExt(right, xlogSuffix) {
+			return -1
+		}
+		if hasExt(left, xlogSuffix) && hasExt(right, snapSuffix) {
+			return 1
+		}
+		lDir, fName := filepath.Split(left)
+		rDir, rName := filepath.Split(right)
+		if lDir != rDir {
+			return strings.Compare(lDir, rDir)
+		}
+		return strings.Compare(fName, rName)
+	})
+}
+
+// collectWALsFromSinglePath is an internal helper to find WAL files starting from a single path.
+// It handles both files and directories, respecting the isRecursive flag for directories.
+// It returns absolute paths of found WAL files.
+func collectWALsFromSinglePath(path string, isRecursive bool) ([]string, error) {
+	collected := []string{}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat path %q: %w", path, err)
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for %q: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		if isWal(info.Name()) {
+			collected = append(collected, path)
+		}
+		return collected, nil
+	}
+
+	// Handle the case where path is a directory.
+	if isRecursive {
+		err := filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				log.Warnf("Skipping %q due to error during walk: %s", p, err)
+				if d != nil && d.IsDir() && errors.Is(err, fs.ErrPermission) {
+					// Skip directory if permission denied, but continue walking other parts.
+					return fs.SkipDir
+				}
+				return nil
+			}
+
+			if !d.IsDir() && isWal(d.Name()) {
+				collected = append(collected, p)
+			}
+			return nil
+		})
+		if err != nil {
+			log.Warnf("Error encountered during recursive walk of %q: %s", path, err)
+		}
+
+	} else {
+		dirEntries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			log.Warnf("Failed to read directory %q: %s", path, readErr)
+			return collected, nil
+		}
+		for _, entry := range dirEntries {
+			if !entry.IsDir() && isWal(entry.Name()) {
+				collected = append(collected, filepath.Join(path, entry.Name()))
+			}
+		}
+	}
+
+	return collected, nil
+}
+
+// CollectWalFiles collects WAL (Write-Ahead Log) files based on the given
+// set of paths. It identifies files with ".snap" or ".xlog" extensions as WAL files.
+// For directory paths, it traverses them based on the isRecursive flag.
+// It skips directories or files it cannot access due to permissions, logging warnings.
+//
+// The function ensures that ".snap" files are sorted before ".xlog" files in the result,
+// and that the returned list contains unique absolute paths.
+//
+// Returns: A sorted, unique slice of strings containing the absolute paths of collected WAL files.
+func CollectWalFiles(paths []string, isRecursive bool) ([]string, error) {
+	allCollectedFiles := make([]string, 0)
+
+	for _, p := range paths {
+		filesFromPath, err := collectWALsFromSinglePath(p, isRecursive)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("required %q not found: %w", p, err)
+			}
+			log.Warnf("Error processing path %q: %v. Skipping this path.", p, err)
+			continue
+		}
+		if len(filesFromPath) == 0 {
+			log.Warnf("No WAL files found at %q", p)
+		} else {
+			allCollectedFiles = append(allCollectedFiles, filesFromPath...)
+		}
+	}
+
+	// Sort the aggregated list.
+	sortWalFiles(allCollectedFiles)
+
+	// For the case a file is included both as an individual file and as part of a directory.
+	return slices.Compact(allCollectedFiles), nil
+}

--- a/cli/util/wal_test.go
+++ b/cli/util/wal_test.go
@@ -1,0 +1,334 @@
+package util_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// createTestFiles creates directories and files structure.
+func createTestFiles(t *testing.T, tstDir string, filesMap map[string][]string) {
+	t.Helper()
+
+	for dir, files := range filesMap {
+		dest := tstDir
+		allowedDir := true
+		if dir[0] == '/' {
+			if dir[len(dir)-1] == '-' {
+				dir = dir[:len(dir)-1]
+				allowedDir = false
+			}
+			dest = filepath.Join(tstDir, dir)
+			require.NoError(t, os.MkdirAll(dest, 0o755))
+		} else {
+			require.Empty(t, files,
+				"Is it a Directory or File? Missed '/' prefix for dir %q", dir)
+			files = append(files, dir)
+		}
+
+		for _, file := range files {
+			require.NoError(t, os.WriteFile(filepath.Join(dest, file), []byte(file), 0o644))
+		}
+
+		if !allowedDir {
+			// Remove permission to read directory.
+			require.NoError(t, os.Chmod(dest, 0o000))
+		}
+	}
+}
+
+// restorePermissions restores permissions for directories.
+// It is needed to avoid permission issues at cleanup phase after tests done.
+func restorePermissions(t *testing.T, path string) {
+	t.Helper()
+
+	require.NoError(t, filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			require.NoError(t, os.Chmod(p, 0o755))
+		}
+		return nil
+	}))
+}
+
+func TestCollectWalFiles_recursive(t *testing.T) {
+	tstDir := t.TempDir()
+
+	testFilesMap := map[string][]string{
+		"01.xlog": {},
+		"02.xlog": {},
+		"01.snap": {},
+		"02.snap": {},
+		"/data1": {
+			"14.xlog",
+			"13.xlog",
+			"13.snap",
+			"14.snap",
+		},
+		"/no_perm-": { // Suffix '-' remove permission to read dir.
+			"p14.xlog",
+			"p13.xlog",
+			"p13.snap",
+			"p14.snap",
+		},
+		"/data1/empty_dir": {},
+		"/data2.xlog": {
+			"21.xlog",
+			"22.xlog",
+			"not_wal.log",
+		},
+		"/data2.snap": {
+			"21.snap",
+			"22.snap",
+			"not_wal.txt",
+		},
+		"/data2/logs": {
+			"01.xlog",
+			"01.snap",
+			"02.xlog",
+			"02.snap",
+		},
+		"/.xlog": {
+			"314.xlog",
+			"313.xlog",
+		},
+		"/.snap": {
+			"314.snap",
+			"313.snap",
+		},
+		"/not_wal_files": {
+			".xlog",
+			".snap",
+			"not.xlog.txt",
+			".snap.bin",
+		},
+		"/empty_dir": {},
+	}
+
+	createTestFiles(t, tstDir, testFilesMap)
+
+	// j is wrapper to join test names with temporary directory name.
+	j := func(f string) string {
+		return filepath.Join(tstDir, f)
+	}
+
+	tests := map[string]struct {
+		input     []string
+		recursive bool
+		output    []string
+		errMsg    string
+		logMsg    string
+	}{
+		"all files": {
+			input:     []string{"."},
+			recursive: true,
+			output: []string{
+				j("01.snap"), j("02.snap"),
+				j(".snap/313.snap"), j(".snap/314.snap"),
+				j("data1/13.snap"), j("data1/14.snap"),
+				j("data2.snap/21.snap"), j("data2.snap/22.snap"),
+				j("data2/logs/01.snap"), j("data2/logs/02.snap"),
+
+				j("01.xlog"), j("02.xlog"),
+				j(".xlog/313.xlog"), j(".xlog/314.xlog"),
+				j("data1/13.xlog"), j("data1/14.xlog"),
+				j("data2.xlog/21.xlog"), j("data2.xlog/22.xlog"),
+				j("data2/logs/01.xlog"), j("data2/logs/02.xlog"),
+			},
+			logMsg: fmt.Sprintf("warn Skipping %q due to error during walk", j("no_perm")),
+		},
+
+		"no file": {
+			input:  []string{},
+			output: []string{},
+		},
+
+		"no wal files": {
+			input:  []string{j("not_wal_files")},
+			output: []string{},
+			logMsg: fmt.Sprintf("No WAL files found at %q", j("not_wal_files")),
+		},
+
+		"not existing file": {
+			input:  []string{j("not-exists-file")},
+			errMsg: "not-exists-file: no such file or directory",
+		},
+
+		"try no permission without recursion": {
+			input:     []string{j("no_perm")},
+			recursive: false,
+			output:    []string{},
+			logMsg:    fmt.Sprintf("warn Failed to read directory %q:", j("no_perm")),
+		},
+
+		"one relative file": {
+			input:  []string{"01.snap"},
+			output: []string{j("01.snap")},
+		},
+
+		"relative directory": {
+			input: []string{"data1"},
+			output: []string{
+				j("data1/13.snap"),
+				j("data1/14.snap"),
+				j("data1/13.xlog"),
+				j("data1/14.xlog"),
+			},
+		},
+
+		"absolute directory": {
+			input: []string{j("data2/logs")},
+			output: []string{
+				j("data2/logs/01.snap"),
+				j("data2/logs/02.snap"),
+				j("data2/logs/01.xlog"),
+				j("data2/logs/02.xlog"),
+			},
+		},
+
+		"recursive directory": {
+			input:     []string{"data2"},
+			recursive: true,
+			output: []string{
+				j("data2/logs/01.snap"),
+				j("data2/logs/02.snap"),
+				j("data2/logs/01.xlog"),
+				j("data2/logs/02.xlog"),
+			},
+		},
+
+		"remove duplicates": {
+			input: []string{
+				"data1/14.snap",
+				"data1",
+				j("data1/13.xlog"),
+			},
+			recursive: true,
+			output: []string{
+				j("data1/13.snap"),
+				j("data1/14.snap"),
+				j("data1/13.xlog"),
+				j("data1/14.xlog"),
+			},
+		},
+	}
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(wd))
+	}()
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if len(test.input) == 0 || test.input[0][0] != '/' {
+				// If the first element of input is relative path,
+				// we need to change the working directory to the test directory.
+				require.NoError(t, os.Chdir(tstDir))
+			} else {
+				// If the first element of input is absolute path,
+				// run test from current directory, not in temp.
+				require.NoError(t, os.Chdir(wd))
+			}
+
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
+
+			result, err := util.CollectWalFiles(test.input, test.recursive)
+
+			if test.errMsg != "" {
+				assert.ErrorContains(t, err, test.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.output, result)
+				if buf.Len() > 0 {
+					logStr := buf.String()
+					if test.logMsg != "" {
+						assert.Contains(t, logStr, test.logMsg)
+					} else {
+						t.Log(logStr)
+					}
+				}
+			}
+		})
+	}
+
+	restorePermissions(t, tstDir)
+}
+
+// TestCollectWalFiles just a copy of the old test, to keep backward compatibility.
+func TestCollectWalFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	// DEBUG: А нужно ли чистить временную директорию?
+	require.NoError(t, os.RemoveAll(srcDir))
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "1.xlog"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "2.xlog"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "1.snap"), []byte{}, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "2.snap"), []byte{}, 0o644))
+	snap1 := fmt.Sprintf("%s/%s", srcDir, "1.snap")
+	snap2 := fmt.Sprintf("%s/%s", srcDir, "2.snap")
+	xlog1 := fmt.Sprintf("%s/%s", srcDir, "1.xlog")
+	xlog2 := fmt.Sprintf("%s/%s", srcDir, "2.xlog")
+
+	tests := []struct {
+		name           string
+		input          []string
+		output         []string
+		expectedErrMsg string
+	}{
+		{
+			name:   "no_file",
+			input:  []string{},
+			output: []string{},
+		},
+		{
+			name:           "incorrect_file",
+			input:          []string{"file"},
+			expectedErrMsg: "stat file: no such file or directory",
+		},
+		{
+			name:   "one_file",
+			input:  []string{xlog1},
+			output: []string{xlog1},
+		},
+		{
+			name:   "directory",
+			input:  []string{srcDir},
+			output: []string{snap1, snap2, xlog1, xlog2},
+		},
+		{
+			name:   "mix",
+			input:  []string{srcDir, "util_test.go"},
+			output: []string{snap1, snap2, xlog1, xlog2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := util.CollectWalFiles(test.input, false)
+
+			if test.expectedErrMsg != "" {
+				assert.ErrorContains(t, err, test.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.output, result)
+			}
+		})
+	}
+}

--- a/test/integration/cat/test_cat.py
+++ b/test/integration/cat/test_cat.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -44,45 +45,44 @@ def test_cat_args_tests_failed(tt_cmd, tmp_path, args, expected_error):
     ),
     (
         ("test.xlog", "test.snap"),
-        ('Result of cat: the file "test.xlog" is processed below',
-         'Result of cat: the file "test.snap" is processed below'),
+        ('Result of cat: the file "{tmp}/test.xlog" is processed below',
+         'Result of cat: the file "{tmp}/test.snap" is processed below'),
     ),
 ])
 def test_cat_args_tests_successed(tt_cmd, tmp_path, args, expected):
     # Copy the .xlog file to the "run" directory.
-    test_xlog_file = os.path.join(os.path.dirname(__file__), "test_file", "test.xlog")
-    test_snap_file = os.path.join(os.path.dirname(__file__), "test_file", "test.snap")
-    shutil.copy(test_xlog_file, tmp_path)
-    shutil.copy(test_snap_file, tmp_path)
+    test_data = Path(__file__).parent / "test_file"
+    shutil.copy(test_data / "test.xlog", tmp_path)
+    shutil.copy(test_data / "test.snap", tmp_path)
 
     cmd = [tt_cmd, "cat"]
     cmd.extend(args)
     rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     for item in expected:
+        item = item.format(tmp=tmp_path)
         assert item in output
 
 
 @pytest.mark.parametrize("args, expected", [
     (
         ("test_file/test.xlog", "test_file/test.snap", "test_file"),
-        ('Result of cat: the file "test_file/test.xlog" is processed below',
-         'Result of cat: the file "test_file/test.snap" is processed below',
-         'Result of cat: the file "test_file/timestamp.snap" is processed below',
-         'Result of cat: the file "test_file/timestamp.xlog" is processed below'),
+        ('Result of cat: the file "{tmp}/test_file/test.xlog" is processed below',
+         'Result of cat: the file "{tmp}/test_file/test.snap" is processed below',
+         'Result of cat: the file "{tmp}/test_file/timestamp.snap" is processed below',
+         'Result of cat: the file "{tmp}/test_file/timestamp.xlog" is processed below'),
     ),
 ])
-def test_cat_directories_tests_successed(tt_cmd, tmp_path, args, expected):
+def test_cat_directories_tests_successed(tt_cmd, tmp_path: Path, args, expected):
     # Copy files to the "run" directory.
-    test_src = os.path.join(os.path.dirname(__file__), "test_file")
-    test_dir = os.path.join(tmp_path, "test_file")
-    shutil.copytree(test_src, test_dir)
+    shutil.copytree(Path(__file__).parent / "test_file", tmp_path / "test_file")
 
     cmd = [tt_cmd, "cat"]
     cmd.extend(args)
     rc, output = run_command_and_get_output(cmd, cwd=tmp_path)
     assert rc == 0
     for item in expected:
+        item = item.format(tmp=tmp_path)
         assert item in output
 
 


### PR DESCRIPTION
This commit improves the functionality of the `cat` and `play` commands in the Tarantool CLI. It allows these commands to work recursively with directories containing multiple files, enhancing their usability and flexibility.

**Usage Example**:

```bash
tt cat -r /path/to/directory1 /path/to/directory2
tt play --recursive app:instance001 /path/to/directory1
```

I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)
- [x] Documentation (see [documentation][go-doc] for documentation style guide)


Closes #TNTP-2367

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits 
