### PR TITLE
cartridge: remove from build, pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ for machine-readable output.
 - `tt init`: tarantoolctl support removed.
 - tarantoolctl layout is no longer supported.
 - `tt init/create`: cartridge support removed.
+- `tt build/pack`: cartridge support removed.
 
 ### Fixed
 

--- a/cli/build/local.go
+++ b/cli/build/local.go
@@ -20,9 +20,9 @@ const (
 
 var (
 	// PreBuildScripts is a list of pre-build script names.
-	PreBuildScripts = []string{"tt.pre-build", "cartridge.pre-build"}
+	PreBuildScripts = []string{"tt.pre-build"}
 	// PostBuildScripts is a list of post-build script names.
-	PostBuildScripts = []string{"tt.post-build", "cartridge.post-build"}
+	PostBuildScripts = []string{"tt.post-build"}
 )
 
 // runBuildHook runs first existing executable from hookNames list.

--- a/cli/build/local_test.go
+++ b/cli/build/local_test.go
@@ -31,11 +31,11 @@ func TestRunHooks(t *testing.T) {
 	assert.NoError(t, os.Remove(filepath.Join(workDir, "tt.post-build")))
 
 	require.NoError(t, runBuildHook(&buildCtx, PreBuildScripts))
-	assert.FileExists(t, filepath.Join(workDir, "cartridge-pre-build-invoked"))
+	assert.NoFileExists(t, filepath.Join(workDir, "cartridge-pre-build-invoked"))
 	assert.NoFileExists(t, filepath.Join(workDir, "tt-pre-build-invoked"))
 
 	require.NoError(t, runBuildHook(&buildCtx, PostBuildScripts))
-	assert.FileExists(t, filepath.Join(workDir, "cartridge-post-build-invoked"))
+	assert.NoFileExists(t, filepath.Join(workDir, "cartridge-post-build-invoked"))
 	assert.NoFileExists(t, filepath.Join(workDir, "tt-post-build-invoked"))
 }
 

--- a/cli/cmd/pack.go
+++ b/cli/cmd/pack.go
@@ -41,8 +41,6 @@ The supported types are: tgz, deb, rpm`,
 			"tt and tcm binaries to the result package")
 	packCmd.Flags().BoolVar(&packCtx.WithBinaries, "with-binaries", packCtx.WithoutBinaries,
 		"Include tarantool, tt and tcm binaries to the result package")
-	packCmd.Flags().BoolVar(&packCtx.CartridgeCompat, "cartridge-compat", false,
-		"Pack cartridge cli compatible archive (only for tgz type)")
 	packCmd.Flags().BoolVar(&packCtx.WithoutModules, "without-modules",
 		packCtx.WithoutModules, "Don't include external modules to the result package")
 

--- a/cli/init/init.go
+++ b/cli/init/init.go
@@ -156,7 +156,7 @@ func Run(initCtx *InitCtx) error {
 
 	var sourceCfg configData
 
-	if !util.IsApp(".") && sourceCfg.instancesEnabled == "" {
+	if !util.IsApp(".") {
 		// Current directory is not app dir, instances enabled dir will be used.
 		sourceCfg.instancesEnabled = configure.InstancesEnabledDirName
 	}

--- a/cli/pack/common.go
+++ b/cli/pack/common.go
@@ -199,9 +199,9 @@ func getAppNamesToPack(packCtx *PackCtx, cliOpts *config.CliOpts) []string {
 
 // updateEnvPath sets base path for the tt environment in temporary package directory.
 // By default it is a base directory passed as an argument. Or an application name sub-dir
-// in case of cartridge compat or single application environment.
+// in case of single application environment.
 func updateEnvPath(basePath string, packCtx *PackCtx, cliOpts *config.CliOpts) (string, error) {
-	if cliOpts.Env.InstancesEnabled == "." || packCtx.CartridgeCompat {
+	if cliOpts.Env.InstancesEnabled == "." {
 		basePath = util.JoinPaths(basePath, packCtx.Name)
 		if err := os.MkdirAll(basePath, dirPermissions); err != nil {
 			return basePath, fmt.Errorf("cannot create bundle directory %q: %s", basePath, err)
@@ -212,7 +212,7 @@ func updateEnvPath(basePath string, packCtx *PackCtx, cliOpts *config.CliOpts) (
 
 // copyEnvModules copies tt modules.
 func copyEnvModules(bundleEnvPath string, packCtx *PackCtx, cliOpts, newOpts *config.CliOpts) {
-	if packCtx.WithoutModules || packCtx.CartridgeCompat || cliOpts.Modules == nil ||
+	if packCtx.WithoutModules || cliOpts.Modules == nil ||
 		len(cliOpts.Modules.Directories) == 0 {
 
 		return
@@ -253,11 +253,7 @@ func copyBinaries(bundleEnvPath string, packCtx *PackCtx, cmdCtx *cmdcontext.Cmd
 		return nil
 	}
 
-	pkgBin := bundleEnvPath
-	if !packCtx.CartridgeCompat {
-		// In cartridge compat mode copy binaries directly to the env dir.
-		pkgBin = util.JoinPaths(bundleEnvPath, newOpts.Env.BinDir)
-	}
+	pkgBin := util.JoinPaths(bundleEnvPath, newOpts.Env.BinDir)
 
 	if err := os.MkdirAll(pkgBin, dirPermissions); err != nil {
 		return fmt.Errorf("failed to create binaries directory in bundle: %s", err)
@@ -300,7 +296,7 @@ func copyBinaries(bundleEnvPath string, packCtx *PackCtx, cmdCtx *cmdcontext.Cmd
 func getDestAppDir(bundleEnvPath, appName string,
 	packCtx *PackCtx, cliOpts *config.CliOpts,
 ) string {
-	if packCtx.CartridgeCompat || cliOpts.Env.InstancesEnabled == "." {
+	if cliOpts.Env.InstancesEnabled == "." {
 		return bundleEnvPath
 	}
 	return filepath.Join(bundleEnvPath, appName)
@@ -334,7 +330,7 @@ func copyApplications(bundleEnvPath string, packCtx *PackCtx,
 			}
 		}
 
-		if !packCtx.CartridgeCompat && newOpts.Env.InstancesEnabled != "." {
+		if newOpts.Env.InstancesEnabled != "." {
 			// Create applications symlink in instances enabled.
 			if err = os.MkdirAll(util.JoinPaths(bundleEnvPath, newOpts.Env.InstancesEnabled),
 				dirPermissions); err != nil {
@@ -418,18 +414,6 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 		}
 	}
 
-	if packCtx.CartridgeCompat {
-		// Generate VERSION file.
-		if err := generateVersionFile(bundleEnvPath, cmdCtx, packCtx); err != nil {
-			log.Warnf("Failed to generate VERSION file: %s", err)
-		}
-
-		// Generate VERSION.lua file.
-		if err := generateVersionLuaFile(bundleEnvPath, packCtx); err != nil {
-			log.Warnf("Failed to generate VERSION.lua file: %s", err)
-		}
-	}
-
 	if packCtx.Archive.All {
 		if err = copyArtifacts(*packCtx, bundleEnvPath, newOpts, packCtx.AppsInfo); err != nil {
 			return "", fmt.Errorf("failed copying artifacts: %s", err)
@@ -443,7 +427,7 @@ func prepareBundle(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 		}
 	}
 
-	writeEnv(newOpts, bundleEnvPath, packCtx.CartridgeCompat)
+	writeEnv(newOpts, bundleEnvPath)
 	if err != nil {
 		return "", err
 	}
@@ -487,7 +471,7 @@ func copyArtifacts(packCtx PackCtx, basePath string, newOpts *config.CliOpts,
 		for _, inst := range appsInfo[appName] {
 			appDirName := filepath.Base(inst.AppDir)
 			destAppDir := util.JoinPaths(basePath, newOpts.Env.InstancesEnabled, appDirName)
-			if packCtx.CartridgeCompat || newOpts.Env.InstancesEnabled == "." {
+			if newOpts.Env.InstancesEnabled == "." {
 				destAppDir = basePath
 			}
 
@@ -571,16 +555,11 @@ func createNewOpts(opts *config.CliOpts, packCtx PackCtx) *config.CliOpts {
 		cliOptsNew.App.WalDir = configure.VarWalPath
 	}
 
-	if packCtx.CartridgeCompat {
-		cliOptsNew.Env.InstancesEnabled = "."
-		cliOptsNew.Env.BinDir = "."
-	}
-
 	return cliOptsNew
 }
 
 // writeEnv writes CLI options to a tt.yaml file.
-func writeEnv(cliOpts *config.CliOpts, destPath string, cartridgeCompat bool) error {
+func writeEnv(cliOpts *config.CliOpts, destPath string) error {
 	file, err := os.Create(filepath.Join(destPath, configure.ConfigName))
 	if err != nil {
 		return err
@@ -645,7 +624,7 @@ func cleanupAfterBuild(appDir string) {
 func buildAppRocks(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	cliOpts *config.CliOpts, bundlePath string,
 ) error {
-	if cliOpts.Env.InstancesEnabled == "." || packCtx.CartridgeCompat {
+	if cliOpts.Env.InstancesEnabled == "." {
 		if err := buildAppInBundle(cmdCtx, cliOpts, bundlePath); err != nil {
 			return err
 		}
@@ -668,32 +647,19 @@ func buildAppRocks(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 // getVersion returns a version of the package.
 // The version depends on passed pack context.
 func getVersion(packCtx *PackCtx, opts *config.CliOpts, defaultVersion string) string {
-	packageVersion := defaultVersion
-	if packCtx.Version == "" {
-		// Get version from git only if packing an application from the current directory,
-		// or packing with cartridge-compat enabled.
-		appPath := opts.Env.InstancesEnabled
-		if opts.Env.InstancesEnabled != "." && packCtx.CartridgeCompat {
-			appPath = filepath.Join(appPath, packCtx.Name)
-		}
-		if opts.Env.InstancesEnabled == "." || packCtx.CartridgeCompat {
-			version, err := util.CheckVersionFromGit(appPath)
-			if err == nil {
-				packageVersion = version
-				if packCtx.CartridgeCompat {
-					if normalVersion, err := normalizeGitVersion(packageVersion); err == nil {
-						packageVersion = normalVersion
-					}
-				}
-			}
-		}
-		if packCtx.CartridgeCompat {
-			packCtx.Version = packageVersion
-		}
-	} else {
-		packageVersion = packCtx.Version
+	if packCtx.Version != "" {
+		return packCtx.Version
 	}
-	return packageVersion
+
+	// Try to get version from git only if packing an application from the current directory.
+	if opts.Env.InstancesEnabled == "." {
+		version, err := util.CheckVersionFromGit(opts.Env.InstancesEnabled)
+		if err == nil {
+			return version
+		}
+	}
+
+	return defaultVersion
 }
 
 // normalizeGitVersion edits raw version from `git describe` command.
@@ -742,11 +708,6 @@ func getPackageFileName(packCtx *PackCtx, opts *config.CliOpts, suffix string,
 	var packageName string
 
 	if packCtx.FileName != "" {
-		if packCtx.CartridgeCompat {
-			// Need to collect info about version
-			// for generating VERSION and VERSION.lua files.
-			getVersion(packCtx, opts, defaultLongVersion)
-		}
 		return packCtx.FileName, nil
 	} else if packCtx.Name != "" {
 		packageName = packCtx.Name

--- a/cli/pack/common_test.go
+++ b/cli/pack/common_test.go
@@ -558,108 +558,6 @@ func Test_prepareBundle(t *testing.T) {
 			},
 		},
 		{
-			name: "Packing cartridge compat",
-			params: params{
-				configPath:    "testdata/env1/tt.yaml",
-				tntExecutable: "testdata/env1/bin/tarantool",
-				packCtx: PackCtx{
-					AppList:           []string{"multi"},
-					CartridgeCompat:   true,
-					Archive:           ArchiveCtx{},
-					TarantoolIsSystem: false,
-				},
-			},
-			wantErr: false,
-			checks: []check{
-				// Root.
-				{assert.NoDirExists, "instances.enabled"},
-				{assert.NoDirExists, "include"},
-				{assert.NoDirExists, "modules"},
-				{assert.NoDirExists, "var"},
-				{assert.NoFileExists, "tt.yaml"},
-
-				// Multi-inst app.
-				{assert.DirExists, "multi"},
-				{assert.FileExists, "multi/init.lua"},
-				{assert.FileExists, "multi/instances.yaml"},
-				{assert.FileExists, "multi/tt.yaml"},
-				{assert.FileExists, "multi/tarantool"},
-				{assert.FileExists, "multi/tt"},
-				{assert.NoDirExists, "multi/var/lib/"},
-				{assert.NoDirExists, "multi/var/log/"},
-			},
-		},
-		{
-			name: "Packing cartridge compat, no tarantool executable",
-			params: params{
-				configPath:    "testdata/env1/tt.yaml",
-				tntExecutable: "",
-				packCtx: PackCtx{
-					AppList:           []string{"multi"},
-					CartridgeCompat:   true,
-					Archive:           ArchiveCtx{},
-					TarantoolIsSystem: false,
-				},
-			},
-			wantErr: false,
-			checks: []check{
-				// Root.
-				{assert.NoDirExists, "instances.enabled"},
-				{assert.NoDirExists, "include"},
-				{assert.NoDirExists, "modules"},
-				{assert.NoDirExists, "var"},
-				{assert.NoFileExists, "tt.yaml"},
-
-				// Multi-inst app.
-				{assert.DirExists, "multi"},
-				{assert.FileExists, "multi/init.lua"},
-				{assert.FileExists, "multi/instances.yaml"},
-				{assert.FileExists, "multi/tt.yaml"},
-				{assert.NoFileExists, "multi/tarantool"},
-				{assert.NoDirExists, "multi/tarantool"},
-				{assert.FileExists, "multi/tt"},
-				{assert.NoDirExists, "multi/var/lib/"},
-				{assert.NoDirExists, "multi/var/log/"},
-			},
-		},
-		{
-			name: "Packing cartridge compat with artifacts",
-			params: params{
-				configPath:    "testdata/env1/tt.yaml",
-				tntExecutable: "testdata/env1/bin/tarantool",
-				packCtx: PackCtx{
-					AppList:         []string{"multi"},
-					CartridgeCompat: true,
-					Archive: ArchiveCtx{
-						All: true,
-					},
-					TarantoolIsSystem: false,
-				},
-			},
-			wantErr: false,
-			checks: []check{
-				// Root.
-				{assert.NoDirExists, "instances.enabled"},
-				{assert.NoDirExists, "include"},
-				{assert.NoDirExists, "modules"},
-				{assert.NoDirExists, "var"},
-				{assert.NoFileExists, "tt.yaml"},
-
-				// Multi-inst app.
-				{assert.DirExists, "multi"},
-				{assert.FileExists, "multi/init.lua"},
-				{assert.FileExists, "multi/instances.yaml"},
-				{assert.FileExists, "multi/tt.yaml"},
-				{assert.FileExists, "multi/tarantool"},
-				{assert.FileExists, "multi/var/lib/inst1/00000000000000000000.snap"},
-				{assert.FileExists, "multi/var/lib/inst1/00000000000000000000.xlog"},
-				{assert.FileExists, "multi/var/lib/inst2/00000000000000000000.snap"},
-				{assert.FileExists, "multi/var/lib/inst2/00000000000000000000.xlog"},
-				{assert.FileExists, "multi/var/log/inst1/tt.log"},
-				{assert.FileExists, "multi/var/log/inst2/tt.log"},
-			},
-		},
-		{
 			name: "Packing env with instances.enabled:.",
 			params: params{
 				configPath:    "testdata/single_app/tt.yml",
@@ -793,42 +691,6 @@ func Test_prepareBundle(t *testing.T) {
 			},
 		},
 		{
-			name: "Packing env with CartridgeCompat and instances.enabled:.",
-			params: params{
-				configPath:    "testdata/single_app/tt.yml",
-				tntExecutable: "testdata/single_app/bin/tarantool",
-				packCtx: PackCtx{
-					TarantoolIsSystem: false,
-					CartridgeCompat:   true,
-				},
-			},
-			wantErr: false,
-			checks: []check{
-				{assert.NoDirExists, "instances.enabled"},
-				{assert.NoFileExists, "tt.yaml"},
-				{assert.NoFileExists, "tt.yml"},
-				{assert.NoDirExists, "include"},
-
-				{assert.NoDirExists, "single_app/instances.enabled"},
-				{assert.NoDirExists, "single_app/include"},
-				{assert.NoDirExists, "single_app/templates"},
-				{assert.NoDirExists, "single_app/modules"},
-				{assert.NoDirExists, "single_app/templates"},
-				{assert.NoDirExists, "single_app/distfiles"},
-				{assert.NoFileExists, "single_app/bin/tarantool"},
-				{assert.NoFileExists, "single_app/bin/tt"},
-				{assert.FileExists, "single_app/init.lua"},
-				{assert.FileExists, "single_app/tt.yaml"},
-				{assert.FileExists, "single_app/VERSION.lua"},
-				{assert.FileExists, "single_app/VERSION"},
-				{assert.NoFileExists, "single_app/tt.yml"},
-				{assert.NoFileExists, "single_app/single_app_0.1.0.0-1_x86_64.deb"},
-				{assert.NoFileExists, "single_app/single_app-0.1.0.0-1.x86_64.rpm"},
-				{assert.NoFileExists, "single_app/single_app-0.1.0.0.x86_64.tar.gz"},
-				{assert.FileExists, "single_app/single_app-0.1.0.0.x86_64.zip"},
-			},
-		},
-		{
 			name: "Packing app and build rocks",
 			params: params{
 				configPath:    "testdata/app_with_rockspec/tt.yaml",
@@ -858,8 +720,6 @@ func Test_prepareBundle(t *testing.T) {
 				{assert.NoFileExists, "app_with_rockspec/app_with_rockspec-scm-1.rockspec"},
 				{assert.NoFileExists, "app_with_rockspec/tt.pre-build"},
 				{assert.NoFileExists, "app_with_rockspec/tt.post-build"},
-				{assert.NoFileExists, "app_with_rockspec/cartridge.pre-build"},
-				{assert.NoFileExists, "app_with_rockspec/cartridge.post-build"},
 			},
 		},
 		{
@@ -893,8 +753,6 @@ func Test_prepareBundle(t *testing.T) {
 				{assert.NoFileExists, "app/app_with_rockspec-scm-1.rockspec"},
 				{assert.NoFileExists, "app/tt.pre-build"},
 				{assert.NoFileExists, "app/tt.post-build"},
-				{assert.NoFileExists, "app/cartridge.pre-build"},
-				{assert.NoFileExists, "app/cartridge.post-build"},
 			},
 		},
 		{

--- a/cli/pack/deb.go
+++ b/cli/pack/deb.go
@@ -89,7 +89,7 @@ func (packer *debPacker) Run(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 	log.Info("Creating a data directory")
 
 	rootPrefix := filepath.Join(dataDirName, defaultEnvPrefix, packCtx.Name)
-	if opts.Env.InstancesEnabled == "." || packCtx.CartridgeCompat {
+	if opts.Env.InstancesEnabled == "." {
 		rootPrefix = filepath.Dir(rootPrefix)
 	}
 	packageDataDir := filepath.Join(packageDir, dataDirName)

--- a/cli/pack/opts.go
+++ b/cli/pack/opts.go
@@ -1,7 +1,6 @@
 package pack
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,7 +73,7 @@ func setBundleName(packCtx *PackCtx, cliOpts *config.CliOpts) {
 		return
 	}
 	packCtx.Name = "package"
-	if packCtx.CartridgeCompat || cliOpts.Env.InstancesEnabled == "." {
+	if cliOpts.Env.InstancesEnabled == "." {
 		packCtx.Name = packCtx.AppList[0]
 		return
 	}
@@ -100,10 +99,6 @@ func FillCtx(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx, cliOpts *config.CliOpt
 
 	packCtx.RpmDeb.pkgFilesInfo = make(map[string]packFileInfo)
 
-	if (packCtx.IntegrityPrivateKey != "") && packCtx.CartridgeCompat {
-		return errors.New("cannot pack with integrity checks in cartridge-compat mode")
-	}
-
 	packCtx.TarantoolIsSystem = cmdCtx.Cli.IsSystem
 	packCtx.TarantoolExecutable = cmdCtx.Cli.TarantoolCli.Executable
 	packCtx.configFilePath = cmdCtx.Cli.ConfigPath
@@ -114,10 +109,6 @@ func FillCtx(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx, cliOpts *config.CliOpt
 	}
 
 	setBundleName(packCtx, cliOpts)
-
-	if packCtx.CartridgeCompat && len(packCtx.AppsInfo) > 1 {
-		return fmt.Errorf("cannot pack multiple applications in cartridge compat mode")
-	}
 
 	// Initialize packignore filter.
 	ignoreFilter, err := createIgnoreFilter(util.GetOsFS(), cmdCtx.Cli.ConfigDir, ignoreFile)

--- a/cli/pack/pack.go
+++ b/cli/pack/pack.go
@@ -34,8 +34,6 @@ type PackCtx struct {
 	RpmDeb RpmDebCtx
 	// UseDocker is set if a package must be built in docker container.
 	UseDocker bool
-	// CartridgeCompat enables backward compatibility with cartridge cli.
-	CartridgeCompat bool
 	// TarantoolVersion specifies the version of the tarantool for pack in docker.
 	TarantoolVersion string
 	// IntegrityPrivateKey contains the path to private key for signing hash files.

--- a/cli/pack/rpm.go
+++ b/cli/pack/rpm.go
@@ -59,7 +59,7 @@ func (packer *rpmPacker) Run(cmdCtx *cmdcontext.CmdCtx, packCtx *PackCtx,
 
 	packagingEnvInstallPath := filepath.Join(packageDir, "usr", "share", "tarantool",
 		bundleName)
-	if opts.Env.InstancesEnabled == "." || packCtx.CartridgeCompat {
+	if opts.Env.InstancesEnabled == "." {
 		packagingEnvInstallPath = filepath.Dir(packagingEnvInstallPath)
 	}
 	if err := copy.Copy(bundlePath, packagingEnvInstallPath); err != nil {

--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -37,17 +37,6 @@ def assert_bundle_structure(path):
     assert not os.path.exists(os.path.join(path, "templates"))
 
 
-def assert_bundle_structure_compat(path):
-    assert not os.path.isfile(os.path.join(path, config_name))
-    assert not os.path.isdir(os.path.join(path, "var"))
-    assert not os.path.isdir(os.path.join(path, "var/run"))
-    assert not os.path.isdir(os.path.join(path, "var/lib"))
-    assert not os.path.isdir(os.path.join(path, "var/log"))
-    assert not os.path.isdir(os.path.join(path, "bin"))
-    assert not os.path.exists(os.path.join(path, "include"))
-    assert not os.path.exists(os.path.join(path, "templates"))
-
-
 def assert_default_env(config):
     assert config["env"]["instances_enabled"] == "instances.enabled"
     assert config["env"]["bin_dir"] == "bin"
@@ -259,72 +248,6 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
             "check_env": ["", assert_default_env, assert_artifacts_env],
         },
         {
-            "bundle_src": "bundle8",
-            "cmd": tt_cmd,
-            "pack_type": "tgz",
-            "args": ["--cartridge-compat"],
-            "app_name": "app_name",
-            "res_file": "app_name-0.1.0.0." + get_arch() + ".tar.gz",
-            "check_exist": [
-                os.path.join("app_name", "VERSION"),
-                os.path.join("app_name", "VERSION.lua"),
-                os.path.join("app_name", config_name),
-            ],
-            "check_not_exist": [
-                os.path.join("bin"),
-                os.path.join("instances.enabled"),
-                os.path.join("modules"),
-                os.path.join("var"),
-                os.path.join(config_name),
-            ],
-            "check_env": ["app_name", assert_cartridge_compat_env, assert_artifacts_env],
-        },
-        {
-            "bundle_src": "bundle1",
-            "cmd": tt_cmd,
-            "pack_type": "tgz",
-            "args": ["--cartridge-compat", "--app-list", "app2"],
-            "app_name": "app2",
-            "res_file": "app2-0.1.0.0." + get_arch() + ".tar.gz",
-            "check_exist": [
-                os.path.join("app2", "VERSION"),
-                os.path.join("app2", "VERSION.lua"),
-                os.path.join("app2", config_name),
-            ],
-            "check_not_exist": [
-                os.path.join("app1"),
-                os.path.join("app"),
-                os.path.join("bin"),
-                os.path.join("instances_enabled"),
-                os.path.join("modules"),
-                os.path.join("var"),
-                os.path.join(config_name),
-            ],
-            "check_env": ["app2", assert_cartridge_compat_env, assert_artifacts_env],
-        },
-        {
-            "bundle_src": "bundle9",
-            "cmd": tt_cmd,
-            "pack_type": "tgz",
-            "args": ["--cartridge-compat"],
-            "app_name": "bundle9",
-            "res_file": "bundle9-0.1.0.0." + get_arch() + ".tar.gz",
-            "check_exist": [
-                os.path.join("bundle9", "init.lua"),
-                os.path.join("bundle9", "tt.yaml"),
-                os.path.join("bundle9", "VERSION"),
-                os.path.join("bundle9", "VERSION.lua"),
-            ],
-            "check_not_exist": [
-                os.path.join("bin"),
-                os.path.join("instances_enabled"),
-                os.path.join("modules"),
-                os.path.join("var"),
-                os.path.join("tt.yaml"),
-            ],
-            "check_env": ["bundle9", assert_cartridge_compat_env, assert_artifacts_env],
-        },
-        {
             "bundle_src": "bundle1",
             "cmd": tt_cmd,
             "pack_type": "tgz",
@@ -431,32 +354,6 @@ def prepare_tgz_test_cases(tt_cmd) -> list:
                 os.path.join("modules", "ext_mod2"),
             ],
             "check_env": ["", assert_default_env, assert_artifacts_env],
-        },
-        {
-            "bundle_src": "cartridge_app",
-            "cmd": tt_cmd,
-            "pack_type": "tgz",
-            "args": ["--name", "cartridge_app", "--version", "v2"],
-            "res_file": "cartridge_app-v2." + get_arch() + ".tar.gz",
-            "check_exist": [
-                os.path.join("cartridge_app"),
-                os.path.join("cartridge_app", "bin", "tarantool"),
-                os.path.join("cartridge_app", "bin", "tt"),
-                os.path.join("cartridge_app", "app", "roles", "custom.lua"),
-                os.path.join("cartridge_app", "app", "admin.lua"),
-                os.path.join("cartridge_app", "init.lua"),
-                os.path.join("cartridge_app", "instances.yml"),
-                os.path.join("cartridge_app", "replicasets.yml"),
-                os.path.join("cartridge_app", "failover.yml"),
-                os.path.join("cartridge_app", ".rocks"),
-                os.path.join("cartridge_app", config_name),
-            ],
-            "check_not_exist": [
-                os.path.join("cartridge_app", "myapp-scm-1.rockspec"),
-                os.path.join("cartridge_app", "cartridge.pre-build"),
-                os.path.join("cartridge_app", "cartridge.post-build"),
-            ],
-            "check_env": ["cartridge_app", assert_single_app_env, assert_artifacts_env],
         },
         {
             "bundle_src": "bundle6",
@@ -666,10 +563,7 @@ def test_pack_tgz_table(tt_cmd, tmp_path):
         tar.extractall(extract_path)
         tar.close()
 
-        if "--cartridge-compat" in test_case["args"]:
-            assert_bundle_structure_compat(extract_path)
-        else:
-            assert_bundle_structure(extract_path)
+        assert_bundle_structure(extract_path)
 
         for file_path in test_case["check_exist"]:
             print("Check exist " + file_path + " in  " + extract_path)
@@ -710,180 +604,6 @@ def test_pack_tgz_missing_app(tt_cmd, tmp_path):
 
 
 @pytest.mark.slow
-def test_pack_tgz_files_with_compat(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle8")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle8"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "tgz", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-
-    assert rc == 0
-
-    package_file = os.path.join(base_dir, "app_name-0.1.0.0." + get_arch() + ".tar.gz")
-
-    extract_path = os.path.join(base_dir, "tmp")
-    os.mkdir(extract_path)
-
-    tar = tarfile.open(package_file)
-    tar.extractall(extract_path)
-    tar.close()
-
-    assert len([name for name in os.listdir(extract_path)]) == 1
-    assert os.path.exists(os.path.join(extract_path, "app_name", "tt"))
-    assert os.path.exists(os.path.join(extract_path, "app_name", "tarantool"))
-    assert os.path.exists(os.path.join(extract_path, "app_name", "tt.yaml"))
-    assert os.path.exists(os.path.join(extract_path, "app_name", "init.lua"))
-    assert os.path.exists(os.path.join(extract_path, "app_name", "VERSION"))
-    assert os.path.exists(os.path.join(extract_path, "app_name", "VERSION.lua"))
-
-
-@pytest.mark.slow
-def test_pack_tgz_git_version_compat(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle9")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle9"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    rc, output = run_command_and_get_output(
-        ["git", "init"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "add", "*"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "config", "user.email", '"none"'],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-    rc, output = run_command_and_get_output(
-        ["git", "config", "user.name", '"none"'],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "commit", "-m", "commit"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "tag", "1.2.3"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "tgz", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    package_file = os.path.join(base_dir, "bundle9-1.2.3.0." + get_arch() + ".tar.gz")
-    assert os.path.isfile(package_file)
-
-
-@pytest.mark.slow
-def test_pack_tgz_git_version_compat_with_instances(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle1")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    app_dir = os.path.join(base_dir, "app2")
-
-    rc, output = run_command_and_get_output(
-        ["git", "init"],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "add", "*"],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "config", "user.email", '"none"'],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-    rc, output = run_command_and_get_output(
-        ["git", "config", "user.name", '"none"'],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "commit", "-m", "commit"],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        ["git", "tag", "1.2.3"],
-        cwd=app_dir,
-        env=dict(os.environ, PWD=app_dir),
-    )
-    assert rc == 0
-
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "tgz", "--app-list", "app2", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-    assert rc == 0
-
-    package_file = os.path.join(base_dir, "app2-1.2.3.0." + get_arch() + ".tar.gz")
-    assert os.path.isfile(package_file)
-
-
-@pytest.mark.slow
 def test_pack_tgz_compat_with_binaries(tt_cmd, tmp_path):
     tmp_path = os.path.join(tmp_path, "bundle8")
     shutil.copytree(
@@ -898,14 +618,14 @@ def test_pack_tgz_compat_with_binaries(tt_cmd, tmp_path):
 
     base_dir = tmp_path
     rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "tgz", "--with-binaries", "--cartridge-compat"],
+        [tt_cmd, "pack", "tgz", "--with-binaries"],
         cwd=base_dir,
         env=dict(os.environ, PWD=base_dir),
     )
 
     assert rc == 0
 
-    package_file = os.path.join(base_dir, "app_name-0.1.0.0." + get_arch() + ".tar.gz")
+    package_file = os.path.join(base_dir, "bundle8-0.1.0.0." + get_arch() + ".tar.gz")
 
     extract_path = os.path.join(base_dir, "tmp")
     os.mkdir(extract_path)
@@ -914,45 +634,25 @@ def test_pack_tgz_compat_with_binaries(tt_cmd, tmp_path):
     tar.extractall(extract_path)
     tar.close()
 
-    app_path = os.path.join(extract_path, "app_name")
+    bin_path = os.path.join(extract_path, "bin")
 
-    assert os.path.isfile(os.path.join(app_path, "tt"))
-    assert os.path.isfile(os.path.join(app_path, "tarantool"))
+    assert os.path.isfile(os.path.join(bin_path, "tt"))
+    assert os.path.isfile(os.path.join(bin_path, "tarantool"))
 
-    script = "cat > tarantool <<EOF\n#!/bin/bash\nprintf 'Hello World'"
-    subprocess.run(script, cwd=app_path, shell=True, env=dict(os.environ, PWD=app_path))
-    subprocess.run(["chmod", "+x", "tarantool"], cwd=app_path, env=dict(os.environ, PWD=app_path))
+    app_path = os.path.join(base_dir)
+
+    script = "cat > script.lua <<EOF\nprint('Hello World')"
+    subprocess.run(script, cwd=app_path, shell=True, env=dict(os.environ, PWD=bin_path))
+    subprocess.run(["chmod", "+x", "script.lua"], cwd=app_path, env=dict(os.environ, PWD=app_path))
 
     rc, output = run_command_and_get_output(
-        [tt_cmd, "run"],
+        [tt_cmd, "run", "script.lua"],
         cwd=app_path,
-        env=dict(os.environ, PWD=app_path),
+        env=dict(os.environ, PWD=bin_path),
     )
 
     assert rc == 0
-    assert output == "Hello World"
-
-
-def test_pack_tgz_multiple_apps_compat(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle1")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "tgz", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-
-    assert rc == 1
+    assert output == "Hello World\n"
 
 
 @pytest.mark.slow
@@ -992,50 +692,6 @@ def test_pack_tgz_relative_symlinks(tt_cmd, tmp_path):
     assert os.path.exists(os.path.join(extract_path, "instances.enabled", "app_name", "symlink"))
 
 
-def test_pack_deb_compat(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle1")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "dep", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-
-    assert rc == 1
-
-
-def test_pack_rpm_compat(tt_cmd, tmp_path):
-    tmp_path = os.path.join(tmp_path, "bundle1")
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "test_bundles", "bundle1"),
-        tmp_path,
-        symlinks=True,
-        ignore=None,
-        copy_function=shutil.copy2,
-        ignore_dangling_symlinks=True,
-        dirs_exist_ok=True,
-    )
-
-    base_dir = tmp_path
-    rc, output = run_command_and_get_output(
-        [tt_cmd, "pack", "rpm", "--cartridge-compat"],
-        cwd=base_dir,
-        env=dict(os.environ, PWD=base_dir),
-    )
-
-    assert rc == 1
-
-
 def prepare_deb_test_cases(tt_cmd) -> list:
     tt_cmd = tt_cmd
     return [
@@ -1066,13 +722,6 @@ def prepare_deb_test_cases(tt_cmd) -> list:
             "pack_type": "deb",
             "args": ["--deps", "tarantool>=1.10,tt=2.0"],
             "res_file": "bundle1_0.1.0.0-1_" + get_arch() + ".deb",
-        },
-        {
-            "bundle_src": "single_app",
-            "cmd": tt_cmd,
-            "pack_type": "deb",
-            "args": ["--cartridge-compat", "--version", "1.2.3"],
-            "res_file": "single_app" + "_1.2.3-1_" + get_arch() + ".deb",
         },
     ]
 
@@ -1107,13 +756,6 @@ def prepare_rpm_test_cases(tt_cmd) -> list:
             "pack_type": "rpm",
             "args": ["--deps", "tarantool>=1.10,tt=2.0"],
             "res_file": "bundle1-0.1.0.0-1." + get_arch() + ".rpm",
-        },
-        {
-            "bundle_src": "single_app",
-            "cmd": tt_cmd,
-            "pack_type": "rpm",
-            "args": ["--cartridge-compat", "--version", "1.2.3"],
-            "res_file": "single_app" + "-1.2.3-1." + get_arch() + ".rpm",
         },
     ]
 
@@ -1442,12 +1084,7 @@ def prepare_pack_deb_single_app_test_cases(tt_cmd) -> list:
             "name": "clean",
             "command": ["pack", "deb"],
             "paths": ["tt.yaml", "instances.yml", "config.yaml", "bin/tt", "bin/tarantool"],
-        },
-        {
-            "name": "with_version",
-            "command": ["pack", "deb", "--cartridge-compat"],
-            "paths": ["tt.yaml", "instances.yml", "config.yaml", "VERSION", "VERSION.lua"],
-        },
+        }
     ]
 
 

--- a/test/integration/ttbuild/test_build.py
+++ b/test/integration/ttbuild/test_build.py
@@ -49,30 +49,6 @@ def test_build_with_tt_hooks(tt_cmd, tmpdir_with_cfg):
     assert os.path.exists(os.path.join(app_dir, "tt-post-build-invoked"))
 
 
-def test_build_with_cartridge_hooks(tt_cmd, tmpdir_with_cfg):
-    app_name = "app1"
-    app_dir = shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps", app_name),
-        os.path.join(tmpdir_with_cfg, app_name),
-    )
-    shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "apps/cartridge_hooks"),
-        os.path.join(tmpdir_with_cfg, app_name),
-        dirs_exist_ok=True,
-    )
-
-    cmd = [tt_cmd, "build"]
-    p = subprocess.run(
-        cmd,
-        cwd=app_dir,
-    )
-    assert p.returncode == 0
-    assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
-    assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
-    assert os.path.exists(os.path.join(app_dir, "cartridge-pre-build-invoked"))
-    assert os.path.exists(os.path.join(app_dir, "cartridge-post-build-invoked"))
-
-
 def test_build_app_name_set(tt_cmd, tmpdir_with_cfg):
     app_name = "app1"
     app_dir = shutil.copytree(
@@ -181,7 +157,6 @@ def test_build_spec_file_set(tt_cmd, tmpdir_with_cfg):
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "checks.lua"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "rocks"))
     assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "metrics"))
-    assert os.path.exists(os.path.join(app_dir, ".rocks", "share", "tarantool", "cartridge"))
 
 
 @pytest.mark.parametrize("flag", [None, "-V"])


### PR DESCRIPTION
This patch removes cartridge support from `build` and `pack` commands.

Closes #TNTP-6976