### PR TITLE
format: turn of pre-commit markdown linter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@ What has been done? Why? What problem is being solved?
 
 I didn't forget about (remove if it is not applicable):
 
-- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
+- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how
+ to write a commit message)
 - [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
 - [ ] Tests (see [documentation][go-testing] for a testing package)
 - [ ] Changelog (see [documentation][keepachangelog] for changelog format)

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -10,14 +10,19 @@ MD004:
   # List style
   style: sublist
 
+MD010:
+  spaces_per_tab: 4
+
 # MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md013.md
 MD013:
   # Number of characters
   line_length: 80
   # Number of characters for headings
   heading_line_length: 80
-  # Number of characters for code blocks
-  code_block_line_length: 80
+  # Ignore line length in code blocks
+  code_blocks: false
+  # Ignore line length in tables
+  tables: false
 
 # MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md024.md
 MD024:
@@ -29,13 +34,21 @@ MD033:
   # Allowed elements
   allowed_elements:
     - version
+    - img
+    - a
 
-# MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md046.md
-MD046:
-  # Block style
-  style: underscore
+# MD041/First line, top-level heading :  https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md041.md
+MD041:
+  # Allow content before first heading
+  allow_preamble: true
+
+# MD049/Emphasis style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md049.md
+MD049:
+  # Emphasis(Italic) within a word is restricted to `asterisk` in order to avoid unwanted emphasis
+  # for words containing internal underscores.
+  style: asterisk
 
 # MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md050.md
 MD050:
-  # Strong style
+  # Strong(Bold) style
   style: asterisk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,8 +134,6 @@ repos:
       - id: markdownlint-cli2
         name: "MD: check markdown files"
         stages: [pre-commit, manual]
-        # TODO: configure the rules and fix the rest of the .md files (#TNTP-3107).
-        files: CHANGELOG.md
         args: [--fix]
 
   - repo: https://github.com/jorisroovers/gitlint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 <a href="http://tarantool.org">
-  <img src="https://avatars2.githubusercontent.com/u/2344919?v=2&s=250" align="right">
+  <img src="https://avatars2.githubusercontent.com/u/2344919?v=2&s=250"
+  align="right" alt="Tarantool logo">
 </a>
 
 # Tarantool CLI
@@ -15,46 +16,47 @@ Tarantool-based applications.
 
 ## Contents
 
-* [Intro](#intro)
-* [Getting started](#getting-started)
-  * [Installation](#installation)
-  * [Build from source](#build-from-source)
+- [Intro](#intro)
+- [Getting started](#getting-started)
+  + [Installation](#installation)
+  + [Build from source](#build-from-source)
     * [Prerequisites](#prerequisites)
     * [Build](#build)
     * [Dependencies](#dependencies)
     * [Run tests](#run-tests)
-* [Configuration](#configuration)
-  * [Configuration file](#configuration-file)
-* [Creating tt environment](#creating-tt-environment)
-* [External modules](#external-modules)
-* [CLI Args](#cli-Args)
-  * [Autocompletion](#autocompletion)
-* [TT usage](#tt-usage)
-  * [Working with a set of instances](#working-with-a-set-of-instances)
-  * [Working with application templates](#Working-with-application-templates)
-  * [Working with tt daemon (experimental)](#working-with-tt-daemon-experimental)
-  * [Setting Tarantool configuration parameters via environment variables](#setting-tarantool-configuration-parameters-via-environment-variables)
-  * [Add current environment binaries location to the PATH variable](#add-current-environment-binaries-location-to-the-path-variable)
-* [Migration from older TT versions](doc/migration_from_older_versions.md)
-* [Known issues](doc/known_issues.md)
-* [Commands](#commands)
+- [Configuration](#configuration)
+  + [Configuration file](#configuration-file)
+- [Creating tt environment](#creating-tt-environment)
+- [External modules](#external-modules)
+- [CLI Args](#cli-args)
+  + [Autocompletion](#autocompletion)
+- [TT usage](#tt-usage)
+  + [Working with a set of instances](#working-with-a-set-of-instances)
+  + [Working with application templates](#working-with-application-templates)
+  + [Working with tt daemon (experimental)](#working-with-tt-daemon-experimental)
+  + [Setting Tarantool configuration parameters via environment variables](#setting-tarantool-configuration-parameters-via-environment-variables)
+  + [Add current environment binaries location to the PATH variable](#add-current-environment-binaries-location-to-the-path-variable)
+- [Migration from older TT versions](doc/migration_from_older_versions.md)
+- [Known issues](doc/known_issues.md)
+- [Commands](#commands)
 
 ## Intro
 
-`tt` is tarantool's instance and environment management utility and is used to develop, deploy, run and operate applications.
+`tt` is tarantool's instance and environment management utility and is used to
+develop, deploy, run and operate applications.
 
-One of the basic concepts that `tt` introduces is "environment". The "environment" is
-an isolated workspace for the tarantool application suite.
-[`tt.yaml` configuration file](#configuration) defines the root and configuration of
-the *environment*. When `tt` is installed from a repository by a package manager (`apt`,
-`rpm`, ...) a "system" config file (`/etc/tarantool/tt.yaml`) is included which forms
-the "system" environment - the case when `tt` replaces the
-[`tarantoolctl`](https://github.com/tarantool/tt/blob/master/doc/examples.md#transition-from-tarantoolctl-to-tt).
-In case we want to form a local environment (very convenient during development), we
-use a "local" `tt.yaml` generated with the [`tt init`](#creating-tt-environment)
+One of the basic concepts that `tt` introduces is "environment".
+The "environment" is an isolated workspace for the tarantool application suite.
+[`tt.yaml` configuration file](#configuration) defines the root and
+configuration of the *environment*. When `tt` is installed from a repository by
+a package manager (`apt`, `rpm`, ...) a "system" config file
+(`/etc/tarantool/tt.yaml`) is included which forms the "system" environment -
+the case when `tt` replaces the [`tarantoolctl`](https://github.com/tarantool/tt/blob/master/doc/examples.md#transition-from-tarantoolctl-to-tt).
+In case we want to form a local environment (very convenient during
+development), we use a "local" `tt.yaml` generated with the [`tt init`](#creating-tt-environment)
 command. In this way, the user/developer can have a large number of different
-"environments" in the system in which different versions of both `tarantool`/`tt` and
-the applications being developed will be used.
+"environments" in the system in which different versions of both
+`tarantool`/`tt` and the applications being developed will be used.
 
 The example of a typical "environment":
 
@@ -115,13 +117,13 @@ Install the tarantool repositories:
 
 Install TT:
 
--   Deb based distributions:
+- Deb based distributions:
 
 ``` console
 apt-get install tt
 ```
 
--   Rpm based distributions:
+- Rpm based distributions:
 
 ``` console
 yum install tt
@@ -147,36 +149,36 @@ binary for your OS from GitHub's Releases page.
 However, on MacOS to run that binary you will need to do additional
 steps:
 
-1.  After first try to run binary, you will encounter an error:
+1. After first try to run binary, you will encounter an error:
 
     <img src="doc/images/macOS_error.jpeg" width="250" alt="MacOS error." />
 
-1.  To fix it, you should go to 'system settings-\>privacy and
+1. To fix it, you should go to 'system settings-\>privacy and
     security', then scroll down and find:
 
     <img src="doc/images/macOS_settings.jpeg" width="350" alt="MacOS settings." />
 
-1.  Click on 'Allow Anyway' and you should be able to use Tarantool Cli.
+1. Click on 'Allow Anyway' and you should be able to use Tarantool Cli.
 
 ### Build from source
 
 #### Prerequisites
 
--   [Go (version 1.18+)](https://golang.org/doc/install)
--   [Mage](https://magefile.org/)
--   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Go (version 1.18+)](https://golang.org/doc/install)
+- [Mage](https://magefile.org/)
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 To run tests:
 
--   [Python3](https://www.python.org/downloads/)
--   [pytest](https://docs.pytest.org/en/7.2.x/getting-started.html#get-started)
--   [ruff](https://pypi.org/project/ruff/)
--   [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
--   [lichen](https://github.com/uw-labs/lichen#install)
--   [docker](https://docs.docker.com/engine/install/)
--   [NodeJS](https://nodejs.org/en/download)
--   [CMake](https://cmake.org/install/)
--   [etcd 3+](https://etcd.io/docs/v3.5/install/)
+- [Python3](https://www.python.org/downloads/)
+- [pytest](https://docs.pytest.org/en/7.2.x/getting-started.html#get-started)
+- [ruff](https://pypi.org/project/ruff/)
+- [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+- [lichen](https://github.com/uw-labs/lichen#install)
+- [docker](https://docs.docker.com/engine/install/)
+- [NodeJS](https://nodejs.org/en/download)
+- [CMake](https://cmake.org/install/)
+- [etcd 3+](https://etcd.io/docs/v3.5/install/)
 
 #### Build
 
@@ -211,18 +213,19 @@ TT_CLI_BUILD_SSL=shared mage build
 
 **tt rocks runtime dependencies:**
 
--   [curl](https://curl.se) or
+- [curl](https://curl.se) or
     [wget](https://www.gnu.org/software/wget/)
--   [zip](http://infozip.sourceforge.net/)
--   [unzip](http://infozip.sourceforge.net/)
+- [zip](http://infozip.sourceforge.net/)
+- [unzip](http://infozip.sourceforge.net/)
 
 **tt install && search runtime dependencies:**
 
--   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 #### Run tests
 
 Disable `etcd` service:
+
 ``` console
 systemctl stop etcd
 systemctl disable etcd
@@ -254,32 +257,35 @@ mage testfull
 ### Commit changes
 
 The project uses [pre-commit](https://pre-commit.com/) to check code before committing.
-After activating the virtual environment for [run tests](#run-tests), the `pre-commit` hooks must be installed in the repository:
+After activating the virtual environment for [run tests](#run-tests), the `pre-commit`
+hooks must be installed in the repository:
 
 ``` console
 pre-commit install
 ```
 
 Now you will perform automatic checks at every commit.
-The first time you use `pre-commit` it will install the dependencies needed for it to work, which may take some time.
-Subsequent runs will be much faster.
+The first time you use `pre-commit` it will install the dependencies needed for
+it to work, which may take some time. Subsequent runs will be much faster.
 
-If errors were found, the commit will fail. If the errors can be corrected automatically, you will receive modified files to add to the commit, checking for correctness.
-In other cases you will get a message with errors that need to be corrected manually.
+If errors were found, the commit will fail. If the errors can be corrected
+automatically, you will receive modified files to add to the commit, checking
+for correctness. In other cases you will get a message with errors that need to
+be corrected manually.
 
 ## Configuration
 
 Tarantool CLI can be launched in several modes:
 
--   System launch (flag `-S`) - the working directory is current,
+- System launch (flag `-S`) - the working directory is current,
     configuration file searched in `/etc/tarantool` directory.
--   Local launch (flag `-L`) - the working directory is the one you
+- Local launch (flag `-L`) - the working directory is the one you
     specified, configuration file is searched in this directory. If
     configuration file doesn't exists, config searched from the working
     directory to the root. If it is also not found, then take config
     from `/etc/tarantool`. If tarantool or tt executable files are found
     in working directory, they will be used further.
--   Default launch (no flags specified) - configuration file searched
+- Default launch (no flags specified) - configuration file searched
     from the current directory to the root, going down the directory
     until file is found. Working directory - the one where the
     configuration file is found. If configuration file isn't found,
@@ -322,68 +328,66 @@ templates:
   - path: path/to/templates_dir2
 ```
 
-**env**
+#### env
 
--   `instances_enabled` (string) - path to directory that stores all
+- `instances_enabled` (string) - path to directory that stores all
     applications.
--   `bin_dir` (string) - directory that stores binary files.
--   `inc_dir` (string) - directory that stores header files. The path
+- `bin_dir` (string) - directory that stores binary files.
+- `inc_dir` (string) - directory that stores header files. The path
     will be padded with a directory named include.
--   `restart_on_failure` (bool) - should it restart on failure.
--   `tarantoolctl_layout` (bool) - enable/disable tarantoolctl layout
+- `restart_on_failure` (bool) - should it restart on failure.
+- `tarantoolctl_layout` (bool) - enable/disable tarantoolctl layout
     compatible mode for artifact files: control socket, pid, log files.
     Data files (wal, vinyl, snapshots) and multi-instance applications
     are not affected by this option.
 
-**modules**
+#### modules
 
--   `directory` (string) - the path to directory where the external
+- `directory` (string) - the path to directory where the external
     modules are stored.
 
-**app**
+#### app
 
--   `run_dir` (string) - path to directory that stores various instance
+- `run_dir` (string) - path to directory that stores various instance
     runtime artifacts like console socket, PID file, etc.
--   `log_dir` (string) - directory that stores log files.
--   `wal_dir` (string) - directory where write-ahead log (.xlog) files
+- `log_dir` (string) - directory that stores log files.
+- `wal_dir` (string) - directory where write-ahead log (.xlog) files
     are stored.
--   `memtx_dir` (string) - directory where memtx stores snapshot (.snap)
+- `memtx_dir` (string) - directory where memtx stores snapshot (.snap)
     files.
--   `vinyl_dir` (string) - directory where vinyl files or subdirectories
+- `vinyl_dir` (string) - directory where vinyl files or subdirectories
     will be stored.
 
-**repo**
+#### repo
 
--   `rocks` (string) - directory that stores rocks files.
--   `distfiles` (string) - directory that stores installation files.
+- `rocks` (string) - directory that stores rocks files.
+- `distfiles` (string) - directory that stores installation files.
 
-**ee**
+#### ee
 
--   `credential_path` (string) - path to file with credentials for
+- `credential_path` (string) - path to file with credentials for
     downloading tarantool-ee. File must contain login and password. Each
     parameter on a separate line. Alternatively credentials can be set
-    via environment variables:
-    <span class="title-ref">TT_CLI_EE_USERNAME</span> and
-    <span class="title-ref">TT_CLI_EE_PASSWORD</span>.
+    via environment variables: `TT_CLI_EE_USERNAME` and `TT_CLI_EE_PASSWORD`.
 
-**templates**
+#### templates
 
--   `path` (string) - the path to templates search directory.
+- `path` (string) - the path to templates search directory.
 
 ## Creating tt environment
 
 tt environment can be created using `init` command:
 
 ``` console
-$ tt init
+tt init
 ```
 
 `tt init` searches for existing configuration files in current
 directory:
 
--   `.cartridge.yml`. If `.cartridge.yml` is found, it is loaded, and
+- `.cartridge.yml`. If `.cartridge.yml` is found, it is loaded, and
     directory information from it is used for `tt.yaml` generation.
--   `.tarantoolctl`. If `.tarantoolctl` is found, it is invoked by
+- `.tarantoolctl`. If `.tarantoolctl` is found, it is invoked by
     Tarantool and directory information from `default_cfg` table is used
     for `tt.yaml` generation. `.tarantoolctl` will not be invoked by
     `tt start` command, so all variables defined in this script will not
@@ -394,6 +398,7 @@ generates default `tt.yaml` and creates a set of environment
 directories. Here is and example of the default environment filesystem
 tree:
 
+```text
     .
     ├── bin
     ├── include
@@ -402,19 +407,20 @@ tree:
     ├── modules
     ├── tt.yaml
     └── templates
+```
 
 Where:
 
--   `bin` - directory that stores binary files.
--   `include` - directory that stores header files.
--   `distfiles` - directory that stores installation files for local
+- `bin` - directory that stores binary files.
+- `include` - directory that stores header files.
+- `distfiles` - directory that stores installation files for local
     install.
--   `instances.enabled` - directory that stores enabled applications or
+- `instances.enabled` - directory that stores enabled applications or
     symlinks.
--   `modules` - the directory where the external modules are stored.
--   `tt.yaml` - tt environment configuration file generated by
+- `modules` - the directory where the external modules are stored.
+- `tt.yaml` - tt environment configuration file generated by
     `tt init`.
--   `templates` - the directory where external templates are stored.
+- `templates` - the directory where external templates are stored.
 
 ## External modules
 
@@ -445,18 +451,18 @@ To see list of available modules, type `tt -h`.
 
 Arguments of Tarantool CLI:
 
--   `--cfg | -c` (string) - path to Tarantool CLI config.
--   `--internal | -I` - use internal module.
--   `--local | -L` (string) - run Tarantool CLI as local, in the
+- `--cfg | -c` (string) - path to Tarantool CLI config.
+- `--internal | -I` - use internal module.
+- `--local | -L` (string) - run Tarantool CLI as local, in the
     specified directory.
--   `--system | -S` - run Tarantool CLI as system.
--   `--help | -h` - help.
+- `--system | -S` - run Tarantool CLI as system.
+- `--help | -h` - help.
 
 ### Autocompletion
 
 You can generate autocompletion for `bash`, `zsh` and `fish` shell:
 
-``` console
+``` sh
 . <(tt completion bash)
 ```
 
@@ -479,8 +485,8 @@ templates from the configuration file.
 To work with a set of instances, you need: a directory where the files
 will be located: `init.lua` and `instances.yml`.
 
--   `init.lua` - application source file.
--   `instances.yml` - description of instances.
+- `init.lua` - application source file.
+- `instances.yml` - description of instances.
 
 Instances are described in `instances.yml` with format:
 
@@ -498,9 +504,9 @@ the format: `instance_name.init.lua`.
 
 The following environment variables are associated with each instance:
 
--   `TARANTOOL_APP_NAME` - application name (the name of the directory
+- `TARANTOOL_APP_NAME` - application name (the name of the directory
     where the application files are present).
--   `TARANTOOL_INSTANCE_NAME` - instance name.
+- `TARANTOOL_INSTANCE_NAME` - instance name.
 
 [Example](https://github.com/tarantool/tt/blob/master/doc/examples.md#working-with-a-set-of-instances)
 
@@ -510,9 +516,9 @@ The following environment variables are associated with each instance:
 
 To work with application template, you need:
 
--   A `<path>` where templates directories or archives are located.
+- A `<path>` where templates directories or archives are located.
 
--   `tt.yaml` configured to search templates in \<path\>:
+- `tt.yaml` configured to search templates in \<path\>:
 
     ``` yaml
     templates:
@@ -522,9 +528,9 @@ To work with application template, you need:
 
 Application template may contain:
 
--   `*.tt.template` - template files, that will be instantiated during
+- `*.tt.template` - template files, that will be instantiated during
     application creation.
--   `MANIFEST.yaml` - template manifest (see details below).
+- `MANIFEST.yaml` - template manifest (see details below).
 
 Template manifest `MANIFEST.yaml` has the following format:
 
@@ -549,17 +555,17 @@ include:
 
 Where:
 
--   `description` (string) - template description.
--   `vars` - template variables used for instantiation.
-    -   `prompt` - user prompt for variable value input.
-    -   `name` - variable name.
-    -   `default` - default value of the variable.
-    -   `re` - regular expression used for value validation.
--   `pre-hook` (string) - executable to run before template
+- `description` (string) - template description.
+- `vars` - template variables used for instantiation.
+  + `prompt` - user prompt for variable value input.
+  + `name` - variable name.
+  + `default` - default value of the variable.
+  + `re` - regular expression used for value validation.
+- `pre-hook` (string) - executable to run before template
     instantiation.
--   `post-hook` (string) - executable to run after template
+- `post-hook` (string) - executable to run after template
     instantiation.
--   `include` (list) - list of files to keep in application directory
+- `include` (list) - list of files to keep in application directory
     after create.
 
 There are pre-defined variables that can be used in template text:
@@ -591,19 +597,19 @@ daemon:
 
 Where:
 
--   `run_dir` (string) - path to directory that stores various instance
+- `run_dir` (string) - path to directory that stores various instance
     runtime artifacts like console socket, PID file, etc. Default:
     `run`.
--   `log_dir` (string) - directory that stores log files. Default:
+- `log_dir` (string) - directory that stores log files. Default:
     `log`.
--   `log_file` (string) - name of file contains log of daemon process.
+- `log_file` (string) - name of file contains log of daemon process.
     Default: `tt_daemon.log`.
--   `listen_interface` (string) - network interface the IP address
+- `listen_interface` (string) - network interface the IP address
     should be found on to bind http server socket. Default: loopback
     (`lo`/`lo0`).
--   `port` (number) - port number to be used for daemon http server.
+- `port` (number) - port number to be used for daemon http server.
     Default: 1024.
--   `pidfile` (string) - name of file contains pid of daemon process.
+- `pidfile` (string) - name of file contains pid of daemon process.
     Default: `tt_daemon.pid`.
 
 [TT daemon
@@ -618,7 +624,7 @@ support it. The name of a variable should have the following pattern:
 [box.cfg](https://www.tarantool.io/en/doc/latest/reference/configuration/#box-cfg-params-ref)
 parameter.
 
-### Add current environment binaries location to the PATH variable.
+### Add current environment binaries location to the PATH variable
 
 You can add current environment binaries location to the PATH variable:
 
@@ -632,41 +638,41 @@ Also TARANTOOL_DIR variable is set.
 
 Common description. For a detailed description, use `tt help command` .
 
--   `start` - start a tarantool instance(s).
--   `stop` - stop the tarantool instance(s).
--   `status` - get current status of the instance(s).
--   `restart` - restart the instance(s).
--   `version` - show Tarantool CLI version information.
--   `completion` - generate autocomplete for a specified shell.
--   `help` - display help for any command.
--   `logrotate` - rotate logs of a started tarantool instance(s).
--   `check` - check an application file for syntax errors.
--   `connect` - connect to the tarantool instance.
--   `rocks` - LuaRocks package manager.
--   `cat` - print into stdout the contents of .snap/.xlog files.
--   `play` - play the contents of .snap/.xlog files to another Tarantool
+- `start` - start a tarantool instance(s).
+- `stop` - stop the tarantool instance(s).
+- `status` - get current status of the instance(s).
+- `restart` - restart the instance(s).
+- `version` - show Tarantool CLI version information.
+- `completion` - generate autocomplete for a specified shell.
+- `help` - display help for any command.
+- `logrotate` - rotate logs of a started tarantool instance(s).
+- `check` - check an application file for syntax errors.
+- `connect` - connect to the tarantool instance.
+- `rocks` - LuaRocks package manager.
+- `cat` - print into stdout the contents of .snap/.xlog files.
+- `play` - play the contents of .snap/.xlog files to another Tarantool
     instance.
--   `coredump` - pack/unpack/inspect tarantool coredump.
--   `run` - start a tarantool instance.
--   `search` - show available tt/tarantool versions.
--   `clean` - clean instance(s) files.
--   `create` - create an application from a template.
--   `build` - build an application.
--   `install` - install tarantool/tt.
--   `uninstall` - uninstall tarantool/tt.
--   `init` - create tt environment configuration file.
--   `daemon (experimental)` - manage tt daemon.
--   `cfg dump` - print tt environment configuration.
--   `pack` - pack an environment into a tarball/RPM/Deb.
--   `instances` - show enabled applications.
--   `binaries list` - show a list of installed binaries and their versions.
--   `binaries switch` - switch to installed binary.
--   `cluster` - manage cluster configuration.
--   `env` - add current environment binaries location to the PATH variable.
--   `replicaset` - manage replicasets.
--   `download` - download Tarantool SDK.
--   `enable` - create a symbolic link in 'instances_enabled' directory to a script or
-    an application directory.
+- `coredump` - pack/unpack/inspect tarantool coredump.
+- `run` - start a tarantool instance.
+- `search` - show available tt/tarantool versions.
+- `clean` - clean instance(s) files.
+- `create` - create an application from a template.
+- `build` - build an application.
+- `install` - install tarantool/tt.
+- `uninstall` - uninstall tarantool/tt.
+- `init` - create tt environment configuration file.
+- `daemon (experimental)` - manage tt daemon.
+- `cfg dump` - print tt environment configuration.
+- `pack` - pack an environment into a tarball/RPM/Deb.
+- `instances` - show enabled applications.
+- `binaries list` - show a list of installed binaries and their versions.
+- `binaries switch` - switch to installed binary.
+- `cluster` - manage cluster configuration.
+- `env` - add current environment binaries location to the PATH variable.
+- `replicaset` - manage replicasets.
+- `download` - download Tarantool SDK.
+- `enable` - create a symbolic link in 'instances_enabled' directory to a script
+   or an application directory.
 
 [godoc-badge]: https://pkg.go.dev/badge/github.com/tarantool/tt.svg
 [godoc-url]: https://pkg.go.dev/github.com/tarantool/tt

--- a/cli/aeon/README.md
+++ b/cli/aeon/README.md
@@ -1,11 +1,16 @@
 # Update Aeon proto submodule
-In case of updating the communication protocol with the Aeon server, the following manual actions are required:
+
+In case of updating the communication protocol with the Aeon server, the
+following manual actions are required:
+
 1. Update `proto` files and re-generate new `.go` sources.
 2. Make appropriate corrections to the `tt aeon connect` application code.
 
 ## Requirements
+
 Ensure that the required utilities are installed on the developer's system.
 Installation of `protoc` compiler may depend on your OS distribution.
+
 ```sh
 apt-get -y install protobuf-compiler
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
@@ -13,7 +18,9 @@ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 ```
 
 ## Update submodule from repository
+
 Get fresh files from the `master` branch.
+
 ```sh
 cd tt/cli/aeon/protoc
 git co master
@@ -23,7 +30,9 @@ git add protoc
 ```
 
 ## Regenerate `pb` modules
+
 After that, you need to regenerate the files and add them to the `git` repository.
+
 ```sh
 tt/cli/aeon/generate-pb.sh
 git add tt/cli/aeon/pb

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -4,18 +4,18 @@ This file contains various examples of working with tt.
 
 ## Contents
 
-* [Working with a set of instances](#working-with-a-set-of-instances)
-* [Creating Cartridge application](#creating-cartridge-application)
-* [Working with application templates](#working-with-application-templates)
-* [Working with tt cluster (experimental)](#working-with-tt-cluster-experimental)
-* [Packing environments](#packing-environments)
-* [Working with tt daemon (experimental)](#working-with-tt-daemon-experimental)
-* [Transition from tarantoolctl to tt](#transition-from-tarantoolctl-to-tt)
-  * [System-wide configuration](#system-wide-configuration)
-  * [Local configuration](#local-configuration)
-  * [Commands difference](#commands-difference)
-* [Transition from Cartridge CLI to tt](#transition-from-cartridge-cli-to-tt)
-  * [Commands difference](#commands-difference)
+- [Working with a set of instances](#working-with-a-set-of-instances)
+- [Creating Cartridge application](#creating-cartridge-application)
+- [Working with application templates](#working-with-application-templates)
+- [Working with tt cluster (experimental)](#working-with-tt-cluster-experimental)
+- [Packing environments](#packing-environments)
+- [Working with tt daemon (experimental)](#working-with-tt-daemon-experimental)
+- [Transition from tarantoolctl to tt](#transition-from-tarantoolctl-to-tt)
+  + [System-wide configuration](#system-wide-configuration)
+  + [Local configuration](#local-configuration)
+  + [Commands difference](#commands-difference)
+- [Transition from Cartridge CLI to tt](#transition-from-cartridge-cli-to-tt)
+  + [Commands difference](#commands-difference)
 
 ## Working with a set of instances
 
@@ -97,27 +97,27 @@ $ tt start
 
 Create new tt environment, if it is not exist:
 
-``` console
-$ tt init
+``` sh
+tt init
 ```
 
 Create Cartridge application:
 
-``` console
-$ tt create cartridge --name myapp
+``` sh
+tt create cartridge --name myapp
 ```
 
 Build and start the application:
 
-``` console
-$ tt build myapp
-$ tt start myapp
+``` sh
+tt build myapp
+tt start myapp
 ```
 
 Bootstrap vshard:
 
-``` console
-$ tt cartridge replicasets setup --bootstrap-vshard --name myapp --run-dir ./var/run/myapp/
+``` sh
+tt cartridge replicasets setup --bootstrap-vshard --name myapp --run-dir ./var/run/myapp/
 ```
 
 Now open <http://localhost:8081/> and see your application's Admin Web
@@ -128,8 +128,8 @@ UI.
 For example, we want to create an application template. In order to do
 this, create a directory for the template:
 
-``` console
-$ mkdir -p ./templates/simple
+``` sh
+mkdir -p ./templates/simple
 ```
 
 with the content:
@@ -167,12 +167,14 @@ Create `./tt.yaml` and add templates search path to it:
 
 Here is how the current directory structure looks like:
 
+``` text
     ./
     ├── tt.yaml
     └── templates
         └── simple
             ├── init.lua.tt.template
             └── MANIFEST.yaml
+```
 
 Directory name `simple` can now be used as template name in create
 command. Create an application from the `simple` template and type
@@ -188,9 +190,11 @@ User name (default: admin): user1
 Your application will appear in the `simple_app` directory with the
 following content:
 
+``` text
     simple_app/
     ├── Dockerfile.build.tt
     └── init.lua
+```
 
 Instantiated `init.lua` content:
 
@@ -209,9 +213,9 @@ in the future.
 
 The module has following commands:
 
--   `tt cluster show SOURCE` - to show a cluster configuration from the
+- `tt cluster show SOURCE` - to show a cluster configuration from the
     `SOURCE`.
--   `tt cluster publish SOURCE config.yaml` - to publish a cluster
+- `tt cluster publish SOURCE config.yaml` - to publish a cluster
     configuration to the `SOURCE`.
 
 The `SOURCE` could be:
@@ -228,6 +232,7 @@ default host and port). We also has two files with a cluster and an instance
 configuration:
 
 `cluster.yaml`:
+
 ```yaml
 groups:
   group_name:
@@ -243,7 +248,9 @@ groups:
               listen:
               - uri: 127.0.0.1:3385
 ```
+
 `instance.yaml`:
+
 ```yaml
 iproto:
   listen:
@@ -252,7 +259,8 @@ iproto:
 ```
 
 Let's publish and show the configurations with a prefix `/tt`:
-```
+
+```text
 $ tt cluster publish "http://localhost:2379/tt" cluster.yaml
 $ tt cluster show "http://localhost:2379/tt"
 groups:
@@ -275,7 +283,8 @@ iproto:
 ```
 
 At now we could update an instance configuration and show the result:
-```
+
+```text
 $ tt cluster publish "http://localhost:2379/tt?name=instance2" instance.yaml
 $ tt cluster show "http://localhost:2379/tt"
 groups:
@@ -300,12 +309,14 @@ iproto:
 ```
 
 You could see the configuration in etcd with the command:
-```
-$ etcdctl get --prefix "/tt/"
+
+```sh
+etcdctl get --prefix "/tt/"
 ```
 
 The same works for an application configuration:
-```
+
+```text
 $ tt cluster publish test_app cluster.yaml
 $ tt cluster publish test_app:instance2 instance.yaml
 $ tt cluster show test_app
@@ -336,7 +347,7 @@ But `tt cluster show` is a little more complicated for the application. It
 collects configuration from all data sources (environment variables, etcd) and
 shows a combined configuration with the same logic as Tarantool:
 
-```
+```text
 $ TT_APP_FILE=init.lua tt cluster show test_app:instance2
 app:
   file: init.lua
@@ -351,9 +362,9 @@ by Tarantool.
 
 To view all available options for the commands, use the help command:
 
-```
-$ tt cluster show --help
-$ tt cluster publish --help
+```sh
+tt cluster show --help
+tt cluster publish --help
 ```
 
 ## Packing environments
@@ -361,9 +372,11 @@ $ tt cluster publish --help
 For example, we want to pack a single application. Here is the content
 of the sample application:
 
+```text
     single_environment/
     ├── tt.yaml
     └── init.lua
+```
 
 `tt.yaml`:
 
@@ -387,6 +400,7 @@ within the resulting package. This directory contains the application's code,
 `tt` and `tarantool`. The file structure of the resulting package can be
 seen below:
 
+``` text
     unpacked_dir/
     └── single_environment
         ├── bin
@@ -394,10 +408,12 @@ seen below:
         │   └── tt
         ├── init.lua
         └── tt.yaml
+```
 
 `tt` also supports multiple applications environment. Here's how a typical
 packed environment for multiple applications looks like:
 
+```text
     bundle/
     ├── bin
     │   ├── tarantool
@@ -415,7 +431,7 @@ packed environment for multiple applications looks like:
     │   ├── init.lua
     │   └── var
     └── tt.yaml
-
+```
 
 `tt.yaml`:
 
@@ -444,7 +460,7 @@ repo:
 ```
 
 Pay attention, that all absolute symlinks from
-<span class="title-ref">instances_enabled</span> will be resolved, all
+`instances_enabled` will be resolved, all
 sources will be copied to the result package and the final
 instances_enabled directory will contain only relative links.
 
@@ -477,10 +493,10 @@ be configured with `tt_daemon.yaml` config.
 
 You can manage TT daemon with following commands:
 
--   `tt daemon start` - launch of a daemon
--   `tt daemon stop` - terminate of the daemon
--   `tt daemon status` - get daemon status
--   `tt daemon restart` - daemon restart
+- `tt daemon start` - launch of a daemon
+- `tt daemon stop` - terminate of the daemon
+- `tt daemon status` - get daemon status
+- `tt daemon restart` - daemon restart
 
 Work scenario:
 
@@ -502,8 +518,8 @@ To send request to daemon you can use CURL. In this example the client
 sends a request to start `test_app` instance on the server side. Note:
 directory `test_app` (or file `test_app.lua`) exists on the server side.
 
-``` console
-$ curl --header "Content-Type: application/json" --request POST \
+``` sh
+curl --header "Content-Type: application/json" --request POST \
 --data '{"command_name":"start", "params":["test_app"]}' \
 http://127.0.0.1:1024/tarantool
 {"res":"   • Starting an instance [test_app]...\n"}
@@ -513,8 +529,8 @@ Below is an example of running a command with flags.
 
 Flag with argument:
 
-``` console
-$ curl --header "Content-Type: application/json" --request POST \
+``` sh
+curl --header "Content-Type: application/json" --request POST \
 --data '{"command_name":"version", "params":["-L", "/path/to/local/dir"]}' \
 http://127.0.0.1:1024/tarantool
 {"res":"Tarantool CLI version 0.1.0, darwin/amd64. commit: bf83f33\n"}
@@ -522,8 +538,8 @@ http://127.0.0.1:1024/tarantool
 
 Flag without argument:
 
-``` console
-$ curl --header "Content-Type: application/json" --request POST \
+``` sh
+curl --header "Content-Type: application/json" --request POST \
 --data '{"command_name":"version", "params":["-V"]}' \
 http://127.0.0.1:1024/tarantool
 {"res":"Tarantool CLI version 0.1.0, darwin/amd64. commit: bf83f33\n
@@ -539,7 +555,7 @@ supports `tarantoolctl` configuration defaults. So, after installation
 from repository `tt` can be used along with `tarantoolctl` for managing
 applications instances. Here is an example:
 
-```
+``` text
 $ sudo tt instances
 List of enabled applications:
 • example
@@ -631,6 +647,7 @@ After that we can use `tt` for managing Tarantool instances, checkpoint
 files and modules. Most of `tt` commands correspond to the same in
 `tarantoolctl`:
 
+``` text
     $ tt start app1
     • Starting an instance [app1]...
 
@@ -642,6 +659,7 @@ files and modules. Most of `tt` commands correspond to the same in
 
     $ tt check app1
     • Result of check: syntax of file '/home/user/instances.enabled/app1.lua' is OK
+```
 
 ### Commands difference
 
@@ -650,6 +668,7 @@ files and modules. Most of `tt` commands correspond to the same in
 
 `tarantoolctl`:
 
+```text
     $ tarantoolctl enter app1
     connected to unix/:./run/tarantool/app1.control
     unix/:./run/tarantool/app1.control>
@@ -669,9 +688,11 @@ files and modules. Most of `tt` commands correspond to the same in
     ---
     - 42
     ...
+```
 
 `tt` analog:
 
+```text
     $ tt connect app1
     • Connecting to the instance...
     • Connected to /home/user/run/tarantool/app1/app1.control
@@ -693,21 +714,25 @@ files and modules. Most of `tt` commands correspond to the same in
     ---
     - 42
     ...
+```
 
 ## Transition from Cartridge CLI to tt
 
 To start using `tt` for an existing Cartridge application run `tt init`
 command in application's directory:
 
+``` text
     $ tt init
     • Found existing config '.cartridge.yml'
     • Environment config is written to 'tt.yaml'
+```
 
 `tt init` searches for `.cartridge.yml` and uses configured paths from
 it in `tt.yaml`. After `tt.yaml` config is generated, `tt` can be used
 to manage cartridge application. Most of `cartridge` commands have their
 counterparts in `tt`: build, start, stop, status, etc.:
 
+``` text
     $ tt start
     • Starting an instance [app:s1-master]...
     • Starting an instance [app:s1-replica]...
@@ -722,14 +747,14 @@ counterparts in `tt`: build, start, stop, status, etc.:
     • app:s2-master: RUNNING. PID: 13179.
     • app:s2-replica: RUNNING. PID: 13180.
     • app:stateboard: RUNNING. PID: 13182.
+```
 
 ### Commands difference
 
--   Some of cartridge application management commands are subcommands of
+- Some of cartridge application management commands are subcommands of
     `tt cartridge`:
 
-<!-- -->
-
+``` text
     USAGE
       tt cartridge [flags] <command> [command flags]
 
@@ -739,12 +764,12 @@ counterparts in `tt`: build, start, stop, status, etc.:
       failover    Manage application failover
       repair      Patch cluster configuration files
       replicasets Manage application replica sets
+```
 
--   `cartridge enter` and `cartridge connect` functionality is covered
+- `cartridge enter` and `cartridge connect` functionality is covered
     by `tt connect`:
 
-<!-- -->
-
+``` text
     $ tt connect app:router
     • Connecting to the instance...
     • Connected to app:router
@@ -756,8 +781,9 @@ counterparts in `tt`: build, start, stop, status, etc.:
     • Connected to localhost:3302
 
     localhost:3302>
+```
 
--   `cartridge log` and `cartridge pack docker` functionality is not
+- `cartridge log` and `cartridge pack docker` functionality is not
     supported in `tt` yet.
--   Shell autocompletion scripts generation command
+- Shell autocompletion scripts generation command
     `cartridge gen completion` is `tt completion` in `tt`.

--- a/doc/known_issues.md
+++ b/doc/known_issues.md
@@ -6,7 +6,7 @@ the [Github Issues page](https://github.com/tarantool/tt/issues).
 
 ## Contents
 
-* [Do not set the box.cfg.background](#do-not-set-the-boxcfgbackground)
+- [Do not set the box.cfg.background](#do-not-set-the-boxcfgbackground)
 
 ## Do not set the box.cfg.background
 

--- a/doc/migration_from_older_versions.md
+++ b/doc/migration_from_older_versions.md
@@ -6,13 +6,14 @@ contains breaking changes descriptions.
 
 ## Contents
 
-* [1.3.1 -> 2.0.0](#1.3.1-->-2.0.0)
+- [1.3.1 -> 2.0.0](#131---200)
 
 ## 1.3.1 -> 2.0.0
 
 ### New format of tt config file
 
 `tt` 2.0.0 configuration file format is incompatible with previous version:
+
 - Root `tt` section is removed.
 - Common environment configuration is moved to the `env` section.
 All relative paths in this section are relative to the config file location.
@@ -21,6 +22,7 @@ All relative paths in this section are relative to the config file location.
 ### New runtime artifacts layout
 
 Runtime artifacts layout is changed:
+
 - Relative paths are relative to the application directory. In case of
 single script instance, a directory is created in the instances
 enabled directory.
@@ -28,7 +30,7 @@ enabled directory.
 only instance name is appended to the result directory. Here is an
 example of 2.0.0 default layout for a local environment:
 
-```
+```text
 instances.enabled/app/
 ├── init.lua
 ├── instances.yml
@@ -45,6 +47,7 @@ instances.enabled/app/
 ```
 
 Moving artifacts from 1.* versions:
+
 - Create artifacts directories in application dir: var/lib, var/log, var/run.
 - Copy instance sub-directories from 1.* environment to application
 dir. Data artifacts copying example:


### PR DESCRIPTION
Enable markdown linter with `pre-commit` hook.
Update markdown files to meet the linter requirements.

- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Closes #TNTP-3107

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
