### PR TITLE
backup: add xlog adapter impl

### DIFF
--- a/.cspell_project-words.txt
+++ b/.cspell_project-words.txt
@@ -37,6 +37,7 @@ heywoodlh
 iconfig
 incdir
 infof
+inprogress
 iproto
 leaderuuid
 libcluster
@@ -113,4 +114,5 @@ vshard
 vylog
 warnf
 xcall
+xdir
 xlog*

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.8.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
-	github.com/klauspost/compress v1.18.5
+	github.com/klauspost/compress v1.18.6
 	github.com/magefile/mage v1.15.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-isatty v0.0.20
@@ -30,10 +30,12 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tarantool/cartridge-cli v0.0.0-00010101000000-000000000000
+	github.com/tarantool/go-iproto v1.1.0
 	github.com/tarantool/go-prompt v1.0.1
 	github.com/tarantool/go-storage v1.5.0
 	github.com/tarantool/go-tarantool v1.12.3
 	github.com/tarantool/go-tarantool/v2 v2.4.2
+	github.com/tarantool/go-xlog v0.0.0-20260707203858-fed522934686
 	github.com/tarantool/tt/lib/cluster v0.0.0
 	github.com/tarantool/tt/lib/connect v0.0.0-0
 	github.com/tarantool/tt/lib/dial v0.0.0-0
@@ -145,7 +147,6 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/tarantool/go-iproto v1.1.0 // indirect
 	github.com/tarantool/go-openssl v1.2.2 // indirect
 	github.com/tarantool/go-option v1.0.0 // indirect
 	github.com/tarantool/go-tlsdialer v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7X
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.11 h1:0OwqZRYI2rFrjS4kvkDnqJkKHdHaRnCm68/DY4OxRzU=
 github.com/klauspost/cpuid/v2 v2.2.11/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
@@ -369,6 +369,8 @@ github.com/tarantool/go-tarantool/v2 v2.4.2 h1:rkzYtFhLJLA9RDIhjzN93MJBN5PBxHW4+
 github.com/tarantool/go-tarantool/v2 v2.4.2/go.mod h1:MTbhdjFc3Jl63Lgi/UJr5D+QbT+QegqOzsNJGmaw7VM=
 github.com/tarantool/go-tlsdialer v1.0.2 h1:TiOkihvC2ufLbOqJcJLuQ9I7W5bsZtmnT7KHF/t8n4s=
 github.com/tarantool/go-tlsdialer v1.0.2/go.mod h1:ztE9J5oh4YzNQkSqlpjA0OkY89zHy/BiJJbbSFm+IiQ=
+github.com/tarantool/go-xlog v0.0.0-20260707203858-fed522934686 h1:2SjjYqDhtjen/3pHeSwpXDBM9dNZoXhuYb/s6vhKnU4=
+github.com/tarantool/go-xlog v0.0.0-20260707203858-fed522934686/go.mod h1:ZDu6simTStt+JG8BlHStzS2JAs/8k9HeynblSoR8+bo=
 github.com/testcontainers/testcontainers-go v0.43.0 h1:oEQx5MW2DGd9z3AeEQfB2lPM0eLs7ztyaGRu75bFo5A=
 github.com/testcontainers/testcontainers-go v0.43.0/go.mod h1:+VxkT2NQnKOZPKi6praMuMKYHYyOGXr0XSBSlSMCzFo=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=

