### PR TITLE
resolve: structural conflicts, registry routing, caching

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,9 @@ linters:
             # pre-release ordering matches the dependency resolver.
             - "github.com/hashicorp/go-version"
             - "github.com/tarantool/tt/lib/luarocks"
+            # cli/manifest/resolve composes the model and the luarocks adapter
+            # into the dependency-resolution engine.
+            - "github.com/tarantool/tt/cli/manifest"
         test:
           files:
             - "$test"

--- a/cli/manifest/resolve/cache.go
+++ b/cli/manifest/resolve/cache.go
@@ -1,0 +1,136 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+)
+
+// resolveCache memoizes the adapter calls and directory hashing across a single
+// Engine.Resolve run, so products that share a dependency resolve, fetch and
+// hash it once rather than once per product. It is scoped to one resolution
+// pass; a rock version's rockspec is immutable, and a requirement is keyed by
+// its exact (name, constraint, registry), so every cached value is sound to
+// reuse within the run. Not safe for concurrent use - resolution is sequential.
+type resolveCache struct {
+	resolved map[string]rocks.ResolvedRock
+	metadata map[string]*luarocks.Rockspec
+	content  map[string]string
+	// local caches LocalMetadata by directory. A cached leaf (a directory with
+	// no rockspec) stores a nil rockspec; the comma-ok on the read distinguishes
+	// it (present, nil) from a not-yet-cached directory (absent).
+	local map[string]*luarocks.Rockspec
+	// warnedNoMD5 records the artifact URLs whose rock published no md5 so the
+	// reproducibility warning is emitted once per run, not once per product that
+	// shares the rock (the walker is per-product, but this cache is run-wide).
+	warnedNoMD5 map[string]bool
+}
+
+func newResolveCache() *resolveCache {
+	return &resolveCache{
+		resolved:    map[string]rocks.ResolvedRock{},
+		metadata:    map[string]*luarocks.Rockspec{},
+		content:     map[string]string{},
+		local:       map[string]*luarocks.Rockspec{},
+		warnedNoMD5: map[string]bool{},
+	}
+}
+
+// markNoMD5 records that the rock at url published no md5 and reports whether
+// this is the first time in the run - so a checksum-less rock shared by several
+// products warns once, not once per product.
+func (c *resolveCache) markNoMD5(url string) bool {
+	if c.warnedNoMD5[url] {
+		return false
+	}
+
+	c.warnedNoMD5[url] = true
+
+	return true
+}
+
+// resolveRock memoizes adapter.Resolve by (name, constraint, registry). Errors
+// are not cached - a transient failure should be retryable on the next product.
+func (c *resolveCache) resolveRock(
+	ctx context.Context, adapter Adapter, name, constraintExpr, registry string,
+) (rocks.ResolvedRock, error) {
+	key := name + "\x00" + constraintExpr + "\x00" + registry
+
+	hit, ok := c.resolved[key]
+	if ok {
+		return hit, nil
+	}
+
+	got, err := adapter.Resolve(ctx, name, constraintExpr, registry)
+	if err != nil {
+		return rocks.ResolvedRock{}, err //nolint:wrapcheck // resolveOne adds context
+	}
+
+	c.resolved[key] = got
+
+	return got, nil
+}
+
+// rockMetadata memoizes adapter.Metadata by the resolved artifact URL. The URL,
+// not (name, version), is the identity of the fetched rockspec: the same name
+// and version can come from different servers (a per-dependency registry
+// override, or the default multi-server order) with different source.md5 and
+// different transitive dependencies, so keying by version alone would share the
+// wrong rockspec across products.
+func (c *resolveCache) rockMetadata(
+	ctx context.Context, adapter Adapter, rock rocks.ResolvedRock,
+) (*luarocks.Rockspec, error) {
+	key := rock.URL
+
+	hit, ok := c.metadata[key]
+	if ok {
+		return hit, nil
+	}
+
+	got, err := adapter.Metadata(ctx, rock)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // resolveOne adds the dependency context
+	}
+
+	c.metadata[key] = got
+
+	return got, nil
+}
+
+// dirContentHash memoizes contentHash by directory.
+func (c *resolveCache) dirContentHash(dir string) (string, error) {
+	hit, ok := c.content[dir]
+	if ok {
+		return hit, nil
+	}
+
+	got, err := contentHash(dir)
+	if err != nil {
+		return "", err
+	}
+
+	c.content[dir] = got
+
+	return got, nil
+}
+
+// localMetadata memoizes adapter.LocalMetadata by directory. A directory with
+// no rockspec (rocks.ErrNoLocalRockspec) is cached as a leaf: a nil rockspec
+// and no error.
+func (c *resolveCache) localMetadata(adapter Adapter, dir string) (*luarocks.Rockspec, error) {
+	hit, ok := c.local[dir]
+	if ok {
+		return hit, nil
+	}
+
+	spec, err := adapter.LocalMetadata(dir)
+	if err != nil && !errors.Is(err, rocks.ErrNoLocalRockspec) {
+		return nil, err //nolint:wrapcheck // resolvePath adds the dependency context
+	}
+
+	c.local[dir] = spec
+
+	return spec, nil
+}

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -24,17 +24,6 @@ const (
 // the engine from panicking on an unvalidated manifest.
 var errUnknownComponent = errors.New("product references unknown component")
 
-// providedRocks are dependency names supplied by the Tarantool VM itself, so
-// they are never resolved against a registry. Mirrors lib/luarocks/deps'
-// unexported set (Tarantool embeds LuaJIT 5.1); kept in sync deliberately.
-//
-//nolint:gochecknoglobals // provided-rock set, effectively a constant.
-var providedRocks = map[string]bool{
-	"lua":      true,
-	"luajit":   true,
-	"luabitop": true,
-}
-
 // depReq is one requirement to resolve: a name, the constraint in both string
 // (for the adapter) and parsed (for compatibility checks) form, and the source
 // it comes from. Direct requirements may carry a registry override or a path;
@@ -82,7 +71,7 @@ func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain [
 			return fmt.Errorf("resolving dependencies: %w", ctxErr)
 		}
 
-		if providedRocks[req.name] {
+		if deps.IsProvided(req.name) {
 			continue
 		}
 

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -54,7 +54,15 @@ type resolvedDep struct {
 // drives the adapter per chosen rock - one rockspec fetch each, honoring
 // per-dependency registry overrides - instead of preloading every candidate.
 type walker struct {
-	engine   *Engine
+	engine *Engine
+	cache  *resolveCache
+	// directs indexes the product's direct declarations by name. A direct
+	// declaration is authoritative for a dependency's identity (source, path,
+	// registry): if the same name is also reached transitively - possibly first,
+	// since the walk order is name-sorted - the transitive edge must not silently
+	// resolve it from the default registry or drop its path source. See
+	// authoritative.
+	directs  map[string]depReq
 	chosen   map[string]*resolvedDep
 	inFlight map[string]bool
 	order    []string // post-order: deepest dependency first
@@ -71,6 +79,13 @@ func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain [
 			return fmt.Errorf("resolving dependencies: %w", ctxErr)
 		}
 
+		// A transitive edge naming a directly-declared dependency defers to that
+		// declaration's identity (its path source or registry override), so the
+		// override holds no matter which branch reaches the rock first.
+		if parent != "" {
+			req = w.authoritative(req)
+		}
+
 		if deps.IsProvided(req.name) {
 			continue
 		}
@@ -81,7 +96,12 @@ func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain [
 
 		existing, chosen := w.chosen[req.name]
 		if chosen {
-			if !deps.Match(existing.version, req.constraints) {
+			// A path-sourced pick is an explicit local override (like a Go
+			// replace or a Cargo path dependency): it satisfies any transitive
+			// version constraint by fiat, so it is never a version conflict - and
+			// its version may be unknown (a leaf directory shipping no rockspec).
+			if existing.lockDep.Source != manifestSourcePath &&
+				!deps.Match(existing.version, req.constraints) {
 				return &conflictError{
 					detail: fmt.Sprintf("chose %s %s but %s requires %s",
 						req.name, existing.version.Raw, parentLabel(parent), constraintLabel(req)),
@@ -114,36 +134,51 @@ func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain [
 	return nil
 }
 
+// authoritative rewrites a transitive requirement so a directly-declared
+// dependency keeps its declared identity. A direct declaration that carries a
+// path source or a registry override wins over the default-registry identity a
+// transitive edge would otherwise impose; the transitive version constraint is
+// AND'd onto the direct declaration's so the pick still satisfies the requiring
+// rock. Transitive names the manifest does not declare directly, and direct
+// declarations with no override, are returned unchanged.
+func (w *walker) authoritative(req depReq) depReq {
+	direct, declared := w.directs[req.name]
+	if !declared || (direct.source != manifestSourcePath && direct.registry == "") {
+		return req
+	}
+
+	req.source = direct.source
+	req.path = direct.path
+	req.registry = direct.registry
+	req.constraints = append(
+		append([]luarocks.VersionConstraint{}, direct.constraints...), req.constraints...)
+	req.constraintExpr = joinConstraints(direct.constraintExpr, req.constraintExpr)
+
+	return req
+}
+
 // resolveOne resolves a single requirement into its lock entry and the
 // transitive requirements it introduces.
 func (w *walker) resolveOne(ctx context.Context, req depReq) (*resolvedDep, []depReq, error) {
 	if req.source == manifestSourcePath {
-		return w.engine.resolvePath(req)
+		return w.resolvePath(req)
 	}
 
-	resolved, err := w.engine.adapter.Resolve(ctx, req.name, req.constraintExpr, req.registry)
+	resolved, err := w.cache.resolveRock(
+		ctx, w.engine.adapter, req.name, req.constraintExpr, req.registry)
 	if err != nil {
-		// A multiply-declared direct dependency with no satisfying version is a
-		// conflict between its declarations, not a plain missing version.
-		if req.multiDeclared && errors.Is(err, rocks.ErrNoMatch) {
-			return nil, nil, &conflictError{
-				detail: fmt.Sprintf(
-					"global and per-component declarations of %q require incompatible versions",
-					req.name),
-				chain: nil,
-			}
-		}
-
 		return nil, nil, fmt.Errorf("resolving %q: %w", req.name, err)
 	}
 
-	spec, err := w.engine.adapter.Metadata(ctx, resolved)
+	spec, err := w.cache.rockMetadata(ctx, w.engine.adapter, resolved)
 	if err != nil {
 		return nil, nil, fmt.Errorf("metadata for %q: %w", req.name, err)
 	}
 
 	checksum, ok := rocks.Checksum(spec)
-	if !ok {
+	if !ok && w.cache.markNoMD5(resolved.URL) {
+		// Emit once per run: resolveOne re-runs per product (the walker is
+		// per-product), but the shared cache dedups the warning across them.
 		w.warnings = append(w.warnings, fmt.Sprintf(
 			"registry gave no md5 for %s %s; reproducibility is not guaranteed",
 			resolved.Name, resolved.Version.Raw))
@@ -221,6 +256,20 @@ func effectiveDeps(man *manifest.Manifest, product manifest.Product) ([]depReq, 
 		constraints, parseErr := deps.ParseConstraints(req.constraintExpr)
 		if parseErr != nil {
 			return nil, fmt.Errorf("dependency %q: %w", name, parseErr)
+		}
+
+		// A dependency declared in more than one place whose merged constraints
+		// cannot be jointly satisfied is a declaration conflict, caught here
+		// before any registry is queried (so it fires even when the rock is not
+		// published at all).
+		multiRegistry := req.multiDeclared && req.source == manifestSourceRegistry
+		if multiRegistry && !satisfiable(constraints) {
+			return nil, &conflictError{
+				detail: fmt.Sprintf(
+					"global and per-component declarations of %q disagree on version (%s)",
+					name, req.constraintExpr),
+				chain: nil,
+			}
 		}
 
 		req.constraints = constraints

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -1,0 +1,374 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+// Dependency source values, mirroring the manifest package's closed enum.
+const (
+	manifestSourceRegistry = "registry"
+	manifestSourcePath     = "path"
+)
+
+// errUnknownComponent guards against a product referencing a component the
+// manifest does not define. Validation already rejects this; the guard keeps
+// the engine from panicking on an unvalidated manifest.
+var errUnknownComponent = errors.New("product references unknown component")
+
+// providedRocks are dependency names supplied by the Tarantool VM itself, so
+// they are never resolved against a registry. Mirrors lib/luarocks/deps'
+// unexported set (Tarantool embeds LuaJIT 5.1); kept in sync deliberately.
+//
+//nolint:gochecknoglobals // provided-rock set, effectively a constant.
+var providedRocks = map[string]bool{
+	"lua":      true,
+	"luajit":   true,
+	"luabitop": true,
+}
+
+// depReq is one requirement to resolve: a name, the constraint in both string
+// (for the adapter) and parsed (for compatibility checks) form, and the source
+// it comes from. Direct requirements may carry a registry override or a path;
+// transitive requirements never do.
+type depReq struct {
+	name           string
+	constraintExpr string
+	constraints    []luarocks.VersionConstraint
+	registry       string
+	source         string
+	path           string
+	// multiDeclared marks a direct dependency declared in more than one place
+	// (global plus a component, or two components), so a no-match resolves to a
+	// declaration conflict rather than a plain "no version" error.
+	multiDeclared bool
+}
+
+// resolvedDep is a chosen dependency: its lock entry plus the parsed version,
+// kept so later branches can check their constraints against the pick.
+type resolvedDep struct {
+	lockDep manifest.LockDependency
+	version luarocks.Version
+}
+
+// walker performs the greedy depth-first closure walk. It mirrors
+// lib/luarocks/deps.Resolve (newest-that-fits, deepest-first topo order, one
+// version per name, cycle and conflict detection with the offending chain) but
+// drives the adapter per chosen rock - one rockspec fetch each, honoring
+// per-dependency registry overrides - instead of preloading every candidate.
+type walker struct {
+	engine   *Engine
+	chosen   map[string]*resolvedDep
+	inFlight map[string]bool
+	order    []string // post-order: deepest dependency first
+	warnings []string
+}
+
+// walk visits each requirement in reqs, recursing into a chosen rock's
+// transitive dependencies before moving on to its siblings. parent and chain
+// are carried for diagnostics.
+func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain []string) error {
+	for _, req := range reqs {
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return fmt.Errorf("resolving dependencies: %w", ctxErr)
+		}
+
+		if providedRocks[req.name] {
+			continue
+		}
+
+		if w.inFlight[req.name] {
+			return &cycleError{name: req.name, chain: appendChain(chain, req.name)}
+		}
+
+		existing, chosen := w.chosen[req.name]
+		if chosen {
+			if !deps.Match(existing.version, req.constraints) {
+				return &conflictError{
+					detail: fmt.Sprintf("chose %s %s but %s requires %s",
+						req.name, existing.version.Raw, parentLabel(parent), constraintLabel(req)),
+					chain: appendChain(chain, req.name),
+				}
+			}
+
+			continue
+		}
+
+		w.inFlight[req.name] = true
+
+		resolved, children, err := w.resolveOne(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		w.chosen[req.name] = resolved
+
+		walkErr := w.walk(ctx, req.name, children, append(chain, req.name))
+		if walkErr != nil {
+			return walkErr
+		}
+
+		delete(w.inFlight, req.name)
+
+		w.order = append(w.order, req.name)
+	}
+
+	return nil
+}
+
+// resolveOne resolves a single requirement into its lock entry and the
+// transitive requirements it introduces.
+func (w *walker) resolveOne(ctx context.Context, req depReq) (*resolvedDep, []depReq, error) {
+	if req.source == manifestSourcePath {
+		return w.engine.resolvePath(req)
+	}
+
+	resolved, err := w.engine.adapter.Resolve(ctx, req.name, req.constraintExpr, req.registry)
+	if err != nil {
+		// A multiply-declared direct dependency with no satisfying version is a
+		// conflict between its declarations, not a plain missing version.
+		if req.multiDeclared && errors.Is(err, rocks.ErrNoMatch) {
+			return nil, nil, &conflictError{
+				detail: fmt.Sprintf(
+					"global and per-component declarations of %q require incompatible versions",
+					req.name),
+				chain: nil,
+			}
+		}
+
+		return nil, nil, fmt.Errorf("resolving %q: %w", req.name, err)
+	}
+
+	spec, err := w.engine.adapter.Metadata(ctx, resolved)
+	if err != nil {
+		return nil, nil, fmt.Errorf("metadata for %q: %w", req.name, err)
+	}
+
+	checksum, ok := rocks.Checksum(spec)
+	if !ok {
+		w.warnings = append(w.warnings, fmt.Sprintf(
+			"registry gave no md5 for %s %s; reproducibility is not guaranteed",
+			resolved.Name, resolved.Version.Raw))
+	}
+
+	resolvedDependency := &resolvedDep{
+		lockDep: manifest.LockDependency{
+			Name:        resolved.Name,
+			Version:     resolved.Version.Raw,
+			Source:      manifestSourceRegistry,
+			Checksum:    checksum,
+			Path:        "",
+			ContentHash: "",
+		},
+		version: resolved.Version,
+	}
+
+	return resolvedDependency, transitiveReqs(spec.Dependencies), nil
+}
+
+// transitiveReqs turns a rockspec's dependency list into requirements. They
+// carry no registry override and no path - transitive rocks come from the
+// default server list.
+func transitiveReqs(rockDeps []luarocks.Dep) []depReq {
+	out := make([]depReq, 0, len(rockDeps))
+
+	for _, dependency := range rockDeps {
+		out = append(out, depReq{
+			name:           dependency.Name,
+			constraintExpr: formatConstraints(dependency.Constraints),
+			constraints:    dependency.Constraints,
+			registry:       "",
+			source:         manifestSourceRegistry,
+			path:           "",
+			multiDeclared:  false,
+		})
+	}
+
+	return out
+}
+
+// effectiveDeps assembles a product's direct dependencies: the union of the
+// global [dependencies] and the per-component [components.<c>.dependencies]
+// over every component of the product. A dependency declared in more than one
+// place is merged - its version constraints are AND'd together - but the
+// declarations must agree on source, path and registry; a disagreement is a
+// conflict. The result is sorted by name for a deterministic closure.
+func effectiveDeps(man *manifest.Manifest, product manifest.Product) ([]depReq, error) {
+	byName := map[string]*depReq{}
+
+	globalErr := mergeDeps(byName, "dependencies", man.Dependencies)
+	if globalErr != nil {
+		return nil, globalErr
+	}
+
+	for _, name := range product.Components {
+		component, defined := man.Components[name]
+		if !defined {
+			return nil, fmt.Errorf("%w: %q", errUnknownComponent, name)
+		}
+
+		field := "components." + name + ".dependencies"
+
+		compErr := mergeDeps(byName, field, component.Dependencies)
+		if compErr != nil {
+			return nil, compErr
+		}
+	}
+
+	out := make([]depReq, 0, len(byName))
+
+	for _, name := range sortedKeys(byName) {
+		req := byName[name]
+
+		constraints, parseErr := deps.ParseConstraints(req.constraintExpr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("dependency %q: %w", name, parseErr)
+		}
+
+		req.constraints = constraints
+		out = append(out, *req)
+	}
+
+	return out, nil
+}
+
+// mergeDeps folds one dependency map into the accumulator, merging repeats and
+// rejecting conflicting declarations.
+func mergeDeps(
+	byName map[string]*depReq, field string, declared map[string]manifest.Dependency,
+) error {
+	for _, name := range sortedKeys(declared) {
+		dependency := declared[name]
+
+		existing, seen := byName[name]
+		if !seen {
+			byName[name] = &depReq{
+				name:           name,
+				constraintExpr: dependency.Version,
+				constraints:    nil,
+				registry:       dependency.Registry,
+				source:         dependency.Source,
+				path:           dependency.Path,
+				multiDeclared:  false,
+			}
+
+			continue
+		}
+
+		mergeErr := mergeInto(existing, name, dependency)
+		if mergeErr != nil {
+			return fmt.Errorf("%s.%s: %w", field, name, mergeErr)
+		}
+	}
+
+	return nil
+}
+
+// mergeInto folds a repeated declaration of name into existing.
+func mergeInto(existing *depReq, name string, dependency manifest.Dependency) error {
+	existing.multiDeclared = true
+
+	if existing.source != dependency.Source {
+		return &conflictError{
+			detail: fmt.Sprintf("%q is declared as source %q and %q",
+				name, existing.source, dependency.Source),
+			chain: nil,
+		}
+	}
+
+	if dependency.Source == manifestSourcePath {
+		if existing.path != dependency.Path {
+			return &conflictError{
+				detail: fmt.Sprintf("%q path %q and %q disagree",
+					name, existing.path, dependency.Path),
+				chain: nil,
+			}
+		}
+
+		return nil
+	}
+
+	if dependency.Registry != "" {
+		if existing.registry != "" && existing.registry != dependency.Registry {
+			return &conflictError{
+				detail: fmt.Sprintf("%q registry %q and %q disagree",
+					name, existing.registry, dependency.Registry),
+				chain: nil,
+			}
+		}
+
+		existing.registry = dependency.Registry
+	}
+
+	existing.constraintExpr = joinConstraints(existing.constraintExpr, dependency.Version)
+
+	return nil
+}
+
+// joinConstraints AND's two constraint expressions by comma-joining their
+// non-empty parts, matching deps.ParseConstraints' grammar.
+func joinConstraints(left, right string) string {
+	switch {
+	case left == "":
+		return right
+	case right == "":
+		return left
+	default:
+		return left + "," + right
+	}
+}
+
+// formatConstraints renders a parsed constraint list back to the comma-joined
+// string form the adapter re-parses. An empty list yields "" (any version).
+func formatConstraints(constraints []luarocks.VersionConstraint) string {
+	parts := make([]string, 0, len(constraints))
+	for _, constraint := range constraints {
+		parts = append(parts, constraint.Op+constraint.Version.Raw)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// appendChain returns chain with name appended, without aliasing chain's array.
+func appendChain(chain []string, name string) []string {
+	return append(append([]string{}, chain...), name)
+}
+
+// parentLabel names the requiring rock in a conflict message, or "the product"
+// for a direct dependency.
+func parentLabel(parent string) string {
+	if parent == "" {
+		return "the product"
+	}
+
+	return parent
+}
+
+// constraintLabel renders a requirement's constraint for a conflict message.
+func constraintLabel(req depReq) string {
+	if req.constraintExpr == "" {
+		return "any version"
+	}
+
+	return req.constraintExpr
+}
+
+func sortedKeys[V any](collection map[string]V) []string {
+	keys := make([]string, 0, len(collection))
+	for key := range collection {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/cli/manifest/resolve/closure_extra_test.go
+++ b/cli/manifest/resolve/closure_extra_test.go
@@ -1,0 +1,184 @@
+package resolve_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// writePathDep creates a path-dependency directory with one file and returns it,
+// so contentHash has real content to hash.
+func writePathDep(t *testing.T, projectDir, rel string) string {
+	t.Helper()
+
+	dir := filepath.Join(projectDir, rel)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.lua"), []byte("return {}\n"), 0o600))
+
+	return dir
+}
+
+// TestRegistryOverrideSurvivesEarlierTransitive guards that a direct dependency's
+// registry override is honored even when an alphabetically-earlier sibling pulls
+// the same rock transitively from the default servers first.
+func TestRegistryOverrideSurvivesEarlierTransitive(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("applib", "1.0.0-1", "ap", dep(t, "metrics", ">=1.0")).
+		add("metrics", "1.0.0-1", "default-md5").
+		addScoped("https://custom", "metrics", "2.0.0-1", "custom-md5")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+applib = '>=1.0.0'
+[dependencies.metrics]
+source = 'registry'
+version = '>=1.0.0'
+registry = 'https://custom'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// applib sorts before metrics and requires it transitively, but the direct
+	// override must still route metrics to the custom server (2.0.0-1), not the
+	// default server's 1.0.0-1.
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "2.0.0-1", got.Version)
+	assert.Equal(t, "md5:custom-md5", got.Checksum)
+}
+
+// TestPathDepSurvivesEarlierTransitive guards that a direct path dependency is
+// pinned from its local source even when an alphabetically-earlier sibling pulls
+// the same name transitively from a registry first.
+func TestPathDepSurvivesEarlierTransitive(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	vendor := writePathDep(t, projectDir, filepath.Join("vendor", "foo"))
+
+	fake := newFakeAdapter().
+		add("bar", "1.0.0-1", "b", dep(t, "foo", ">=1.0")).
+		add("foo", "9.9.9-1", "registry-foo"). // Would wrongly win without the fix.
+		addLocal(vendor, "foo", "1.0.0-1")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+bar = '>=1.0.0'
+[dependencies.foo]
+source = 'path'
+path = 'vendor/foo'
+`)
+
+	engine := resolve.NewEngine(fake, projectDir, "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// bar sorts before foo and requires it transitively, but foo is a path
+	// dependency and must be pinned from the local source, not the registry.
+	foo := findDep(t, lock.Products["default"].Dependencies, "foo")
+	assert.Equal(t, "path", foo.Source)
+	assert.Equal(t, "vendor/foo", foo.Path)
+	assert.Equal(t, "1.0.0-1", foo.Version)
+	assert.NotEmpty(t, foo.ContentHash)
+}
+
+// TestLeafPathDepSatisfiesTransitiveConstraint guards that a leaf path dependency
+// (one shipping no rockspec, so its version is unknown) is not falsely rejected
+// when another branch constrains the same name - a path dependency is an explicit
+// local override and satisfies any version constraint by fiat.
+func TestLeafPathDepSatisfiesTransitiveConstraint(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	writePathDep(t, projectDir, filepath.Join("vendor", "foo"))
+
+	// foo ships no local rockspec (leaf, zero version); zbar transitively
+	// requires foo >=1.0. Before the fix this raised a spurious ErrConflict.
+	fake := newFakeAdapter().
+		add("zbar", "1.0.0-1", "z", dep(t, "foo", ">=1.0"))
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+zbar = '>=1.0.0'
+[dependencies.foo]
+source = 'path'
+path = 'vendor/foo'
+`)
+
+	engine := resolve.NewEngine(fake, projectDir, "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	foo := findDep(t, lock.Products["default"].Dependencies, "foo")
+	assert.Equal(t, "path", foo.Source)
+	assert.NotEmpty(t, foo.ContentHash)
+}
+
+// TestDependencyCycleDetected guards the cycle guard: a rock depending on a rock
+// that transitively depends back on it aborts with ErrCycle and the offending
+// chain, instead of recursing forever.
+func TestDependencyCycleDetected(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("aa", "1.0.0-1", "a", dep(t, "bb", ">=1.0")).
+		add("bb", "1.0.0-1", "b", dep(t, "aa", ">=1.0"))
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+aa = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, _, err := engine.Resolve(context.Background(), man)
+	require.ErrorIs(t, err, resolve.ErrCycle)
+	assert.Contains(t, err.Error(), "aa")
+	// The chain that closed the loop is reported.
+	assert.Contains(t, err.Error(), "->")
+}
+
+// TestSharedMissingMD5WarnsOnce guards that a checksum-less rock shared by several
+// products yields a single reproducibility warning, not one per product.
+func TestSharedMissingMD5WarnsOnce(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "") // No md5.
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.c1]
+path = 'a'
+[components.c1.dependencies]
+metrics = '>=1.0.0'
+[components.c2]
+path = 'b'
+[components.c2.dependencies]
+metrics = '>=1.0.0'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "no md5")
+}

--- a/cli/manifest/resolve/constraints.go
+++ b/cli/manifest/resolve/constraints.go
@@ -1,0 +1,199 @@
+package resolve
+
+import (
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+// satisfiable reports whether some version could satisfy every constraint at
+// once. It is a structural check over the version order (deps.Compare), so a
+// contradiction between merged declarations is caught before any registry is
+// queried - a conflict is reported regardless of whether the rock is even
+// published.
+//
+// The check is sound (it never rejects a satisfiable set): it intersects the
+// lower/upper bounds from >, >=, <, <=, == and ~>, and rejects only a proven
+// empty interval or conflicting == pins. The pessimistic ~> is translated to
+// its exact [v, next) interval for the common case and to an == when it also
+// pins a revision. ~= only narrows the single-point case, where it can make an
+// otherwise-unique version impossible.
+func satisfiable(constraints []luarocks.VersionConstraint) bool {
+	var lower, upper, equal bound
+
+	var excludes []luarocks.Version
+
+	for _, constraint := range constraints {
+		switch constraint.Op {
+		case "==":
+			if equal.set && deps.Compare(equal.version, constraint.Version) != 0 {
+				return false
+			}
+
+			equal = bound{version: constraint.Version, set: true, inclusive: true}
+		case "~=":
+			excludes = append(excludes, constraint.Version)
+		case ">":
+			lower.tightenLower(constraint.Version, false)
+		case ">=":
+			lower.tightenLower(constraint.Version, true)
+		case "<":
+			upper.tightenUpper(constraint.Version, false)
+		case "<=":
+			upper.tightenUpper(constraint.Version, true)
+		case "~>":
+			narrowPessimistic(&lower, &upper, constraint.Version)
+		}
+	}
+
+	if equal.set {
+		return equalFits(equal.version, lower, upper, excludes)
+	}
+
+	return intervalNonEmpty(lower, upper, excludes)
+}
+
+// bound is one side of a version interval: a version, whether it is set, and
+// whether the endpoint itself is allowed.
+type bound struct {
+	version   luarocks.Version
+	set       bool
+	inclusive bool
+}
+
+// tightenLower raises the lower bound to version, keeping the more restrictive
+// (exclusive) endpoint on a tie.
+func (b *bound) tightenLower(version luarocks.Version, inclusive bool) {
+	if !b.set {
+		*b = bound{version: version, set: true, inclusive: inclusive}
+
+		return
+	}
+
+	cmp := deps.Compare(version, b.version)
+	switch {
+	case cmp > 0:
+		*b = bound{version: version, set: true, inclusive: inclusive}
+	case cmp == 0 && !inclusive:
+		b.inclusive = false
+	}
+}
+
+// tightenUpper lowers the upper bound to version, keeping the more restrictive
+// (exclusive) endpoint on a tie.
+func (b *bound) tightenUpper(version luarocks.Version, inclusive bool) {
+	if !b.set {
+		*b = bound{version: version, set: true, inclusive: inclusive}
+
+		return
+	}
+
+	cmp := deps.Compare(version, b.version)
+	switch {
+	case cmp < 0:
+		*b = bound{version: version, set: true, inclusive: inclusive}
+	case cmp == 0 && !inclusive:
+		b.inclusive = false
+	}
+}
+
+// narrowPessimistic applies the ~> operator's interval. `~> 1.2` allows
+// [1.2, 1.3); `~> 1.2.3` allows [1.2.3, 1.2.4).
+//
+// A revision-pinned ~> (`~> 1.2.3-2`) is only lower-bounded here, deliberately.
+// deps.partialMatch accepts any version whose leading components match and
+// whose revision equals the pin - including versions with extra trailing
+// components that are not Compare-equal to the pin - so no single interval
+// captures that set. Under-constraining (lower bound only) keeps satisfiable
+// sound: it never reports a spurious conflict; a genuinely empty case just
+// defers to the resolver.
+func narrowPessimistic(lower, upper *bound, version luarocks.Version) {
+	lower.tightenLower(version, true)
+
+	if version.Revision != 0 {
+		return
+	}
+
+	next, ok := bumpLastComponent(version)
+	if ok {
+		upper.tightenUpper(next, false)
+	}
+}
+
+// bumpLastComponent returns version with its last numeric component incremented
+// and everything below it cleared - the exclusive upper edge of a ~> interval.
+// ok is false when version has no components.
+func bumpLastComponent(version luarocks.Version) (luarocks.Version, bool) {
+	if len(version.Components) == 0 {
+		return luarocks.Version{
+			Raw: "", Components: nil, Revision: 0, IsSCM: false, IsDev: false,
+		}, false
+	}
+
+	components := append([]int(nil), version.Components...)
+	components[len(components)-1]++
+
+	return luarocks.Version{
+		Raw:        "",
+		Components: components,
+		Revision:   0,
+		IsSCM:      false,
+		IsDev:      false,
+	}, true
+}
+
+// equalFits reports whether an == pin falls inside the bounds and is not
+// excluded.
+func equalFits(
+	version luarocks.Version, lower, upper bound, excludes []luarocks.Version,
+) bool {
+	if lower.set && !aboveLower(version, lower) {
+		return false
+	}
+
+	if upper.set && !belowUpper(version, upper) {
+		return false
+	}
+
+	return !excluded(version, excludes)
+}
+
+// intervalNonEmpty reports whether [lower, upper] contains a usable version.
+func intervalNonEmpty(lower, upper bound, excludes []luarocks.Version) bool {
+	if !lower.set || !upper.set {
+		return true
+	}
+
+	cmp := deps.Compare(lower.version, upper.version)
+	switch {
+	case cmp > 0:
+		return false
+	case cmp == 0:
+		// A single point survives only if both ends include it and it is not
+		// excluded.
+		return lower.inclusive && upper.inclusive && !excluded(lower.version, excludes)
+	default:
+		return true
+	}
+}
+
+func aboveLower(version luarocks.Version, lower bound) bool {
+	cmp := deps.Compare(version, lower.version)
+
+	return cmp > 0 || (cmp == 0 && lower.inclusive)
+}
+
+func belowUpper(version luarocks.Version, upper bound) bool {
+	cmp := deps.Compare(version, upper.version)
+
+	return cmp < 0 || (cmp == 0 && upper.inclusive)
+}
+
+func excluded(version luarocks.Version, excludes []luarocks.Version) bool {
+	for _, exclude := range excludes {
+		if deps.Compare(version, exclude) == 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cli/manifest/resolve/constraints_test.go
+++ b/cli/manifest/resolve/constraints_test.go
@@ -1,0 +1,50 @@
+//nolint:testpackage // white-box: exercises the unexported satisfiable directly.
+package resolve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+func TestSatisfiable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{name: "single range", expr: ">=1.0.0,<2.0.0", want: true},
+		{name: "conflicting equals", expr: "==1.0.0,==2.0.0", want: false},
+		{name: "equal inside range", expr: "==1.5.0,>=1.0.0,<2.0.0", want: true},
+		{name: "equal below range", expr: "==0.9.0,>=1.0.0", want: false},
+		{name: "equal above range", expr: "==2.0.0,<2.0.0", want: false},
+		{name: "disjoint ranges", expr: ">=2.0.0,<1.0.0", want: false},
+		{name: "touching exclusive", expr: ">2.0.0,<=2.0.0", want: false},
+		{name: "touching inclusive", expr: ">=2.0.0,<=2.0.0", want: true},
+		{name: "point excluded", expr: ">=2.0.0,<=2.0.0,~=2.0.0", want: false},
+		{name: "exclude in open range", expr: ">=1.0.0,~=1.5.0", want: true},
+		{name: "pessimistic compatible", expr: "~>1.2,>=1.2.5", want: true},
+		{name: "pessimistic excludes upper", expr: "~>1.2,>=1.3.0", want: false},
+		{name: "pessimistic with equal outside", expr: "~>1.2,==1.3.0", want: false},
+		// A revision-pinned ~> must not over-reject: 1.2.3.4-2 matches ~>1.2.3-2
+		// and is >1.2.3-2, so the set is non-empty.
+		{name: "pessimistic revision alone", expr: "~>1.2.3-2", want: true},
+		{name: "pessimistic revision with strict greater", expr: "~>1.2.3-2,>1.2.3-2", want: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			constraints, err := deps.ParseConstraints(testCase.expr)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.want, satisfiable(constraints))
+		})
+	}
+}

--- a/cli/manifest/resolve/coverage_test.go
+++ b/cli/manifest/resolve/coverage_test.go
@@ -1,0 +1,217 @@
+package resolve_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// TestRegistryOverrideRoutesToNamedServer checks that a dependency's registry
+// override is threaded to the adapter: the rock is taken from the named
+// registry, not the default servers.
+func TestRegistryOverrideRoutesToNamedServer(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "default").
+		addScoped("https://custom", "metrics", "2.0.0-1", "custom")
+
+	man := parseManifest(t, oneProduct+`[dependencies.metrics]
+source = 'registry'
+version = '>=1.0.0'
+registry = 'https://custom'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// The default server would have given 1.0.0-1; the override routes to the
+	// custom registry's 2.0.0-1.
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "2.0.0-1", got.Version)
+	assert.Equal(t, "md5:custom", got.Checksum)
+}
+
+// TestPathDependencyTransitiveResolves checks that a path dependency's local
+// rockspec contributes its version and its transitive registry dependencies to
+// the closure.
+func TestPathDependencyTransitiveResolves(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+
+	vendor := filepath.Join(projectDir, "vendor", "mymod")
+	require.NoError(t, os.MkdirAll(vendor, 0o750))
+
+	initLua := filepath.Join(vendor, "init.lua")
+	require.NoError(t, os.WriteFile(initLua, []byte("return {}\n"), 0o600))
+
+	fake := newFakeAdapter().
+		add("checks", "3.1.0-1", "c").
+		addLocal(vendor, "mymod", "1.0.0-1", dep(t, "checks", ">=3.0"))
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies.mymod]
+source = 'path'
+path = 'vendor/mymod'
+[components.app]
+path = '.'
+[products.default]
+components = ['app']
+default = true
+`)
+
+	engine := resolve.NewEngine(fake, projectDir, "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	dependencies := lock.Products["default"].Dependencies
+	// Topological order: the path dep's transitive checks precedes mymod.
+	assert.Equal(t, []string{"checks", "mymod"}, depNames(dependencies))
+
+	mymod := findDep(t, dependencies, "mymod")
+	assert.Equal(t, "path", mymod.Source)
+	assert.Equal(t, "1.0.0-1", mymod.Version)
+	assert.NotEmpty(t, mymod.ContentHash)
+
+	checks := findDep(t, dependencies, "checks")
+	assert.Equal(t, "registry", checks.Source)
+	assert.Equal(t, "3.1.0-1", checks.Version)
+}
+
+// TestSharedDependencyResolvedOncePerRun checks the cross-product cache: two
+// products depending on the same rock resolve and fetch it once, not once per
+// product.
+func TestSharedDependencyResolvedOncePerRun(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "m")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.c1]
+path = 'a'
+[components.c1.dependencies]
+metrics = '>=1.0.0'
+[components.c2]
+path = 'b'
+[components.c2.dependencies]
+metrics = '>=1.0.0'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// Both products pin the same version.
+	assert.Equal(t, "1.0.0-1", findDep(t, lock.Products["p1"].Dependencies, "metrics").Version)
+	assert.Equal(t, "1.0.0-1", findDep(t, lock.Products["p2"].Dependencies, "metrics").Version)
+
+	// But the registry was queried and the rockspec fetched exactly once.
+	assert.Equal(t, 1, fake.resolves["metrics"])
+	assert.Equal(t, 1, fake.metadatas["metrics"])
+}
+
+// TestMetadataCacheIsRegistryDistinct guards against sharing a rockspec across
+// products when the same name and version resolve from different servers: the
+// metadata cache is keyed by artifact URL, so a per-registry override gets its
+// own server's checksum, not another product's.
+func TestMetadataCacheIsRegistryDistinct(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("foo", "1.0.0-1", "default-md5").
+		addScoped("https://custom", "foo", "1.0.0-1", "custom-md5")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.c1]
+path = 'a'
+[components.c1.dependencies]
+foo = '>=1.0.0'
+[components.c2]
+path = 'b'
+[components.c2.dependencies.foo]
+source = 'registry'
+version = '>=1.0.0'
+registry = 'https://custom'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// Same name and version, but each product's checksum comes from its own
+	// server's rockspec - the cache must not share one across the two.
+	assert.Equal(t, "md5:default-md5", findDep(t, lock.Products["p1"].Dependencies, "foo").Checksum)
+	assert.Equal(t, "md5:custom-md5", findDep(t, lock.Products["p2"].Dependencies, "foo").Checksum)
+}
+
+// TestDeclarationConflictWithoutRegistry checks that a global-vs-component
+// version conflict is detected structurally, before any registry lookup - even
+// when the rock is not published anywhere.
+func TestDeclarationConflictWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter() // empty: metrics is not published on any server
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+metrics = '==1.0.0-1'
+[components.app]
+path = '.'
+[components.app.dependencies]
+metrics = '==2.0.0-1'
+[products.default]
+components = ['app']
+default = true
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, _, err := engine.Resolve(context.Background(), man)
+	require.ErrorIs(t, err, resolve.ErrConflict)
+	assert.Contains(t, err.Error(), "metrics")
+
+	// The conflict is structural: the registry is never consulted.
+	assert.Equal(t, 0, fake.resolves["metrics"])
+}

--- a/cli/manifest/resolve/errors.go
+++ b/cli/manifest/resolve/errors.go
@@ -1,0 +1,46 @@
+package resolve
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrConflict reports that two requirements for the same dependency cannot both
+// be satisfied - either a global and a per-component declaration disagree, or
+// two branches of the dependency graph demand incompatible versions. Callers
+// match it with errors.Is; the wrapping message carries the offending
+// dependency and, for graph conflicts, the chain that led there.
+var ErrConflict = errors.New("dependency conflict")
+
+// ErrCycle reports a cycle in the dependency graph. The wrapping message
+// carries the chain that closed the loop.
+var ErrCycle = errors.New("dependency cycle")
+
+// conflictError renders "<detail> (via a -> b -> c): dependency conflict".
+type conflictError struct {
+	detail string
+	chain  []string
+}
+
+func (e *conflictError) Error() string {
+	if len(e.chain) == 0 {
+		return fmt.Sprintf("%s: %s", e.detail, ErrConflict)
+	}
+
+	return fmt.Sprintf("%s (via %s): %s", e.detail, strings.Join(e.chain, " -> "), ErrConflict)
+}
+
+func (e *conflictError) Unwrap() error { return ErrConflict }
+
+// cycleError renders "dependency cycle on <name> (via a -> b -> name)".
+type cycleError struct {
+	name  string
+	chain []string
+}
+
+func (e *cycleError) Error() string {
+	return fmt.Sprintf("%s on %q (via %s)", ErrCycle, e.name, strings.Join(e.chain, " -> "))
+}
+
+func (e *cycleError) Unwrap() error { return ErrCycle }

--- a/cli/manifest/resolve/golden_test.go
+++ b/cli/manifest/resolve/golden_test.go
@@ -1,0 +1,62 @@
+package resolve_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// goldenManifest is a fixed manifest whose resolution the golden lock pins
+// byte-for-byte. Its bytes also determine manifest_hash, so it must not drift.
+const goldenManifest = `manifest_version = '0.1'
+[package]
+name = 'my-app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+metrics = '>=1.0.0'
+[components.app]
+path = '.'
+[products.default]
+components = ['app']
+default = true
+`
+
+// TestGoldenLock resolves a fixed manifest against a fixed fake registry and
+// asserts the marshaled lock reproduces testdata/my-app.lock byte-for-byte. Run
+// with UPDATE_GOLDEN=1 to regenerate the golden after an intended format change.
+func TestGoldenLock(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "d41d8cd98f00b204e9800998ecf8427e", dep(t, "checks", ">=3.0")).
+		add("checks", "3.1.0-1", "0cc175b9c0f1b6a831c399e269772661")
+
+	man := parseManifest(t, goldenManifest)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	got, err := lock.Marshal()
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "my-app.lock")
+
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.WriteFile(goldenPath, got, 0o600))
+	}
+
+	want, err := os.ReadFile(goldenPath) //nolint:gosec // fixed testdata path
+	require.NoError(t, err)
+
+	assert.Equal(t, string(want), string(got))
+}

--- a/cli/manifest/resolve/hash_test.go
+++ b/cli/manifest/resolve/hash_test.go
@@ -1,0 +1,107 @@
+//nolint:testpackage // white-box: exercises the unexported contentHash directly.
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContentHashFromDirectoryContents pins the content-hash contract: it is a
+// function of the files' relative paths and bytes, stable across identical
+// trees and sensitive to any change in content, a file's name, or the set of
+// files.
+func TestContentHashFromDirectoryContents(t *testing.T) {
+	t.Parallel()
+
+	write := func(dir, rel, content string) {
+		path := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	base := t.TempDir()
+	write(base, "init.lua", "return {}\n")
+	write(base, "lib/util.lua", "return 1\n")
+
+	baseHash, err := contentHash(base)
+	require.NoError(t, err)
+	assert.Contains(t, baseHash, "sha256:")
+
+	// Identical contents in a different directory hash the same.
+	twin := t.TempDir()
+	write(twin, "init.lua", "return {}\n")
+	write(twin, "lib/util.lua", "return 1\n")
+
+	twinHash, err := contentHash(twin)
+	require.NoError(t, err)
+	assert.Equal(t, baseHash, twinHash)
+
+	// Changing a byte changes the hash.
+	changed := t.TempDir()
+	write(changed, "init.lua", "return {}\n")
+	write(changed, "lib/util.lua", "return 2\n")
+
+	changedHash, err := contentHash(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseHash, changedHash)
+
+	// Adding a file changes the hash.
+	extra := t.TempDir()
+	write(extra, "init.lua", "return {}\n")
+	write(extra, "lib/util.lua", "return 1\n")
+	write(extra, "extra.lua", "\n")
+
+	extraHash, err := contentHash(extra)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseHash, extraHash)
+}
+
+// TestContentHashSkipsSymlinks checks that a symlink - including one pointing at
+// a directory, which would otherwise be read as a file and error - is skipped,
+// not followed, so a valid tree still hashes.
+func TestContentHashSkipsSymlinks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lua"), []byte("return 1\n"), 0o600))
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "b.lua"), []byte("return 2\n"), 0o600))
+
+	before, err := contentHash(dir)
+	require.NoError(t, err)
+
+	// A symlink to the subdirectory must not abort the hash, and must not change
+	// it (symlinks are skipped, not part of the content).
+	require.NoError(t, os.Symlink(sub, filepath.Join(dir, "link")))
+
+	after, err := contentHash(dir)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+// TestContentHashTracksExecutableBit checks that flipping a file's executable
+// bit changes the hash, so a path dependency's build script going +x is not
+// invisible to the lock and staleness.
+func TestContentHashTracksExecutableBit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	script := filepath.Join(dir, "build.sh")
+	require.NoError(t, os.WriteFile(script, []byte("echo hi\n"), 0o600))
+
+	plain, err := contentHash(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chmod(script, 0o700)) //nolint:gosec // the test sets the executable bit
+
+	executable, err := contentHash(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, plain, executable)
+}

