### PR TITLE
test: disable config storage tests for Tarantool CE

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,27 +104,14 @@ def tmpdir_with_cfg(tmp_path):
 @pytest.fixture(scope="session")
 def tmpdir_with_tarantool(tt_cmd, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("tarantool_env")
-    init_cmd = [tt_cmd, "init"]
-    tt_process = subprocess.Popen(
-        init_cmd,
-        cwd=tmpdir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.DEVNULL,
-        text=True,
-    )
-    tt_process.wait()
-    assert tt_process.returncode == 0
 
-    init_cmd = [tt_cmd, "install", "-f", "tarantool", "--dynamic"]
-    tt_process = subprocess.Popen(
-        init_cmd,
-        cwd=tmpdir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.DEVNULL,
-        text=True,
-    )
-    tt_process.wait()
-    assert tt_process.returncode == 0
+    cmd = [tt_cmd, "init"]
+    p = subprocess.run(cmd, cwd=tmpdir)
+    assert p.returncode == 0
+
+    cmd = [tt_cmd, "install", "-f", "tarantool", "--dynamic"]
+    p = subprocess.run(cmd, cwd=tmpdir)
+    assert p.returncode == 0
 
     return tmpdir
 

--- a/test/integration/create/test_create.py
+++ b/test/integration/create/test_create.py
@@ -12,6 +12,7 @@ from utils import (
     config_name,
     extract_status,
     get_tarantool_version,
+    is_tarantool_ee,
     pid_file,
     run_command_and_get_output,
     wait_event,
@@ -1101,6 +1102,10 @@ def wait_for_master(tt_cmd, workdir, app_name):
     tarantool_major_version < 3,
     reason="skip centralized config test for Tarantool < 3",
 )
+@pytest.mark.skipif(
+    not is_tarantool_ee(),
+    reason="required Tarantool EE",
+)
 @pytest.mark.parametrize("num_replicas", [3, 5])
 def test_create_config_storage(tt_cmd, tmp_path, num_replicas):
     with open(os.path.join(tmp_path, config_name), "w") as tnt_env_file:
@@ -1198,7 +1203,10 @@ def test_create_config_storage(tt_cmd, tmp_path, num_replicas):
     [
         "cartridge",
         "vshard_cluster",
-        "config_storage",
+        pytest.param(
+            "config_storage",
+            marks=pytest.mark.skipif(not is_tarantool_ee(), reason="required Tarantool EE"),
+        ),
     ],
 )
 def test_create_builtin_template_with_defaults(tt_cmd, tmp_path, template):

