### PR TITLE
logrotate: fix log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `tt logrotate`: properly release descriptor of the old log file.
+
 ## [2.10.0] - 2025-06-09
 
 The release introduces command support for working with Tarantool

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -110,8 +110,8 @@ func StdErrOpt(writer io.Writer) InstanceOption {
 func StdLoggerOpt(logger ttlog.Logger) InstanceOption {
 	return func(inst *baseInstance) error {
 		inst.logger = logger
-		inst.stdOut = logger.Writer()
-		inst.stdErr = logger.Writer()
+		inst.stdOut = logger
+		inst.stdErr = logger
 		return nil
 	}
 }


### PR DESCRIPTION
Watchdog launches tarantool in a way that produce log to stderr and thus tarantool itself does nothing to handle log rotation, it is handled entirely at watchdog side.
Prior to this patch `os.File` was used in `Cmd.Stdout`, when watchdog launches tarantool binary and according to golang [documentation](https://pkg.go.dev/os/exec#Cmd) (see `Exec.Cmd.Stdout`) in this special case output from the child process is connected directly to that file. It means that even if it is closed at watchdog side, its child process (tarantool) keeps using the original one, i.e. it proceeds with logging to the original file even after renaming it.
Now `Logger` is used as `Cmd.Stdout`, and according to the mentioned documentation separate goroutine reads output from the child process over a pipe and delivers that data to the `Logger`. It allows proper handling of log rotation at watchdog side.

@TarantoolBot document
Title: `tt logrotate` properly release descriptor of the old log file.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1174

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
