### PR TITLE
connect: remove ttv1 dependency

### DIFF
--- a/cli/search/bundle.go
+++ b/cli/search/bundle.go
@@ -174,7 +174,12 @@ func FetchBundlesInfo(searchCtx *SearchCtx, cliOpts *config.CliOpts) (
 			searchCtx.Program)
 	}
 
-	credentials, err := connect.GetCreds(cliOpts)
+	var credPath string
+	if cliOpts.EE != nil {
+		credPath = cliOpts.EE.CredPath
+	}
+
+	credentials, err := connect.GetCreds(credPath)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/cluster/go.mod
+++ b/lib/cluster/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tarantool/go-iproto v1.1.0 // indirect
 	github.com/tarantool/go-openssl v1.2.1 // indirect
-	github.com/tarantool/tt v1.3.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect

--- a/lib/cluster/go.sum
+++ b/lib/cluster/go.sum
@@ -155,8 +155,6 @@ github.com/tarantool/go-tarantool/v2 v2.4.2 h1:rkzYtFhLJLA9RDIhjzN93MJBN5PBxHW4+
 github.com/tarantool/go-tarantool/v2 v2.4.2/go.mod h1:MTbhdjFc3Jl63Lgi/UJr5D+QbT+QegqOzsNJGmaw7VM=
 github.com/tarantool/go-tlsdialer v1.0.2 h1:TiOkihvC2ufLbOqJcJLuQ9I7W5bsZtmnT7KHF/t8n4s=
 github.com/tarantool/go-tlsdialer v1.0.2/go.mod h1:ztE9J5oh4YzNQkSqlpjA0OkY89zHy/BiJJbbSFm+IiQ=
-github.com/tarantool/tt v1.3.1 h1:bczu649MCQaX6k9HFA71MJ5V70nY4E0grBxGLJvYSD8=
-github.com/tarantool/tt v1.3.1/go.mod h1:Z+YuHc9FNtWDcKyrOVjZ7B3fw7s0imW3QKSMAV7Qjpk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/lib/connect/credentials.go
+++ b/lib/connect/credentials.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/tarantool/tt/cli/config"
 	"golang.org/x/term"
 )
 
@@ -102,9 +101,9 @@ func getCredsFromEnvVars() (UserCredentials, error) {
 	return res, nil
 }
 
-// getCreds gets credentials for tarantool-ee download.
-func GetCreds(cliOpts *config.CliOpts) (UserCredentials, error) {
-	if cliOpts.EE == nil || (cliOpts.EE != nil && cliOpts.EE.CredPath == "") {
+// GetCreds gets credentials for tarantool-ee download.
+func GetCreds(credPath string) (UserCredentials, error) {
+	if credPath == "" {
 		creds, err := getCredsFromEnvVars()
 		if err == nil {
 			return creds, nil
@@ -112,5 +111,5 @@ func GetCreds(cliOpts *config.CliOpts) (UserCredentials, error) {
 		return getCredsInteractive()
 	}
 
-	return getCredsFromFile(cliOpts.EE.CredPath)
+	return getCredsFromFile(credPath)
 }

--- a/lib/connect/go.mod
+++ b/lib/connect/go.mod
@@ -5,13 +5,12 @@ go 1.25.7
 require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.10.0
-	github.com/tarantool/tt v1.3.1
 	golang.org/x/term v0.40.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
 	golang.org/x/sys v0.41.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/lib/connect/go.sum
+++ b/lib/connect/go.sum
@@ -9,8 +9,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tarantool/tt v1.3.1 h1:bczu649MCQaX6k9HFA71MJ5V70nY4E0grBxGLJvYSD8=
-github.com/tarantool/tt v1.3.1/go.mod h1:Z+YuHc9FNtWDcKyrOVjZ7B3fw7s0imW3QKSMAV7Qjpk=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=


### PR DESCRIPTION
Now lib/connect require tt v1.3 for credentials. It was changed.

Closes TNTP-7579