--- a/test/integration/ttbuild/test_build.py
+++ b/test/integration/ttbuild/test_build.py
@@ -9,53 +9,40 @@ from utils import config_name
 
 
 def test_build_no_options(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
 
-    buid_cmd = [tt_cmd, "build"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build"]
+    p = subprocess.run(
+        cmd,
         cwd=app_dir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    print(tt_process.stdout.read())
-    assert tt_process.returncode == 0
-
+    assert p.returncode == 0
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
 
 
 def test_build_with_tt_hooks(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
     shutil.copytree(
         os.path.join(os.path.dirname(__file__), "apps/tt_hooks"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(tmpdir_with_cfg, app_name),
         dirs_exist_ok=True,
     )
 
-    buid_cmd = [tt_cmd, "build"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build"]
+    p = subprocess.run(
+        cmd,
         cwd=app_dir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
+    assert p.returncode == 0
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
     assert os.path.exists(os.path.join(app_dir, "tt-pre-build-invoked"))
@@ -63,29 +50,23 @@ def test_build_with_tt_hooks(tt_cmd, tmpdir_with_cfg):
 
 
 def test_build_with_cartridge_hooks(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
     shutil.copytree(
         os.path.join(os.path.dirname(__file__), "apps/cartridge_hooks"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(tmpdir_with_cfg, app_name),
         dirs_exist_ok=True,
     )
 
-    buid_cmd = [tt_cmd, "build"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build"]
+    p = subprocess.run(
+        cmd,
         cwd=app_dir,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
+    assert p.returncode == 0
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
     assert os.path.exists(os.path.join(app_dir, "cartridge-pre-build-invoked"))
@@ -93,144 +74,110 @@ def test_build_with_cartridge_hooks(tt_cmd, tmpdir_with_cfg):
 
 
 def test_build_app_name_set(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
 
-    buid_cmd = [tt_cmd, "build", "app1"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build", app_name]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
+    assert p.returncode == 0
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
 
 
 def test_build_absolute_path(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
 
     with tempfile.TemporaryDirectory() as tmpWorkDir:
-        buid_cmd = [tt_cmd, "--cfg", os.path.join(tmpdir_with_cfg, config_name), "build", app_dir]
-        tt_process = subprocess.Popen(
-            buid_cmd,
+        cmd = [tt_cmd, "--cfg", os.path.join(tmpdir_with_cfg, config_name), "build", app_dir]
+        p = subprocess.run(
+            cmd,
             cwd=tmpWorkDir,
-            stderr=subprocess.STDOUT,
-            stdout=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            text=True,
         )
-        tt_process.stdin.close()
-        tt_process.wait()
-        assert tt_process.returncode == 0
-
+        assert p.returncode == 0
         assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
         assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
 
 
 def test_build_error_omit_stdout(tt_cmd, tmpdir_with_cfg):
-    build_cmd = [tt_cmd, "build"]
-    tt_process = subprocess.Popen(
-        build_cmd,
+    cmd = [tt_cmd, "build"]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
         stderr=subprocess.PIPE,
         stdout=subprocess.DEVNULL,
-        stdin=subprocess.PIPE,
         text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 1
-    output = tt_process.stderr.read()
-    assert "please specify a rockspec to use on current directory" in output
+    print(p.stderr)
+    assert p.returncode != 0
+    assert "please specify a rockspec to use on current directory" in p.stderr
 
 
 def test_build_missing_rockspec(tt_cmd, tmpdir_with_cfg):
-    buid_cmd = [tt_cmd, "build"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build"]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
         text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 1
-
-    tt_process.stdout.readline()  # Skip empty line.
-    tt_process.stdout.readline()  # Skip log line.
-    assert (
-        tt_process.stdout.readline().find("please specify a rockspec to use on current directory")
-        != -1
-    )
+    print(p.stdout)
+    assert p.returncode != 0
+    assert "please specify a rockspec to use on current directory" in p.stdout
 
 
 def test_build_missing_app_dir(tt_cmd, tmpdir_with_cfg):
-    buid_cmd = [tt_cmd, "build", "app1"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    app_name = "app1"
+    cmd = [tt_cmd, "build", app_name]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
         text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 1
-
-    assert tt_process.stdout.readline().find("app1: no such file or directory") != -1
+    print(p.stdout)
+    assert p.returncode != 0
+    assert f"{app_name}: no such file or directory" in p.stdout
 
 
 def test_build_multiple_paths(tt_cmd, tmpdir_with_cfg):
-    buid_cmd = [tt_cmd, "build", "app1", "app2"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build", "app1", "app2"]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
         text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 1
-
-    assert tt_process.stdout.readline().find("Error: accepts at most 1 arg(s), received 2") != -1
+    print(p.stdout)
+    assert p.returncode != 0
+    assert "Error: accepts at most 1 arg(s), received 2" in p.stdout
 
 
 def test_build_spec_file_set(tt_cmd, tmpdir_with_cfg):
+    app_name = "app1"
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmpdir_with_cfg, "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmpdir_with_cfg, app_name),
     )
 
-    buid_cmd = [tt_cmd, "build", "app1", "--spec", "app1-scm-1.rockspec"]
-    tt_process = subprocess.Popen(
-        buid_cmd,
+    cmd = [tt_cmd, "build", app_name, "--spec", "app1-scm-1.rockspec"]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_cfg,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        text=True,
     )
-    tt_process.stdin.close()
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
+    assert p.returncode == 0
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "metrics"))
@@ -239,72 +186,65 @@ def test_build_spec_file_set(tt_cmd, tmpdir_with_cfg):
 
 @pytest.mark.parametrize("flag", [None, "-V"])
 def test_build_app_by_name(tt_cmd, tmp_path, flag):
-    init_cmd = [tt_cmd, "init"]
-    tt_process = subprocess.Popen(
-        init_cmd,
+    cmd = [tt_cmd, "init"]
+    p = subprocess.run(
+        cmd,
         cwd=tmp_path,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True,
     )
-    tt_process.wait()
-    assert tt_process.returncode == 0
+    assert p.returncode == 0
 
+    app_name = "app1"
     os.mkdir(os.path.join(tmp_path, "appdir"))
     app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/app1"),
-        os.path.join(tmp_path, "appdir", "app1"),
+        os.path.join(os.path.dirname(__file__), "apps", app_name),
+        os.path.join(tmp_path, "appdir", app_name),
+    )
+    os.symlink(
+        os.path.join("../appdir", app_name),
+        os.path.join(tmp_path, "instances.enabled", app_name),
+        True,
     )
 
-    os.symlink("../appdir/app1", os.path.join(tmp_path, "instances.enabled", "app1"), True)
-    build_cmd = [tt_cmd]
+    cmd = [tt_cmd]
     if flag:
-        build_cmd.append(flag)
-    build_cmd.extend(["build", "app1"])
-    tt_process = subprocess.Popen(
-        build_cmd,
+        cmd.append(flag)
+    cmd.extend(["build", app_name])
+    p = subprocess.run(
+        cmd,
         cwd=tmp_path,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True,
     )
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
-    build_output = tt_process.stdout.readlines()
-    assert "Application was successfully built" in build_output[len(build_output) - 1]
+    print(p.stdout)
+    assert p.returncode == 0
+    assert "Application was successfully built" in p.stdout
     assert os.path.exists(os.path.join(app_dir, ".rocks"))
 
 
 @pytest.mark.notarantool
 @pytest.mark.skipif(shutil.which("tarantool") is not None, reason="tarantool found in PATH")
 def test_build_app_local_tarantool(tt_cmd, tmpdir_with_tarantool):
-    build_cmd = [tt_cmd, "create", "cartridge", "--name", "app1", "--non-interactive"]
-    tt_process = subprocess.Popen(
-        build_cmd,
+    app_name = "app1"
+    app_dir = os.path.join(tmpdir_with_tarantool, app_name)
+
+    cmd = [tt_cmd, "create", "cartridge", "--name", app_name, "--non-interactive"]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_tarantool,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True,
     )
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
-    app_dir = os.path.join(tmpdir_with_tarantool, "app1")
-
+    assert p.returncode == 0
     assert os.path.exists(app_dir)
 
-    build_cmd = [tt_cmd, "build", "app1"]
-    tt_process = subprocess.Popen(
-        build_cmd,
+    cmd = [tt_cmd, "build", app_name]
+    p = subprocess.run(
+        cmd,
         cwd=tmpdir_with_tarantool,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True,
     )
-    tt_process.wait()
-    assert tt_process.returncode == 0
-
-    build_output = tt_process.stdout.readlines()
-    assert "Application was successfully built" in build_output[len(build_output) - 1]
+    print(p.stdout)
+    assert p.returncode == 0
+    assert "Application was successfully built" in p.stdout
     assert os.path.exists(os.path.join(app_dir, ".rocks"))

--- a/test/utils.py
+++ b/test/utils.py
@@ -554,15 +554,17 @@ def is_tarantool_less_3():
 
 def is_tarantool_ee():
     cmd = ["tarantool", "--version"]
-    instance_process = subprocess.run(
-        cmd,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-    if instance_process.returncode == 0:
-        return "Tarantool Enterprise" in instance_process.stdout
-    return False
+    try:
+        instance_process = subprocess.run(
+            cmd,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+    assert instance_process.returncode == 0
+    return "Tarantool Enterprise" in instance_process.stdout
 
 
 def skip_if_tarantool_ce():


### PR DESCRIPTION
I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Tests (see [documentation][go-testing] for a testing package)

Related issues:

Closes #TNTP-3710

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
