### PR TITLE
format: turn off Markdown linter for github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,7 @@ What has been done? Why? What problem is being solved?
 
 I didn't forget about (remove if it is not applicable):
 
-- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how
- to write a commit message)
+- [ ] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
 - [ ] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
 - [ ] Tests (see [documentation][go-testing] for a testing package)
 - [ ] Changelog (see [documentation][keepachangelog] for changelog format)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         types_or: [go, python, markdown]
         exclude: |
           (?x)^(
-                .*\.pb.go|
+                .*\.pb\.go|
                 .*/third_party/.*
           )$
         additional_dependencies:
@@ -134,6 +134,8 @@ repos:
       - id: markdownlint-cli2
         name: "MD: check markdown files"
         stages: [pre-commit, manual]
+        # Ignore Markdown rules for `.github`, due to specific formatting for Pull Requests.
+        exclude: \.github/.*\.md$
         args: [--fix]
 
   - repo: https://github.com/jorisroovers/gitlint


### PR DESCRIPTION
Restore `.github/pull_request_template.md` and disable Markdown's linters for `.github` directory.

I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Part of #TNTP-3107

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
