### PR TITLE
rs: retry to bootstrap vshard within the timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a crash in `tt aeon connect` when processing responses
   from certain SQL commands.
 - `tt cat|play <DIR>` with directories handles only `.snap` or `.xlog` files.
+- `rs vshard bootstrap`: ignore an error and retry within `timeout` flag
+  period.
 
 ## [2.9.1] - 2025-04-15
 

--- a/test/integration/modules/test_modules_list.py
+++ b/test/integration/modules/test_modules_list.py
@@ -141,7 +141,7 @@ def test_list_available_modules_path(tt_cmd, tmp_path):
     assert rc == 0
     expected = ""
     for module in sorted(modules):
-        expected += f"{module} - { tmp_path / 'modules' / module / 'main'}\n"
+        expected += f"{module} - {tmp_path / 'modules' / module / 'main'}\n"
     assert expected == output
 
 
@@ -161,5 +161,5 @@ def test_list_available_modules_version_and_path(tt_cmd, tmp_path):
     assert rc == 0
     expected = ""
     for module in sorted(modules):
-        expected += f"0.0.1\t{module} - { tmp_path / 'modules' / module / 'main'}\n"
+        expected += f"0.0.1\t{module} - {tmp_path / 'modules' / module / 'main'}\n"
     assert expected == output

--- a/test/integration/replicaset/test_vshard_app_timeout/config.yaml
+++ b/test/integration/replicaset/test_vshard_app_timeout/config.yaml
@@ -1,0 +1,65 @@
+credentials:
+  users:
+    client:
+      password: 'secret'
+      roles: [super]
+    replicator:
+      password: 'secret'
+      roles: [replication]
+    storage:
+      password: 'secret'
+      roles: [sharding]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+    sharding:
+      login: storage
+
+sharding:
+  bucket_count: 3000
+
+groups:
+  storages:
+    app:
+      module: storage
+    sharding:
+      roles: [storage]
+    replication:
+      failover: manual
+    replicasets: 
+      storage-001:
+        leader: storage-001-a
+        instances: 
+          storage-001-a:
+            iproto:
+              listen:
+                - uri: localhost:3301
+          storage-001-b:
+            iproto:
+              listen:
+                - uri: localhost:3302
+      storage-002:
+        leader: storage-002-a
+        instances: 
+          storage-002-a:
+            iproto:
+              listen:
+                - uri: localhost:3303
+          storage-002-b:
+            iproto:
+              listen:
+                - uri: localhost:3304
+  routers:
+    app:
+      module: router
+    sharding:
+      roles: [router]
+    replicasets: 
+      router-001:
+        instances: 
+          router-001-a:
+            iproto:
+              listen:
+                - uri: localhost:3305

--- a/test/integration/replicaset/test_vshard_app_timeout/instances.yaml
+++ b/test/integration/replicaset/test_vshard_app_timeout/instances.yaml
@@ -1,0 +1,11 @@
+---
+storage-001-a:
+
+storage-001-b:
+
+storage-002-a:
+
+storage-002-b:
+
+router-001-a:
+

--- a/test/integration/replicaset/test_vshard_app_timeout/router.lua
+++ b/test/integration/replicaset/test_vshard_app_timeout/router.lua
@@ -1,0 +1,23 @@
+local vshard = require('vshard')
+local log = require('log')
+
+-- Put data into the cluster.
+function put(id, name, age)
+    local bucket_id = vshard.router.bucket_id_mpcrc32({id})
+    vshard.router.callrw(bucket_id, 'put', {id, bucket_id, name, age})
+end
+
+-- Get data from the cluster.
+function get(id)
+    local bucket_id = vshard.router.bucket_id_mpcrc32({id})
+    return vshard.router.callro(bucket_id, 'get', {id})
+end
+
+-- Put sample data.
+function put_sample_data()
+    put(1, 'Elizabeth', 12)
+    put(2, 'Mary', 46)
+    put(3, 'David', 33)
+    put(4, 'William', 81)
+    put(5, 'Jack', 35)
+end

--- a/test/integration/replicaset/test_vshard_app_timeout/storage.lua
+++ b/test/integration/replicaset/test_vshard_app_timeout/storage.lua
@@ -1,0 +1,56 @@
+local vshard = require('vshard')
+
+-- Create 'customers' space.
+box.once('customers', function()
+    box.schema.create_space('customers', {
+        format = {{
+            name = 'id',
+            type = 'unsigned'
+        }, {
+            name = 'bucket_id',
+            type = 'unsigned'
+        }, {
+            name = 'name',
+            type = 'string'
+        }, {
+            name = 'age',
+            type = 'number'
+        }}
+    })
+    box.space.customers:create_index('primary_index', {
+        parts = {{
+            field = 1,
+            type = 'unsigned'
+        }}
+    })
+    box.space.customers:create_index('bucket_id', {
+        parts = {{
+            field = 2,
+            type = 'unsigned'
+        }},
+        unique = false
+    })
+    box.space.customers:create_index('age', {
+        parts = {{
+            field = 4,
+            type = 'number'
+        }},
+        unique = false
+    })
+end)
+
+-- Put data to the 'customers' space.
+-- Function should be called by the router.
+function put(id, bucket_id, name, age)
+    box.space.customers:insert({id, bucket_id, name, age})
+end
+
+-- Get data from the 'customers' space.
+-- Function should be called by the router.
+function get(id)
+    local tuple = box.space.customers:get(id)
+    if tuple == nil then
+        return nil
+    end
+    return {tuple.id, tuple.name, tuple.age}
+end

--- a/test/integration/replicaset/test_vshard_app_timeout/vshard_app-scm-1.rockspec
+++ b/test/integration/replicaset/test_vshard_app_timeout/vshard_app-scm-1.rockspec
@@ -1,0 +1,11 @@
+package = 'vshard_app'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+dependencies = {
+    'vshard == 0.1.25'
+}
+build = {
+    type = 'none';
+}


### PR DESCRIPTION
This commit makes the `timeout` parameter define the duration for `vshard` bootstrapping attemps.

Closes #TNTP-2729