### PR TITLE
cli/manifest: derive package version and generate version.lua

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,11 +90,15 @@ linters:
           allow:
             - $gostd
             - "github.com/pelletier/go-toml/v2"
+            # cli/manifest/version derives SemVer with go-version so its
+            # pre-release ordering matches the dependency resolver.
+            - "github.com/hashicorp/go-version"
         test:
           files:
             - "$test"
           allow:
             - $gostd
             - "github.com/pelletier/go-toml/v2"
+            - "github.com/hashicorp/go-version"
             - "github.com/stretchr/testify"
             - "github.com/tarantool/tt/cli/manifest"

--- a/cli/manifest/version/lua.go
+++ b/cli/manifest/version/lua.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// GenerateVersionLua renders the version.lua descriptor for ver, stamped with
+// builtAt. The build drops the result at
+// .rocks/share/tarantool/<package>/version.lua; this function only produces the
+// text and never touches the filesystem, so detecting a pre-existing
+// version.lua is the build's job.
+//
+// Generation is on by default and disabled per-package via
+// [package].generate_version_lua = false; that gate lives in the build, which
+// consults manifest.Package.GenerateVersionLuaValue before calling here.
+func GenerateVersionLua(ver Version, builtAt time.Time) string {
+	var buf strings.Builder
+
+	buf.WriteString("return {\n")
+	fmt.Fprintf(&buf, "    version  = %s,\n", luaString(ver.SemVer))
+	fmt.Fprintf(&buf, "    commit   = %s,\n", luaString(ver.Commit))
+	fmt.Fprintf(&buf, "    dirty    = %t,\n", ver.Dirty)
+	fmt.Fprintf(&buf, "    flavor   = %s,\n", luaString(ver.Flavor))
+	fmt.Fprintf(&buf, "    built_at = %s,\n", luaString(builtAt.UTC().Format(time.RFC3339)))
+	buf.WriteString("}\n")
+
+	return buf.String()
+}
+
+// luaString renders s as a double-quoted Lua string literal, escaping the two
+// characters that would otherwise break out of it.
+func luaString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+
+	return `"` + s + `"`
+}

--- a/cli/manifest/version/lua_test.go
+++ b/cli/manifest/version/lua_test.go
@@ -1,0 +1,75 @@
+package version_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+func TestGenerateVersionLua(t *testing.T) {
+	t.Parallel()
+
+	ver := version.Version{
+		SemVer: "1.4.1-dev.3+gabc1234.dirty",
+		Commit: "abc1234",
+		Dirty:  true,
+		Flavor: "ce",
+	}
+	builtAt := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	got := version.GenerateVersionLua(ver, builtAt)
+
+	assert.Equal(t, `return {
+    version  = "1.4.1-dev.3+gabc1234.dirty",
+    commit   = "abc1234",
+    dirty    = true,
+    flavor   = "ce",
+    built_at = "2026-06-15T12:00:00Z",
+}
+`, got)
+}
+
+func TestGenerateVersionLuaNormalizesTimeToUTC(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("MSK", 3*60*60)
+	builtAt := time.Date(2026, 6, 15, 15, 0, 0, 0, loc)
+
+	ver := version.Version{SemVer: "", Commit: "", Dirty: false, Flavor: "ee"}
+	got := version.GenerateVersionLua(ver, builtAt)
+
+	assert.Contains(t, got, `built_at = "2026-06-15T12:00:00Z"`)
+	assert.Contains(t, got, `flavor   = "ee"`)
+	assert.Contains(t, got, `dirty    = false`)
+}
+
+// TestGenerateVersionLuaToggle pins where the on/off switch lives: the generator
+// always renders, and the build consults the manifest to decide whether to call
+// it. Default is on; only an explicit false turns it off.
+func TestGenerateVersionLuaToggle(t *testing.T) {
+	t.Parallel()
+
+	disabled := false
+	enabled := true
+
+	pkg := func(toggle *bool) manifest.Package {
+		return manifest.Package{
+			Name:               "x",
+			Description:        "",
+			License:            "",
+			LicenseFiles:       nil,
+			Include:            nil,
+			Repository:         "",
+			Authors:            nil,
+			GenerateVersionLua: toggle,
+		}
+	}
+
+	assert.True(t, pkg(nil).GenerateVersionLuaValue())
+	assert.True(t, pkg(&enabled).GenerateVersionLuaValue())
+	assert.False(t, pkg(&disabled).GenerateVersionLuaValue())
+}

