### PR TITLE
test: skip follow tests on CI

### DIFF
--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -103,6 +103,10 @@ func TestFollow2_ReadExistingContent(t *testing.T) {
 }
 
 func TestFollow2_FollowNewContent(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping flaky test on CI until issue #TNTP-3131 is fixed")
+	}
+
 	lf := createTmpLogFile(t, linesPerStep, logLineFormat)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -251,6 +255,10 @@ func rotationTest(t *testing.T, use_delay bool) {
 // does not handle file rotation correctly.
 //   - TODO: Need fix `tail` library, see #TNTP-3131 for more details.
 func TestFollow2_FileRotation_Flaky(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping flaky test on CI until issue #TNTP-3131 is fixed")
+	}
+
 	const flakyRepeatCount = 3
 
 	test_pass := false

--- a/test/integration/tcm/test_tcm_log.py
+++ b/test/integration/tcm/test_tcm_log.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import sys
 import time
@@ -202,6 +203,10 @@ def final_checks(
     check_output("".join(stdout_lines), update_testdata, expected_file)
 
 
+@pytest.mark.skipif(
+    condition=os.getenv("CI") is not None,
+    reason="Skip on CI runs until issue #TNTP-3131 is fixed.",
+)
 @pytest.mark.parametrize("delay_time", (0.1, 0.01, 0))
 @pytest.mark.parametrize("lines, options", TEST_CASES)
 @pytest.mark.parametrize("mode", TEST_DATA_MODES)
@@ -231,6 +236,10 @@ def test_log_follow(
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    condition=os.getenv("CI") is not None,
+    reason="Skip on CI runs until issue #TNTP-3131 is fixed.",
+)
 @pytest.mark.flaky(reruns=5)  # See notes below about issues with `tail` package.
 @pytest.mark.parametrize("delay_time", (0.1, 0.01, 0))
 @pytest.mark.parametrize("lines, options", TEST_CASES)


### PR DESCRIPTION
Turn off running some tests with `follow` log on CI. Issue depend on #TNTP-3131 and required fixes in `tail` library.

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Tests (see [documentation][go-testing] for a testing package)

Related to #TNTP-3131
Closes #TNTP-3832


[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
