### PR TITLE
connect: add history command feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt connect`: \history command.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ env:
   inc_dir: path/to/inc_dir
   restart_on_failure: bool
   tarantoolctl_layout: bool
+  ouptut_history_max: 15
 modules:
   directory: path/to/modules/dir
 app:
@@ -341,6 +342,8 @@ templates:
     compatible mode for artifact files: control socket, pid, log files.
     Data files (wal, vinyl, snapshots) and multi-instance applications
     are not affected by this option.
+- `ouptut_history_max` (int) - the maximum number of commands output 
+    by the "\history" command. Default vaule is 10
 
 #### modules
 

--- a/cli/cfg/dump_test.go
+++ b/cli/cfg/dump_test.go
@@ -92,6 +92,7 @@ env:
   instances_enabled: %[1]s
   restart_on_failure: false
   tarantoolctl_layout: false
+  ouptut_history_max: 0
 modules:
   directory: /root/modules
 app:
@@ -128,6 +129,7 @@ env:
   instances_enabled: %[1]s
   restart_on_failure: false
   tarantoolctl_layout: false
+  ouptut_history_max: 0
 modules:
   directory:
   - /root/modules
@@ -166,6 +168,7 @@ env:
   instances_enabled: %[1]s/instances.enabled
   restart_on_failure: false
   tarantoolctl_layout: false
+  ouptut_history_max: 0
 modules:
   directory: %[1]s/my_modules
 app:
@@ -203,6 +206,7 @@ env:
   instances_enabled: .
   restart_on_failure: false
   tarantoolctl_layout: false
+  ouptut_history_max: 0
 modules:
   directory: /root/modules
 app:

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -124,6 +124,13 @@ func makeConnOpts(network, address string, connCtx connect.ConnectCtx) connector
 	}
 }
 
+func getMaxHistoryOutputLen(cliOpts *config.CliOpts) int {
+	if cliOpts.Env == nil || cliOpts.Env.OutputHistoryMax <= 0 {
+		return connect.DefaultOutputHistorySize
+	}
+	return cliOpts.Env.OutputHistoryMax
+}
+
 // resolveConnectOpts tries to resolve target argument to replace it
 // with a control socket or as a URI with/without credentials.
 // It returns connection options and the remaining args.
@@ -183,6 +190,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 	if connectCtx.ConnectTarget == "" {
 		connectCtx.ConnectTarget = target
 	}
+	connOpts.MaxOutputHistoryLen = getMaxHistoryOutputLen(cliOpts)
 	return connOpts, err
 }
 

--- a/cli/cmd/connect_test.go
+++ b/cli/cmd/connect_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/tt/cli/config"
+	"github.com/tarantool/tt/cli/connect"
+)
+
+func TestGenMaxHistoryOption(t *testing.T) {
+	t.Run("not configured", func(t *testing.T) {
+		opts := config.CliOpts{}
+		actual := getMaxHistoryOutputLen(&opts)
+		assert.Equal(t, connect.DefaultOutputHistorySize, actual)
+	})
+	t.Run("invalid configuration", func(t *testing.T) {
+		opts := config.CliOpts{Env: &config.TtEnvOpts{OutputHistoryMax: 0}}
+		actual := getMaxHistoryOutputLen(&opts)
+		assert.Equal(t, connect.DefaultOutputHistorySize, actual)
+	})
+	t.Run("correct configuration", func(t *testing.T) {
+		opts := config.CliOpts{Env: &config.TtEnvOpts{OutputHistoryMax: 2}}
+		actual := getMaxHistoryOutputLen(&opts)
+		assert.Equal(t, 2, actual)
+	})
+}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -67,6 +67,9 @@ type TtEnvOpts struct {
 	// application sub-directories are not created for runtime artifacts like
 	// control socket, pid files and logs.
 	TarantoolctlLayout bool `mapstructure:"tarantoolctl_layout" yaml:"tarantoolctl_layout"`
+	// The maximum number of commands output by the "\history" command.
+	// Default vaule is 10
+	OutputHistoryMax int `mapstructure:"ouptut_history_max" yaml:"ouptut_history_max"`
 }
 
 // TemplateOpts contains configuration for applications templates.

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -420,8 +420,8 @@ func getHistoryFunc(console *Console, _ string, _ []string) (string, error) {
 		return "", nil
 	}
 	outputData := console.history.commands
-	if len(console.history.commands) > maxHistorySize {
-		outputData = outputData[len(outputData)-maxHistorySize:]
+	if len(console.history.commands) > console.connOpts.MaxOutputHistoryLen {
+		outputData = outputData[len(outputData)-console.connOpts.MaxOutputHistoryLen:]
 	}
 	return strings.Join(outputData, "\n-----\n"), nil
 }

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -414,6 +414,18 @@ func getShortcutsFunc(console *Console, cmd string, args []string) (string, erro
 	return shortcutListText, nil
 }
 
+// getHistoryFunc returns last {maxHistorySize} executed commands
+func getHistoryFunc(console *Console, _ string, _ []string) (string, error) {
+	if len(console.history.commands) == 0 {
+		return "", nil
+	}
+	outputData := console.history.commands
+	if len(console.history.commands) > maxHistorySize {
+		outputData = outputData[len(outputData)-maxHistorySize:]
+	}
+	return strings.Join(outputData, "\n-----\n"), nil
+}
+
 // setQuitFunc sets the quit flag for the console.
 func setQuitFunc(console *Console, cmd string, arg []string) (string, error) {
 	console.quit = true
@@ -556,6 +568,13 @@ var cmdInfos = []cmdInfo{
 		Long:  "show available hotkeys and shortcuts",
 		Cmd: newNoArgsCmdDecorator(
 			newBaseCmd([]string{getShortcutsList}, getShortcutsFunc),
+		),
+	},
+	{
+		Short: getHistoryList,
+		Long:  "show history of executed commands",
+		Cmd: newNoArgsCmdDecorator(
+			newBaseCmd([]string{getHistoryList}, getHistoryFunc),
 		),
 	},
 	// The Tarantool console has `\quit` command, but it requires execute

--- a/cli/connect/commands_test.go
+++ b/cli/connect/commands_test.go
@@ -1,0 +1,52 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tarantool/tt/cli/connector"
+)
+
+func TestConsoleHistoryOutput(t *testing.T) {
+	t.Run("empty command list", func(t *testing.T) {
+		history, err := newCommandHistory("test", 100)
+		assert.NoError(t, err)
+		console := Console{history: history}
+		actual, err := getHistoryFunc(&console, "", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "", actual)
+	})
+	t.Run("history is less than max len", func(t *testing.T) {
+		history, err := newCommandHistory("test", 100)
+		history.appendCommand("test1")
+		history.appendCommand("test2")
+		assert.NoError(t, err)
+		console := Console{history: history, connOpts: connector.ConnectOpts{MaxOutputHistoryLen: 5}}
+		actual, err := getHistoryFunc(&console, "", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "test1\n-----\ntest2", actual)
+	})
+	t.Run("history is equal max len", func(t *testing.T) {
+		history, err := newCommandHistory("test", 100)
+		history.appendCommand("test1")
+		history.appendCommand("test2")
+		history.appendCommand("test3")
+		assert.NoError(t, err)
+		console := Console{history: history, connOpts: connector.ConnectOpts{MaxOutputHistoryLen: 3}}
+		actual, err := getHistoryFunc(&console, "", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "test1\n-----\ntest2\n-----\ntest3", actual)
+	})
+	t.Run("history is more max len", func(t *testing.T) {
+		history, err := newCommandHistory("test", 100)
+		history.appendCommand("test1")
+		history.appendCommand("test2")
+		history.appendCommand("test3")
+		history.appendCommand("test4")
+		assert.NoError(t, err)
+		console := Console{history: history, connOpts: connector.ConnectOpts{MaxOutputHistoryLen: 3}}
+		actual, err := getHistoryFunc(&console, "", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "test2\n-----\ntest3\n-----\ntest4", actual)
+	})
+}

--- a/cli/connect/const.go
+++ b/cli/connect/const.go
@@ -86,5 +86,5 @@ const shortcutListText = `---
        Alt + F                     -- Move forwards one word
 ...`
 
-// maximal count of commands to output in \history command.
-const maxHistorySize = 10
+// Default maximal count of commands to output in \history command.
+const DefaultOutputHistorySize = 10

--- a/cli/connect/const.go
+++ b/cli/connect/const.go
@@ -55,6 +55,9 @@ var setQuit = []string{"\\quit", "\\q"}
 // getShortcutsList is a command to get shortcuts and a list of hotkeys.
 const getShortcutsList = "\\shortcuts"
 
+// getHistoryList is a command to get history of executed commands.
+const getHistoryList = "\\history"
+
 // getHelpCmd is a command to get a help message.
 var getHelp = []string{"\\help", "?"}
 
@@ -82,3 +85,6 @@ const shortcutListText = `---
        Alt + B                     -- Move backwards one word
        Alt + F                     -- Move forwards one word
 ...`
+
+// maximal count of commands to output in \history command.
+const maxHistorySize = 10

--- a/cli/connector/opts.go
+++ b/cli/connector/opts.go
@@ -18,6 +18,8 @@ type ConnectOpts struct {
 	Password string
 	// Ssl options for a connection.
 	Ssl SslOpts
+	// maximal count of commands to output in \history command.
+	MaxOutputHistoryLen int
 }
 
 // SslOpts is a way to configure SSL connection.

--- a/test/integration/connect/test_connect.py
+++ b/test/integration/connect/test_connect.py
@@ -186,6 +186,7 @@ def test_connect_and_get_commands_outputs(tt_cmd, tmpdir_with_cfg):
   \\x[l,t,T,y]                     -- set output format lua, table, ttable or yaml
   \\x[g,G]                         -- disables/enables pseudographics for table modes
   \\shortcuts                      -- show available hotkeys and shortcuts
+  \\history                        -- show history of executed commands
   \\quit, \\q                       -- quit from the console
 
 """


### PR DESCRIPTION
The user can view the history of executed commands in the tt connect tool by using the "\history" command. The maximum number of commands displayed is 10.
Samples:
<img width="654" height="634" alt="image" src="https://github.com/user-attachments/assets/ed95b72e-17b7-4312-be4c-6aeb2bc96bba" />
```
127.0.0.1:3301> \help
...
  \shortcuts                      -- show available hotkeys and shortcuts
  \history                        -- show history of executed commands
  \quit, \q                       -- quit from the console
```


