### PR TITLE
cli: implement cluster worker show command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `tt cluster`: worker publish subcommand.
+- `tt cluster`: worker show subcommand.
 
 ### Changed
 

--- a/cli/cluster/cmd/worker.go
+++ b/cli/cluster/cmd/worker.go
@@ -29,10 +29,10 @@ type WorkerPublishCtx struct {
 // WorkerShowCtx contains information about cluster worker show command
 // execution context.
 type WorkerShowCtx struct {
-	// Username defines a username for connection.
-	Username string
-	// Password defines a password for connection.
-	Password string
+	// Storage is the storage instance for the operation.
+	Storage storage.Storage
+	// Key is the key in storage for the worker configuration.
+	Key string
 }
 
 // WorkerDeleteCtx contains information about cluster worker delete command
@@ -147,9 +147,24 @@ func WorkerPublish(publishCtx WorkerPublishCtx) error {
 	return nil
 }
 
-// WorkerShow shows a worker configuration. Unimplemented.
-func WorkerShow(url string, ctx WorkerShowCtx) error {
-	return errors.New("unimplemented")
+// WorkerShow shows a worker configuration from storage.
+// It returns an error if the configuration is not found.
+func WorkerShow(showCtx WorkerShowCtx) ([]byte, error) {
+	ctx := context.Background()
+	key := []byte(showCtx.Key)
+
+	resp, err := showCtx.Storage.Tx(ctx).Then(operation.Get(key)).Commit()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get worker configuration: %w", err)
+	}
+
+	if len(resp.Results) == 0 || len(resp.Results[0].Values) == 0 {
+		return nil, fmt.Errorf("worker configuration not found at %q", showCtx.Key)
+	}
+
+	value := resp.Results[0].Values[0].Value
+
+	return value, nil
 }
 
 // WorkerDelete deletes a worker configuration. Unimplemented.

--- a/cli/cluster/cmd/worker_test.go
+++ b/cli/cluster/cmd/worker_test.go
@@ -1,9 +1,17 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/kv"
+	"github.com/tarantool/go-storage/operation"
+	"github.com/tarantool/go-storage/predicate"
+	"github.com/tarantool/go-storage/tx"
+	"github.com/tarantool/go-storage/watch"
 
 	libconnect "github.com/tarantool/tt/lib/connect"
 )
@@ -239,9 +247,132 @@ func TestResolveWorkerCredentials(t *testing.T) {
 	}
 }
 
