### PR TITLE
ci: put static code check into a separate job

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -15,6 +15,18 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
+  static-code-check:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Static code check
+        uses: ./.github/actions/static-code-check
+
   full-ci-ce:
     if: |
       (github.event_name == 'push') ||
@@ -39,9 +51,6 @@ jobs:
         uses: ./.github/actions/prepare-ce-test-env
         with:
           tarantool-version: '${{ matrix.tarantool-version }}'
-
-      - name: Static code check
-        uses: ./.github/actions/static-code-check
 
       - name: Unit tests
         run: mage unitfull
@@ -143,9 +152,6 @@ jobs:
         with:
           sdk-version: '${{ matrix.sdk-version }}'
           sdk-download-token: '${{ secrets.SDK_DOWNLOAD_TOKEN }}'
-
-      - name: Static code check
-        uses: ./.github/actions/static-code-check
 
       - name: Unit tests
         run: mage unitfull


### PR DESCRIPTION
Fixup for #3dd8f0b6f (also applied to full-ci workflow).

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Needed for TNTP-6083

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