--- a/lib/backup/xlog/adapters.go
+++ b/lib/backup/xlog/adapters.go
@@ -1,0 +1,195 @@
+package xlog
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/google/uuid"
+
+	xdir "github.com/tarantool/go-xlog/dir"
+	"github.com/tarantool/go-xlog/filter"
+	"github.com/tarantool/go-xlog/format"
+	"github.com/tarantool/go-xlog/pipe"
+	"github.com/tarantool/go-xlog/reader"
+	"github.com/tarantool/go-xlog/tools"
+	"github.com/tarantool/go-xlog/writer"
+
+	"github.com/tarantool/tt/lib/backup"
+)
+
+// PatchInstanceUUID rewrites the Instance field in the src header
+// writing to dst.
+func PatchInstanceUUID(src, dst, newUUID string) error {
+	id, err := uuid.Parse(newUUID)
+	if err != nil {
+		return fmt.Errorf("%w: %q: %w", ErrInvalidUUID, newUUID, err)
+	}
+
+	if src == dst {
+		err := tools.ReplaceInstanceUUIDInPlace(src, id)
+		if errors.Is(err, tools.ErrUUIDWidthMismatch) {
+			return fmt.Errorf("%w: %q", ErrInPlaceWidthMismatch, src)
+		}
+
+		if err != nil {
+			return fmt.Errorf("xlog: patch instance uuid in place %q: %w", src, err)
+		}
+
+		return nil
+	}
+
+	if err := tools.RewriteMeta(src, dst, tools.ReplaceInstanceUUID(id)); err != nil {
+		return fmt.Errorf("xlog: patch instance uuid %q to %q: %w", src, dst, err)
+	}
+
+	return nil
+}
+
+// TruncateAt copies transactions from src to dst up to and including the
+// recovery point, dropping the rest.
+func TruncateAt(src, dst string, replicaID uint32, lsn int64) error {
+	pred := filter.UntilVClock(format.VClock{replicaID: lsn})
+
+	outVClock, err := computeTruncatedVClock(src, pred)
+	if err != nil {
+		return err
+	}
+
+	meta, err := reader.ReadHeader(src)
+	if err != nil {
+		return fmt.Errorf("xlog: truncate: read header %q: %w", src, err)
+	}
+
+	meta.VClock = outVClock
+
+	return copyKeptTxs(src, dst, meta, pred)
+}
+
+// FindTrimFile returns the .xlog in dir whose transaction stream includes the
+// point (replicaID, lsn).
+func FindTrimFile(dir string, replicaID uint32, lsn int64) (string, error) {
+	d, err := xdir.OpenDir(dir, format.FiletypeXLOG)
+	if err != nil {
+		return "", fmt.Errorf("xlog: index xlog dir %q: %w", dir, err)
+	}
+
+	entry, err := d.LocateLSN(replicaID, lsn)
+	if err != nil {
+		if errors.Is(err, xdir.ErrNotFound) {
+			return "", fmt.Errorf("%w: dir %q replica %d lsn %d",
+				ErrTrimFileNotFound, dir, replicaID, lsn)
+		}
+
+		return "", fmt.Errorf("xlog: locate trim file in %q: %w", dir, err)
+	}
+
+	return entry.Path, nil
+}
+
+// toFormatVClock converts a manifest vclock to format.VClock.
+func toFormatVClock(v backup.Vclock) (format.VClock, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	out := make(format.VClock, len(v))
+
+	for id, lsn := range v {
+		if lsn > math.MaxInt64 {
+			return nil, fmt.Errorf("%w: replica %d lsn %d exceeds int64", ErrLSNOverflow, id, lsn)
+		}
+
+		out[id] = int64(lsn)
+	}
+
+	return out, nil
+}
+
+// fromFormatVClock is the inverse of toFormatVClock, returning ErrLSNOverflow
+// if any LSN is negative.
+func fromFormatVClock(v format.VClock) (backup.Vclock, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	out := make(backup.Vclock, len(v))
+
+	for id, lsn := range v {
+		if lsn < 0 {
+			return nil, fmt.Errorf("%w: replica %d lsn %d is negative", ErrLSNOverflow, id, lsn)
+		}
+
+		out[id] = uint64(lsn)
+	}
+
+	return out, nil
+}
+
+// computeTruncatedVClock returns the per-replica high-water of every row in
+// every kept transaction — the exact VClock for the truncated output.
+func computeTruncatedVClock(src string, pred filter.Filter) (format.VClock, error) {
+	r, err := reader.Open(src)
+	if err != nil {
+		return nil, fmt.Errorf("xlog: truncate: open %q: %w", src, err)
+	}
+
+	defer func() { _ = r.Close() }()
+
+	out := format.VClock{}
+
+	for tx, err := range r.Txs() {
+		if err != nil {
+			return nil, fmt.Errorf("xlog: truncate: read tx from %q: %w", src, err)
+		}
+
+		if !slices.ContainsFunc(tx.Rows, pred) {
+			continue
+		}
+
+		for i := range tx.Rows {
+			if row := tx.Rows[i]; row.LSN > out[row.ReplicaID] {
+				out[row.ReplicaID] = row.LSN
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// copyKeptTxs writes meta to dst and streams every transaction from src that
+// passes pred, discarding the .inprogress file on any error.
+func copyKeptTxs(src, dst string, meta *format.Meta, pred filter.Filter) error {
+	r, err := reader.Open(src)
+	if err != nil {
+		return fmt.Errorf("xlog: truncate: open %q: %w", src, err)
+	}
+
+	defer func() { _ = r.Close() }()
+
+	w, err := writer.Create(dst, meta)
+	if err != nil {
+		return fmt.Errorf("xlog: truncate: create %q: %w", dst, err)
+	}
+
+	committed := false
+
+	defer func() {
+		if !committed {
+			_ = w.Discard()
+		}
+	}()
+
+	if _, err := pipe.Copy(r, w, pred); err != nil {
+		return fmt.Errorf("xlog: truncate: copy %q to %q: %w", src, dst, err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("xlog: truncate: finalize %q: %w", dst, err)
+	}
+
+	committed = true
+
+	return nil
+}

--- a/lib/backup/xlog/convert_test.go
+++ b/lib/backup/xlog/convert_test.go
@@ -1,0 +1,86 @@
+package xlog
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-xlog/format"
+
+	"github.com/tarantool/tt/lib/backup"
+)
+
+func TestToFormatVClock_RoundTrip(t *testing.T) {
+	src := backup.Vclock{0: 0, 1: 42, 2: 9000}
+
+	got, err := toFormatVClock(src)
+	require.NoError(t, err)
+	require.Equal(t, format.VClock{0: 0, 1: 42, 2: 9000}, got)
+
+	back, err := fromFormatVClock(got)
+	require.NoError(t, err)
+	require.Equal(t, src, back)
+}
+
+func TestToFormatVClock_Empty(t *testing.T) {
+	got, err := toFormatVClock(backup.Vclock{})
+	require.NoError(t, err)
+	require.Equal(t, format.VClock{}, got)
+}
+
+func TestToFormatVClock_Nil(t *testing.T) {
+	got, err := toFormatVClock(nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestToFormatVClock_Overflow(t *testing.T) {
+	src := backup.Vclock{1: math.MaxInt64 + 1}
+
+	_, err := toFormatVClock(src)
+	require.ErrorIs(t, err, ErrLSNOverflow)
+}
+
+func TestToFormatVClock_MaxInt64OK(t *testing.T) {
+	src := backup.Vclock{1: math.MaxInt64}
+
+	got, err := toFormatVClock(src)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt64), got[1])
+}
+
+func TestFromFormatVClock_Negative(t *testing.T) {
+	src := format.VClock{1: -1}
+
+	_, err := fromFormatVClock(src)
+	require.ErrorIs(t, err, ErrLSNOverflow)
+}
+
+func TestFromFormatVClock_Nil(t *testing.T) {
+	got, err := fromFormatVClock(nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestVClock_RoundTripBoundaries(t *testing.T) {
+	src := backup.Vclock{
+		0:  0,
+		1:  1,
+		7:  math.MaxInt64,
+		13: 1 << 40,
+	}
+
+	fv, err := toFormatVClock(src)
+	require.NoError(t, err)
+
+	back, err := fromFormatVClock(fv)
+	require.NoError(t, err)
+	require.Equal(t, src, back)
+}
+
+func TestVClock_OverflowIsSentinel(t *testing.T) {
+	_, err := toFormatVClock(backup.Vclock{1: math.MaxUint64})
+	require.True(t, errors.Is(err, ErrLSNOverflow))
+}

--- a/lib/backup/xlog/errors.go
+++ b/lib/backup/xlog/errors.go
@@ -1,0 +1,11 @@
+package xlog
+
+import "errors"
+
+var (
+	ErrInvalidUUID          = errors.New("xlog: invalid instance UUID")
+	ErrTrimFileNotFound     = errors.New("xlog: no xlog file contains the recovery point")
+	ErrLSNOverflow          = errors.New("xlog: lsn out of range for int64<->uint64 conversion")
+	ErrInPlaceWidthMismatch = errors.New(
+		"xlog: on-disk UUID width differs from replacement; use distinct src and dst")
+)

--- a/lib/backup/xlog/find_test.go
+++ b/lib/backup/xlog/find_test.go
@@ -1,0 +1,101 @@
+package xlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-xlog/format"
+)
+
+// buildChain builds three .xlog files on replica 1:
+//
+//	A: vclock {1:0}  rows 1..3  -> 0.xlog
+//	B: vclock {1:3}  rows 4..6  -> 3.xlog
+//	C: vclock {1:6}  rows 7..9  -> 6.xlog
+//
+// Each file's VClock is its start boundary; it holds rows with lsn strictly
+// greater than that value (Tarantool's <signature>.xlog convention).
+// dir.LocateLSN returns the file with the largest VClock[replica] <= lsn.
+func buildChain(t *testing.T, dir string) (a, b, c string) {
+	t.Helper()
+
+	a = writeChainFile(t, dir, format.VClock{1: 0}, nil, [][]format.XRow{
+		{row(t, 1, 1)}, {row(t, 1, 2)}, {row(t, 1, 3)},
+	})
+	b = writeChainFile(t, dir, format.VClock{1: 3}, format.VClock{1: 0}, [][]format.XRow{
+		{row(t, 1, 4)}, {row(t, 1, 5)}, {row(t, 1, 6)},
+	})
+	c = writeChainFile(t, dir, format.VClock{1: 6}, format.VClock{1: 3}, [][]format.XRow{
+		{row(t, 1, 7)}, {row(t, 1, 8)}, {row(t, 1, 9)},
+	})
+
+	return a, b, c
+}
+
+func TestFindTrimFile_MidChain(t *testing.T) {
+	dir := t.TempDir()
+	a, b, _ := buildChain(t, dir)
+
+	got, err := FindTrimFile(dir, 1, 2) // lsn 2 in A (start 0 <= 2)
+	require.NoError(t, err)
+	require.Equal(t, a, got)
+
+	got, err = FindTrimFile(dir, 1, 5) // lsn 5 in B (start 3 <= 5)
+	require.NoError(t, err)
+	require.Equal(t, b, got)
+}
+
+func TestFindTrimFile_LastFile(t *testing.T) {
+	dir := t.TempDir()
+	_, _, c := buildChain(t, dir)
+
+	got, err := FindTrimFile(dir, 1, 8)
+	require.NoError(t, err)
+	require.Equal(t, c, got)
+}
+
+// lsn equal to a file's start vclock resolves to that file (largest VClock <= lsn).
+func TestFindTrimFile_OnBoundary(t *testing.T) {
+	dir := t.TempDir()
+	_, b, _ := buildChain(t, dir)
+
+	got, err := FindTrimFile(dir, 1, 3)
+	require.NoError(t, err)
+	require.Equal(t, b, got)
+}
+
+func TestFindTrimFile_AboveChain(t *testing.T) {
+	dir := t.TempDir()
+	_, _, c := buildChain(t, dir)
+
+	got, err := FindTrimFile(dir, 1, 100)
+	require.NoError(t, err)
+	require.Equal(t, c, got)
+}
+
+func TestFindTrimFile_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := FindTrimFile(dir, 1, 1)
+	require.ErrorIs(t, err, ErrTrimFileNotFound)
+}
+
+func TestFindTrimFile_BelowChain(t *testing.T) {
+	dir := t.TempDir()
+	writeChainFile(t, dir, format.VClock{1: 10}, nil, [][]format.XRow{{row(t, 1, 11)}})
+
+	_, err := FindTrimFile(dir, 1, -1)
+	require.ErrorIs(t, err, ErrTrimFileNotFound)
+}
+
+// For a replica absent from every file all VClock[replica]=0 entries tie;
+// LocateLSN breaks ties toward the last (highest-signature) file.
+func TestFindTrimFile_UnknownReplicaTiesToLast(t *testing.T) {
+	dir := t.TempDir()
+	_, _, c := buildChain(t, dir)
+
+	got, err := FindTrimFile(dir, 2, 0)
+	require.NoError(t, err)
+	require.Equal(t, c, got)
+}

--- a/lib/backup/xlog/helpers_test.go
+++ b/lib/backup/xlog/helpers_test.go
@@ -1,0 +1,150 @@
+package xlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-iproto"
+
+	"github.com/tarantool/go-xlog/format"
+	"github.com/tarantool/go-xlog/reader"
+	"github.com/tarantool/go-xlog/writer"
+)
+
+const testUUID = "11111111-1111-1111-1111-111111111111"
+
+// mkBody builds a minimal valid msgpack DML body: {IPROTO_TUPLE: [v]}.
+func mkBody(t *testing.T, v uint64) []byte {
+	t.Helper()
+
+	buf := []byte{0x81, byte(iproto.IPROTO_TUPLE), 0x91}
+	if v < 0x80 {
+		return append(buf, byte(v))
+	}
+
+	return append(buf, 0xcf,
+		byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32),
+		byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+func row(t *testing.T, rep uint32, lsn int64) format.XRow {
+	t.Helper()
+
+	return format.XRow{
+		Type:      iproto.IPROTO_INSERT,
+		ReplicaID: rep,
+		LSN:       lsn,
+		BodyRaw:   mkBody(t, uint64(lsn)),
+	}
+}
+
+// writeXlog creates a finalized journal at path with one tx per element of txs.
+func writeXlog(t *testing.T, path string, meta *format.Meta, txs [][]format.XRow) {
+	t.Helper()
+
+	w, err := writer.Create(path, meta)
+	require.NoError(t, err)
+
+	for _, tx := range txs {
+		require.NoError(t, w.WriteTx(tx))
+	}
+
+	require.NoError(t, w.Close())
+}
+
+func xlogMeta(t *testing.T, instUUID string, vclock, prev format.VClock) *format.Meta {
+	t.Helper()
+
+	id, err := uuid.Parse(instUUID)
+	require.NoError(t, err)
+
+	return &format.Meta{
+		Filetype:     format.FiletypeXLOG,
+		Version:      "tt-test/1.0",
+		InstanceUUID: id,
+		VClock:       vclock,
+		PrevVClock:   prev,
+	}
+}
+
+func snapMeta(t *testing.T, instUUID string, vclock format.VClock) *format.Meta {
+	t.Helper()
+
+	id, err := uuid.Parse(instUUID)
+	require.NoError(t, err)
+
+	return &format.Meta{
+		Filetype:     format.FiletypeSNAP,
+		Version:      "tt-test/1.0",
+		InstanceUUID: id,
+		VClock:       vclock,
+	}
+}
+
+type rowKey struct {
+	ReplicaID uint32
+	LSN       int64
+}
+
+// readAllRows returns every row's (ReplicaID, LSN), asserting a clean,
+// EOF-terminated file.
+func readAllRows(t *testing.T, path string) []rowKey {
+	t.Helper()
+
+	r, err := reader.Open(path)
+	require.NoError(t, err)
+
+	defer func() { _ = r.Close() }()
+
+	var out []rowKey
+
+	for row, err := range r.Rows() {
+		require.NoError(t, err)
+		out = append(out, rowKey{ReplicaID: row.ReplicaID, LSN: row.LSN})
+	}
+
+	require.True(t, r.SawEOFMarker(), "file %s must end with a valid EOF marker", path)
+
+	return out
+}
+
+func readMeta(t *testing.T, path string) *format.Meta {
+	t.Helper()
+
+	m, err := reader.ReadHeader(path)
+	require.NoError(t, err)
+
+	return m
+}
+
+func fileBytes(t *testing.T, path string) []byte {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return b
+}
+
+func tmpPath(t *testing.T, name string) string {
+	t.Helper()
+
+	return filepath.Join(t.TempDir(), name)
+}
+
+// writeChainFile writes one .xlog named after its vclock signature (the
+// <signature>.xlog convention dir.OpenDir validates) and returns the path.
+func writeChainFile(
+	t *testing.T, dir string, vclock, prev format.VClock, txs [][]format.XRow,
+) string {
+	t.Helper()
+
+	path := filepath.Join(dir, fmt.Sprintf("%020d.xlog", vclock.Signature()))
+	writeXlog(t, path, xlogMeta(t, testUUID, vclock, prev), txs)
+
+	return path
+}

--- a/lib/backup/xlog/patch_test.go
+++ b/lib/backup/xlog/patch_test.go
@@ -1,0 +1,132 @@
+package xlog
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-xlog/format"
+)
+
+const patchedUUID = "22222222-2222-2222-2222-222222222222"
+
+// metaEnd returns the offset just past the header's blank-line terminator,
+// where tx blocks begin.
+func metaEnd(b []byte) int {
+	i := bytes.Index(b, []byte("\n\n"))
+	if i < 0 {
+		return len(b)
+	}
+
+	return i + 2
+}
+
+func TestPatchInstanceUUID_OnCopy_XLOG(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	meta := xlogMeta(t, testUUID, format.VClock{1: 3}, format.VClock{1: 0})
+	writeXlog(t, src, meta, [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2)},
+		{row(t, 1, 3)},
+	})
+
+	require.NoError(t, PatchInstanceUUID(src, dst, patchedUUID))
+
+	dm := readMeta(t, dst)
+	require.Equal(t, patchedUUID, dm.InstanceUUID.String())
+
+	// Everything else in the header is preserved.
+	sm := readMeta(t, src)
+	require.Equal(t, sm.Version, dm.Version)
+	require.Equal(t, sm.FormatVer, dm.FormatVer)
+	require.Equal(t, sm.VClock, dm.VClock)
+	require.Equal(t, sm.PrevVClock, dm.PrevVClock)
+
+	// Source untouched, rows identical.
+	require.Equal(t, testUUID, readMeta(t, src).InstanceUUID.String())
+	require.Equal(t, readAllRows(t, src), readAllRows(t, dst))
+}
+
+// Bodies and CRCs are preserved byte-for-byte: the tail after the header is
+// identical between src and dst.
+func TestPatchInstanceUUID_PreservesTailBytes(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	meta := xlogMeta(t, testUUID, format.VClock{1: 2}, nil)
+	writeXlog(t, src, meta, [][]format.XRow{
+		{row(t, 1, 1), row(t, 1, 2)},
+	})
+
+	require.NoError(t, PatchInstanceUUID(src, dst, patchedUUID))
+
+	sb := fileBytes(t, src)
+	db := fileBytes(t, dst)
+
+	require.Equal(t, sb[metaEnd(sb):], db[metaEnd(db):])
+}
+
+func TestPatchInstanceUUID_OnCopy_SNAP(t *testing.T) {
+	src := tmpPath(t, "src.snap")
+	dst := tmpPath(t, "dst.snap")
+
+	meta := snapMeta(t, testUUID, format.VClock{1: 2})
+	writeXlog(t, src, meta, [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2)},
+	})
+
+	require.NoError(t, PatchInstanceUUID(src, dst, patchedUUID))
+
+	dm := readMeta(t, dst)
+	require.Equal(t, format.FiletypeSNAP, dm.Filetype)
+	require.Equal(t, patchedUUID, dm.InstanceUUID.String())
+	require.Equal(t, readAllRows(t, src), readAllRows(t, dst))
+}
+
+// src == dst re-stamps in place, leaving the rest of the file intact.
+func TestPatchInstanceUUID_InPlace(t *testing.T) {
+	path := tmpPath(t, "inplace.xlog")
+
+	meta := xlogMeta(t, testUUID, format.VClock{1: 2}, nil)
+	writeXlog(t, path, meta, [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2)},
+	})
+
+	before := fileBytes(t, path)
+
+	require.NoError(t, PatchInstanceUUID(path, path, patchedUUID))
+
+	require.Equal(t, patchedUUID, readMeta(t, path).InstanceUUID.String())
+
+	after := fileBytes(t, path)
+	require.Equal(t, before[metaEnd(before):], after[metaEnd(after):])
+	require.Len(t, after, len(before))
+}
+
+func TestPatchInstanceUUID_InvalidUUID(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 1}, nil),
+		[][]format.XRow{{row(t, 1, 1)}})
+
+	err := PatchInstanceUUID(src, dst, "not-a-uuid")
+	require.ErrorIs(t, err, ErrInvalidUUID)
+}
+
+// A no-op re-stamp (new == current) still succeeds.
+func TestPatchInstanceUUID_SameUUID(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 1}, nil),
+		[][]format.XRow{{row(t, 1, 1)}})
+
+	require.NoError(t, PatchInstanceUUID(src, dst, testUUID))
+	require.Equal(t, testUUID, readMeta(t, dst).InstanceUUID.String())
+}

