### PR TITLE
running: detect missing tarantool through wrapped errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ for machine-readable output.
 ### Fixed
 
 - `tt`: return non-zero exit code on unknown command.
+- `tt run`: report `tarantool executable is not found` instead of a raw
+  `open "": no such file or directory` error when Tarantool is missing.
 
 ## [2.11.5] - 2026-03-19
 

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -152,7 +152,7 @@ func (inst *baseInstance) StopWithSignal(waitTimeout time.Duration, usedSignal o
 func (inst *baseInstance) Run(opts RunOpts) error {
 	f, err := inst.integrityCtx.Repository.Read(inst.tarantoolPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return errors.New("tarantool executable is not found")
 		}
 		return err


### PR DESCRIPTION
On `v3`, `full-ci-ce-no-tarantool` fails: `test/integration/run/test_run.py::test_run_without_tarantool`.

Running `tt run` without a Tarantool binary prints the raw, unhelpful:
```
⨯ open "": open : no such file or directory
```
instead of the expected `tarantool executable is not found`. The job passes on `master`, so this is a v3 regression.

The v3 integrity refactor changed `dummyRepository.Read` (`lib/integrity/integrity.go`) to wrap the `os.Open` error:
```go
return nil, fmt.Errorf("open %q: %w", path, err)
```
But `baseInstance.Run` (`cli/running/base_instance.go`) detected the missing binary with the legacy `os.IsNotExist(err)`, which does **not** unwrap. The wrapped `ErrNotExist` slipped past the check, so the friendly message was skipped and the raw error leaked