### PR TITLE
replicaset: more informative error at bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tt cluster failover switch`: minor change in output that displays corresponding
   `switch-status` command with quoted URI argument so it could be copy-pasted for
   subsequent launch as-is.
+- `tt rs vshard bootstrap`: make more informative error message when sharding roles
+  are not configured (for example when launched against non-vshard cluster).
 
 ### Fixed
 

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -26,7 +26,8 @@ var (
 	//go:embed lua/cconfig/bootstrap_vshard_body.lua
 	cconfigBootstrapVShardBody string
 
-	cconfigGetShardingRolesBody = "return require('config'):get().sharding.roles"
+	//go:embed lua/cconfig/get_sharding_roles_body.lua
+	cconfigGetShardingRolesBody string
 )
 
 // cconfigTopology used to export topology information from a Tarantool

--- a/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
+++ b/cli/replicaset/lua/cconfig/bootstrap_vshard_body.lua
@@ -1,12 +1,15 @@
+local sharding = require('config'):get().sharding
+if sharding == nil or sharding.roles == nil then
+    error("sharding roles are not configured, please make sure managed cluster is sharded")
+end
+
 local ok, vshard = pcall(require, 'vshard')
 if not ok then
     error("failed to require vshard module")
 end
-local fiber = require('fiber')
-local config = require('config')
 
 local is_router = false
-for _, role in ipairs(config:get().sharding.roles) do
+for _, role in ipairs(sharding.roles) do
     if role == "router" then
         is_router = true
         break
@@ -19,6 +22,7 @@ end
 
 pcall(vshard.router.master_search_wakeup)
 
+local fiber = require('fiber')
 local timeout = ...
 local deadline = fiber.time() + timeout
 local ok, err

--- a/cli/replicaset/lua/cconfig/get_sharding_roles_body.lua
+++ b/cli/replicaset/lua/cconfig/get_sharding_roles_body.lua
@@ -1,0 +1,5 @@
+local sharding = require('config'):get().sharding
+if sharding == nil or sharding.roles == nil then
+    error("sharding roles are not configured, please make sure managed cluster is sharded")
+end
+return sharding.roles

--- a/test/integration/replicaset/test_replicaset_vshard.py
+++ b/test/integration/replicaset/test_replicaset_vshard.py
@@ -352,3 +352,19 @@ def test_vshard_bootstrap_not_enough_timeout(tt_cmd, vshard_cconfig_app_timeout_
     assert rc == 1
     assert "failed to bootstrap vshard" in out
     assert "attempt to index field '_configdata_applied' (a nil value)" in out
+
+
+@pytest.mark.parametrize("target_type", ["APP", "INST", "URI"])
+def test_vshard_bootstrap_non_vshard(tt, cluster, target_type):
+    targets = {
+        "APP": cluster.app_name,
+        "INST": f"{cluster.app_name}:{cluster.instances[0]['name']}",
+        "URI": f"client:secret@{cluster.instances[0]['endpoint']}",
+    }
+
+    p = cluster.start()
+    assert p.returncode == 0
+    assert cluster.wait_for_running(5)
+    p = tt.run("rs", "vshard", "bootstrap", targets[target_type])
+    assert p.returncode != 0
+    assert "sharding roles are not configured" in p.stdout


### PR DESCRIPTION
Make more invormative error when trying to bootstrap non-vshard cluster with `tt rs vshard bootstrap` command.

I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Tests (see [documentation][go-testing] for a testing package)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1201

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