--- a/lib/backup/xlog/truncate_test.go
+++ b/lib/backup/xlog/truncate_test.go
@@ -1,0 +1,138 @@
+package xlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-xlog/format"
+)
+
+// The point is inclusive: LSN == lsn is kept, everything above dropped.
+func TestTruncateAt_InclusivePoint(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 5}, nil), [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2)},
+		{row(t, 1, 3)},
+		{row(t, 1, 4)},
+		{row(t, 1, 5)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 3))
+
+	require.Equal(t, []rowKey{{1, 1}, {1, 2}, {1, 3}}, readAllRows(t, dst))
+}
+
+// The output VClock is clamped to the point so the signature matches content.
+func TestTruncateAt_ClampsVClock(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 5}, nil), [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2)},
+		{row(t, 1, 3)},
+		{row(t, 1, 4)},
+		{row(t, 1, 5)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 3))
+
+	require.Equal(t, int64(3), readMeta(t, dst).VClock[1])
+}
+
+// A multi-row tx straddling the point is kept whole — truncation never splits
+// a transaction.
+func TestTruncateAt_MultiRowTxAcrossPointKeptWhole(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 5}, nil), [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 1, 2), row(t, 1, 3), row(t, 1, 4)},
+		{row(t, 1, 5)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 3))
+
+	require.Equal(t, []rowKey{{1, 1}, {1, 2}, {1, 3}, {1, 4}}, readAllRows(t, dst))
+}
+
+// A transaction entirely above the point is dropped whole.
+func TestTruncateAt_TxWhollyAbovePointDropped(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 4}, nil), [][]format.XRow{
+		{row(t, 1, 1), row(t, 1, 2)},
+		{row(t, 1, 3), row(t, 1, 4)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 2))
+
+	require.Equal(t, []rowKey{{1, 1}, {1, 2}}, readAllRows(t, dst))
+}
+
+// Truncating on replica 1 keeps replica-2 rows riding along in kept txs, and
+// each replica's high-water reflects only the written rows.
+func TestTruncateAt_MultiReplica(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 3, 2: 2}, nil), [][]format.XRow{
+		{row(t, 1, 1)},
+		{row(t, 2, 1), row(t, 1, 2)},
+		{row(t, 2, 2), row(t, 1, 3)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 2))
+
+	require.Equal(t, []rowKey{{1, 1}, {2, 1}, {1, 2}}, readAllRows(t, dst))
+
+	m := readMeta(t, dst)
+	require.Equal(t, int64(2), m.VClock[1])
+	require.Equal(t, int64(1), m.VClock[2])
+}
+
+// Point on the last row: output equals input.
+func TestTruncateAt_PointOnLastRow(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 3}, nil), [][]format.XRow{
+		{row(t, 1, 1)}, {row(t, 1, 2)}, {row(t, 1, 3)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 3))
+
+	require.Equal(t, readAllRows(t, src), readAllRows(t, dst))
+}
+
+// An empty xlog truncates to a valid, empty, EOF-terminated file.
+func TestTruncateAt_EmptyXlog(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{}, nil), nil)
+
+	require.NoError(t, TruncateAt(src, dst, 1, 10))
+
+	require.Empty(t, readAllRows(t, dst))
+}
+
+// The output always ends with a valid EOF marker.
+func TestTruncateAt_OutputIsFinalized(t *testing.T) {
+	src := tmpPath(t, "src.xlog")
+	dst := tmpPath(t, "dst.xlog")
+
+	writeXlog(t, src, xlogMeta(t, testUUID, format.VClock{1: 4}, nil), [][]format.XRow{
+		{row(t, 1, 1)}, {row(t, 1, 2)}, {row(t, 1, 3)}, {row(t, 1, 4)},
+	})
+
+	require.NoError(t, TruncateAt(src, dst, 1, 2))
+
+	require.Equal(t, []rowKey{{1, 1}, {1, 2}}, readAllRows(t, dst))
+}

--- a/test/integration/running/cluster_app/storage.lua
+++ b/test/integration/running/cluster_app/storage.lua
@@ -13,7 +13,7 @@ end
 box.cfg{}
 
 -- Create something to generate xlogs.
-box.schema.space.create('test-' .. box.cfg.instance_name)
+box.schema.space.create('test-' .. box.cfg.instance_name, {if_not_exists = true})
 
 while true do
     log.info(pid_path)


### PR DESCRIPTION
Wrap go-xlog with three restore operations against .snap/.xlog files: PatchInstanceUUID (re-stamp instance UUID, bodies/CRCs preserved), TruncateAt (transaction-aware truncation at a recovery point), and FindTrimFile (locate the xlog for a point).

Closes TNTP-8390