--- a/cli/manifest/resolve/hash_test.go
+++ b/cli/manifest/resolve/hash_test.go
@@ -84,6 +84,34 @@ func TestContentHashSkipsSymlinks(t *testing.T) {
 	assert.Equal(t, before, after)
 }
 
+// TestContentHashFollowsSymlinkedRoot checks that a path dependency vendored as
+// a symlink to a directory hashes its actual contents - not the empty tree - so
+// two distinct symlinked modules do not collide and edits stay visible to
+// staleness. Symlinks *inside* the tree remain skipped (see the test above).
+func TestContentHashFollowsSymlinkedRoot(t *testing.T) {
+	t.Parallel()
+
+	realDir := t.TempDir()
+	initLua := filepath.Join(realDir, "init.lua")
+	require.NoError(t, os.WriteFile(initLua, []byte("return {}\n"), 0o600))
+
+	realHash, err := contentHash(realDir)
+	require.NoError(t, err)
+
+	// A symlinked root must hash the same contents as the real directory.
+	link := filepath.Join(t.TempDir(), "mymod")
+	require.NoError(t, os.Symlink(realDir, link))
+
+	linkHash, err := contentHash(link)
+	require.NoError(t, err)
+	assert.Equal(t, realHash, linkHash)
+
+	// And it must not be the empty-tree hash a non-descended symlink would yield.
+	empty, err := contentHash(t.TempDir())
+	require.NoError(t, err)
+	assert.NotEqual(t, empty, linkHash)
+}
+
 // TestContentHashTracksExecutableBit checks that flipping a file's executable
 // bit changes the hash, so a path dependency's build script going +x is not
 // invisible to the lock and staleness.

