### PR TITLE
ci: update cached pre-commit if Python is updated

### DIFF
--- a/.github/actions/check-commit-msg/action.yml
+++ b/.github/actions/check-commit-msg/action.yml
@@ -6,6 +6,7 @@ runs:
   steps:
     - name: Setup python
       uses: actions/setup-python@v4
+      id: setup-python
       with:
         python-version: "${{ env.PYTHON_VERSION }}"
 
@@ -21,7 +22,7 @@ runs:
       id: cache-pre_commit-venv
       uses: actions/cache@v4
       with:
-        key: ${{ env.PRE_COMMIT }}-venv-${{ runner.os }}-Py_${{ env.PYTHON_VERSION }}-${{ hashFiles('test/requirements.txt') }}
+        key: ${{ env.PRE_COMMIT }}-venv-${{ runner.os }}-Py_${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('test/requirements.txt') }}
         path: ${{ env.VIRTUAL_ENV }}
 
     - name: Install pre-commit in virtualenv
@@ -31,7 +32,6 @@ runs:
         # Install pre-commit
         python3 -m venv "${{ env.VIRTUAL_ENV }}"
         python -m pip install $PRE_COMMIT
-
 
     - name: Set git config user info
       shell: bash
@@ -44,7 +44,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
-        key: ${{ env.PRE_COMMIT }}|${{ runner.os }}|Py_${{ env.PYTHON_VERSION }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: ${{ env.PRE_COMMIT }}|${{ runner.os }}|Py_${{ steps.setup-python.outputs.python-version }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Get commit messages
       id: get_commit_msgs


### PR DESCRIPTION
Python's full version is MAJOR.MINOR.PATCH and prior to this commit pre-commit was not re-cached if only patch version was updated. It occurs if python is updated on github-runners due to python release.

I didn't forget about:

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Closes #1254

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
