### PR TITLE
ci: run check-commit-msg only with 'check-commit-msg' label

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   static-code-check:
-    if: github.event_name == 'push'
+    if: contains(github.event.pull_request.labels.*.name, 'full-commit-check')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   check-commit-msg:
-    if: github.event_name == 'push'
+    if: contains(github.event.pull_request.labels.*.name, 'full-commit-check')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/check-commit-msg
 
   static-code-check:
-    if: github.event_name == 'push'
+    if: contains(github.event.pull_request.labels.*.name, 'full-commit-check')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Commit message checks are excessively strict for feature branch development.
Make them opt-in via label, for now, instead of running on every push.

Part of TNTP-7088