### PR TITLE
ci: add auto checks for commit message

### DIFF
--- a/.github/actions/check-commit-msg/action.yml
+++ b/.github/actions/check-commit-msg/action.yml
@@ -1,0 +1,71 @@
+name: "Check commit messages"
+description: "Performs checks for commit messages format."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "${{ env.PYTHON_VERSION }}"
+
+    - name: Activate Python virtualenv
+      shell: bash
+      run: |
+        # Activate Python virtualenv
+        echo "VIRTUAL_ENV=${PWD}/.venv" >> "${GITHUB_ENV}"
+        echo "${PWD}/.venv/bin" >> "${GITHUB_PATH}"
+        echo "PRE_COMMIT=$(grep -m1 pre-commit test/requirements.txt)" >> ${GITHUB_ENV}
+
+    - name: Cache Python virtualenv
+      id: cache-pre_commit-venv
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.PRE_COMMIT }}-venv-${{ runner.os }}-Py_${{ env.PYTHON_VERSION }}-${{ hashFiles('test/requirements.txt') }}
+        path: ${{ env.VIRTUAL_ENV }}
+
+    - name: Install pre-commit in virtualenv
+      if: steps.cache-pre_commit-venv.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Install pre-commit
+        python3 -m venv "${{ env.VIRTUAL_ENV }}"
+        python -m pip install $PRE_COMMIT
+
+
+    - name: Set git config user info
+      shell: bash
+      run: |
+        # Set git config user info
+        git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+        git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
+    - name: Cache pre-commit repo data
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ env.PRE_COMMIT }}|${{ runner.os }}|Py_${{ env.PYTHON_VERSION }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Get commit messages
+      id: get_commit_msgs
+      shell: bash
+      run: |
+        # Get commit messages
+        dir=$(mktemp -d -t commit_msgs_XXXXXXX)
+        echo "COMMIT_MSG_DIR=$dir" >> $GITHUB_OUTPUT
+        commits=$(git log --pretty=format:"%H" "origin/master..HEAD")
+        for hash in $commits; do
+          git show -s --format=%B $hash > $dir/$hash.txt
+        done
+
+    - name: Checks for commit messages format
+      id: check_commit_msgs
+      shell: bash
+      run: |
+        # Checks for commit messages format
+        for file in ${{ steps.get_commit_msgs.outputs.COMMIT_MSG_DIR }}/*.txt; do
+          hash=$(basename ${file%.*})
+          echo "Check message for <${hash}>"
+          echo "  > \"$(git log --pretty=format:%s ${hash}^..${hash})\""
+          pre-commit run --commit-msg-filename $file --hook-stage commit-msg
+        done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,17 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
+  check-commit-msg:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages
+        uses: ./.github/actions/check-commit-msg
+
   tests-ce:
     if: |
       (github.event_name == 'push') ||


### PR DESCRIPTION
Auto validation on CI for format of commit message.

- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Closes #TNTP-3712

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
