### PR TITLE
fix: change integrity check signal

### DIFF
--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -189,7 +189,7 @@ func (wd *Watchdog) startIntegrityChecks(ctx context.Context) {
 				if err != nil {
 					// Integrity check failed.
 					wd.logger.Printf("(ERROR): periodic integrity check failed: %q.", err)
-					wd.instance.SendSignal(syscall.SIGUSR2)
+					wd.instance.SendSignal(syscall.SIGKILL)
 					return
 				}
 


### PR DESCRIPTION
The functionality to block the instance when an error is received in integrity check on the SIGUSR2 signal was not implemented by Tarantool. Instead, starting with Tarantool 3.5, SIGUSR2 restarts the config, which means it is not suitable for the integrity check functionality. It needs to be changed to a different signal.

Part of TNTP-6578