### PR TITLE
Release 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.11.1] - 2026-01-19
+
+The release allows `--cartridge-compat` flag for the `tt pack deb|rpm` commands.
+Also it includes several fixes for the `tt install` and `tt pack` commands and
+docker container used by these commands is upgraded to Ubuntu 20.04.
+
+### Added
+
 - `pack`: if the `--cartridge-compat` flag is set `pack deb` and `pack rpm`
   commands add files with application and tarantool versions to the package.
 


### PR DESCRIPTION
The release allows `--cartridge-compat` flag for the `tt pack deb|rpm` commands.
Also it includes several fixes for the `tt install` and `tt pack` commands and
docker container used by these commands is upgraded to Ubuntu 20.04.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)
- [x] Changelog (see [documentation][keepachangelog] for changelog format)

Closes TNTP-5621

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
