### PR TITLE
play: extend error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ In addition, code verification with `pre-commit` hooks has been configured.
 - `pack` with modules include only under root `tt` environment directory.
   Modules outside of the directory with `tt.yaml` will be ignored.
 - `tt connect|replicaset|cluster|aeon|play`: fixed using of IPv6 in instance URI.
+- `play`: extend error message if space to play is unavailable or user
+  does not have permission to work with it, because the `net.box` module does not
+  have means to distinguish between these errors.
 
 ## [2.9.1] - 2025-04-15
 

--- a/cli/checkpoint/lua/play.lua
+++ b/cli/checkpoint/lua/play.lua
@@ -94,8 +94,8 @@ local function play(positional_arguments, keyword_arguments, opts)
             if sid ~= nil then
                 local args, so = {}, remote.space[sid]
                 if so == nil then
-                   log.error('Fatal error: no space #%s, stopping work', sid)
-                   os.exit(1)
+                    log.error('Fatal error: no space #%s or permissions to work with it, stopping', sid)
+                    os.exit(1)
                 end
                 table.insert(args, so)
                 table.insert(args, record.BODY.key)


### PR DESCRIPTION
This patch extends error message if space to play data is unavailable or user does not have permission to work with it, because the `net.box` module does not have means to distinguish between these errors.

Closes #TNTP-2366