--- a/cli/manifest/version/version.go
+++ b/cli/manifest/version/version.go
@@ -1,0 +1,300 @@
+// Package version derives a package version from a git tree and an optional
+// VERSION file, and renders the version.lua descriptor that the build drops
+// into a package.
+//
+// It only derives the version string and generates version.lua; dependency
+// resolution and the actual build live elsewhere.
+package version
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+// versionFileName is the optional one-line SemVer override that sits next to
+// the manifest and takes precedence over git.
+const versionFileName = "VERSION"
+
+// lockFileName is excluded from the dirty check: a regenerated lock on an
+// otherwise clean release commit must not spuriously mark the version .dirty.
+const lockFileName = "app.manifest.lock"
+
+// porcelainPrefix is the width of the two status columns plus a space that
+// "git status --porcelain" prints in front of every path.
+const porcelainPrefix = 3
+
+// Version is a derived package version.
+type Version struct {
+	SemVer string // Rendered SemVer, e.g. "1.4.1-dev.3+gabc1234.dirty".
+	Commit string // Short sha "abc1234", or empty when there is no commit.
+	Dirty  bool   // Working tree had uncommitted changes (lock excluded).
+	Flavor string // ce|ee - a build fact, set by the build, not by Derive.
+}
+
+// Derive determines the package version from the git tree rooted at dir and a
+// VERSION file in dir, if present.
+//
+// Source precedence:
+//  1. a VERSION file next to the manifest (one line, SemVer 2.0.0);
+//  2. the most recent v* tag reachable from HEAD (git describe);
+//  3. a tagless fallback of 0.0.0-dev.<N>+g<sha>, N = commits in HEAD's history.
+//
+// A missing git binary or .git directory is not fatal: derivation falls through
+// to the next source rather than panicking.
+func Derive(dir string) (Version, error) {
+	ver, ok, err := deriveFromFile(dir)
+	if err != nil {
+		return ver, err
+	}
+
+	if ok {
+		return ver, nil
+	}
+
+	dirty := isDirty(dir)
+
+	ver, ok = deriveFromGitDescribe(dir, dirty)
+	if ok {
+		return ver, nil
+	}
+
+	return deriveFallback(dir, dirty), nil
+}
+
+// deriveFromFile reads the VERSION file. The file is an explicit pin: the
+// version is taken verbatim (minus a leading "v"), without git metadata or a
+// dirty marker. ok is false when the file is absent.
+func deriveFromFile(dir string) (Version, bool, error) {
+	var ver Version
+
+	//nolint:gosec // Reads the caller's own manifest directory, not user input.
+	raw, err := os.ReadFile(filepath.Join(dir, versionFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return ver, false, nil
+	}
+
+	if err != nil {
+		return ver, false, fmt.Errorf("reading %s: %w", versionFileName, err)
+	}
+
+	semver := strings.TrimPrefix(strings.TrimSpace(string(raw)), "v")
+
+	_, err = goversion.NewSemver(semver)
+	if err != nil {
+		return ver, false, fmt.Errorf("%s: %q is not SemVer 2.0.0: %w",
+			versionFileName, semver, err)
+	}
+
+	ver.SemVer = semver
+
+	return ver, true, nil
+}
+
+// deriveFromGitDescribe runs git describe and applies the pre-release / dev
+// cycle rules. ok is false when there is no usable SemVer v* tag, in which case
+// the caller falls back to deriveFallback.
+func deriveFromGitDescribe(dir string, dirty bool) (Version, bool) {
+	var ver Version
+
+	// The --match 'v[0-9]*' pattern requires a digit after the v, so vfinal and
+	// friends never reach the parser; --long always prints the <tag>-<N>-g<sha> form.
+	out, err := runGit(dir, "describe", "--tags", "--long", "--match", "v[0-9]*", "HEAD")
+	if err != nil {
+		return ver, false
+	}
+
+	tag, count, sha, ok := splitDescribe(out)
+	if !ok {
+		return ver, false
+	}
+
+	parsed, err := goversion.NewSemver(strings.TrimPrefix(tag, "v"))
+	if err != nil {
+		// A v* tag that is not SemVer (e.g. vfinal) is not a version: skip it.
+		return ver, false
+	}
+
+	ver.SemVer = renderDescribed(parsed, count, sha, dirty)
+	ver.Commit = shortSHA(sha)
+	ver.Dirty = dirty
+
+	return ver, true
+}
+
+// deriveFallback builds the tagless 0.0.0-dev.<N>+g<sha> version. N is the total
+// commit count of HEAD; both N and the sha degrade to empty values when git is
+// unavailable, yielding a still-valid 0.0.0-dev.0.
+func deriveFallback(dir string, dirty bool) Version {
+	var ver Version
+
+	count := "0"
+
+	out, err := runGit(dir, "rev-list", "--count", "HEAD")
+	if err == nil {
+		count = out
+	}
+
+	sha := ""
+
+	out, err = runGit(dir, "rev-parse", "--short", "HEAD")
+	if err == nil {
+		sha = out
+	}
+
+	ver.SemVer = "0.0.0-dev." + count + buildMetadata(gitSHA(sha), dirty)
+	ver.Commit = sha
+	ver.Dirty = dirty
+
+	return ver
+}
+
+// renderDescribed applies rules 1-5 to a parsed tag, the number of commits since
+// it, and the short sha.
+func renderDescribed(parsed *goversion.Version, count int, sha string, dirty bool) string {
+	core := coreString(parsed)
+	pre := parsed.Prerelease()
+
+	switch {
+	case count == 0 && pre == "":
+		// Exactly on a release tag: bare version (plus a dirty marker if any).
+		return core + buildMetadata("", dirty)
+	case count == 0:
+		// Exactly on a pre-release tag.
+		return core + "-" + pre + buildMetadata("", dirty)
+	case pre == "":
+		// Commits after a release tag bump the patch and open a -dev cycle.
+		return bumpPatch(parsed) + "-dev." + strconv.Itoa(count) +
+			buildMetadata(gitSHA(sha), dirty)
+	default:
+		// Commits after a pre-release tag extend the same pre-release segment;
+		// the patch does not grow.
+		return core + "-" + pre + ".dev." + strconv.Itoa(count) +
+			buildMetadata(gitSHA(sha), dirty)
+	}
+}
+
+// buildMetadata assembles the +<sha>.<dirty> build-metadata suffix, omitting the
+// leading '+' entirely when there is nothing to attach.
+func buildMetadata(sha string, dirty bool) string {
+	var parts []string
+
+	if sha != "" {
+		parts = append(parts, sha)
+	}
+
+	if dirty {
+		parts = append(parts, "dirty")
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return "+" + strings.Join(parts, ".")
+}
+
+// coreString renders the major.minor.patch core of a parsed version.
+func coreString(ver *goversion.Version) string {
+	s := ver.Segments()
+	return fmt.Sprintf("%d.%d.%d", s[0], s[1], s[2])
+}
+
+// bumpPatch renders the core with the patch incremented by one.
+func bumpPatch(ver *goversion.Version) string {
+	s := ver.Segments()
+	return fmt.Sprintf("%d.%d.%d", s[0], s[1], s[2]+1)
+}
+
+// splitDescribe pulls apart "<tag>-<N>-g<sha>". The tag may itself contain
+// dashes (pre-release tags do), so the count and sha are taken from the right.
+// The final bool is false when the input is not in describe --long shape.
+func splitDescribe(desc string) (string, int, string, bool) {
+	dash := strings.LastIndex(desc, "-")
+	if dash < 0 {
+		return "", 0, "", false
+	}
+
+	sha := desc[dash+1:]
+	if !strings.HasPrefix(sha, "g") {
+		return "", 0, "", false
+	}
+
+	rest := desc[:dash]
+
+	dash = strings.LastIndex(rest, "-")
+	if dash < 0 {
+		return "", 0, "", false
+	}
+
+	count, err := strconv.Atoi(rest[dash+1:])
+	if err != nil {
+		return "", 0, "", false
+	}
+
+	return rest[:dash], count, sha, true
+}
+
+// gitSHA normalizes a short sha to the g-prefixed form used in build metadata
+// (+gabc1234); an empty sha stays empty.
+func gitSHA(sha string) string {
+	if sha == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(sha, "g") {
+		return sha
+	}
+
+	return "g" + sha
+}
+
+// shortSHA strips the g prefix that git describe puts in front of the sha.
+func shortSHA(sha string) string {
+	return strings.TrimPrefix(sha, "g")
+}
+
+// isDirty reports whether the working tree has uncommitted changes, ignoring
+// the manifest lock so a regenerated lock alone does not mark a clean release.
+func isDirty(dir string) bool {
+	out, err := runGit(dir, "status", "--porcelain")
+	if err != nil {
+		return false
+	}
+
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Porcelain lines are "XY <path>"; drop the two status columns.
+		path := strings.TrimSpace(line[min(porcelainPrefix, len(line)):])
+		if filepath.Base(path) == lockFileName {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// runGit runs git in dir and returns its trimmed stdout.
+func runGit(dir string, args ...string) (string, error) {
+	//nolint:gosec // Fixed program (git) with internally built args on the caller's dir.
+	cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dir}, args...)...)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cli/manifest/version/version_test.go
+++ b/cli/manifest/version/version_test.go
@@ -1,0 +1,225 @@
+package version_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+// lockFile is the manifest lock; a change to it alone must not mark the tree
+// dirty.
+const lockFile = "app.manifest.lock"
+
+// git runs a git command in dir and fails the test on error.
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	//nolint:gosec // Fixed program (git) with test-controlled args.
+	cmd := exec.CommandContext(
+		context.Background(), "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+}
+
+// initRepo creates a fresh repository with a deterministic identity.
+func initRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	git(t, dir, "init", "-q")
+	git(t, dir, "config", "user.email", "test@example.com")
+	git(t, dir, "config", "user.name", "Test")
+	git(t, dir, "config", "commit.gpgsign", "false")
+
+	return dir
+}
+
+// commit records an empty commit so history can grow without touching files.
+func commit(t *testing.T, dir, msg string) {
+	t.Helper()
+	git(t, dir, "commit", "--allow-empty", "-q", "-m", msg)
+}
+
+func TestDerive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string)
+		wantMatch string
+		wantDirty bool
+	}{
+		{
+			name: "clean release tag",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0")
+			},
+			wantMatch: `^1\.4\.0$`,
+			wantDirty: false,
+		},
+		{
+			name: "commits after release tag",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0")
+				commit(t, dir, "next")
+			},
+			wantMatch: `^1\.4\.1-dev\.1\+g[0-9a-f]+$`,
+			wantDirty: false,
+		},
+		{
+			name: "clean pre-release tag",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0-rc.1")
+			},
+			wantMatch: `^1\.4\.0-rc\.1$`,
+			wantDirty: false,
+		},
+		{
+			name: "commits after pre-release tag",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0-rc.1")
+				commit(t, dir, "a")
+				commit(t, dir, "b")
+			},
+			wantMatch: `^1\.4\.0-rc\.1\.dev\.2\+g[0-9a-f]+$`,
+			wantDirty: false,
+		},
+		{
+			name: "no tags",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "a")
+				commit(t, dir, "b")
+				commit(t, dir, "c")
+			},
+			wantMatch: `^0\.0\.0-dev\.3\+g[0-9a-f]+$`,
+			wantDirty: false,
+		},
+		{
+			name: "non-semver tag is skipped",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "a")
+				git(t, dir, "tag", "release-2026")
+				commit(t, dir, "b")
+			},
+			wantMatch: `^0\.0\.0-dev\.2\+g[0-9a-f]+$`,
+			wantDirty: false,
+		},
+		{
+			name: "uncommitted changes mark dirty",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0")
+				commit(t, dir, "next")
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "stray.txt"), []byte("x"), 0o600))
+			},
+			wantMatch: `^1\.4\.1-dev\.1\+g[0-9a-f]+\.dirty$`,
+			wantDirty: true,
+		},
+		{
+			name: "lock change alone is not dirty",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				commit(t, dir, "init")
+				git(t, dir, "tag", "v1.4.0")
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, lockFile), []byte("x"), 0o600))
+			},
+			wantMatch: `^1\.4\.0$`,
+			wantDirty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := initRepo(t)
+			tt.setup(t, dir)
+
+			ver, err := version.Derive(dir)
+			require.NoError(t, err)
+			assert.Regexp(t, tt.wantMatch, ver.SemVer)
+			assert.Equal(t, tt.wantDirty, ver.Dirty)
+
+			// Whatever we render must round-trip as SemVer 2.0.0.
+			_, err = goversion.NewSemver(ver.SemVer)
+			assert.NoError(t, err, "rendered %q is not valid SemVer", ver.SemVer)
+		})
+	}
+}
+
+func TestDeriveVersionFileOverridesGit(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepo(t)
+	commit(t, dir, "init")
+	git(t, dir, "tag", "v1.4.0")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "VERSION"), []byte("v2.0.0\n"), 0o600))
+
+	ver, err := version.Derive(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", ver.SemVer)
+	assert.Empty(t, ver.Commit)
+	assert.False(t, ver.Dirty)
+}
+
+func TestDeriveVersionFileRejectsNonSemVer(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepo(t)
+	commit(t, dir, "init")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "VERSION"), []byte("final\n"), 0o600))
+
+	_, err := version.Derive(dir)
+	assert.Error(t, err)
+}
+
+func TestDeriveCommitShort(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepo(t)
+	commit(t, dir, "init")
+	git(t, dir, "tag", "v1.4.0")
+	commit(t, dir, "next")
+
+	ver, err := version.Derive(dir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ver.Commit)
+	assert.NotContains(t, ver.Commit, "g", "Commit must not keep the describe g prefix")
+	assert.Regexp(t, `^[0-9a-f]+$`, ver.Commit)
+}
+
+// TestPreReleaseOrdering pins the lexical ordering the resolver relies on:
+// a pre-release sorts below its release.
+func TestPreReleaseOrdering(t *testing.T) {
+	t.Parallel()
+
+	prerelease, err := goversion.NewVersion("1.4.0-rc.1")
+	require.NoError(t, err)
+
+	release, err := goversion.NewVersion("1.4.0")
+	require.NoError(t, err)
+
+	assert.True(t, prerelease.LessThan(release), "1.4.0-rc.1 must sort below 1.4.0")
+}


### PR DESCRIPTION
Add cli/manifest/version, the source of truth for a package's version so it is never written by hand. Derive resolves, in order, a VERSION file next to the manifest, the most recent v* tag (git describe), then a tagless 0.0.0-dev.<N>+g<sha> fallback. It strips a leading v, keeps only SemVer 2.0.0 tags, passes pre-releases through, opens a -dev.N cycle after a release tag (bumping the patch) or a .dev.N cycle after a pre-release tag (patch frozen), and appends .dirty build metadata for uncommitted changes - excluding the manifest lock so a regenerated lock alone does not stale a clean release.

GenerateVersionLua renders the version.lua descriptor (version, commit, dirty, flavor, built_at); the build decides whether to emit it via package.generate_version_lua and where to drop it. Versions are parsed and compared with go-version so pre-release ordering matches the resolver.

The new code sits under the strict cli/manifest golangci ruleset; go-version is added to its depguard allow-list as the package's one dependency.

Closes TNTP-8229