### PR TITLE
test: fix flaky test_restart_simple_app_auto_yes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -273,6 +273,7 @@ def tt_app(tt, tt_path, tt_instances, tt_running_targets, tt_post_start):
         p = tt.run("start", target)
         assert p.returncode == 0
     app.running_instances = app.instances_of(*tt_running_targets)
+    assert tt_helper.wait_status(5, app, app.running_instances, ["RUNNING"])
     if tt_post_start is not None:
         tt_post_start(app)
     yield app

--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -109,6 +109,12 @@ def check_restart(tt, tt_app, target, input, is_confirm, *args):
     for inst in tt_app.instances:
         was_running = inst in tt_app.running_instances
         if is_confirm and inst in target_instances:
+            if status[inst]["STATUS"] != "RUNNING":
+                with open(tt_app.log_path(inst, utils.log_file)) as f:
+                    print(f"log of instance {inst} ======")
+                    print(f.read())
+                    print("=============================")
+                    assert False
             assert status[inst]["STATUS"] == "RUNNING"
             assert f"Starting an instance [{inst}]" in out
             if was_running:

--- a/test/tt_helper.py
+++ b/test/tt_helper.py
@@ -251,6 +251,21 @@ def wait_box_status(timeout, tt_app, instances, acceptable_statuses, interval=0.
     )
 
 
+def wait_status(timeout, tt_app, instances, acceptable_statuses, interval=0.1):
+    def are_all_statuses_acceptable(tt, instances, acceptable_statuses):
+        status_ = status(tt)
+        return all([(status_[inst].get("STATUS") in acceptable_statuses) for inst in instances])
+
+    return utils.wait_event(
+        timeout,
+        are_all_statuses_acceptable,
+        interval,
+        tt_app.tt,
+        instances,
+        acceptable_statuses,
+    )
+
+
 def post_start_base(tt_app):
     assert utils.wait_files(5, pid_files(tt_app, tt_app.running_instances))
 


### PR DESCRIPTION
The patch add proper check that tarantool is started.
Also logging was improved to get more information in case of failure.

I didn't forget about (remove if it is not applicable):

- [x] Well-written commit messages (see [documentation][how-to-write-commit] how to write a commit message)

Related issues:

Closes TNTP-7654

[go-doc]: https://go.dev/blog/godoc
[go-testing]: https://pkg.go.dev/testing
[how-to-write-commit]: https://www.tarantool.io/en/doc/latest/contributing/developer_guidelines/#how-to-write-a-commit-message
[keepachangelog]: https://keepachangelog.com/en/1.0.0/
[tarantoolbot-example]: https://github.com/tarantool/tt/pull/1030/commits
