### PR TITLE
status: add support for multiple output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt pack`: support nested `.packignore` at the root of tt environment.
+- `tt status`: add `--format` option to support JSON and YAML output formats
+for machine-readable output.
 
 ### Changed
+
+- `tt status`: deprecate `--pretty` option in favor of `--format=pretty-table`.
 
 ### Fixed
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmd/internal"
 	"github.com/tarantool/tt/cli/cmdcontext"
@@ -8,7 +10,17 @@ import (
 	"github.com/tarantool/tt/cli/status"
 )
 
-var opts status.StatusOpts
+// statusOpts contains options for tt status.
+type statusOpts struct {
+	// Output format: json, yaml, table, pretty-table.
+	format string
+	// Option for detailed alerts output for each instance, such as warnings and errors.
+	details bool
+	// Deprecated: use --format instead.
+	pretty bool
+}
+
+var opts statusOpts
 
 // NewStatusCmd creates status command.
 func NewStatusCmd() *cobra.Command {
@@ -43,8 +55,12 @@ Columns:
 		},
 	}
 
-	statusCmd.Flags().BoolVarP(&opts.Pretty, "pretty", "p", false, "pretty-print table")
-	statusCmd.Flags().BoolVarP(&opts.Details, "details", "d", false, "print detailed alerts.")
+	statusCmd.Flags().StringVarP(&opts.format, "format", "f", "table",
+		"output format: json, yaml, table, pretty-table")
+	statusCmd.Flags().BoolVarP(&opts.details, "details", "d", false, "print detailed alerts.")
+	statusCmd.Flags().BoolVarP(&opts.pretty, "pretty", "p", false,
+		"output a pretty-formatted table (deprecated, use --format instead)")
+	statusCmd.Flags().MarkDeprecated("pretty", "use --format instead")
 
 	return statusCmd
 }
@@ -55,12 +71,40 @@ func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return errNoConfig
 	}
 
+	// Handle deprecated --pretty flag.
+	if opts.pretty {
+		opts.format = "pretty-table"
+	}
+
+	// Validate format option.
+	validFormats := map[string]bool{
+		"json":         true,
+		"yaml":         true,
+		"table":        true,
+		"pretty-table": true,
+	}
+	if !validFormats[opts.format] {
+		return fmt.Errorf("invalid format: %s. Valid formats are: json, yaml, table, pretty-table",
+			opts.format)
+	}
+
 	var runningCtx running.RunningCtx
 	err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args, running.ConfigLoadSkip)
 	if err != nil {
 		return err
 	}
 
-	err = status.Status(runningCtx, opts)
-	return err
+	var printer status.InstanceStatusPrinter
+	switch opts.format {
+	case "json":
+		printer = status.NewJSONPrinter()
+	case "yaml":
+		printer = status.NewYAMLPrinter()
+	case "pretty-table":
+		printer = status.NewTablePrinter(status.WithPretty(), status.WithDetails(opts.details))
+	case "table":
+		printer = status.NewTablePrinter(status.WithDetails(opts.details))
+	}
+
+	return status.Status(runningCtx, printer)
 }

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -22,7 +22,7 @@ const defaultDirPerms = 0o770
 
 type ProcessState struct {
 	Code        int
-	ColorSprint func(a ...interface{}) string
+	colorSprint func(a ...any) string
 	Status      string
 	PID         int
 }
@@ -36,20 +36,25 @@ const (
 var (
 	ProcStateRunning = ProcessState{
 		Code:        ProcessRunningCode,
-		ColorSprint: color.New(color.FgGreen).SprintFunc(),
+		colorSprint: color.New(color.FgGreen).SprintFunc(),
 		Status:      "RUNNING",
 	}
 	ProcStateStopped = ProcessState{
 		Code:        ProcessStoppedCode,
-		ColorSprint: color.New(color.FgYellow).SprintFunc(),
+		colorSprint: color.New(color.FgYellow).SprintFunc(),
 		Status:      "NOT RUNNING",
 	}
 	ProcStateDead = ProcessState{
 		Code:        ProcessDeadCode,
-		ColorSprint: color.New(color.FgRed).SprintFunc(),
+		colorSprint: color.New(color.FgRed).SprintFunc(),
 		Status:      "ERROR. The process is dead",
 	}
 )
+
+// FormattedStatus returns the status string formatted with the appropriate color.
+func (procState ProcessState) FormattedStatus() string {
+	return procState.colorSprint(procState.Status)
+}
 
 // String makes a string from ProcessState.
 func (procState ProcessState) String() string {

--- a/cli/status/json_printer.go
+++ b/cli/status/json_printer.go
@@ -1,0 +1,24 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JSONPrinter implements InstanceStatusPrinter for JSON output.
+type JSONPrinter struct{}
+
+// NewJSONPrinter creates a new JSONPrinter instance.
+func NewJSONPrinter() *JSONPrinter {
+	return &JSONPrinter{}
+}
+
+// Print outputs the instance status map in JSON format.
+func (j JSONPrinter) Print(instances map[string]*instanceStatus) error {
+	jsonData, err := json.MarshalIndent(instances, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal instances to JSON: %w", err)
+	}
+	fmt.Println(string(jsonData))
+	return nil
+}

--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -3,17 +3,18 @@ package status
 import (
 	_ "embed"
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/fatih/color"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/mitchellh/mapstructure"
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/running"
 )
+
+// InstanceStatusPrinter interface defines methods to output instance status information.
+type InstanceStatusPrinter interface {
+	Print(instances map[string]*instanceStatus) error
+}
 
 //go:embed lua/instance_state.lua
 var instanceInfoLuaScript string
@@ -32,14 +33,6 @@ func filterComments(script string) string {
 	return strings.Join(filteredLines, "\n")
 }
 
-// StatusOpts contains options for tt status.
-type StatusOpts struct {
-	// Option for pretty-formatted table output.
-	Pretty bool
-	// Option for detailed alerts output for each instance, such as warnings and errors.
-	Details bool
-}
-
 type alert struct {
 	Type    string `mapstructure:"type"`
 	Message string `mapstructure:"message"`
@@ -55,44 +48,63 @@ type upstream struct {
 	Message string `mapstructure:"message"`
 }
 
-type replicationInfo struct {
+type rawReplicationInfo struct {
 	UUID     string   `mapstructure:"uuid"`
 	Name     *string  `mapstructure:"name"`
 	Upstream upstream `mapstructure:"upstream"`
 }
 
-type instanceState struct {
-	ReplicationInfo []replicationInfo `mapstructure:"replication_info"`
-	ConfigInfo      configInfo        `mapstructure:"config_info"`
-	ReadOnly        string            `mapstructure:"read_only"`
-	BoxStatus       string            `mapstructure:"box_status"`
-	UUID            string            `mapstructure:"uuid"`
+type rawInstanceState struct {
+	ReplicationInfo []rawReplicationInfo `mapstructure:"replication_info"`
+	ConfigInfo      configInfo           `mapstructure:"config_info"`
+	ReadOnly        string               `mapstructure:"read_only"`
+	BoxStatus       string               `mapstructure:"box_status"`
+	UUID            string               `mapstructure:"uuid"`
 }
 
-func newInstanceStatusMap() map[string]interface{} {
-	return map[string]interface{}{
-		"STATUS":   "",
-		"PID":      nil,
-		"MODE":     "",
-		"CONFIG":   defaultModuleStatus,
-		"BOX":      defaultModuleStatus,
-		"UPSTREAM": defaultModuleStatus,
+type severity string
+
+const (
+	severityError   severity = "error"
+	severityWarning severity = "warning"
+)
+
+type instanceAlert struct {
+	Message  string   `json:"message"`
+	Severity severity `json:"severity"`
+}
+
+type instanceStatus struct {
+	Status             string                     `json:"status"`
+	PID                *int                       `json:"pid"`
+	Mode               string                     `json:"mode"`
+	Config             string                     `json:"config"`
+	Box                string                     `json:"box"`
+	Upstream           string                     `json:"upstream"`
+	Alerts             []instanceAlert            `json:"alerts"`
+	rawReplicationInfo []rawReplicationInfo       `json:"-" yaml:"-"`
+	procStatus         process_utils.ProcessState `json:"-" yaml:"-"`
+}
+
+func (is *instanceStatus) addAlert(message string, severity severity) {
+	is.Alerts = append(is.Alerts, instanceAlert{
+		Message:  message,
+		Severity: severity,
+	})
+}
+
+func newInstanceStatus() instanceStatus {
+	return instanceStatus{
+		Config:   defaultModuleStatus,
+		Box:      defaultModuleStatus,
+		Upstream: defaultModuleStatus,
 	}
 }
 
-var (
-	instances       = map[string]map[string]interface{}{}
-	instancesAlerts = map[string][]string{}
-	uuid2name       = map[string]string{}
-)
+type instanceStatusMap = map[string]*instanceStatus
 
-var (
-	printYellow = color.New(color.FgYellow).SprintFunc()
-	printRed    = color.New(color.FgRed).SprintFunc()
-)
-
-func processReplicationInfo(fullInstanceName string, instanceState instanceState) {
-	for _, repl := range instanceState.ReplicationInfo {
+func processReplicationInfo(instStatus *instanceStatus, uuid2name map[string]string) {
+	for _, repl := range instStatus.rawReplicationInfo {
 		fullInstanceUpstreamName, ok := uuid2name[repl.UUID]
 		// Use repl.Name if available, otherwise fallback to repl.UUID
 		if !ok {
@@ -105,7 +117,7 @@ func processReplicationInfo(fullInstanceName string, instanceState instanceState
 		if repl.Upstream.Status == "follow" || len(repl.Upstream.Message) == 0 {
 			continue
 		}
-		instances[fullInstanceName]["UPSTREAM"] = repl.Upstream.Status
+		instStatus.Upstream = repl.Upstream.Status
 
 		var upstreamInstanceDesc string
 		if ok || repl.Name != nil {
@@ -115,91 +127,91 @@ func processReplicationInfo(fullInstanceName string, instanceState instanceState
 			upstreamInstanceDesc = fmt.Sprintf("instance with UUID %s",
 				fullInstanceUpstreamName)
 		}
-		instancesAlerts[fullInstanceName] = append(instancesAlerts[fullInstanceName],
-			printYellow(fmt.Sprintf(
-				"[upstream][warning]: replication from %s is in %q status: %q",
-				upstreamInstanceDesc, repl.Upstream.Status,
-				repl.Upstream.Message)))
+		instStatus.addAlert(fmt.Sprintf(
+			"[upstream][warning]: replication from %s is in %q status: %q",
+			upstreamInstanceDesc, repl.Upstream.Status,
+			repl.Upstream.Message), severityWarning)
 	}
 }
 
-func processConfigInfo(fullInstanceName string, instanceState instanceState) {
+func processConfigInfo(instStatus *instanceStatus, instanceState rawInstanceState) {
 	if len(instanceState.ConfigInfo.Alerts) == 0 {
 		return
 	}
 	for _, alert := range instanceState.ConfigInfo.Alerts {
-		msg := ""
+		severity := severityWarning
 		if alert.Type == "error" {
-			msg = printRed(fmt.Sprintf("[config][error]: %s", alert.Message))
-		} else {
-			msg = printYellow(fmt.Sprintf("[config][warning]: %s", alert.Message))
+			severity = severityError
 		}
-		instancesAlerts[fullInstanceName] = append(instancesAlerts[fullInstanceName], msg)
+		instStatus.addAlert(fmt.Sprintf("[config][%s]: %s", alert.Type, alert.Message), severity)
 	}
 }
 
+// collectInstanceState connects to an instance and collects its state.
+func collectInstanceState(run running.InstanceCtx, fullInstanceName string,
+	instStatus *instanceStatus,
+) (rawInstanceState, error) {
+	var instanceState rawInstanceState
+
+	conn, err := connector.Connect(connector.ConnectOpts{
+		Network: "unix",
+		Address: run.ConsoleSocket,
+	})
+	if err != nil {
+		if instStatus.procStatus.Code == process_utils.ProcessRunningCode {
+			instStatus.addAlert(fmt.Sprintf(
+				"Error while connecting to instance %s via socket %s: %v",
+				fullInstanceName, run.ConsoleSocket, err), severityError)
+		}
+		return instanceState, fmt.Errorf("failed to connect to instance %s: %w",
+			fullInstanceName, err)
+	}
+
+	res, err := conn.Eval(filterComments(instanceInfoLuaScript), []any{},
+		connector.RequestOpts{})
+	if err != nil {
+		instStatus.addAlert(fmt.Sprintf(
+			"Error while executing Lua script on instance %s: %v",
+			fullInstanceName, err), severityError)
+		return instanceState, fmt.Errorf("failed to execute Lua script on instance %s: %w",
+			fullInstanceName, err)
+	}
+
+	if len(res) == 0 {
+		instStatus.addAlert(fmt.Sprintf(
+			"No data returned from Lua script on instance %s",
+			fullInstanceName), severityError)
+		return instanceState, fmt.Errorf("no data returned from Lua script")
+	}
+
+	err = mapstructure.Decode(res[0], &instanceState)
+	if err != nil {
+		instStatus.addAlert(fmt.Sprintf("Error while decoding data from "+
+			"instance %s: %v", fullInstanceName, err), severityError)
+		return instanceState, fmt.Errorf("failed to decode data from instance %s: %w",
+			fullInstanceName, err)
+	}
+
+	return instanceState, nil
+}
+
 // Status writes the status as a table.
-func Status(runningCtx running.RunningCtx, opts StatusOpts) error {
-	ts := table.NewWriter()
-	ts.SetOutputMirror(os.Stdout)
-	ts.AppendHeader(
-		table.Row{"INSTANCE", "STATUS", "PID", "MODE", "CONFIG", "BOX", "UPSTREAM"})
-
-	instanceRawState := map[string]instanceState{}
-
+func Status(runningCtx running.RunningCtx, printer InstanceStatusPrinter) error {
+	instances := make(instanceStatusMap)
+	uuid2name := map[string]string{}
 	for _, run := range runningCtx.Instances {
 		fullInstanceName := running.GetAppInstanceName(run)
-		procStatus := running.Status(&run)
-		instances[fullInstanceName] = newInstanceStatusMap()
-		instances[fullInstanceName]["STATUS"] = procStatus.ColorSprint(procStatus.Status)
+		instStatus := newInstanceStatus()
+		instStatus.procStatus = running.Status(&run)
+		instStatus.Status = instStatus.procStatus.Status
+		instances[fullInstanceName] = &instStatus
 
-		if procStatus.Code == process_utils.ProcessRunningCode {
-			instances[fullInstanceName]["PID"] = procStatus.PID
+		if instStatus.procStatus.Code == process_utils.ProcessRunningCode {
+			instStatus.PID = &instStatus.procStatus.PID
 		}
 
-		conn, err := connector.Connect(connector.ConnectOpts{
-			Network: "unix",
-			Address: run.ConsoleSocket,
-		})
-
-		if err != nil && procStatus.Code == process_utils.ProcessRunningCode {
-			instancesAlerts[fullInstanceName] = append(
-				instancesAlerts[fullInstanceName],
-				printRed(fmt.Sprintf(
-					"Error while connecting to instance %s via socket %s: %v",
-					fullInstanceName, run.ConsoleSocket, err)))
-			continue
-		} else if err != nil {
-			continue
-		}
-
-		var instanceState instanceState
-		res, err := conn.Eval(filterComments(instanceInfoLuaScript), []any{},
-			connector.RequestOpts{})
+		instanceState, err := collectInstanceState(run, fullInstanceName, &instStatus)
 		if err != nil {
-			instancesAlerts[fullInstanceName] = append(
-				instancesAlerts[fullInstanceName],
-				printRed(fmt.Sprintf(
-					"Error while executing Lua script on instance %s: %v",
-					fullInstanceName, err)))
-			continue
-		}
-
-		if len(res) == 0 {
-			instancesAlerts[fullInstanceName] = append(
-				instancesAlerts[fullInstanceName],
-				printRed(fmt.Sprintf(
-					"No data returned from Lua script on instance %s",
-					fullInstanceName)))
-			continue
-		}
-
-		err = mapstructure.Decode(res[0], &instanceState)
-		if err != nil {
-			instancesAlerts[fullInstanceName] = append(
-				instancesAlerts[fullInstanceName],
-				printRed(fmt.Sprintf("Error while decoding data from "+
-					"instance %s: %v", fullInstanceName, err)))
 			continue
 		}
 
@@ -207,71 +219,15 @@ func Status(runningCtx running.RunningCtx, opts StatusOpts) error {
 		// To make the alerts more readable, we map the UUIDs to instance names.
 		uuid2name[instanceState.UUID] = fullInstanceName
 
-		instanceRawState[fullInstanceName] = instanceState
-		instances[fullInstanceName]["MODE"] = instanceState.ReadOnly
-		instances[fullInstanceName]["CONFIG"] = instanceState.ConfigInfo.Status
-		instances[fullInstanceName]["BOX"] = instanceState.BoxStatus
+		processConfigInfo(&instStatus, instanceState)
+		instStatus.Mode = instanceState.ReadOnly
+		instStatus.Config = instanceState.ConfigInfo.Status
+		instStatus.Box = instanceState.BoxStatus
 	}
 
-	// Alert handling placed later because we need to know the mapping of instance UUIDs
-	// to their names for a more user-friendly output.
-	for fullInstanceName, instanceState := range instanceRawState {
-		processReplicationInfo(fullInstanceName, instanceState)
-		processConfigInfo(fullInstanceName, instanceState)
+	for _, instStatus := range instances {
+		processReplicationInfo(instStatus, uuid2name)
 	}
 
-	for instName, instData := range instances {
-		row := []interface{}{}
-		row = append(row, instName)
-		row = append(row, instData["STATUS"])
-		if instData["PID"] == nil {
-			ts.AppendRow(row)
-			continue
-		}
-		row = append(row, instData["PID"])
-		row = append(row, instData["MODE"])
-		row = append(row, instData["CONFIG"])
-		row = append(row, instData["BOX"])
-		row = append(row, instData["UPSTREAM"])
-		ts.AppendRow(row)
-	}
-	ts.SortBy([]table.SortBy{{Name: "INSTANCE", Mode: table.Asc}})
-
-	if opts.Details {
-		for instance, alerts := range instancesAlerts {
-			fmt.Printf("Alerts for %s:\n", instance)
-			for _, alert := range alerts {
-				fmt.Printf("  • %s\n", alert)
-			}
-			fmt.Println()
-		}
-	}
-	if opts.Pretty {
-		ts.SetStyle(table.StyleRounded)
-	} else {
-		ts.Style().Options.DrawBorder = false
-		ts.Style().Options.SeparateColumns = false
-		ts.Style().Options.SeparateHeader = false
-	}
-	ts.SetColumnConfigs([]table.ColumnConfig{
-		{Number: 1, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 2, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 3, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 4, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-	})
-	ts.Render()
-
-	if !opts.Details {
-		msg := "\nThe status of some instances requires attention.\n" +
-			"Please rerun the command with the --details flag to see " +
-			"more information"
-		for _, alerts := range instancesAlerts {
-			if len(alerts) > 0 {
-				fmt.Println(msg)
-				break
-			}
-		}
-	}
-
-	return nil
+	return printer.Print(instances)
 }

--- a/cli/status/table_printer.go
+++ b/cli/status/table_printer.go
@@ -1,0 +1,139 @@
+package status
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+var (
+	printYellow = color.New(color.FgYellow).SprintFunc()
+	printRed    = color.New(color.FgRed).SprintFunc()
+)
+
+// TablePrinterOption represents a configuration option for TablePrinter.
+type TablePrinterOption func(*TablePrinter)
+
+// TablePrinter implements InstanceStatusPrinter for table output.
+type TablePrinter struct {
+	// Options for table formatting
+	pretty  bool
+	details bool
+}
+
+// WithPretty enables pretty table formatting.
+func WithPretty() TablePrinterOption {
+	return func(tp *TablePrinter) {
+		tp.pretty = true
+	}
+}
+
+// WithDetails controls detailed alert output.
+func WithDetails(withDetails bool) TablePrinterOption {
+	return func(tp *TablePrinter) {
+		tp.details = withDetails
+	}
+}
+
+// NewTablePrinter creates a new TablePrinter with the given options.
+func NewTablePrinter(opts ...TablePrinterOption) *TablePrinter {
+	tp := &TablePrinter{
+		pretty:  false,
+		details: false,
+	}
+	for _, opt := range opts {
+		opt(tp)
+	}
+	return tp
+}
+
+// formatAlert formats an alert message based on its severity.
+func formatAlert(alert instanceAlert) string {
+	switch alert.Severity {
+	case severityError:
+		return printRed(alert.Message)
+	case severityWarning:
+		return printYellow(alert.Message)
+	default:
+		return alert.Message
+	}
+}
+
+// printInstanceAlerts prints alerts for a specific instance.
+func (t TablePrinter) printInstanceAlerts(instanceName string, instStatus *instanceStatus) {
+	if len(instStatus.Alerts) == 0 {
+		return
+	}
+	fmt.Printf("Alerts for %s:\n", instanceName)
+	for _, alert := range instStatus.Alerts {
+		fmt.Printf("  • %s\n", formatAlert(alert))
+	}
+	fmt.Println()
+}
+
+// hasAlerts checks if any instance has alerts.
+func hasAlerts(instances map[string]*instanceStatus) bool {
+	for _, instStatus := range instances {
+		if len(instStatus.Alerts) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Print outputs the instance status map in table format.
+func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
+	ts := table.NewWriter()
+	ts.SetOutputMirror(os.Stdout)
+	ts.AppendHeader(
+		table.Row{"INSTANCE", "STATUS", "PID", "MODE", "CONFIG", "BOX", "UPSTREAM"})
+
+	for instName, instData := range instances {
+		row := []any{}
+		row = append(row, instName)
+		row = append(row, instData.procStatus.FormattedStatus())
+		if instData.PID == nil {
+			ts.AppendRow(row)
+			continue
+		}
+		row = append(row, *instData.PID)
+		row = append(row, instData.Mode)
+		row = append(row, instData.Config)
+		row = append(row, instData.Box)
+		row = append(row, instData.Upstream)
+		ts.AppendRow(row)
+	}
+	ts.SortBy([]table.SortBy{{Name: "INSTANCE", Mode: table.Asc}})
+
+	if t.details {
+		for instanceName, instStatus := range instances {
+			t.printInstanceAlerts(instanceName, instStatus)
+		}
+	}
+	if t.pretty {
+		ts.SetStyle(table.StyleRounded)
+	} else {
+		ts.Style().Options.DrawBorder = false
+		ts.Style().Options.SeparateColumns = false
+		ts.Style().Options.SeparateHeader = false
+	}
+	ts.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 1, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: 2, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: 3, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: 4, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+	})
+	ts.Render()
+
+	if !t.details && hasAlerts(instances) {
+		msg := "\nThe status of some instances requires attention.\n" +
+			"Please rerun the command with the --details flag to see " +
+			"more information"
+		fmt.Println(msg)
+	}
+
+	return nil
+}

--- a/cli/status/yaml_printer.go
+++ b/cli/status/yaml_printer.go
@@ -1,0 +1,25 @@
+package status
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLPrinter implements InstanceStatusPrinter for YAML output.
+type YAMLPrinter struct{}
+
+// NewYAMLPrinter creates a new YAMLPrinter instance.
+func NewYAMLPrinter() *YAMLPrinter {
+	return &YAMLPrinter{}
+}
+
+// Print outputs the instance status map in YAML format.
+func (y YAMLPrinter) Print(instances map[string]*instanceStatus) error {
+	yamlData, err := yaml.Marshal(instances)
+	if err != nil {
+		return fmt.Errorf("failed to marshal instances to YAML: %w", err)
+	}
+	fmt.Println(string(yamlData))
+	return nil
+}

--- a/test/integration/status/test_status.py
+++ b/test/integration/status/test_status.py
@@ -11,6 +11,8 @@ import tarantool
 from utils import (
     control_socket,
     extract_status,
+    extract_status_from_json,
+    extract_status_from_yaml,
     get_tarantool_version,
     pid_file,
     run_command_and_get_output,
@@ -19,6 +21,34 @@ from utils import (
 )
 
 tarantool_major_version, tarantool_minor_version = get_tarantool_version()
+
+# Define field mappings for different extract functions.
+field_mappings = {
+    extract_status: {
+        "status": "STATUS",
+        "mode": "MODE",
+        "pid": "PID",
+        "upstream": "UPSTREAM",
+        "box": "BOX",
+        "config": "CONFIG",
+    },
+    extract_status_from_json: {
+        "status": "status",
+        "mode": "mode",
+        "pid": "pid",
+        "upstream": "upstream",
+        "box": "box",
+        "config": "config",
+    },
+    extract_status_from_yaml: {
+        "status": "status",
+        "mode": "mode",
+        "pid": "pid",
+        "upstream": "upstream",
+        "box": "box",
+        "config": "config",
+    },
+}
 
 
 def start_application(cmd, workdir, app_name, instances):
@@ -118,17 +148,25 @@ def test_t3_instance_names_with_config(tt_cmd, tmpdir_with_cfg):
             file = wait_file(os.path.join(run_dir, inst), control_socket, [])
             assert file != ""
 
-        status_cmd = [tt_cmd, "status", app_name]
-        status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
-        assert status_rc == 0
-        status_info = extract_status(status_out)
-        for inst in instances:
-            assert status_info[app_name + ":" + inst]["STATUS"] == "RUNNING"
-            assert os.path.exists(os.path.join(tmpdir, app_name, "var", "lib", inst))
-            assert os.path.exists(os.path.join(tmpdir, app_name, "var", "log", inst, "tt.log"))
-            assert not os.path.exists(
-                os.path.join(tmpdir, app_name, "var", "log", inst, "tarantool.log"),
-            )
+            for status_cmd, extract_func in [
+                ([tt_cmd, "status", app_name], extract_status),
+                ([tt_cmd, "status", app_name, "--format=json"], extract_status_from_json),
+                ([tt_cmd, "status", app_name, "--format=yaml"], extract_status_from_yaml),
+            ]:
+                status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+                assert status_rc == 0
+                status_info = extract_func(status_out)
+
+                field_mapping = field_mappings[extract_func]
+                for inst in instances:
+                    assert status_info[app_name + ":" + inst][field_mapping["status"]] == "RUNNING"
+                    assert os.path.exists(os.path.join(tmpdir, app_name, "var", "lib", inst))
+                    assert os.path.exists(
+                        os.path.join(tmpdir, app_name, "var", "log", inst, "tt.log"),
+                    )
+                    assert not os.path.exists(
+                        os.path.join(tmpdir, app_name, "var", "log", inst, "tarantool.log"),
+                    )
 
         full_master_inst_name = f"{app_name}:{instances[0]}"
 
@@ -204,6 +242,16 @@ def test_t3_instance_names_no_config(tt_cmd):
                     print(os.path.join(test_app_path, "run", "app", instName))
                     file = wait_file(os.path.join(test_app_path, run_path, instName), pid_file, [])
                     assert file != ""
+                    file = wait_file(
+                        os.path.join(test_app_path, run_path, instName),
+                        control_socket,
+                        [],
+                    )
+                    assert file != ""
+                    # We need to remove console explicitly to avoid a race.
+                    os.remove(
+                        os.path.join(test_app_path, run_path, instName, control_socket),
+                    )
 
                 status_cmd = [tt_cmd, "status", "app", "--details"]
                 status_rc, status_out = run_command_and_get_output(status_cmd, cwd=test_app_path)
@@ -228,6 +276,28 @@ def test_t3_instance_names_no_config(tt_cmd):
                 pattern = r"app:(master|replica|router|stateboard)\s+RUNNING\s+\d+\s+--\s+--\s+--"
                 matches = re.findall(pattern, status_out)
                 assert len(matches) == 4
+
+                # No separate details block for json and yaml formats, so check alerts list.
+                for status_cmd, extract_func in [
+                    ([tt_cmd, "status", "app", "--format=json"], extract_status_from_json),
+                    ([tt_cmd, "status", "app", "--format=yaml"], extract_status_from_yaml),
+                ]:
+                    status_rc, status_out = run_command_and_get_output(
+                        status_cmd,
+                        cwd=test_app_path,
+                    )
+                    assert status_rc == 0
+                    status_info = extract_func(status_out)
+                    field_mapping = field_mappings[extract_func]
+                    for inst_name, info in status_info.items():
+                        assert info[field_mapping["status"]] == "RUNNING"
+                        alerts = info["alerts"]
+                        assert len(alerts) == 1
+                        assert (
+                            f"Error while connecting to instance {inst_name}"
+                            in alerts[0]["message"]
+                        )
+                        assert alerts[0]["severity"] == "error"
 
             finally:
                 stop_application(tt_cmd, "app", test_app_path)
@@ -255,16 +325,23 @@ def test_t3_no_instance_names_no_config(tt_cmd, tmpdir_with_cfg):
         start_output = instance_process.stdout.read()
         assert re.search(r"Starting an instance \[single_app\]", start_output)
         assert wait_instance_status(tt_cmd, app_path, app_name, "box", port=3303)
-        status_cmd = [tt_cmd, "status", app_name]
-        status_rc, status_out = run_command_and_get_output(status_cmd, cwd=app_path)
-        assert status_rc == 0
-        status_out = extract_status(status_out)
 
-        assert status_out[app_name]["STATUS"] == "RUNNING"
-        assert status_out[app_name]["MODE"] == "RW"
-        assert status_out[app_name]["CONFIG"] == "uninitialized"
-        assert status_out[app_name]["BOX"] == "running"
-        assert status_out[app_name]["UPSTREAM"] == "--"
+        for status_cmd, extract_func in [
+            ([tt_cmd, "status", app_name], extract_status),
+            ([tt_cmd, "status", app_name, "--format=json"], extract_status_from_json),
+            ([tt_cmd, "status", app_name, "--format=yaml"], extract_status_from_yaml),
+        ]:
+            status_rc, status_out = run_command_and_get_output(status_cmd, cwd=app_path)
+            assert status_rc == 0
+            status_out = extract_func(status_out)
+
+            field_mapping = field_mappings[extract_func]
+            assert status_out[app_name][field_mapping["status"]] == "RUNNING"
+            assert status_out[app_name][field_mapping["mode"]] == "RW"
+            assert status_out[app_name][field_mapping["config"]] == "uninitialized"
+            assert status_out[app_name][field_mapping["box"]] == "running"
+            assert status_out[app_name][field_mapping["upstream"]] == "--"
+
     finally:
         stop_application(tt_cmd, app_name, app_path)
 
@@ -285,17 +362,20 @@ def test_status_custom_app(tt_cmd, tmpdir_with_cfg):
         file = wait_file(os.path.join(tmpdir, app_name), "ready", [])
         assert file != ""
 
-        status_cmd = [tt_cmd, "status"]
-        status_cmd.append("test_custom_app")
-
-        rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir)
-        assert rc == 0
-        status_out = extract_status(out)
-        assert status_out[app_name]["STATUS"] == "RUNNING"
-        assert status_out[app_name]["MODE"] == "RW"
-        assert status_out[app_name]["CONFIG"] == "uninitialized"
-        assert status_out[app_name]["BOX"] == "running"
-        assert status_out[app_name]["UPSTREAM"] == "--"
+        for status_cmd, extract_func in [
+            ([tt_cmd, "status", "test_custom_app"], extract_status),
+            ([tt_cmd, "status", "test_custom_app", "--format=json"], extract_status_from_json),
+            ([tt_cmd, "status", "test_custom_app", "--format=yaml"], extract_status_from_yaml),
+        ]:
+            rc, out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+            assert rc == 0
+            status_out = extract_func(out)
+            field_mapping = field_mappings[extract_func]
+            assert status_out[app_name][field_mapping["status"]] == "RUNNING"
+            assert status_out[app_name][field_mapping["mode"]] == "RW"
+            assert status_out[app_name][field_mapping["config"]] == "uninitialized"
+            assert status_out[app_name][field_mapping["box"]] == "running"
+            assert status_out[app_name][field_mapping["upstream"]] == "--"
     finally:
         stop_application(tt_cmd, app_name, tmpdir)
 
@@ -326,3 +406,12 @@ def test_status_cartridge(tt_cmd, cartridge_app):
         assert status_out[app_name]["CONFIG"] == "uninitialized"
         assert status_out[app_name]["BOX"] == "running"
         assert status_out[app_name]["UPSTREAM"] == "--"
+
+
+def test_status_invalid_format(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    status_cmd = [tt_cmd, "status", "--format=invalid"]
+    status_rc, status_out = run_command_and_get_output(status_cmd, cwd=tmpdir)
+    assert status_rc != 0
+    assert "invalid format: invalid" in status_out
+    assert "Valid formats are: json, yaml, table, pretty-table" in status_out

--- a/test/utils.py
+++ b/test/utils.py
@@ -479,6 +479,18 @@ def extract_status(status_output):
     return result
 
 
+def extract_status_from_json(status_json_output):
+    import json
+
+    return json.loads(status_json_output)
+
+
+def extract_status_from_yaml(status_yaml_output):
+    import yaml
+
+    return yaml.safe_load(status_yaml_output)
+
+
 def is_valid_tarantool_installed(bin_path, inc_path, expected_bin=None, expected_inc=None):
     tarantool_binary_symlink = os.path.join(bin_path, "tarantool")
     tarantool_include_symlink = os.path.join(inc_path, "tarantool")


### PR DESCRIPTION
The status command now supports JSON and YAML output formats in addition to the existing table format. This change introduces a printer interface that separates output formatting logic from core status functionality.

New --format CLI option allows users to get machine-readable output for automation purposes.

Closes tarantool/tt#1245

@TarantoolBot document
Title: `tt status` supports JSON and YAML output formats

The `tt status` command now supports multiple output formats:
- Table format (default, human-readable)
- JSON format (machine-readable, for automation)
- YAML format (machine-readable, for automation)

Usage:
- `tt status` - default table output
- `tt status --format=json` - JSON output
- `tt status --format=yaml` - YAML output

The JSON and YAML formats include all status information:
- Instance name
- Status (RUNNING, STOPPED, etc.)
- PID (if running)
- Mode (RW/RO)
- Config status
- Box status
- Upstream status
- Alerts (with severity levels)

Example JSON output:
```json
{
  "app:master": {
    "status": "RUNNING",
    "pid": 12345,
    "mode": "RW",
    "config": "ready",
    "box": "running",
    "upstream": "--",
    "alerts": []
  }
}
```