### PR TITLE
coredump: fix fiber commands of gdb extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `tt coredump`: adjust Tarantool GDB-extention to avoid load failure if `main_cord`
+  symbol is `optimized out` in gdb session.
+
 ## [2.11.0] - 2025-09-10
 
 The release supports Tarantool Config Storage in `tt cluster failover` commands and

--- a/cli/coredump/extensions/tarantool-gdb.py
+++ b/cli/coredump/extensions/tarantool-gdb.py
@@ -1560,7 +1560,7 @@ class ListLut(object):
         if not hasattr(cls, '_containers_map'):
             cls._containers_map = cls.__build_containers_map(cls._containers)
 
-    __symbol_re = re.compile('(\w+)(?:\s*\+\s*(\d+))?')
+    __symbol_re = re.compile(r'(\w+)(?:\s*\+\s*(\d+))?')
 
     @classmethod
     def lookup_entry_info(cls, address):
@@ -2582,16 +2582,14 @@ def fiber():
 
 
 class Cord(object):
-    __main_cord_fibers = gdb.parse_and_eval('main_cord.alive')
-    __list_entry_info = RlistLut.lookup_entry_info(__main_cord_fibers.address)
-
     def __init__(self):
         self.__cord_ptr = cord()
 
     def fibers(self):
         fibers = self.__cord_ptr['alive']
         fibers = Rlist(fibers.address)
-        fibers = map(lambda x: self.__class__.__list_entry_info.container_from_field(x), fibers)
+        list_entry_info = RlistLut.lookup_entry_info_by_container(ContainerFieldInfo("cord::alive"))
+        fibers = map(lambda x: list_entry_info.container_from_field(x), fibers)
         return itertools.chain(fibers, [self.__cord_ptr['sched'].address])
 
     def fiber(self, fid):


### PR DESCRIPTION
Prior to this patch Tarantool GDB-extension failed during loading if `main_cord` symbol is optimized out. As a result fiber-related commands were not available, namely `info tt-fibers` and `tt-fiber`.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Don't forget about TarantoolBot in a commit message (see [example][tarantoolbot-example])
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Related issues:

Closes #1206

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits

