### PR TITLE
test: fix template name in notarantool tests

### DIFF
--- a/test/integration/pack/test_pack.py
+++ b/test/integration/pack/test_pack.py
@@ -1943,7 +1943,7 @@ def test_pack_app_local_tarantool(tt_cmd, tmpdir_with_tarantool, tmp_path):
         dirs_exist_ok=True,
     )
 
-    build_cmd = [tt_cmd, "create", "basic", "--name", "app", "--non-interactive"]
+    build_cmd = [tt_cmd, "create", "single_instance", "--name", "app", "--non-interactive"]
     tt_process = subprocess.Popen(
         build_cmd,
         cwd=tmp_path,

--- a/test/integration/ttbuild/test_build.py
+++ b/test/integration/ttbuild/test_build.py
@@ -203,7 +203,7 @@ def test_build_app_local_tarantool(tt_cmd, tmpdir_with_tarantool):
     app_name = "app1"
     app_dir = os.path.join(tmpdir_with_tarantool, app_name)
 
-    cmd = [tt_cmd, "create", "basic", "--name", app_name, "--non-interactive"]
+    cmd = [tt_cmd, "create", "single_instance", "--name", app_name, "--non-interactive"]
     p = subprocess.run(
         cmd,
         cwd=tmpdir_with_tarantool,


### PR DESCRIPTION
Commit e897f95 (cartridge: remove vendored cartridge-cli and all references) replaced `tt create cartridge` with `tt create basic` in `test_build_app_local_tarantool` and `test_pack_app_local_tarantool`, but `basic` is not a built-in template — only `cluster`, `config_storage`, `single_instance`, and `vshard_cluster` exist under `cli/create/builtin_templates/templates/`.

- Use `single_instance` as the closest analog of the old `cartridge` template (a minimal runnable single-instance app).

Follows TNTP-6979