### PR TITLE
integrity: consider 'instances.enabled' directory

### DIFF
--- a/.gitlint-precommit.ini
+++ b/.gitlint-precommit.ini
@@ -27,17 +27,17 @@ min-length=10
 line-length = 72
 
 [body-match-regex:reference_task_id]
-; Task ID can be in digital format as "#123" or with capital letters "#ABC-123"
+; Task ID can be in digital format as "#123" (github task) or "ABC-123" (external task).
+; NOTE: External task ID starts with letter, there should be no number sign (#) at the beginning.
 ; Allows following reference like:
 ; - Closes #123
-; - Closes #TNTP-123
-; - Fixes #TNTP-123
+; - Fixes #123
 ; - Related to #123
-; - Part of #TNTP-123
+; - Part of #123
 ; - Needed for #123
-regex = (?m)^(?:Closes|Fixes|Related to|Part of|Needed for) #(?:[A-Z]+-)?\d+$
+regex = (?m)^(?:Closes|Fixes|Related to|Part of|Needed for) (?:(?:\w+/\w+)?#|[A-Z]+-)\d+$
 
-; TODO: If required to let following markers: "See also #1234, #TNTP-3456, ..." (#TNTP-3108).
+; TODO: If required to let following markers: "See also #1234, TNTP-3456, ..." (TNTP-3108).
 ; https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
 ; Need solve how to enable both regexes at once. Now they works as AND rules, while we need here OR.
 ;? [body-match-regex:multiple_tasks]

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -278,11 +278,14 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 			return nil, "", fmt.Errorf("cannot determine config file path: %s", err)
 		}
 		// Config file is found, load it.
-		f, err := repository.Read(configPath)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to validate integrity of %q: %w", configPath, err)
+		if repository != nil {
+			f, err := repository.Read(configPath)
+			if err != nil {
+				return nil, "",
+					fmt.Errorf("failed to validate integrity of %q: %w", configPath, err)
+			}
+			f.Close()
 		}
-		f.Close()
 		rawConfigOpts, err := util.ParseYAML(configPath)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to parse Tarantool CLI configuration: %s", err)

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -190,7 +190,10 @@ func appSrcCopySkip(packCtx *PackCtx, cliOpts *config.CliOpts,
 }
 
 // getAppNamesToPack generates application names list to pack.
-func getAppNamesToPack(packCtx *PackCtx) []string {
+func getAppNamesToPack(packCtx *PackCtx, cliOpts *config.CliOpts) []string {
+	if cliOpts.Env.InstancesEnabled == "." {
+		return nil
+	}
 	appList := make([]string, len(packCtx.AppsInfo))
 	i := 0
 	for appName := range packCtx.AppsInfo {
@@ -394,7 +397,7 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	}()
 	bundleEnvPath := tmpDir
 
-	packCtx.AppList = getAppNamesToPack(packCtx)
+	packCtx.AppList = getAppNamesToPack(packCtx, cliOpts)
 	log.Infof("Apps to pack: %s", strings.Join(packCtx.AppList, " "))
 
 	if bundleEnvPath, err = updateEnvPath(bundleEnvPath, packCtx, cliOpts); err != nil {
@@ -449,7 +452,7 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 		return "", err
 	}
 
-	if packCtx.IntegrityPrivateKey != "" {
+	if signer != nil {
 		err = signer.Sign(bundleEnvPath, packCtx.AppList)
 		if err != nil {
 			return "", err

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -44,7 +44,9 @@ func RegisterIntegrityCheckFlag(flagset *pflag.FlagSet, dst *string) {}
 func RegisterIntegrityCheckPeriodFlag(flagset *pflag.FlagSet, dst *int) {}
 
 // InitializeIntegrityCheck is a noop setup of integrity checking.
-func InitializeIntegrityCheck(publicKeyPath, configDir string) (IntegrityCtx, error) {
+func InitializeIntegrityCheck(
+	publicKeyPath, configDir, instancesEnabledDir string,
+) (IntegrityCtx, error) {
 	if publicKeyPath != "" {
 		return IntegrityCtx{}, errors.New("integrity checks should never be initialized in ce")
 	}

--- a/lib/integrity/integrity_test.go
+++ b/lib/integrity/integrity_test.go
@@ -35,26 +35,41 @@ func TestNewSigner(t *testing.T) {
 
 func TestInitializeIntegrityCheckWithKey(t *testing.T) {
 	testCases := []struct {
-		name          string
-		publicKeyPath string
-		configDir     string
+		name                string
+		publicKeyPath       string
+		configDir           string
+		instancesEnabledDir string
 	}{
 		{
-			name:          "Empty config path",
-			publicKeyPath: "public.pem",
-			configDir:     "",
+			name:                "Empty config path",
+			publicKeyPath:       "public.pem",
+			configDir:           "",
+			instancesEnabledDir: "instances.enabled",
 		},
 		{
-			name:          "Arbitrary config path",
-			publicKeyPath: "public.pem",
-			configDir:     "app",
+			name:                "Arbitrary config path",
+			publicKeyPath:       "public.pem",
+			configDir:           "app",
+			instancesEnabledDir: "instances.enabled",
+		},
+		{
+			name:                "Empty instance.enabled path",
+			publicKeyPath:       "public.pem",
+			configDir:           "app",
+			instancesEnabledDir: "",
+		},
+		{
+			name:                "Special instance.enabled path",
+			publicKeyPath:       "public.pem",
+			configDir:           "app",
+			instancesEnabledDir: ".",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := integrity.InitializeIntegrityCheck(testCase.publicKeyPath,
-				testCase.configDir)
+				testCase.configDir, testCase.instancesEnabledDir)
 			require.EqualError(t, err,
 				"integrity checks should never be initialized in ce",
 				"an error should be produced")
@@ -64,26 +79,41 @@ func TestInitializeIntegrityCheckWithKey(t *testing.T) {
 
 func TestInitializeIntegrityCheckWithoutKey(t *testing.T) {
 	testCases := []struct {
-		name          string
-		publicKeyPath string
-		configDir     string
+		name                string
+		publicKeyPath       string
+		configDir           string
+		instancesEnabledDir string
 	}{
 		{
-			name:          "Empty config path",
-			publicKeyPath: "",
-			configDir:     "",
+			name:                "Empty config path",
+			publicKeyPath:       "",
+			configDir:           "",
+			instancesEnabledDir: "instances.enabled",
 		},
 		{
-			name:          "Arbitrary config path",
-			publicKeyPath: "",
-			configDir:     "app",
+			name:                "Arbitrary config path",
+			publicKeyPath:       "",
+			configDir:           "app",
+			instancesEnabledDir: "instances.enabled",
+		},
+		{
+			name:                "Empty instance.enabled path",
+			publicKeyPath:       "",
+			configDir:           "app",
+			instancesEnabledDir: "",
+		},
+		{
+			name:                "Special instance.enabled path",
+			publicKeyPath:       "",
+			configDir:           "app",
+			instancesEnabledDir: ".",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx, err := integrity.InitializeIntegrityCheck(testCase.publicKeyPath,
-				testCase.configDir)
+				testCase.configDir, testCase.instancesEnabledDir)
 			require.NoError(t, err,
 				"initialization should pass successfully")
 			require.NotNil(t, ctx.Repository,


### PR DESCRIPTION
Adjust API of integrity library which is common for CE/EE. It doesn't affect functionality of CE at all, but is needed to implement lack of functionality in EE.

Also there were failing test and it is resolved into a bunch of problems that appeared mostly with `tt install tarantool`. All the discovered problems were resolved and included into this PR (in separate commits).

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Part of TNTP-5214
Closes #1220
Closes #1221 
Closes #1222 
Related to tarantool/tarantool#12167

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
