### PR TITLE
running: watchdog runtime behaviour refactoring

### DIFF
--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -74,6 +74,7 @@ func GetPIDFromFile(pidFileName string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf(`can't open the PID file. Error: "%v"`, err)
 	}
+	defer pidFile.Close()
 
 	pidBytes, err := io.ReadAll(pidFile)
 	if err != nil {

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -32,7 +32,7 @@ type Watchdog struct {
 	// logger represents an active logging object.
 	logger ttlog.Logger
 	// doneBarrier used to indicate the completion of the
-	// signal handling goroutine.
+	// signal handling and integrity checking goroutines.
 	doneBarrier sync.WaitGroup
 	// restartTimeout describes the timeout between
 	// restarting the Instance.
@@ -41,17 +41,21 @@ type Watchdog struct {
 	// and updating may depend on changing external parameters
 	// (such as configuration file).
 	provider Provider
-	// stopMutex used to avoid a race condition under shouldStop field.
-	stopMutex sync.Mutex
-	// shouldStop indicates whether the Watchdog should be stopped.
-	shouldStop bool
 	// preStartAction is a hook that is to be run before the start of a new Instance.
 	preStartAction func() error
 	// IntegrityCtx contains information necessary to perform integrity checks.
 	integrityCtx integrity.IntegrityCtx
 	// integrityCheckPeriod is period between integrity checks.
 	integrityCheckPeriod time.Duration
+	// instShutdownCh signals instance termination to the event loop.
+	instTerminatedCh chan struct{}
+	// osSignalCh receives OS signals for the whole watchdog lifetime.
+	osSignalCh chan os.Signal
 }
+
+const (
+	signalBufferSize = 128
+)
 
 // NewWatchdog creates a new instance of Watchdog.
 func NewWatchdog(restartable bool, restartTimeout time.Duration, logger ttlog.Logger,
@@ -66,125 +70,176 @@ func NewWatchdog(restartable bool, restartTimeout time.Duration, logger ttlog.Lo
 		preStartAction:       preStartAction,
 		integrityCtx:         integrityCtx,
 		integrityCheckPeriod: integrityCheckPeriod,
+		instTerminatedCh:     make(chan struct{}),
+		osSignalCh:           make(chan os.Signal, 1),
 	}
 
 	return &wd
 }
 
-// Start starts the Instance and signal handling.
-func (wd *Watchdog) Start() error {
+func (wd *Watchdog) Start() {
+	wd.eventLoop()
+}
+
+// eventLoop serializes instance lifecycle: start, signal handling, stop, and restart.
+func (wd *Watchdog) eventLoop() {
+	wd.startSignalHandling()
+	defer signal.Stop(wd.osSignalCh)
+
+	if err := wd.preStartAction(); err != nil {
+		wd.logger.Printf(`(ERROR): Pre-start action error: %v`, err)
+		return
+	}
+
+outer:
+	for {
+		// Ignore signals accumulated while the previous instance was down.
+		wd.dropPendingSignals()
+
+		handlerCtx, handlerCancel := context.WithCancel(context.Background())
+
+		// Make local signal channel for every cycle, so that
+		// the old signals in the buffer cannot affect the already new cycle.
+		signalCh := make(chan os.Signal, signalBufferSize)
+
+		// Buffer signals during startup, to process them after.
+		wd.signalHandler(handlerCtx, signalCh)
+
+		// cleanup stops signal handler and integration check.
+		cleanup := func() {
+			handlerCancel()
+			wd.doneBarrier.Wait()
+		}
+
+		// Every iteration we start the instance and then
+		// check events.
+		if started := wd.startInstance(handlerCtx); !started {
+			// We have already logged the error.
+			cleanup()
+			return
+		}
+
+		shouldStop := false
+
+		for {
+			// We have two cases during instance's lifecycle:
+			// 1. The user has sent a `tt stop` or another signal.
+			// 2. The instance has terminated, and we should(n't) restart it.
+			// In the second case, we have no to stop instance.
+			select {
+			case sig := <-signalCh:
+				// After handling a stop signal, eventually we will get an
+				// event in instTerminatedCh.
+				shouldStop = wd.sendSignal(sig) || shouldStop
+			case <-wd.instTerminatedCh:
+				cleanup()
+
+				if !wd.shouldRestart() || shouldStop {
+					wd.logger.Println("(INFO): the Instance has shutdown.")
+					return
+				}
+
+				if logger, err := wd.provider.UpdateLogger(wd.logger); err != nil {
+					wd.logger.Println("(ERROR): can't update logger parameters.")
+					return
+				} else {
+					wd.logger = logger
+				}
+
+				wd.logger.Printf(`(INFO): waiting for restart timeout %s.`, wd.restartTimeout)
+				time.Sleep(wd.restartTimeout)
+
+				// Start a new start instance loop.
+				continue outer
+			}
+		}
+	}
+}
+
+// shouldRestart checks if the instance should be restarted.
+func (wd *Watchdog) shouldRestart() bool {
+	restartable, err := wd.provider.IsRestartable()
+	if err != nil {
+		wd.logger.Println("(ERROR): can't check if the instance is restartable.")
+		return false
+	}
+
+	return restartable
+}
+
+// startInstance starts the Instance and signal handling.
+func (wd *Watchdog) startInstance(ctx context.Context) bool {
 	var err error
+
 	// Create Instance.
 	if wd.instance, err = wd.provider.CreateInstance(wd.logger); err != nil {
 		wd.logger.Printf(`(ERROR): instance creation failed: %v.`, err)
-		return err
+		return false
 	}
-
-	// The signal handling loop must be started before the instance
-	// get started for avoiding a race condition between tt start
-	// and tt stop. This way we avoid a situation when we receive
-	// a signal before starting a handler for it.
-	watchdogCtx, watchdogCancel := context.WithCancel(context.Background())
-	wd.startSignalHandling(watchdogCtx, watchdogCancel)
 
 	// Launch integrity checking goroutine.
 	if wd.integrityCheckPeriod != 0 {
 		wd.logger.Printf("(INFO): starting periodic integrity checks each %s.",
 			wd.integrityCheckPeriod)
-		wd.startIntegrityChecks(watchdogCtx)
+		wd.startIntegrityChecks(ctx)
 	}
 
-	if err = wd.preStartAction(); err != nil {
-		wd.logger.Printf(`(ERROR): Pre-start action error: %v`, err)
-		// Finish the signal handling and periodic integrity checking goroutines.
-		watchdogCancel()
-		wd.doneBarrier.Wait()
-		return err
+	// Start the Instance.
+	if err := wd.instance.Start(context.Background()); err != nil {
+		wd.logger.Printf(`(ERROR):  instance start failed: %v.`, err)
+		return false
 	}
 
-	// The Instance must be restarted on completion if the "restartable"
-	// parameter is set to "true".
-	for {
-		var err error
-
-		wd.stopMutex.Lock()
-		if wd.shouldStop {
-			wd.logger.Printf(`(ERROR): terminated before instance start.`)
-			wd.stopMutex.Unlock()
-			return nil
-		}
-		// Start the Instance.
-		if err := wd.instance.Start(context.Background()); err != nil {
-			wd.logger.Printf(`(ERROR):  instance start failed: %v.`, err)
-			wd.stopMutex.Unlock()
-			break
-		}
-		wd.stopMutex.Unlock()
-
-		// Wait while the Instance will be terminated.
+	// Wait for the instance to terminate.
+	go func() {
 		if err := wd.instance.Wait(); err != nil {
 			wd.logger.Printf(`(WARN): "%v".`, err)
 		}
 
-		// Set Instance process completion indication.
-		watchdogCancel()
-		// Wait for the signal processing goroutine to complete.
-		wd.doneBarrier.Wait()
+		wd.instTerminatedCh <- struct{}{}
+	}()
 
-		// Stop the process if the Instance is not restartable.
-		restartable, err := wd.provider.IsRestartable()
-		if err != nil {
-			wd.logger.Println("(ERROR): can't check if the instance is restartable.")
-			break
-		}
-		if wd.shouldStop || !restartable {
-			wd.logger.Println("(INFO): the Instance has shutdown.")
-			break
-		}
+	return true
+}
 
-		if logger, err := wd.provider.UpdateLogger(wd.logger); err != nil {
-			wd.logger.Println("(ERROR): can't update logger parameters.")
-			break
-		} else {
-			wd.logger = logger
-		}
-		wd.logger.Printf(`(INFO): waiting for restart timeout %s.`, wd.restartTimeout)
-		time.Sleep(wd.restartTimeout)
+// sendSignal sends signal to the instance and
+// returns whether watchdog should stop.
+func (wd *Watchdog) sendSignal(sig os.Signal) bool {
+	wd.logger.Printf("(INFO): %s received.", sig.String())
 
-		wd.shouldStop = false
-
-		// Recreate Instance.
-		if wd.instance, err = wd.provider.CreateInstance(wd.logger); err != nil {
-			wd.logger.Printf(`(ERROR): "%v".`, err)
-			return err
+	switch sig {
+	case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
+		if wd.instance.IsAlive() {
+			wd.instance.StopWithSignal(30*time.Second, sig)
 		}
-
-		// Before the restart of an instance create a fresh context,
-		// restart integrity checks and signal handling.
-		watchdogCtx, watchdogCancel = context.WithCancel(context.Background())
-		if wd.integrityCheckPeriod != 0 {
-			wd.startIntegrityChecks(watchdogCtx)
+		return true
+	case syscall.SIGHUP:
+		// Rotate the log files.
+		wd.logger.Rotate()
+		if wd.instance.IsAlive() {
+			wd.instance.SendSignal(sig)
 		}
-		wd.startSignalHandling(watchdogCtx, watchdogCancel)
+	default:
+		if wd.instance.IsAlive() {
+			wd.instance.SendSignal(sig)
+		}
 	}
-	return nil
+
+	return false
 }
 
 // startIntegrityChecks launches goroutine that performs periodic integrity checks.
 func (wd *Watchdog) startIntegrityChecks(ctx context.Context) {
 	ticker := time.NewTicker(wd.integrityCheckPeriod)
 
-	// Set barrier to synchronize with the main loop.
-	wd.doneBarrier.Add(1)
-
-	go func() {
-		// Set indication that the periodic integrity checking has been completed.
-		defer wd.doneBarrier.Done()
+	wd.doneBarrier.Go(func() {
+		defer ticker.Stop()
 
 		for {
 			select {
 			case <-ticker.C:
 				wd.logger.Printf("(INFO): periodic integrity check successfully passed.")
+
 				err := wd.integrityCtx.Repository.ValidateAll()
 				if err != nil {
 					// Integrity check failed.
@@ -192,20 +247,18 @@ func (wd *Watchdog) startIntegrityChecks(ctx context.Context) {
 					wd.instance.SendSignal(syscall.SIGKILL)
 					return
 				}
-
 			case <-ctx.Done():
 				return
 			}
 		}
-	}()
+	})
 }
 
 // startSignalHandling starts signal handling in a separate goroutine.
-func (wd *Watchdog) startSignalHandling(ctx context.Context, cancel context.CancelFunc) {
-	sigChan := make(chan os.Signal, 1)
+func (wd *Watchdog) startSignalHandling() {
 	// Reset the signal mask before starting of the new loop.
 	signal.Reset()
-	signal.Notify(sigChan)
+	signal.Notify(wd.osSignalCh)
 
 	// This call is needed to ignore SIGURG signals which are part of
 	// preemptive multitasking implementation in go. See:
@@ -213,50 +266,31 @@ func (wd *Watchdog) startSignalHandling(ctx context.Context, cancel context.Canc
 	// Also, there is no way to detect if a signal is related to the runtime or not:
 	// https://github.com/golang/go/issues/37942.
 	signal.Ignore(syscall.SIGURG)
+}
 
-	// Set barrier to synchronize with the main loop when the Instance stops.
-	wd.doneBarrier.Add(1)
+func (wd *Watchdog) dropPendingSignals() {
+	select {
+	case <-wd.osSignalCh:
+	default:
+	}
+}
 
-	// Start signals handling.
-	go func() {
-		// Set indication that the signal handling has been completed.
-		defer wd.doneBarrier.Done()
-
+// signalHandler handles OS signals and sends them to the event loop.
+func (wd *Watchdog) signalHandler(ctx context.Context, ch chan os.Signal) {
+	wd.doneBarrier.Go(func() {
 		for {
 			select {
-			case sig := <-sigChan:
-				switch sig {
-				case syscall.SIGINT, syscall.SIGTERM:
-					wd.stopMutex.Lock()
-					// If we receive one of the "stop" signals, the
-					// program should be terminated.
-					wd.shouldStop = true
-					wd.stopMutex.Unlock()
-					if wd.instance.IsAlive() {
-						wd.instance.Stop(30 * time.Second)
-					}
-				case syscall.SIGQUIT:
-					wd.logger.Println("(INFO): SIGQUIT received.")
-					wd.stopMutex.Lock()
-					wd.shouldStop = true
-					wd.stopMutex.Unlock()
-					if wd.instance.IsAlive() {
-						wd.instance.StopWithSignal(30*time.Second, syscall.SIGQUIT)
-					}
-				case syscall.SIGHUP:
-					// Rotate the log files.
-					wd.logger.Rotate()
-					if wd.instance.IsAlive() {
-						wd.instance.SendSignal(sig)
-					}
+			case sig := <-wd.osSignalCh:
+				select {
+				// Send signal event to the eventloop.
+				case ch <- sig:
 				default:
-					if wd.instance.IsAlive() {
-						wd.instance.SendSignal(sig)
-					}
+					// If signals are sent to the instance without control,
+					// when the buffer is filled, the signals will be dropped.
 				}
 			case <-ctx.Done():
 				return
 			}
 		}
-	}()
+	})
 }


### PR DESCRIPTION
Currently, watchdog is subject to a data race between calls to the ``tt start`` and ``tt stop`` commands.

This was solved by introducing serialized execution of calls to instances. Now any tt call above the instance is queued, which prevents possible crashes due to racing.

Closes TNTP-6356
