### PR TITLE
create: add config_storage template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt create`: add template for Tarantool Config Storage.
+
 ### Changed
 
 ### Fixed

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -44,7 +44,8 @@ func NewCreateCmd() *cobra.Command {
 Built-in templates:
 	cartridge: a simple Cartridge application.
 	single_instance: Tarantool 3 application with a single instance configuration.
-	vshard_cluster: Tarantool 3 vshard cluster application.`,
+	vshard_cluster: Tarantool 3 vshard cluster application.
+	config_storage: Tarantool 3 cluster configuration storage.`,
 		Example: `
 # Create an application app1 from a template.
 
@@ -62,7 +63,11 @@ Built-in templates:
 
 # Create Tarantool 3 vshard cluster.
 
-    $ tt create vshard_cluster --name cluster_app`,
+    $ tt create vshard_cluster --name cluster_app
+
+# Create Tarantool 3 cluster configuration storage.
+
+    $ tt create config_storage --name cs_app`,
 	}
 
 	createCmd.Flags().StringVarP(&appName, "name", "n", "", "Application name")

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -41,6 +41,7 @@ func TestCreateValidArgsFunction(t *testing.T) {
 		"cartridge",
 		"vshard_cluster",
 		"single_instance",
+		"config_storage",
 		"archive",
 		"template2",
 		tdir1Name,

--- a/cli/codegen/generate_code.go
+++ b/cli/codegen/generate_code.go
@@ -136,6 +136,14 @@ func main() {
 	if err != nil {
 		log.Errorf("error while generating file modes: %s", err)
 	}
+	err = generateFileModeFile(
+		"cli/create/builtin_templates/templates/config_storage",
+		"cli/create/builtin_templates/static/config_storage_template_filemodes_gen.go",
+		"ConfigStorage",
+	)
+	if err != nil {
+		log.Errorf("error while generating file modes: %s", err)
+	}
 
 	if err = generateLuaCodeVar(); err != nil {
 		log.Errorf("error while generating lua code string variables: %s", err)

--- a/cli/create/builtin_templates/builtin_templates.go
+++ b/cli/create/builtin_templates/builtin_templates.go
@@ -14,7 +14,13 @@ var FileModes = map[string]map[string]int{
 	"cartridge":       static.CartridgeFileModes,
 	"vshard_cluster":  static.VshardClusterFileModes,
 	"single_instance": static.SingleInstanceFileModes,
+	"config_storage":  static.ConfigStorageFileModes,
 }
 
 // Names contains built-in template names.
-var Names = [...]string{"cartridge", "vshard_cluster", "single_instance"}
+var Names = [...]string{
+	"cartridge",
+	"vshard_cluster",
+	"single_instance",
+	"config_storage",
+}

--- a/cli/create/builtin_templates/templates/config_storage/MANIFEST.yaml
+++ b/cli/create/builtin_templates/templates/config_storage/MANIFEST.yaml
@@ -1,0 +1,27 @@
+description: Config storage template
+follow-up-message: |
+  What's next?
+  Start '{{ .name }}' application:
+      $ tt start {{ .name }}
+
+  Pay attention that default user and password were generated
+  for the 'replication' role, you can change it in the config.yaml.
+
+vars:
+  - prompt: Storages replicas (odd, >=3)
+    name: replicas_count
+    default: '3'
+    re: ^([3579]|[1-9]\d*[13579])$
+
+  - prompt: Status check interval
+    name: status_check_interval
+    default: '5'
+    re: ^[1-9]\d*$
+
+  - prompt: User name
+    name: username
+    default: 'client'
+
+  - prompt: Password
+    name: password
+    default: 'secret'

--- a/cli/create/builtin_templates/templates/config_storage/config.yaml.tt.template
+++ b/cli/create/builtin_templates/templates/config_storage/config.yaml.tt.template
@@ -1,0 +1,50 @@
+credentials:
+  users:
+    replicator:
+      password: 'topsecret'
+      roles: [replication]
+    {{.username}}:
+      password: '{{.password}}'
+      privileges:
+        - permissions: [execute]
+          lua_call:
+            - config.storage.get
+            - config.storage.put
+            - config.storage.delete
+            - config.storage.keepalive
+            - config.storage.txn
+            - config.storage.info
+        # Not necessary since tarantool 3.5.0, 3.4.1, 3.3.3, 3.2.2.
+        - permissions: [read, write]
+          spaces: [config_storage, config_storage_meta]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+
+replication:
+  failover: election
+
+database:
+  use_mvcc_engine: true
+
+groups:
+  group-001:
+    replicasets:
+{{- $status_check_interval := atoi .status_check_interval}}
+{{- $replicas := atoi .replicas_count}}
+{{- range replicasets "replicaset" 1 $replicas}}
+      {{.Name}}:
+        roles: [config.storage]
+        roles_cfg:
+          config.storage:
+            status_check_interval: {{$status_check_interval}}
+        instances:
+{{- range .InstNames}}
+          {{.}}:
+            iproto:
+              listen:
+              - uri: 127.0.0.1:{{port}}
+{{- end}}
+{{- end}}

--- a/cli/create/builtin_templates/templates/config_storage/instances.yaml.tt.template
+++ b/cli/create/builtin_templates/templates/config_storage/instances.yaml.tt.template
@@ -1,0 +1,7 @@
+---
+{{- $replicas := atoi .replicas_count}}
+{{- range replicasets "replicaset" 1 $replicas}}
+{{- range .InstNames}}
+{{.}}:
+{{- end}}
+{{- end}}


### PR DESCRIPTION
@TarantoolBot document
Title: `tt create` support `config_storage` template.

Configurable parameters:
- Number of instances in replicaset
- Interval of status checking
- User name
- Password

<details>

<summary>Example of generated config</summary>

Number of instances in replicaset: 3
Interval of status checking: 4
User: me
Password: bla-BLA-bla

instances.yaml
```yaml
---
replicaset-001-a:
replicaset-001-b:
replicaset-001-c:
```

config.yaml
```yaml
credentials:
  users:
    replicator:
      password: 'topsecret'
      roles: [replication]
    me:
      password: 'bla-BLA-bla'
      privileges:
        - permissions: [execute]
          lua_call:
            - config.storage.get
            - config.storage.put
            - config.storage.delete
            - config.storage.keepalive
            - config.storage.txn
            - config.storage.info
        # Not necessary since tarantool 3.5.0, 3.4.1, 3.3.3, 3.2.2.
        - permissions: [read, write]
          spaces: [config_storage, config_storage_meta]

iproto:
  advertise:
    peer:
      login: replicator

replication:
  failover: election

database:
  use_mvcc_engine: true

groups:
  group-001:
    replicasets:
      replicaset-001:
        roles: [config.storage]
        roles_cfg:
          config.storage:
            status_check_interval: 4
        instances:
          replicaset-001-a:
            iproto:
              listen:
              - uri: 127.0.0.1:3301
          replicaset-001-b:
            iproto:
              listen:
              - uri: 127.0.0.1:3302
          replicaset-001-c:
            iproto:
              listen:
              - uri: 127.0.0.1:3303
```

</details>

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1180

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
