### PR TITLE
stop: pre-interrupt processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- `tt stop`: preliminary interrupts the processes to enable parallel termination.
+
 ### Fixed
 
 ## [2.13.0] - 2026-05-21

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -79,11 +79,6 @@ func internalStopModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	for _, run := range runningCtx.Instances {
-		if err = running.Stop(&run); err != nil {
-			log.Infof(err.Error())
-		}
-	}
-
+	running.Stop(runningCtx.Instances)
 	return nil
 }

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -31,6 +31,9 @@ const (
 	ProcessRunningCode = iota
 	ProcessStoppedCode
 	ProcessDeadCode
+
+	ProcessTermWaitTimeout     = 30 * time.Second
+	ProcessTermWaitCheckPeriod = 100 * time.Millisecond
 )
 
 var (
@@ -187,18 +190,30 @@ func getRunningPid(pidFile string) (int, error) {
 	return pid, nil
 }
 
-// StopProcess stops the process by pidFile.
-func StopProcess(pidFile string) (int, error) {
+// InterruptProcess requests the process interruption by pidFile.
+func InterruptProcess(pidFile string) (int, error) {
 	pid, err := getRunningPid(pidFile)
 	if err != nil {
 		return 0, fmt.Errorf("can't get pid of running process: %w", err)
 	}
-
 	if err = syscall.Kill(pid, syscall.SIGINT); err != nil {
 		return 0, fmt.Errorf(`can't terminate the process. Error: "%v"`, err)
 	}
+	return pid, nil
+}
 
-	if res := waitProcessTermination(pid, 30*time.Second, 100*time.Millisecond); !res {
+// StopProcess stops the process by pidFile.
+func StopProcess(pidFile string) (int, error) {
+	pid, err := InterruptProcess(pidFile)
+	if err != nil {
+		return 0, err
+	}
+
+	if res := WaitProcessTermination(
+		pid,
+		ProcessTermWaitTimeout,
+		ProcessTermWaitCheckPeriod,
+	); !res {
 		return 0, fmt.Errorf("can't terminate the process")
 	}
 
@@ -216,7 +231,11 @@ func QuitProcess(pidFile string) (int, error) {
 		return 0, fmt.Errorf("can't terminate the process with SIGQUIT: %s", err)
 	}
 
-	if res := waitProcessTermination(pid, 30*time.Second, 100*time.Millisecond); !res {
+	if res := WaitProcessTermination(
+		pid,
+		ProcessTermWaitTimeout,
+		ProcessTermWaitCheckPeriod,
+	); !res {
 		return 0, fmt.Errorf("can't terminate the process with SIGQUIT")
 	}
 
@@ -274,9 +293,9 @@ func IsProcessAlive(pid int) (bool, error) {
 	return true, nil
 }
 
-// waitProcessTermination waits while the process will be terminated.
+// WaitProcessTermination waits while the process will be terminated.
 // Returns true if the process was terminated and false if is steel alive.
-func waitProcessTermination(pid int, timeout time.Duration,
+func WaitProcessTermination(pid int, timeout time.Duration,
 	checkPeriod time.Duration,
 ) bool {
 	if res, _ := IsProcessAlive(pid); !res {

--- a/cli/replicaset/rebootstrap.go
+++ b/cli/replicaset/rebootstrap.go
@@ -88,7 +88,7 @@ func Rebootstrap(cmdCtx cmdcontext.CmdCtx, cliOpts config.CliOpts, rbCtx Reboots
 	}
 
 	log.Debugf("Stopping the instance")
-	if err = running.Stop(&instCtx); err != nil {
+	if err = running.Stop([]running.InstanceCtx{instCtx}); err != nil {
 		return fmt.Errorf("failed to stop the instance %s: %s", rbCtx.InstanceName, err)
 	}
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -822,27 +822,55 @@ func Start(cmdCtx *cmdcontext.CmdCtx, inst *InstanceCtx) error {
 	return nil
 }
 
-// Stop the Instance.
-func Stop(run *InstanceCtx) error {
-	fullInstanceName := GetAppInstanceName(*run)
+type instanceProc struct {
+	run      InstanceCtx
+	pid      int
+	fullName string
+}
 
-	pid, err := process_utils.StopProcess(run.PIDFile)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			log.Debugf("The instance %s is already stopped", fullInstanceName)
-			return nil
+// Stop the Instances.
+func Stop(runs []InstanceCtx) error {
+
+	// Request an interruption for each process.
+	// This is done in advance to enable parallel termination.
+	procsToWait := make([]instanceProc, 0, len(runs))
+	for _, run := range runs {
+		fullName := GetAppInstanceName(run)
+		pid, err := process_utils.InterruptProcess(run.PIDFile)
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			log.Debugf("The instance %s is already stopped", fullName)
+		case err != nil:
+			log.Infof(err.Error())
+		default:
+			procsToWait = append(procsToWait, instanceProc{
+				run,
+				pid,
+				fullName,
+			})
 		}
-		return err
 	}
 
-	// tarantool 1.10 does not have a trigger on terminate a process.
-	// So the socket will be closed automatically on termination and
-	// we need to delete the file.
-	if _, err := os.Stat(run.ConsoleSocket); err == nil {
-		os.Remove(run.ConsoleSocket)
+	// Await for the processes termination.
+	for _, proc := range procsToWait {
+		isTerminated := process_utils.WaitProcessTermination(
+			proc.pid,
+			process_utils.ProcessTermWaitTimeout,
+			process_utils.ProcessTermWaitCheckPeriod,
+		)
+		if !isTerminated {
+			log.Infof("Can't terminate the instance %s (PID = %v).", proc.fullName, proc.pid)
+			continue
+		}
+		// tarantool 1.10 does not have a trigger on terminate a process.
+		// So the socket will be closed automatically on termination and
+		// we need to delete the file.
+		consoleSocket := proc.run.ConsoleSocket
+		if _, err := os.Stat(consoleSocket); err == nil {
+			os.Remove(consoleSocket)
+		}
+		log.Infof("The Instance %s (PID = %v) has been terminated.", proc.fullName, proc.pid)
 	}
-
-	log.Infof("The Instance %s (PID = %v) has been terminated.", fullInstanceName, pid)
 
 	return nil
 }


### PR DESCRIPTION
This patch changes the behavior of tt stop: process interruption is now
performed before wait to enable parallel termination. This provides a
multiplicative speedup of the command on clusters with multiple instances.