--- a/cli/manifest/resolve/pathdep.go
+++ b/cli/manifest/resolve/pathdep.go
@@ -1,0 +1,146 @@
+package resolve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+// resolvePath resolves a path dependency: it hashes the local directory and,
+// if the directory ships a rockspec, reads the version and transitive
+// dependencies from it. A path dependency is pinned by path and content hash
+// rather than by registry version and checksum.
+func (e *Engine) resolvePath(req depReq) (*resolvedDep, []depReq, error) {
+	dir := filepath.Join(e.projectDir, req.path)
+
+	hash, hashErr := contentHash(dir)
+	if hashErr != nil {
+		return nil, nil, fmt.Errorf("hashing path dependency %q: %w", req.name, hashErr)
+	}
+
+	spec, metaErr := e.adapter.LocalMetadata(dir)
+	if metaErr != nil && !errors.Is(metaErr, rocks.ErrNoLocalRockspec) {
+		return nil, nil, fmt.Errorf("local metadata for %q: %w", req.name, metaErr)
+	}
+
+	var (
+		version  luarocks.Version
+		children []depReq
+	)
+
+	if spec != nil {
+		// Best-effort: a malformed version leaves the pin's parsed form zero,
+		// which only matters if another branch constrains this same name.
+		version, _ = deps.ParseVersion(spec.Version)
+		children = transitiveReqs(spec.Dependencies)
+	}
+
+	resolved := &resolvedDep{
+		lockDep: manifest.LockDependency{
+			Name:        req.name,
+			Version:     version.Raw,
+			Source:      manifestSourcePath,
+			Checksum:    "",
+			Path:        req.path,
+			ContentHash: hash,
+		},
+		version: version,
+	}
+
+	return resolved, children, nil
+}
+
+// fileEntry is one regular file discovered under a path dependency: its
+// slash-normalized path relative to the root and whether it is executable.
+type fileEntry struct {
+	rel  string
+	exec bool
+}
+
+// contentHash is the SHA-256 of a directory's contents, tagged "sha256:". It
+// walks every regular file, sorts them by slash-normalized relative path for a
+// platform-stable order, and frames each path, its executable bit and its byte
+// length before the content so distinct trees cannot collide. Non-regular
+// entries (symlinks, devices) are skipped rather than followed, so a symlink to
+// a directory does not abort the hash. Directory structure without files does
+// not contribute.
+func contentHash(dir string) (string, error) {
+	files, walkErr := walkFiles(dir)
+	if walkErr != nil {
+		return "", walkErr
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+
+	hasher := sha256.New()
+
+	for _, file := range files {
+		//nolint:gosec // engine-owned project path, not user-controlled input
+		content, readErr := os.ReadFile(filepath.Join(dir, filepath.FromSlash(file.rel)))
+		if readErr != nil {
+			return "", fmt.Errorf("reading %s: %w", file.rel, readErr)
+		}
+
+		_, _ = fmt.Fprintf(hasher, "%s\x00%d\x00%d\x00",
+			file.rel, boolToInt(file.exec), len(content))
+		_, _ = hasher.Write(content)
+	}
+
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// walkFiles collects every regular file under dir as a fileEntry.
+func walkFiles(dir string) ([]fileEntry, error) {
+	var files []fileEntry
+
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !entry.Type().IsRegular() {
+			// Directories, symlinks, devices, sockets: not content to hash.
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return fmt.Errorf("relativizing %s: %w", path, relErr)
+		}
+
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return fmt.Errorf("stat %s: %w", path, infoErr)
+		}
+
+		files = append(files, fileEntry{
+			rel:  filepath.ToSlash(rel),
+			exec: info.Mode().Perm()&0o111 != 0,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", dir, err)
+	}
+
+	return files, nil
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+
+	return 0
+}

--- a/cli/manifest/resolve/pathdep.go
+++ b/cli/manifest/resolve/pathdep.go
@@ -3,15 +3,14 @@ package resolve
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/tarantool/tt/cli/manifest"
-	"github.com/tarantool/tt/cli/manifest/rocks"
 	luarocks "github.com/tarantool/tt/lib/luarocks"
 	"github.com/tarantool/tt/lib/luarocks/deps"
 )
@@ -20,16 +19,16 @@ import (
 // if the directory ships a rockspec, reads the version and transitive
 // dependencies from it. A path dependency is pinned by path and content hash
 // rather than by registry version and checksum.
-func (e *Engine) resolvePath(req depReq) (*resolvedDep, []depReq, error) {
-	dir := filepath.Join(e.projectDir, req.path)
+func (w *walker) resolvePath(req depReq) (*resolvedDep, []depReq, error) {
+	dir := filepath.Join(w.engine.projectDir, req.path)
 
-	hash, hashErr := contentHash(dir)
+	hash, hashErr := w.cache.dirContentHash(dir)
 	if hashErr != nil {
 		return nil, nil, fmt.Errorf("hashing path dependency %q: %w", req.name, hashErr)
 	}
 
-	spec, metaErr := e.adapter.LocalMetadata(dir)
-	if metaErr != nil && !errors.Is(metaErr, rocks.ErrNoLocalRockspec) {
+	spec, metaErr := w.cache.localMetadata(w.engine.adapter, dir)
+	if metaErr != nil {
 		return nil, nil, fmt.Errorf("local metadata for %q: %w", req.name, metaErr)
 	}
 
@@ -39,9 +38,19 @@ func (e *Engine) resolvePath(req depReq) (*resolvedDep, []depReq, error) {
 	)
 
 	if spec != nil {
-		// Best-effort: a malformed version leaves the pin's parsed form zero,
-		// which only matters if another branch constrains this same name.
-		version, _ = deps.ParseVersion(spec.Version)
+		parsed, parseErr := deps.ParseVersion(spec.Version)
+		if parseErr != nil {
+			// Non-fatal: the pin still holds by content hash, and a path
+			// dependency satisfies any constraint by fiat (see walker.walk), so a
+			// zero version cannot force a false conflict. Surface it as a warning
+			// rather than discarding it silently.
+			w.warnings = append(w.warnings, fmt.Sprintf(
+				"path dependency %q has an unparseable version %q; pinned by content hash only",
+				req.name, spec.Version))
+		} else {
+			version = parsed
+		}
+
 		children = transitiveReqs(spec.Dependencies)
 	}
 
@@ -70,12 +79,20 @@ type fileEntry struct {
 // contentHash is the SHA-256 of a directory's contents, tagged "sha256:". It
 // walks every regular file, sorts them by slash-normalized relative path for a
 // platform-stable order, and frames each path, its executable bit and its byte
-// length before the content so distinct trees cannot collide. Non-regular
-// entries (symlinks, devices) are skipped rather than followed, so a symlink to
-// a directory does not abort the hash. Directory structure without files does
-// not contribute.
+// length before the content so distinct trees cannot collide. Symlinks
+// discovered *inside* the tree are skipped rather than followed, so a symlink to
+// a directory does not abort the hash; a symlinked *root* is resolved first so a
+// module vendored as a symlink still hashes its contents. Directory structure
+// without files does not contribute.
 func contentHash(dir string) (string, error) {
-	files, walkErr := walkFiles(dir)
+	// Resolve a symlinked root so its contents are walked (WalkDir does not
+	// descend a symlink). Symlinks *within* the tree are still skipped below.
+	root, symErr := filepath.EvalSymlinks(dir)
+	if symErr != nil {
+		return "", fmt.Errorf("resolving %s: %w", dir, symErr)
+	}
+
+	files, walkErr := walkFiles(root)
 	if walkErr != nil {
 		return "", walkErr
 	}
@@ -85,18 +102,42 @@ func contentHash(dir string) (string, error) {
 	hasher := sha256.New()
 
 	for _, file := range files {
-		//nolint:gosec // engine-owned project path, not user-controlled input
-		content, readErr := os.ReadFile(filepath.Join(dir, filepath.FromSlash(file.rel)))
-		if readErr != nil {
-			return "", fmt.Errorf("reading %s: %w", file.rel, readErr)
+		hashErr := hashFile(hasher, root, file)
+		if hashErr != nil {
+			return "", hashErr
 		}
-
-		_, _ = fmt.Fprintf(hasher, "%s\x00%d\x00%d\x00",
-			file.rel, boolToInt(file.exec), len(content))
-		_, _ = hasher.Write(content)
 	}
 
 	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// hashFile frames one file's relative path, executable bit and byte length into
+// hasher, then streams its content, so a large file is not read whole into
+// memory. The size prefix is the delimiter that keeps distinct trees from
+// colliding; it is read from the open handle so it matches the bytes streamed.
+func hashFile(hasher io.Writer, root string, file fileEntry) error {
+	//nolint:gosec // engine-owned project path, not user-controlled input
+	handle, openErr := os.Open(filepath.Join(root, filepath.FromSlash(file.rel)))
+	if openErr != nil {
+		return fmt.Errorf("opening %s: %w", file.rel, openErr)
+	}
+
+	defer func() { _ = handle.Close() }()
+
+	info, statErr := handle.Stat()
+	if statErr != nil {
+		return fmt.Errorf("stat %s: %w", file.rel, statErr)
+	}
+
+	_, _ = fmt.Fprintf(hasher, "%s\x00%d\x00%d\x00",
+		file.rel, boolToInt(file.exec), info.Size())
+
+	_, copyErr := io.Copy(hasher, handle)
+	if copyErr != nil {
+		return fmt.Errorf("reading %s: %w", file.rel, copyErr)
+	}
+
+	return nil
 }
 
 // walkFiles collects every regular file under dir as a fileEntry.

--- a/cli/manifest/resolve/products_test.go
+++ b/cli/manifest/resolve/products_test.go
@@ -1,0 +1,113 @@
+package resolve_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+func TestProductsGetDistinctClosures(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("xx", "1.0.0-1", "x").
+		add("yy", "1.0.0-1", "y")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.c1]
+path = 'a'
+[components.c1.dependencies]
+xx = '>=1.0.0'
+[components.c2]
+path = 'b'
+[components.c2.dependencies]
+yy = '>=1.0.0'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"xx"}, depNames(lock.Products["p1"].Dependencies))
+	assert.Equal(t, []string{"yy"}, depNames(lock.Products["p2"].Dependencies))
+}
+
+func TestComponentDependencyMergesWithGlobal(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "b").
+		add("metrics", "2.0.0-1", "c")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+metrics = '>=1.0.0'
+[components.app]
+path = '.'
+[components.app.dependencies]
+metrics = '<2.0.0'
+[products.default]
+components = ['app']
+default = true
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// Global >=1.0.0 AND component <2.0.0 => the newest in [1.0.0, 2.0.0).
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "1.5.0-1", got.Version)
+}
+
+func TestGlobalComponentConflictErrors(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "a").
+		add("metrics", "2.0.0-1", "b")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+metrics = '==1.0.0-1'
+[components.app]
+path = '.'
+[components.app.dependencies]
+metrics = '==2.0.0-1'
+[products.default]
+components = ['app']
+default = true
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, _, err := engine.Resolve(context.Background(), man)
+	require.ErrorIs(t, err, resolve.ErrConflict)
+	assert.Contains(t, err.Error(), "metrics")
+}

--- a/cli/manifest/resolve/resolve.go
+++ b/cli/manifest/resolve/resolve.go
@@ -94,8 +94,12 @@ func (e *Engine) Resolve(
 
 	var warnings []string
 
+	// One cache for the whole run: products that share a dependency resolve,
+	// fetch and hash it once, not once per product.
+	cache := newResolveCache()
+
 	for _, name := range sortedKeys(man.Products) {
-		dependencies, warns, err := e.resolveProduct(ctx, man, man.Products[name])
+		dependencies, warns, err := e.resolveProduct(ctx, cache, man, man.Products[name])
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolving product %q: %w", name, err)
 		}
@@ -110,15 +114,22 @@ func (e *Engine) Resolve(
 // resolveProduct assembles a product's effective direct dependencies and walks
 // them into a pinned, topologically ordered closure.
 func (e *Engine) resolveProduct(
-	ctx context.Context, man *manifest.Manifest, product manifest.Product,
+	ctx context.Context, cache *resolveCache, man *manifest.Manifest, product manifest.Product,
 ) ([]manifest.LockDependency, []string, error) {
 	directs, err := effectiveDeps(man, product)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	directsByName := make(map[string]depReq, len(directs))
+	for _, direct := range directs {
+		directsByName[direct.name] = direct
+	}
+
 	walk := &walker{
 		engine:   e,
+		cache:    cache,
+		directs:  directsByName,
 		chosen:   map[string]*resolvedDep{},
 		inFlight: map[string]bool{},
 		order:    nil,

--- a/cli/manifest/resolve/resolve.go
+++ b/cli/manifest/resolve/resolve.go
@@ -1,0 +1,139 @@
+// Package resolve is the dependency-resolution engine for tt packages: it turns
+// the declared constraints of a manifest into a pinned closure and builds the
+// lock (app.manifest.lock) - declared, resolved, locked.
+//
+// Resolution runs per product: each product gets its own closure over the
+// newest versions that satisfy every constraint. The engine takes an already
+// parsed manifest plus an adapter over lib/luarocks; it never touches the
+// network itself. The adapter (cli/manifest/rocks) queries registries, fetches
+// rockspecs and reports source checksums; the policy - which versions, by which
+// product, what lands in the lock - lives here.
+//
+// Materializing .rocks/ from a lock, editing the manifest on add/remove and
+// bundling runtimes into the lock are other packages' work. The tt package
+// resolve/update/deps commands are thin wrappers over this engine.
+package resolve
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+)
+
+// Adapter is the slice of cli/manifest/rocks the engine drives. The engine
+// depends on this interface rather than the concrete *rocks.Adapter so tests
+// can substitute a fake registry without a live server; *rocks.Adapter
+// satisfies it directly.
+type Adapter interface {
+	// Resolve picks the newest version of name satisfying constraintExpr,
+	// querying servers in order (first-found-wins) or the single registry when
+	// non-empty. It returns rocks.ErrNotFound when no server has the rock and
+	// rocks.ErrNoMatch when none of its versions satisfy the constraints.
+	Resolve(ctx context.Context, name, constraintExpr, registry string) (rocks.ResolvedRock, error)
+
+	// Metadata fetches and evaluates a resolved rock's rockspec, with the
+	// runtime platforms merged in, so its transitive dependencies and
+	// source.md5 are visible.
+	Metadata(ctx context.Context, rock rocks.ResolvedRock) (*luarocks.Rockspec, error)
+
+	// LocalMetadata evaluates the rockspec of a path dependency's directory, or
+	// returns (nil, nil) when the directory ships no rockspec (a leaf path
+	// dependency).
+	LocalMetadata(dir string) (*luarocks.Rockspec, error)
+}
+
+// Engine resolves a manifest into a lock over an Adapter.
+type Engine struct {
+	adapter Adapter
+
+	// projectDir is the directory the manifest lives in; path dependencies are
+	// resolved relative to it and their content hashes are read from it.
+	projectDir string
+
+	// generatedBy is the "tt <version>" string stamped into the lock. It is
+	// injected rather than read from the build so the lock is reproducible in
+	// tests; the CLI passes the real tt version.
+	generatedBy string
+}
+
+// NewEngine builds an Engine. projectDir anchors path dependencies; generatedBy
+// is stamped into lock.generated_by (e.g. "tt 3.4.0").
+func NewEngine(adapter Adapter, projectDir, generatedBy string) *Engine {
+	return &Engine{
+		adapter:     adapter,
+		projectDir:  projectDir,
+		generatedBy: generatedBy,
+	}
+}
+
+// Resolve resolves every product of m into a lock. Each product's dependencies
+// are the transitive closure of its effective direct dependencies (see
+// effectiveDeps), pinned to exact versions in topological order.
+//
+// The returned warnings are non-fatal diagnostics - notably rocks whose
+// registry publishes no md5, whose lock entry then carries no checksum.
+//
+// The lock's manifest_hash is m.Hash(); bundled_*_version are left empty for
+// the packaging phase to fill. generated_by carries the engine's tt version.
+func (e *Engine) Resolve(
+	ctx context.Context, man *manifest.Manifest,
+) (*manifest.Lock, []string, error) {
+	lock := &manifest.Lock{
+		LockVersion:      manifest.LockVersion,
+		ManifestVersion:  man.ManifestVersion,
+		GeneratedBy:      e.generatedBy,
+		ManifestHash:     man.Hash(),
+		BundledTarantool: "",
+		BundledTt:        "",
+		BundledTcm:       "",
+		Products:         map[string]manifest.LockProduct{},
+	}
+
+	var warnings []string
+
+	for _, name := range sortedKeys(man.Products) {
+		dependencies, warns, err := e.resolveProduct(ctx, man, man.Products[name])
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving product %q: %w", name, err)
+		}
+
+		warnings = append(warnings, warns...)
+		lock.Products[name] = manifest.LockProduct{Dependencies: dependencies}
+	}
+
+	return lock, warnings, nil
+}
+
+// resolveProduct assembles a product's effective direct dependencies and walks
+// them into a pinned, topologically ordered closure.
+func (e *Engine) resolveProduct(
+	ctx context.Context, man *manifest.Manifest, product manifest.Product,
+) ([]manifest.LockDependency, []string, error) {
+	directs, err := effectiveDeps(man, product)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	walk := &walker{
+		engine:   e,
+		chosen:   map[string]*resolvedDep{},
+		inFlight: map[string]bool{},
+		order:    nil,
+		warnings: nil,
+	}
+
+	walkErr := walk.walk(ctx, "", directs, nil)
+	if walkErr != nil {
+		return nil, nil, walkErr
+	}
+
+	out := make([]manifest.LockDependency, 0, len(walk.order))
+	for _, name := range walk.order {
+		out = append(out, walk.chosen[name].lockDep)
+	}
+
+	return out, walk.warnings, nil
+}

--- a/cli/manifest/resolve/resolve_test.go
+++ b/cli/manifest/resolve/resolve_test.go
@@ -17,19 +17,60 @@ import (
 
 // fakeAdapter is an in-memory registry standing in for cli/manifest/rocks so
 // the resolution engine can be exercised without a live server. It mirrors the
-// adapter's newest-that-fits selection and ErrNotFound / ErrNoMatch contract.
+// adapter's newest-that-fits selection and ErrNotFound / ErrNoMatch contract,
+// routes by registry override, serves path-dependency rockspecs, and counts
+// calls so tests can assert cross-product caching.
 type fakeAdapter struct {
-	registry map[string][]*luarocks.Rockspec
+	servers   map[string][]*luarocks.Rockspec            // Default server candidates.
+	scoped    map[string]map[string][]*luarocks.Rockspec // Registry -> name -> candidates.
+	specs     map[string]*luarocks.Rockspec              // Artifact URL -> rockspec.
+	local     map[string]*luarocks.Rockspec              // Path-dep dir -> rockspec.
+	resolves  map[string]int                             // adapter.Resolve calls by name.
+	metadatas map[string]int                             // adapter.Metadata calls by name.
 }
 
 func newFakeAdapter() *fakeAdapter {
-	return &fakeAdapter{registry: map[string][]*luarocks.Rockspec{}}
+	return &fakeAdapter{
+		servers:   map[string][]*luarocks.Rockspec{},
+		scoped:    map[string]map[string][]*luarocks.Rockspec{},
+		specs:     map[string]*luarocks.Rockspec{},
+		local:     map[string]*luarocks.Rockspec{},
+		resolves:  map[string]int{},
+		metadatas: map[string]int{},
+	}
+}
+
+// urlFor builds an artifact URL that, like a real registry, is server-specific:
+// the same name and version on different registries yield different URLs.
+func urlFor(registry, name, version string) string {
+	if registry == "" {
+		return name + "-" + version
+	}
+
+	return registry + "|" + name + "-" + version
+}
+
+func newSpec(name, version, md5 string, rockDeps []luarocks.Dep) *luarocks.Rockspec {
+	spec := new(luarocks.Rockspec)
+
+	spec.Package = name
+	spec.Version = version
+	spec.Source.MD5 = md5
+	spec.Dependencies = rockDeps
+
+	return spec
 }
 
 func (fake *fakeAdapter) Resolve(
-	_ context.Context, name, constraintExpr, _ string,
+	_ context.Context, name, constraintExpr, registry string,
 ) (rocks.ResolvedRock, error) {
-	candidates := fake.registry[name]
+	fake.resolves[name]++
+
+	candidates := fake.servers[name]
+	if registry != "" {
+		candidates = fake.scoped[registry][name]
+	}
+
 	if len(candidates) == 0 {
 		return rocks.ResolvedRock{}, rocks.ErrNotFound
 	}
@@ -64,39 +105,69 @@ func (fake *fakeAdapter) Resolve(
 		return rocks.ResolvedRock{}, rocks.ErrNoMatch
 	}
 
-	return rocks.ResolvedRock{Name: name, Version: bestVer, URL: name + "-" + best.Version}, nil
+	url := urlFor(registry, name, best.Version)
+
+	return rocks.ResolvedRock{Name: name, Version: bestVer, URL: url}, nil
 }
 
 func (fake *fakeAdapter) Metadata(
 	_ context.Context, rock rocks.ResolvedRock,
 ) (*luarocks.Rockspec, error) {
-	for _, candidate := range fake.registry[rock.Name] {
-		if candidate.Version == rock.Version.Raw {
-			return candidate, nil
-		}
+	fake.metadatas[rock.Name]++
+
+	spec, ok := fake.specs[rock.URL]
+	if !ok {
+		return nil, fmt.Errorf("fake: no metadata for %s", rock.URL)
 	}
 
-	return nil, fmt.Errorf("fake: no metadata for %s %s", rock.Name, rock.Version.Raw)
+	return spec, nil
 }
 
-func (fake *fakeAdapter) LocalMetadata(_ string) (*luarocks.Rockspec, error) {
-	return nil, rocks.ErrNoLocalRockspec
+func (fake *fakeAdapter) LocalMetadata(dir string) (*luarocks.Rockspec, error) {
+	spec, ok := fake.local[dir]
+	if !ok {
+		return nil, rocks.ErrNoLocalRockspec
+	}
+
+	return spec, nil
 }
 
-// add registers one rock version with an md5 and zero or more dependencies.
-// Fields are assigned rather than composed so the fixture stays exhaustive
-// without listing every rockspec field.
+// add registers one rock version on the default servers with an md5 and zero or
+// more dependencies.
 func (fake *fakeAdapter) add(
 	name, version, md5 string, rockDeps ...luarocks.Dep,
 ) *fakeAdapter {
-	spec := new(luarocks.Rockspec)
+	spec := newSpec(name, version, md5, rockDeps)
 
-	spec.Package = name
-	spec.Version = version
-	spec.Source.MD5 = md5
-	spec.Dependencies = rockDeps
+	fake.servers[name] = append(fake.servers[name], spec)
+	fake.specs[urlFor("", name, version)] = spec
 
-	fake.registry[name] = append(fake.registry[name], spec)
+	return fake
+}
+
+// addScoped registers a rock version on the named registry only, so a
+// dependency's registry override routes to it instead of the default servers.
+func (fake *fakeAdapter) addScoped(
+	registry, name, version, md5 string, rockDeps ...luarocks.Dep,
+) *fakeAdapter {
+	if fake.scoped[registry] == nil {
+		fake.scoped[registry] = map[string][]*luarocks.Rockspec{}
+	}
+
+	spec := newSpec(name, version, md5, rockDeps)
+
+	fake.scoped[registry][name] = append(fake.scoped[registry][name], spec)
+	fake.specs[urlFor(registry, name, version)] = spec
+
+	return fake
+}
+
+// addLocal registers the rockspec a path dependency's directory ships, so
+// LocalMetadata returns its version and transitive dependencies.
+func (fake *fakeAdapter) addLocal(
+	dir, name, version string, rockDeps ...luarocks.Dep,
+) *fakeAdapter {
+	fake.local[dir] = newSpec(name, version, "", rockDeps)
 
 	return fake
 }

--- a/cli/manifest/resolve/resolve_test.go
+++ b/cli/manifest/resolve/resolve_test.go
@@ -1,0 +1,285 @@
+package resolve_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+// fakeAdapter is an in-memory registry standing in for cli/manifest/rocks so
+// the resolution engine can be exercised without a live server. It mirrors the
+// adapter's newest-that-fits selection and ErrNotFound / ErrNoMatch contract.
+type fakeAdapter struct {
+	registry map[string][]*luarocks.Rockspec
+}
+
+func newFakeAdapter() *fakeAdapter {
+	return &fakeAdapter{registry: map[string][]*luarocks.Rockspec{}}
+}
+
+func (fake *fakeAdapter) Resolve(
+	_ context.Context, name, constraintExpr, _ string,
+) (rocks.ResolvedRock, error) {
+	candidates := fake.registry[name]
+	if len(candidates) == 0 {
+		return rocks.ResolvedRock{}, rocks.ErrNotFound
+	}
+
+	constraints, parseErr := deps.ParseConstraints(constraintExpr)
+	if parseErr != nil {
+		return rocks.ResolvedRock{}, fmt.Errorf("fake: %w", parseErr)
+	}
+
+	var (
+		best    *luarocks.Rockspec
+		bestVer luarocks.Version
+		found   bool
+	)
+
+	for _, candidate := range candidates {
+		parsed, verErr := deps.ParseVersion(candidate.Version)
+		if verErr != nil {
+			continue
+		}
+
+		if !deps.Match(parsed, constraints) {
+			continue
+		}
+
+		if !found || deps.Compare(parsed, bestVer) > 0 {
+			best, bestVer, found = candidate, parsed, true
+		}
+	}
+
+	if !found {
+		return rocks.ResolvedRock{}, rocks.ErrNoMatch
+	}
+
+	return rocks.ResolvedRock{Name: name, Version: bestVer, URL: name + "-" + best.Version}, nil
+}
+
+func (fake *fakeAdapter) Metadata(
+	_ context.Context, rock rocks.ResolvedRock,
+) (*luarocks.Rockspec, error) {
+	for _, candidate := range fake.registry[rock.Name] {
+		if candidate.Version == rock.Version.Raw {
+			return candidate, nil
+		}
+	}
+
+	return nil, fmt.Errorf("fake: no metadata for %s %s", rock.Name, rock.Version.Raw)
+}
+
+func (fake *fakeAdapter) LocalMetadata(_ string) (*luarocks.Rockspec, error) {
+	return nil, rocks.ErrNoLocalRockspec
+}
+
+// add registers one rock version with an md5 and zero or more dependencies.
+// Fields are assigned rather than composed so the fixture stays exhaustive
+// without listing every rockspec field.
+func (fake *fakeAdapter) add(
+	name, version, md5 string, rockDeps ...luarocks.Dep,
+) *fakeAdapter {
+	spec := new(luarocks.Rockspec)
+
+	spec.Package = name
+	spec.Version = version
+	spec.Source.MD5 = md5
+	spec.Dependencies = rockDeps
+
+	fake.registry[name] = append(fake.registry[name], spec)
+
+	return fake
+}
+
+// dep builds a rockspec dependency from a name and a constraint expression.
+func dep(t *testing.T, name, constraintExpr string) luarocks.Dep {
+	t.Helper()
+
+	constraints, err := deps.ParseConstraints(constraintExpr)
+	require.NoError(t, err)
+
+	return luarocks.Dep{Name: name, Constraints: constraints}
+}
+
+// parseManifest turns a manifest TOML body into a *Manifest.
+func parseManifest(t *testing.T, body string) *manifest.Manifest {
+	t.Helper()
+
+	parsed, _, err := manifest.ParseManifest([]byte(body))
+	require.NoError(t, err)
+
+	return parsed
+}
+
+// depNames extracts the dependency names of a resolved product, in lock order.
+func depNames(dependencies []manifest.LockDependency) []string {
+	out := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
+		out = append(out, dependency.Name)
+	}
+
+	return out
+}
+
+// findDep returns the lock entry for name, or fails.
+func findDep(
+	t *testing.T, dependencies []manifest.LockDependency, name string,
+) manifest.LockDependency {
+	t.Helper()
+
+	for _, dependency := range dependencies {
+		if dependency.Name == name {
+			return dependency
+		}
+	}
+
+	t.Fatalf("dependency %q not in lock (%v)", name, depNames(dependencies))
+
+	var zero manifest.LockDependency
+
+	return zero
+}
+
+const oneProduct = `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.app]
+path = '.'
+[products.default]
+components = ['app']
+default = true
+`
+
+func TestDirectConstraintPicksHighestMatch(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "aaa").
+		add("metrics", "1.5.0-1", "bbb").
+		add("metrics", "2.0.0-1", "ccc")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0,<2.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "1.5.0-1", got.Version)
+	assert.Equal(t, "registry", got.Source)
+	assert.Equal(t, "md5:bbb", got.Checksum)
+}
+
+func TestTransitiveClosure(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "m", dep(t, "checks", ">=3.0")).
+		add("checks", "3.1.0-1", "c")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// Topological order: the transitive dep precedes the rock that needs it.
+	dependencies := lock.Products["default"].Dependencies
+	assert.Equal(t, []string{"checks", "metrics"}, depNames(dependencies))
+}
+
+func TestSharedTransitiveResolvesOnce(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a", dep(t, "common", ">=1.0")).
+		add("beta", "1.0.0-1", "b", dep(t, "common", ">=1.1")).
+		add("common", "1.0.0-1", "c10").
+		add("common", "1.2.0-1", "c12")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+beta = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	dependencies := lock.Products["default"].Dependencies
+
+	commonCount := 0
+
+	for _, dependency := range dependencies {
+		if dependency.Name == "common" {
+			commonCount++
+		}
+	}
+
+	assert.Equal(t, 1, commonCount,
+		"shared transitive must appear once: %v", depNames(dependencies))
+	// The first branch (alpha) pins common to the newest satisfying >=1.0; the
+	// second branch's >=1.1 is compatible with that pick.
+	assert.Equal(t, "1.2.0-1", findDep(t, dependencies, "common").Version)
+}
+
+func TestIncompatibleConstraintsConflict(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a", dep(t, "common", ">=2.0")).
+		add("beta", "1.0.0-1", "b", dep(t, "common", "<2.0")).
+		add("common", "1.0.0-1", "c10").
+		add("common", "2.0.0-1", "c20")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+beta = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, _, err := engine.Resolve(context.Background(), man)
+	require.ErrorIs(t, err, resolve.ErrConflict)
+	assert.Contains(t, err.Error(), "common")
+}
+
+func TestMissingMD5Warns(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "no md5")
+	assert.Empty(t, findDep(t, lock.Products["default"].Dependencies, "metrics").Checksum)
+}

--- a/cli/manifest/resolve/stale.go
+++ b/cli/manifest/resolve/stale.go
@@ -22,16 +22,26 @@ func (e *Engine) IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, str
 		return true, "manifest changed since the lock was written", nil
 	}
 
+	// A path dependency shared by several products is hashed once, not once per
+	// product referencing it.
+	hashes := map[string]string{}
+
 	for _, product := range sortedKeys(lock.Products) {
 		for _, dependency := range lock.Products[product].Dependencies {
 			if dependency.Source != manifestSourcePath {
 				continue
 			}
 
-			hash, err := contentHash(filepath.Join(e.projectDir, dependency.Path))
-			if err != nil {
-				return false, "", fmt.Errorf(
-					"checking path dependency %q: %w", dependency.Name, err)
+			hash, cached := hashes[dependency.Path]
+			if !cached {
+				computed, err := contentHash(filepath.Join(e.projectDir, dependency.Path))
+				if err != nil {
+					return false, "", fmt.Errorf(
+						"checking path dependency %q: %w", dependency.Name, err)
+				}
+
+				hash = computed
+				hashes[dependency.Path] = computed
 			}
 
 			if hash != dependency.ContentHash {

--- a/cli/manifest/resolve/stale.go
+++ b/cli/manifest/resolve/stale.go
@@ -1,0 +1,44 @@
+package resolve
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// IsStale reports whether lock no longer reflects m, and why. A lock goes stale
+// from exactly two things: the manifest's raw bytes changed (manifest_hash
+// diverged), or a path dependency's local content changed (its content_hash
+// diverged). New registry versions never make a lock stale - only an explicit
+// tt package update pulls them; a changed tt version or package VERSION does
+// not either.
+//
+// What to do with a stale lock is the caller's call: an unflagged build
+// re-resolves and rewrites it (Engine.Resolve); a --locked build treats
+// staleness as a hard error. The engine only reports the fact.
+func (e *Engine) IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, string, error) {
+	if lock.ManifestHash != man.Hash() {
+		return true, "manifest changed since the lock was written", nil
+	}
+
+	for _, product := range sortedKeys(lock.Products) {
+		for _, dependency := range lock.Products[product].Dependencies {
+			if dependency.Source != manifestSourcePath {
+				continue
+			}
+
+			hash, err := contentHash(filepath.Join(e.projectDir, dependency.Path))
+			if err != nil {
+				return false, "", fmt.Errorf(
+					"checking path dependency %q: %w", dependency.Name, err)
+			}
+
+			if hash != dependency.ContentHash {
+				return true, fmt.Sprintf("path dependency %q changed on disk", dependency.Name), nil
+			}
+		}
+	}
+
+	return false, "", nil
+}

--- a/cli/manifest/resolve/stale_test.go
+++ b/cli/manifest/resolve/stale_test.go
@@ -1,0 +1,118 @@
+package resolve_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+func TestStaleOnManifestEdit(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "a")
+
+	body := oneProduct + `[dependencies]
+metrics = '>=1.0.0'
+`
+	man := parseManifest(t, body)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// The same manifest is not stale.
+	stale, _, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.False(t, stale)
+
+	// Any byte change - even a comment - re-hashes the manifest and staleness fires.
+	edited := parseManifest(t, body+"# touched\n")
+
+	stale, reason, err := engine.IsStale(edited, lock)
+	require.NoError(t, err)
+	assert.True(t, stale)
+	assert.Contains(t, reason, "manifest changed")
+}
+
+func TestNotStaleOnNewRegistryVersion(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "a")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	// A newer version appearing in the registry must not make the lock stale;
+	// only tt package update pulls it. Staleness never consults the registry.
+	fake.add("metrics", "2.0.0-1", "b")
+
+	stale, _, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.False(t, stale)
+}
+
+func TestStaleOnPathContentChange(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+
+	vendor := filepath.Join(projectDir, "vendor", "mymod")
+	require.NoError(t, os.MkdirAll(vendor, 0o750))
+
+	initLua := filepath.Join(vendor, "init.lua")
+	require.NoError(t, os.WriteFile(initLua, []byte("return {}\n"), 0o600))
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+[dependencies.mymod]
+source = 'path'
+path = 'vendor/mymod'
+[components.app]
+path = '.'
+[products.default]
+components = ['app']
+default = true
+`)
+
+	engine := resolve.NewEngine(newFakeAdapter(), projectDir, "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	dependency := findDep(t, lock.Products["default"].Dependencies, "mymod")
+	assert.Equal(t, "path", dependency.Source)
+	assert.Equal(t, "vendor/mymod", dependency.Path)
+	assert.NotEmpty(t, dependency.ContentHash)
+
+	// Unchanged tree: not stale.
+	stale, _, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.False(t, stale)
+
+	// Change local content: stale.
+	changed := []byte("return {changed=true}\n")
+	require.NoError(t, os.WriteFile(initLua, changed, 0o600))
+
+	stale, reason, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.True(t, stale)
+	assert.Contains(t, reason, "mymod")
+}

--- a/cli/manifest/resolve/testdata/my-app.lock
+++ b/cli/manifest/resolve/testdata/my-app.lock
@@ -1,0 +1,19 @@
+lock_version = '0.1'
+manifest_version = '0.1'
+generated_by = 'tt 3.4.0'
+manifest_hash = 'sha256:f475efcd87290984dc1342324726c12222eb8cf352f19febde08bc5c644ecd73'
+
+[lock]
+[lock.products]
+[lock.products.default]
+[[lock.products.default.dependencies]]
+name = 'checks'
+version = '3.1.0-1'
+source = 'registry'
+checksum = 'md5:0cc175b9c0f1b6a831c399e269772661'
+
+[[lock.products.default.dependencies]]
+name = 'metrics'
+version = '1.5.0-1'
+source = 'registry'
+checksum = 'md5:d41d8cd98f00b204e9800998ecf8427e'

--- a/cli/manifest/rocks/localmeta.go
+++ b/cli/manifest/rocks/localmeta.go
@@ -1,0 +1,45 @@
+package rocks
+
+import (
+	"errors"
+	"fmt"
+
+	luarocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/rockspec"
+)
+
+// ErrNoLocalRockspec reports that a path dependency's directory ships no
+// rockspec. It is not a failure: the dependency is a leaf pinned by path and
+// content hash, without a version or transitive closure. Callers match it with
+// errors.Is.
+var ErrNoLocalRockspec = errors.New("no rockspec in path dependency directory")
+
+// LocalMetadata evaluates the rockspec of a path dependency: the single
+// top-level *.rockspec under dir, evaluated with the runtime platforms merged
+// in, so its declared version and transitive dependencies are visible to the
+// resolver. Unlike Metadata it fetches nothing - the source is a local
+// directory already on disk.
+//
+// When the directory ships no rockspec it returns ErrNoLocalRockspec, which the
+// caller treats as a leaf dependency rather than a failure.
+func (a *Adapter) LocalMetadata(dir string) (*luarocks.Rockspec, error) {
+	specPath, err := findRockspec(dir)
+	if err != nil {
+		// No rockspec in the directory is a leaf, not a failure. Any other
+		// failure (e.g. the directory is unreadable) is real.
+		if errors.Is(err, errNoRockspec) {
+			return nil, ErrNoLocalRockspec
+		}
+
+		return nil, err
+	}
+
+	spec, err := rockspec.Eval(specPath, a.cfg.Rockspec)
+	if err != nil {
+		return nil, fmt.Errorf("rocks: eval %s: %w", specPath, err)
+	}
+
+	rockspec.MergePlatforms(spec, rockspec.RuntimePlatforms())
+
+	return spec, nil
+}

--- a/cli/manifest/rocks/registry.go
+++ b/cli/manifest/rocks/registry.go
@@ -110,18 +110,35 @@ func (a *Adapter) Download(
 // findRockspec returns the single top-level *.rockspec in dir. It does not
 // recurse: a bare .rockspec download is one top-level file, and a .src.rock
 // carries its rockspec at the archive root, while the bundled source tree may
-// ship unrelated rockspecs deeper down.
+// ship unrelated rockspecs deeper down. More than one top-level rockspec is
+// ambiguous - which version to pin is undecidable - so it is an error rather
+// than a silent alphabetical pick, matching client.findRockspecIn and upstream
+// luarocks make.
 func findRockspec(dir string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", fmt.Errorf("rocks: read %s: %w", dir, err)
 	}
 
+	found := ""
+
 	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".rockspec") {
-			return filepath.Join(dir, entry.Name()), nil
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".rockspec") {
+			continue
 		}
+
+		path := filepath.Join(dir, entry.Name())
+		if found != "" {
+			return "", fmt.Errorf("rocks: %w in %s: %s and %s",
+				errMultipleRockspec, dir, filepath.Base(found), entry.Name())
+		}
+
+		found = path
 	}
 
-	return "", fmt.Errorf("rocks: %w: %s", errNoRockspec, dir)
+	if found == "" {
+		return "", fmt.Errorf("rocks: %w: %s", errNoRockspec, dir)
+	}
+
+	return found, nil
 }

--- a/cli/manifest/rocks/registry_internal_test.go
+++ b/cli/manifest/rocks/registry_internal_test.go
@@ -1,0 +1,52 @@
+package rocks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindRockspecSingle returns the sole top-level rockspec.
+func TestFindRockspecSingle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	spec := filepath.Join(dir, "mymod-1.0-1.rockspec")
+	require.NoError(t, os.WriteFile(spec, []byte("package = 'mymod'\n"), 0o600))
+
+	got, err := findRockspec(dir)
+	require.NoError(t, err)
+	assert.Equal(t, spec, got)
+}
+
+// TestFindRockspecNone reports errNoRockspec so LocalMetadata can treat the
+// directory as a leaf.
+func TestFindRockspecNone(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.lua"), []byte("return {}\n"), 0o600))
+
+	_, err := findRockspec(dir)
+	require.ErrorIs(t, err, errNoRockspec)
+}
+
+// TestFindRockspecMultiple errors instead of silently pinning an arbitrary
+// (alphabetically-first) rockspec when the directory ships more than one.
+func TestFindRockspecMultiple(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "mymod-1.0-1.rockspec"), []byte("package = 'mymod'\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "mymod-2.0-1.rockspec"), []byte("package = 'mymod'\n"), 0o600))
+
+	_, err := findRockspec(dir)
+	require.ErrorIs(t, err, errMultipleRockspec)
+	// It is not the leaf sentinel: an ambiguous directory is a real failure.
+	assert.NotErrorIs(t, err, errNoRockspec)
+}

--- a/cli/manifest/rocks/rocks.go
+++ b/cli/manifest/rocks/rocks.go
@@ -41,6 +41,9 @@ var (
 	ErrNoMatch = errors.New("no version satisfies the constraints")
 	// errNoRockspec reports that a fetched rock artifact carries no rockspec.
 	errNoRockspec = errors.New("no rockspec in fetched artifact")
+	// errMultipleRockspec reports that a directory ships more than one top-level
+	// rockspec, so which version to pin is ambiguous.
+	errMultipleRockspec = errors.New("multiple top-level rockspecs")
 )
 
 // DefaultServers returns the ordered default server list: Tarantool rocks

--- a/lib/luarocks/client/native.go
+++ b/lib/luarocks/client/native.go
@@ -112,7 +112,15 @@ func (e *nativeEngine) Install(ctx context.Context, name string, opts InstallOpt
 
 	var plan []rocks.InstallStep
 	if opts.Deps != DepsNone {
-		plan, err = deps.Resolve(ctx, rootSpec, idx)
+		// The remote index returns bare name/version/URL rows without a
+		// preloaded rockspec, so hand Resolve a fetcher: it evaluates each
+		// chosen rock's rockspec on demand and walks the full transitive
+		// closure, not just the root's direct dependencies.
+		fetchSpec := func(ctx context.Context, rock rocks.VersionedRock) (*rocks.Rockspec, error) {
+			return e.fetchAndEval(ctx, rock.URL)
+		}
+
+		plan, err = deps.Resolve(ctx, rootSpec, idx, deps.WithSpecFetcher(fetchSpec))
 		if err != nil {
 			return fmt.Errorf("rocks.Install: resolve deps: %w", err)
 		}
@@ -335,12 +343,17 @@ func (e *nativeEngine) Unpack(ctx context.Context, archive, destDir string) erro
 // --- internal helpers (used only by the five native write operations) ---
 
 func (e *nativeEngine) installStep(ctx context.Context, step rocks.InstallStep) error {
-	spec, err := e.fetchAndEval(ctx, step.URL)
-	if err != nil {
-		return err
-	}
+	// deps.Resolve populates step.Rockspec via the spec fetcher; reuse it rather
+	// than fetching and evaluating the same version-pinned artifact a second
+	// time. It is nil only if a caller resolved without the fetcher.
+	if step.Rockspec == nil {
+		spec, err := e.fetchAndEval(ctx, step.URL)
+		if err != nil {
+			return err
+		}
 
-	step.Rockspec = spec
+		step.Rockspec = spec
+	}
 
 	return e.installFromSource(ctx, step)
 }

--- a/lib/luarocks/deps/resolver.go
+++ b/lib/luarocks/deps/resolver.go
@@ -20,6 +20,13 @@ var providedRocks = map[string]bool{
 	"luabitop": true,
 }
 
+// IsProvided reports whether name is a rock the Tarantool VM supplies itself,
+// so callers building their own resolution over the same registry can skip it
+// exactly as Resolve does, without duplicating the set.
+func IsProvided(name string) bool {
+	return providedRocks[name]
+}
+
 // Resolve performs a greedy depth-first walk over root.Dependencies,
 // choosing the newest version of each dep that satisfies its constraints
 // and recursing into the chosen rock's transitive dependencies before
@@ -36,7 +43,9 @@ var providedRocks = map[string]bool{
 //
 // `lua` and other VM-provided names short-circuit: they are silently
 // dropped from the install list.
-func Resolve(ctx context.Context, root *rocks.Rockspec, idx rocks.RemoteIndex) ([]rocks.InstallStep, error) {
+func Resolve(
+	ctx context.Context, root *rocks.Rockspec, idx rocks.RemoteIndex, opts ...Option,
+) ([]rocks.InstallStep, error) {
 	if root == nil {
 		return nil, errors.New("deps.Resolve: nil root rockspec")
 	}
@@ -45,6 +54,10 @@ func Resolve(ctx context.Context, root *rocks.Rockspec, idx rocks.RemoteIndex) (
 		idx:      idx,
 		chosen:   map[string]*rocks.InstallStep{},
 		inFlight: map[string]bool{},
+	}
+
+	for _, opt := range opts {
+		opt(r)
 	}
 
 	if err := r.walk(ctx, root.Package, root.Dependencies, nil); err != nil {
@@ -61,8 +74,30 @@ func Resolve(ctx context.Context, root *rocks.Rockspec, idx rocks.RemoteIndex) (
 	return out, nil
 }
 
+// SpecFetcher supplies a picked rock's rockspec on demand. See WithSpecFetcher.
+type SpecFetcher func(ctx context.Context, rock rocks.VersionedRock) (*rocks.Rockspec, error)
+
+// Option configures Resolve.
+type Option func(*resolver)
+
+// WithSpecFetcher makes Resolve fetch a chosen rock's rockspec on demand when
+// the index did not preload it. After pickNewest selects a version, if that
+// version has no Spec, Resolve calls fetch on the picked rock only (never on
+// the rejected candidates) and continues the transitive walk with the result.
+//
+// This is what lets a non-preloading index (e.g. remote.HTTPRemoteIndex, which
+// returns bare name/version/URL rows) drive a full transitive resolution
+// without fetching every candidate's rockspec: one fetch per chosen rock. A
+// fetch error aborts the resolution. Without this option Resolve keeps its
+// preload-only behavior — it recurses only into versions whose Spec the index
+// already populated.
+func WithSpecFetcher(fetch SpecFetcher) Option {
+	return func(r *resolver) { r.fetch = fetch }
+}
+
 type resolver struct {
 	idx      rocks.RemoteIndex
+	fetch    SpecFetcher
 	chosen   map[string]*rocks.InstallStep
 	inFlight map[string]bool
 	order    []string // post-order — deepest first
@@ -110,6 +145,17 @@ func (r *resolver) walk(ctx context.Context, parent string, deps []rocks.Dep, ch
 				"deps.Resolve: no version of %q satisfies %s (parent=%s, %d candidates)",
 				d.Name, formatConstraints(d.Constraints), parent, len(candidates))
 		}
+		// Preload the picked rock's rockspec on demand when the index did not
+		// carry one, so the transitive walk below can proceed. Only the chosen
+		// version is fetched — never the rejected candidates.
+		if picked.Spec == nil && r.fetch != nil {
+			spec, err := r.fetch(ctx, picked)
+			if err != nil {
+				return fmt.Errorf("deps.Resolve: fetch rockspec for %q: %w", d.Name, err)
+			}
+
+			picked.Spec = spec
+		}
 
 		step := &rocks.InstallStep{
 			Name:     picked.Name,
@@ -119,9 +165,9 @@ func (r *resolver) walk(ctx context.Context, parent string, deps []rocks.Dep, ch
 		}
 		r.chosen[d.Name] = step
 
-		// Recurse into the picked version's deps. We only have transitive
-		// info if the index preloaded a *Rockspec; otherwise the caller
-		// must invoke Resolve again after fetching the rockspec (the
+		// Recurse into the picked version's deps. With a spec fetcher the
+		// picked version now carries its rockspec; without one we only have
+		// transitive info when the index preloaded a *Rockspec (the
 		// facade does this; manifest-based indices typically don't preload).
 		if picked.Spec != nil {
 			child := append(append([]string{}, chain...), d.Name)

--- a/lib/luarocks/deps/resolver_test.go
+++ b/lib/luarocks/deps/resolver_test.go
@@ -1,0 +1,129 @@
+package deps_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rocks "github.com/tarantool/tt/lib/luarocks"
+	"github.com/tarantool/tt/lib/luarocks/deps"
+)
+
+// bareIndex is a RemoteIndex that returns name/version/URL rows without a
+// preloaded Spec, like remote.HTTPRemoteIndex.
+type bareIndex map[string][]rocks.VersionedRock
+
+func (b bareIndex) Query(_ context.Context, name string) ([]rocks.VersionedRock, error) {
+	return b[name], nil
+}
+
+func mustVer(t *testing.T, raw string) rocks.Version {
+	t.Helper()
+
+	v, err := deps.ParseVersion(raw)
+	require.NoError(t, err)
+
+	return v
+}
+
+func mustDep(t *testing.T, name, expr string) rocks.Dep {
+	t.Helper()
+
+	cs, err := deps.ParseConstraints(expr)
+	require.NoError(t, err)
+
+	return rocks.Dep{Name: name, Constraints: cs}
+}
+
+// TestResolveWithoutFetcherStopsAtPreloadedSpecs shows the baseline: a bare
+// index that preloads nothing resolves only the root's direct dependencies.
+func TestResolveWithoutFetcherStopsAtPreloadedSpecs(t *testing.T) {
+	idx := bareIndex{
+		"a": {{Name: "a", Version: mustVer(t, "1.0.0-1"), URL: "a-1.0.0-1"}},
+		"b": {{Name: "b", Version: mustVer(t, "2.0.0-1"), URL: "b-2.0.0-1"}},
+	}
+
+	root := &rocks.Rockspec{Package: "root", Dependencies: []rocks.Dep{mustDep(t, "a", ">=1.0")}}
+
+	steps, err := deps.Resolve(context.Background(), root, idx)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(steps))
+	for _, s := range steps {
+		names = append(names, s.Name)
+	}
+
+	// Without a fetcher, a's transitive dep on b is never discovered.
+	assert.Equal(t, []string{"a"}, names)
+}
+
+// TestResolveWithSpecFetcherWalksTransitively shows the fetcher completing the
+// closure, fetching only the chosen version of each name.
+func TestResolveWithSpecFetcherWalksTransitively(t *testing.T) {
+	idx := bareIndex{
+		"a": {
+			{Name: "a", Version: mustVer(t, "0.5.0-1"), URL: "a-0.5.0-1"},
+			{Name: "a", Version: mustVer(t, "1.0.0-1"), URL: "a-1.0.0-1"},
+		},
+		"b": {{Name: "b", Version: mustVer(t, "2.0.0-1"), URL: "b-2.0.0-1"}},
+	}
+
+	specs := map[string]*rocks.Rockspec{
+		"a-1.0.0-1": {Package: "a", Dependencies: []rocks.Dep{mustDep(t, "b", ">=1.0")}},
+		"b-2.0.0-1": {Package: "b"},
+	}
+
+	var fetched []string
+
+	fetcher := func(_ context.Context, rock rocks.VersionedRock) (*rocks.Rockspec, error) {
+		fetched = append(fetched, rock.URL)
+
+		spec, ok := specs[rock.URL]
+		if !ok {
+			return nil, fmt.Errorf("no spec for %s", rock.URL)
+		}
+
+		return spec, nil
+	}
+
+	root := &rocks.Rockspec{Package: "root", Dependencies: []rocks.Dep{mustDep(t, "a", ">=1.0")}}
+
+	steps, err := deps.Resolve(context.Background(), root, idx, deps.WithSpecFetcher(fetcher))
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(steps))
+	for _, s := range steps {
+		names = append(names, s.Name)
+	}
+
+	// Full closure, deepest-first topo order.
+	assert.Equal(t, []string{"b", "a"}, names)
+	// Only the chosen version of each name is fetched: a-1.0.0-1 (not the
+	// rejected a-0.5.0-1) and b-2.0.0-1.
+	assert.ElementsMatch(t, []string{"a-1.0.0-1", "b-2.0.0-1"}, fetched)
+}
+
+// TestResolveSpecFetcherErrorAborts shows that a spec fetcher failure aborts the
+// resolution with the wrapped error, rather than silently truncating the
+// transitive closure of the rock whose rockspec could not be fetched.
+func TestResolveSpecFetcherErrorAborts(t *testing.T) {
+	idx := bareIndex{
+		"a": {{Name: "a", Version: mustVer(t, "1.0.0-1"), URL: "a-1.0.0-1"}},
+	}
+
+	errFetch := errors.New("network down")
+
+	fetcher := func(_ context.Context, _ rocks.VersionedRock) (*rocks.Rockspec, error) {
+		return nil, errFetch
+	}
+
+	root := &rocks.Rockspec{Package: "root", Dependencies: []rocks.Dep{mustDep(t, "a", ">=1.0")}}
+
+	_, err := deps.Resolve(context.Background(), root, idx, deps.WithSpecFetcher(fetcher))
+	require.ErrorIs(t, err, errFetch)
+	assert.Contains(t, err.Error(), "a")
+}


### PR DESCRIPTION
Add the dependency-resolution engine that turns a manifest's declared constraints into a pinned closure and builds app.manifest.lock. Resolution runs per product: the global and per-component dependency declarations are merged into each product's effective direct dependencies, then walked into a transitive closure (newest-that-fits, deepest-first, one version per name, cycle and conflict detection) that drives the luarocks adapter per chosen rock, honoring per-dependency registry overrides. Each lock entry pins an exact version plus a checksum — md5 for registry rocks, path + content_hash for path dependencies — and IsStale flags the lock on a changed manifest hash or path-dependency content.

Closes TNTP-8231