+type mockTx struct {
+	results    []tx.RequestResponse
+	succeeded  bool
+	err        error
+	operations []operation.Operation
+}
+
+func (m *mockTx) If(predicates ...predicate.Predicate) tx.Tx {
+	return m
+}
+
+func (m *mockTx) Then(operations ...operation.Operation) tx.Tx {
+	m.operations = operations
+	return m
+}
+
+func (m *mockTx) Else(operations ...operation.Operation) tx.Tx {
+	return m
+}
+
+func (m *mockTx) Commit() (tx.Response, error) {
+	if m.err != nil {
+		return tx.Response{}, m.err
+	}
+	return tx.Response{
+		Succeeded: m.succeeded,
+		Results:   m.results,
+	}, nil
+}
+
+type mockStorage struct {
+	tx *mockTx
+}
+
+func (m *mockStorage) Watch(
+	ctx context.Context,
+	key []byte,
+	opts ...watch.Option,
+) <-chan watch.Event {
+	return nil
+}
+
+func (m *mockStorage) Tx(ctx context.Context) tx.Tx {
+	return m.tx
+}
+
+func (m *mockStorage) Range(
+	ctx context.Context,
+	opts ...storage.RangeOption,
+) ([]kv.KeyValue, error) {
+	return nil, nil
+}
+
 func TestWorkerShow(t *testing.T) {
-	err := WorkerShow("http://localhost:2379/prefix/host/worker", WorkerShowCtx{})
-	require.EqualError(t, err, "unimplemented")
+	workerCfg := `type: nontarantool
+instrumentation:
+  url: host1:8080
+  metrics_url: /metrics
+  metrics_format: prometheus
+config:
+  addr: host1:9080
+`
+
+	cases := []struct {
+		name        string
+		key         string
+		value       []byte
+		txErr       error
+		expectedErr string
+	}{
+		{
+			name:  "key found",
+			key:   "/prefix/instances/host1/worker1",
+			value: []byte(workerCfg),
+		},
+		{
+			name:        "key not found",
+			key:         "/prefix/instances/host1/worker1",
+			value:       nil,
+			expectedErr: "worker configuration not found",
+		},
+		{
+			name:        "storage error",
+			key:         "/prefix/instances/host1/worker1",
+			txErr:       errors.New("connection refused"),
+			expectedErr: "failed to get worker configuration",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var results []tx.RequestResponse
+			if tc.value != nil {
+				results = []tx.RequestResponse{
+					{
+						Values: []kv.KeyValue{
+							{Key: []byte(tc.key), Value: tc.value},
+						},
+					},
+				}
+			}
+
+			mockStg := &mockStorage{
+				tx: &mockTx{
+					results: results,
+					err:     tc.txErr,
+				},
+			}
+
+			showCtx := WorkerShowCtx{
+				Storage: mockStg,
+				Key:     tc.key,
+			}
+
+			output, err := WorkerShow(showCtx)
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Contains(t, string(output), "type: nontarantool")
+			require.Contains(t, string(output), "host1:8080")
+		})
+	}
 }
 
 func TestWorkerDelete(t *testing.T) {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -75,6 +75,11 @@ var (
 
 var workerShowCtx = clustercmd.WorkerShowCtx{}
 
+var (
+	workerShowUsername string
+	workerShowPassword string
+)
+
 var workerDeleteCtx = clustercmd.WorkerDeleteCtx{}
 
 var (
@@ -317,9 +322,9 @@ func newClusterWorkerCmd() *cobra.Command {
 		Run:  RunModuleFunc(internalClusterWorkerShowModule),
 		Args: cobra.ExactArgs(1),
 	}
-	showCmd.Flags().StringVarP(&workerShowCtx.Username, "username", "u", "",
+	showCmd.Flags().StringVarP(&workerShowUsername, "username", "u", "",
 		"username (used as etcd/tarantool config storage credentials)")
-	showCmd.Flags().StringVarP(&workerShowCtx.Password, "password", "p", "",
+	showCmd.Flags().StringVarP(&workerShowPassword, "password", "p", "",
 		"password (used as etcd/tarantool config storage credentials)")
 
 	deleteCmd := &cobra.Command{
@@ -640,12 +645,28 @@ func internalClusterWorkerShowModule(cmdCtx *cmdcontext.CmdCtx, args []string) e
 		return fmt.Errorf("invalid URL %q: %w", args[0], err)
 	}
 
-	workerShowCtx.Username, workerShowCtx.Password = clustercmd.ResolveWorkerCredentials(
-		opts, workerShowCtx.Username, workerShowCtx.Password)
+	prefix, hostName, workerName, err := clustercmd.ParseWorkerPath(opts.Prefix)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL path: %w", err)
+	}
+	workerShowCtx.Key = clustercmd.BuildWorkerStorageKey(prefix, hostName, workerName)
 
-	if err := clustercmd.WorkerShow(args[0], workerShowCtx); err != nil {
+	username, password := clustercmd.ResolveWorkerCredentials(
+		opts, workerShowUsername, workerShowPassword)
+
+	stg, closeFunc, err := clustercmd.ConnectStorage(opts, username, password)
+	if err != nil {
+		return fmt.Errorf("failed to connect to storage: %w", err)
+	}
+	defer closeFunc()
+	workerShowCtx.Storage = stg
+
+	output, err := clustercmd.WorkerShow(workerShowCtx)
+	if err != nil {
 		return fmt.Errorf("failed to show worker configuration: %w", err)
 	}
+
+	fmt.Print(string(output))
 	return nil
 }
 

--- a/test/integration/cluster/test_cluster_worker.py
+++ b/test/integration/cluster/test_cluster_worker.py
@@ -116,26 +116,6 @@ def test_cluster_worker_delete_help(tt_cmd, tmp_path):
     assert "-p" in help_output or "--password" in help_output
 
 
-def test_cluster_worker_show_unimplemented(tt_cmd, tmp_path):
-    show_cmd = [
-        tt_cmd,
-        "cluster",
-        "worker",
-        "show",
-        "https://localhost:2379/prefix/host/worker",
-    ]
-    instance_process = subprocess.Popen(
-        show_cmd,
-        cwd=tmp_path,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-    output = instance_process.stdout.read()
-
-    assert "unimplemented" in output
-
-
 def test_cluster_worker_delete_unimplemented(tt_cmd, tmp_path):
     delete_cmd = [
         tt_cmd,
@@ -764,3 +744,433 @@ def test_cluster_worker_publish_auth_bad_credentials(
     finally:
         if instance_name == "etcd":
             instance.disable_auth()
+
+
+def test_cluster_worker_show_invalid_url(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "not-a-valid-url",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    output = instance_process.stdout.read()
+
+    assert "invalid URL" in output
+
+
+def test_cluster_worker_show_invalid_path(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "http://localhost:2379/onlyhost?timeout=0.1",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    output = instance_process.stdout.read()
+
+    assert output == (
+        "   ⨯ failed to parse URL path:"
+        " URL path must contain at least a host-name and a worker-name,"
+        ' got: "/onlyhost"\n'
+    )
+
+
+def test_cluster_worker_show_connection_failed(tt_cmd, tmpdir_with_cfg):
+    tmpdir = tmpdir_with_cfg
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "https://localhost:12344/prefix/host1/worker1?timeout=0.1",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    output = instance_process.stdout.read()
+
+    assert "failed to connect to storage: failed to connect to etcd or tarantool" in output
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show(tt_cmd, tmpdir_with_cfg, instance_name, request):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/prefix/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    creds = (
+        f"{instance.connection_username}:{instance.connection_password}@"
+        if instance_name == "tcs"
+        else ""
+    )
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "http://" + creds + f"{instance.host}:{instance.port}/prefix/host1/worker1?timeout=5",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    show_output = instance_process.stdout.read()
+
+    assert show_output.strip() == worker_cfg.strip()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show_nested_prefix(tt_cmd, tmpdir_with_cfg, instance_name, request):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/tdb-workers/cluster1/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    creds = (
+        f"{instance.connection_username}:{instance.connection_password}@"
+        if instance_name == "tcs"
+        else ""
+    )
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "http://"
+        + creds
+        + f"{instance.host}:{instance.port}/tdb-workers/cluster1/host1/worker1?timeout=5",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    show_output = instance_process.stdout.read()
+
+    assert show_output.strip() == worker_cfg.strip()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show_not_found(tt_cmd, tmpdir_with_cfg, instance_name, request):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    creds = (
+        f"{instance.connection_username}:{instance.connection_password}@"
+        if instance_name == "tcs"
+        else ""
+    )
+    show_cmd = [
+        tt_cmd,
+        "cluster",
+        "worker",
+        "show",
+        "http://" + creds + f"{instance.host}:{instance.port}/prefix/host1/worker1?timeout=5",
+    ]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    show_output = instance_process.stdout.read()
+
+    assert "worker configuration not found" in show_output
+
+
+@pytest.mark.parametrize(
+    "auth, instance_name",
+    [
+        pytest.param("url", "etcd"),
+        pytest.param("flag", "etcd"),
+        pytest.param("env", "etcd"),
+        pytest.param("url", "tcs"),
+        pytest.param("flag", "tcs"),
+        pytest.param("env", "tcs"),
+    ],
+)
+def test_cluster_worker_show_auth(tt_cmd, tmpdir_with_cfg, auth, instance_name, request):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/prefix/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    if instance_name == "etcd":
+        instance.enable_auth()
+
+    try:
+        if auth == "url":
+            env = None
+            url = (
+                f"http://{instance.connection_username}:{instance.connection_password}@"
+                f"{instance.host}:{instance.port}/prefix/host1/worker1?timeout=5"
+            )
+            show_cmd = [tt_cmd, "cluster", "worker", "show", url]
+        elif auth == "flag":
+            env = None
+            url = f"{instance.endpoint}/prefix/host1/worker1?timeout=5"
+            show_cmd = [
+                tt_cmd,
+                "cluster",
+                "worker",
+                "show",
+                url,
+                "-u",
+                instance.connection_username,
+                "-p",
+                instance.connection_password,
+            ]
+        elif auth == "env":
+            env = {
+                (
+                    "TT_CLI_ETCD_USERNAME" if instance_name == "etcd" else "TT_CLI_USERNAME"
+                ): instance.connection_username,
+                (
+                    "TT_CLI_ETCD_PASSWORD" if instance_name == "etcd" else "TT_CLI_PASSWORD"
+                ): instance.connection_password,
+            }
+            url = f"{instance.endpoint}/prefix/host1/worker1?timeout=5"
+            show_cmd = [tt_cmd, "cluster", "worker", "show", url]
+
+        instance_process = subprocess.Popen(
+            show_cmd,
+            env=env,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        show_output = instance_process.stdout.read()
+
+        assert show_output.strip() == worker_cfg.strip()
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show_auth_priority_url_over_flag(
+    tt_cmd,
+    tmpdir_with_cfg,
+    instance_name,
+    request,
+):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/prefix/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    if instance_name == "etcd":
+        instance.enable_auth()
+
+    try:
+        url = (
+            f"http://{instance.connection_username}:{instance.connection_password}@"
+            f"{instance.host}:{instance.port}/prefix/host1/worker1?timeout=5"
+        )
+        show_cmd = [
+            tt_cmd,
+            "cluster",
+            "worker",
+            "show",
+            url,
+            "-u",
+            "invalid_user",
+            "-p",
+            "invalid_pass",
+        ]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        show_output = instance_process.stdout.read()
+
+        assert show_output.strip() == worker_cfg.strip()
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show_auth_priority_flag_over_env(
+    tt_cmd,
+    tmpdir_with_cfg,
+    instance_name,
+    request,
+):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/prefix/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    if instance_name == "etcd":
+        instance.enable_auth()
+
+    try:
+        env = {
+            "TT_CLI_ETCD_USERNAME"
+            if instance_name == "etcd"
+            else "TT_CLI_USERNAME": "invalid_env_user",
+            "TT_CLI_ETCD_PASSWORD"
+            if instance_name == "etcd"
+            else "TT_CLI_PASSWORD": "invalid_env_pass",
+        }
+        url = f"{instance.endpoint}/prefix/host1/worker1?timeout=5"
+        show_cmd = [
+            tt_cmd,
+            "cluster",
+            "worker",
+            "show",
+            url,
+            "-u",
+            instance.connection_username,
+            "-p",
+            instance.connection_password,
+        ]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            env=env,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        show_output = instance_process.stdout.read()
+
+        assert show_output.strip() == worker_cfg.strip()
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_show_auth_bad_credentials(
+    tt_cmd,
+    tmpdir_with_cfg,
+    instance_name,
+    request,
+):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+
+    conn = instance.conn()
+    storage_key = "/prefix/instances/host1/worker1"
+    if instance_name == "etcd":
+        conn.put(storage_key, worker_cfg)
+    else:
+        conn.call("config.storage.put", storage_key, worker_cfg)
+
+    if instance_name == "etcd":
+        instance.enable_auth()
+
+    try:
+        url = f"http://invalid_user:invalid_pass@{instance.host}:{instance.port}/prefix/host1/worker1?timeout=1"
+        show_cmd = [tt_cmd, "cluster", "worker", "show", url]
+        instance_process = subprocess.Popen(
+            show_cmd,
+            cwd=tmpdir,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        show_output = instance_process.stdout.read()
+
+        assert "failed to connect to storage: failed to connect to etcd or tarantool" in show_output
+    finally:
+        if instance_name == "etcd":
+            instance.disable_auth()
+
+
+@pytest.mark.parametrize("instance_name", ["etcd", "tcs"])
+def test_cluster_worker_publish_then_show(tt_cmd, tmpdir_with_cfg, instance_name, request):
+    instance = request.getfixturevalue(instance_name)
+    tmpdir = tmpdir_with_cfg
+    worker_cfg_path = os.path.join(tmpdir, "worker.yaml")
+    with open(worker_cfg_path, "w") as f:
+        f.write(worker_cfg)
+
+    creds = (
+        f"{instance.connection_username}:{instance.connection_password}@"
+        if instance_name == "tcs"
+        else ""
+    )
+    url = "http://" + creds + f"{instance.host}:{instance.port}/prefix/host1/worker1?timeout=5"
+
+    publish_cmd = [tt_cmd, "cluster", "worker", "publish", url, "worker.yaml"]
+    instance_process = subprocess.Popen(
+        publish_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    publish_output = instance_process.stdout.read()
+    assert "" == publish_output
+
+    show_cmd = [tt_cmd, "cluster", "worker", "show", url]
+    instance_process = subprocess.Popen(
+        show_cmd,
+        cwd=tmpdir,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    show_output = instance_process.stdout.read()
+
+    assert show_output.strip() == worker_cfg.strip()


### PR DESCRIPTION
@TarantoolBot document
Title: `tt cluster worker show` implementation

Implement `tt cluster worker show` command for showing worker configurations from etcd or tarantool config storage (TCS). The command accepts a URL with format:

```
http(s)://[username:password@]host:port/prefix/host-name/worker-name
```

* prefix - a base path to the worker configuration.
* host-name - a name of the host.
* worker-name - a name of the worker.

Possible arguments:

* timeout - a request timeout in seconds (default 3.0).
* ssl_key_file - a path to a private SSL key file.
* ssl_cert_file - a path to an SSL certificate file.
* ssl_ca_file - a path to a trusted certificate authorities (CA) file.
* ssl_ca_path - a path to a trusted certificate authorities (CA) directory.
* ssl_ciphers - a list of allowed SSL ciphers.
* verify_host - set off (default true) verification of the certificate's name against the host.
* verify_peer - set off (default true) verification of the peer's SSL certificate.

The command supports the following environment variables:

* TT_CLI_USERNAME - specifies a Tarantool username;
* TT_CLI_PASSWORD - specifies a Tarantool password.
* TT_CLI_ETCD_USERNAME - specifies a Etcd username;
* TT_CLI_ETCD_PASSWORD - specifies a Etcd password.

The priority of credentials:

environment variables < command flags < URL credentials.

Usage:

```
tt cluster worker show <URI>
```

Supported flags:
```
-h, --help              help for show
-p, --password string   password (used as etcd/tarantool config
                        storage credentials)
-u, --username string   username (used as etcd/tarantool config
                        storage credentials)
```
Example:

```
tt cluster worker show \
  https://user:pass@localhost:2379/cluster/workers/host/server-1
```

The implementation uses go-storage library for both etcd and TCS. It reads the worker configuration from the storage key `/<prefix>/instances/<host-name>/<worker-name>` and outputs it in YAML format. If the worker configuration is not found, an error is returned.

Closes TNTP-7060
