### PR TITLE
running: detect missing tarantool through wrapped errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ for machine-readable output.
 ### Fixed
 
 - `tt`: return non-zero exit code on unknown command.
+- `tt run`: report `tarantool executable is not found` instead of a raw
+  `open "": no such file or directory` error when Tarantool is missing.
 
 ## [2.11.5] - 2026-03-19
 

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -152,7 +152,7 @@ func (inst *baseInstance) StopWithSignal(waitTimeout time.Duration, usedSignal o
 func (inst *baseInstance) Run(opts RunOpts) error {
 	f, err := inst.integrityCtx.Repository.Read(inst.tarantoolPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return errors.New("tarantool executable is not found")
 		}
 		return err


### PR DESCRIPTION
The integrity dummyRepository.Read now wraps the os.Open error with fmt.Errorf("open %q: %w", ...). baseInstance.Run checked the result with the legacy os.IsNotExist, which does not unwrap, so a missing tarantool binary leaked a raw 'open "": no such file or directory' message instead of the friendly 'tarantool executable is not found'.

Use errors.Is(err, os.ErrNotExist) so the wrapped not-exist error is recognized again. Fixes test_run_without_tarantool on v3.