### PR TITLE
backup: add manifest chain impl

### DIFF
--- a/lib/backup/chain/api.go
+++ b/lib/backup/chain/api.go
@@ -1,0 +1,203 @@
+package chain
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tarantool/tt/lib/backup"
+)
+
+// String returns the status name.
+func (s Status) String() string {
+	switch s {
+	case StatusOK:
+		return "ok"
+	case StatusTopologyBoundary:
+		return "topology_boundary"
+	case StatusNoRecoveryPoint:
+		return "no_recovery_point"
+	case StatusChainBroken:
+		return "chain_broken"
+	case StatusOutOfRange:
+		return "out_of_range"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON encodes a status as its string.
+func (s Status) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(s.String())
+	if err != nil {
+		return nil, fmt.Errorf("marshal status: %w", err)
+	}
+
+	return data, nil
+}
+
+// Resolve maps a requested recovery time to a cluster recovery point.
+func (c *Chain) Resolve(t time.Time) Resolution {
+	if len(c.points) == 0 {
+		return Resolution{Status: StatusOutOfRange}
+	}
+
+	first := c.points[0]
+	last := c.points[len(c.points)-1]
+
+	if t.Before(first.Timestamp) {
+		return Resolution{Status: StatusNoRecoveryPoint, After: &first}
+	}
+
+	if t.After(last.Timestamp) {
+		return Resolution{Status: StatusOutOfRange, Before: &last}
+	}
+
+	// t is within overall coverage. Scan segments in time order: t either lands
+	// in the gap right after a segment (report it) or is covered by one.
+	for i := range c.segments {
+		seg := &c.segments[i]
+		segLast := seg.points[len(seg.points)-1]
+		if t.After(segLast.Timestamp) {
+			// A later segment exists (t is within coverage); if it starts after t,
+			// t is in the gap between them.
+			next := &c.segments[i+1]
+			if t.Before(next.points[0].Timestamp) {
+				return gapResolution(next.gapBefore, &segLast, &next.points[0])
+			}
+			continue
+		}
+
+		// A point ≤ t exists in this segment: pick the latest such one.
+		var candidate *ClusterPoint
+		for j := range seg.points {
+			p := &seg.points[j]
+			if !p.Timestamp.After(t) {
+				candidate = p
+			}
+		}
+		return Resolution{Status: StatusOK, Point: candidate}
+	}
+
+	// Unreachable: the loop always returns for a t within overall coverage.
+	return Resolution{Status: StatusOK, Point: &last}
+}
+
+// gapResolution builds the resolution for a t that fell into a segment gap. A
+// chain break also offers the last point before the break as Point.
+func gapResolution(gap gapKind, before, after *ClusterPoint) Resolution {
+	res := Resolution{Status: gap.status(), Before: before, After: after}
+	if gap == gapBroken {
+		res.Point = before
+	}
+
+	return res
+}
+
+// PlanFor builds per-replicaset backup paths for a cluster recovery point, or
+// errors if p is not a point produced by this chain.
+func (c *Chain) PlanFor(p ClusterPoint) (Plan, error) {
+	found := false
+	for i := range c.points {
+		if c.points[i].Name == p.Name {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return Plan{}, fmt.Errorf("cluster point %q not found in chain", p.Name)
+	}
+
+	index := c.byID
+	shards := make(map[string]ShardPlan, len(p.Shards))
+	for replicasetUUID, pos := range p.Shards {
+		sp, err := shardPlan(replicasetUUID, pos, p, index)
+		if err != nil {
+			return Plan{}, fmt.Errorf("build plan for replicaset %q: %w", replicasetUUID, err)
+		}
+		shards[replicasetUUID] = sp
+	}
+
+	return Plan{Point: p, Shards: shards}, nil
+}
+
+// shardPlan builds the ordered backup path (full first, incrementals after) for
+// one replicaset by walking previous_backup_id back from the manifest carrying
+// the point.
+func shardPlan(
+	replicasetUUID string,
+	pos Position,
+	point ClusterPoint,
+	index map[backup.BackupID]*Entry,
+) (ShardPlan, error) {
+	source, err := findSourceEntry(replicasetUUID, point.Name, index)
+	if err != nil {
+		return ShardPlan{}, fmt.Errorf("find source entry: %w", err)
+	}
+
+	// Walk back via previous_backup_id, keeping only manifests carrying this shard.
+	var reversed []*backup.ClusterManifest
+	visited := make(map[backup.BackupID]bool)
+	current := source
+
+	for {
+		if current.Manifest.Shards[replicasetUUID].Instance != nil {
+			reversed = append(reversed, current.Manifest)
+		}
+		prevID := current.Manifest.PreviousBackupID
+		if prevID == "" || visited[current.Manifest.BackupID] {
+			break
+		}
+		visited[current.Manifest.BackupID] = true
+		parent, ok := index[prevID]
+		if !ok {
+			break
+		}
+		current = parent
+	}
+
+	// Reverse to chronological order: full backup first.
+	backups := make([]*backup.ClusterManifest, len(reversed))
+	for i, m := range reversed {
+		backups[len(reversed)-1-i] = m
+	}
+
+	var trimTo *Position
+
+	shard := source.Manifest.Shards[replicasetUUID]
+	if shard.Instance != nil {
+		vclockEnd := shard.Instance.VclockEnd
+		if endLSN, ok := vclockEnd[pos.ReplicaID]; !ok || pos.LSN < endLSN {
+			trimTo = &pos
+		}
+	}
+
+	return ShardPlan{Backups: backups, TrimTo: trimTo}, nil
+}
+
+// findSourceEntry returns the entry whose manifest carries the named recovery
+// point for the given replicaset.
+func findSourceEntry(
+	replicasetUUID string,
+	pointName string,
+	index map[backup.BackupID]*Entry,
+) (*Entry, error) {
+	for _, entry := range index {
+		shard := entry.Manifest.Shards[replicasetUUID]
+		if shard.Instance == nil {
+			continue
+		}
+
+		for _, rp := range shard.Instance.Artifact.RecoveryPoints {
+			if rp.UUID == pointName {
+				return entry, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"no manifest carries point %q for replicaset %q",
+		pointName, replicasetUUID,
+	)
+}

--- a/lib/backup/chain/build.go
+++ b/lib/backup/chain/build.go
@@ -1,0 +1,383 @@
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/tarantool/tt/lib/backup"
+	"github.com/tarantool/tt/lib/backup/storage"
+)
+
+// Load reads every stored manifest and builds a fully marked chain.
+func Load(ctx context.Context, store storage.Storage) (*Chain, error) {
+	manifests, err := loadManifests(ctx, store)
+	if err != nil {
+		if errors.Is(err, errManifestVanished) {
+			manifests, err = loadManifests(ctx, store)
+			if errors.Is(err, errManifestVanished) {
+				return nil, fmt.Errorf("load manifests: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("load manifests: %w", err)
+		}
+	}
+
+	chain, err := Build(manifests)
+	if err != nil {
+		return nil, fmt.Errorf("build chain: %w", err)
+	}
+
+	return chain, nil
+}
+
+// errManifestVanished marks a manifest that LIST reported but GET could not find.
+var errManifestVanished = errors.New("manifest vanished between list and get")
+
+// loadManifests lists and reads every manifest once, reporting errManifestVanished
+// when a listed key is missing on GET so Load can retry.
+func loadManifests(
+	ctx context.Context,
+	store storage.Storage,
+) ([]*backup.ClusterManifest, error) {
+	objects, err := store.List(ctx, storage.ManifestsPrefix())
+	if err != nil {
+		return nil, fmt.Errorf("list manifests: %w", err)
+	}
+
+	manifests := make([]*backup.ClusterManifest, 0, len(objects))
+	for _, object := range objects {
+		data, err := storage.GetBytes(ctx, store, object.Key)
+		if err != nil {
+			if errors.Is(err, storage.ErrKeyNotFound) {
+				return nil, fmt.Errorf("%w: %q", errManifestVanished, object.Key)
+			}
+
+			return nil, fmt.Errorf("load manifest %q: %w", object.Key, err)
+		}
+
+		var manifest backup.ClusterManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return nil, fmt.Errorf("decode manifest %q: %w", object.Key, err)
+		}
+
+		manifests = append(manifests, &manifest)
+	}
+
+	return manifests, nil
+}
+
+// Build groups manifests, attaches own and inherited chain problems, and
+// stitches cluster recovery points.
+func Build(manifests []*backup.ClusterManifest) (*Chain, error) {
+	// Index every backup_id first, then reverse the previous_backup_id links.
+	entries := make(map[backup.BackupID]*Entry, len(manifests))
+	groups := make(map[backup.BackupID]*Group)
+	for i, manifest := range manifests {
+		if manifest == nil {
+			return nil, fmt.Errorf("manifest %d is nil", i)
+		}
+
+		if _, exists := entries[manifest.BackupID]; exists {
+			return nil, fmt.Errorf("duplicate backup_id %q", manifest.BackupID)
+		}
+
+		entry := &Entry{Manifest: manifest}
+		entries[manifest.BackupID] = entry
+		baseID := manifest.BaseFullBackupID
+		if groups[baseID] == nil {
+			groups[baseID] = &Group{}
+		}
+
+		groups[baseID].Entries = append(groups[baseID].Entries, entry)
+	}
+
+	// Reverse previous_backup_id links after every backup_id is indexed.
+	children := make(map[backup.BackupID][]*Entry, len(entries))
+
+	for _, entry := range entries {
+		if previousID := entry.Manifest.PreviousBackupID; previousID != "" {
+			children[previousID] = append(children[previousID], entry)
+		}
+	}
+
+	for previousID := range children {
+		slices.SortFunc(children[previousID], compareEntries)
+	}
+
+	markProblems(entries, children)
+
+	orderedGroups := orderGroups(groups, children)
+	byID := make(map[backup.BackupID]*Entry, len(entries))
+
+	for i := range orderedGroups {
+		for _, entry := range orderedGroups[i].Entries {
+			byID[entry.Manifest.BackupID] = entry
+		}
+	}
+
+	segments := buildSegments(orderedGroups)
+
+	return &Chain{
+		groups:   orderedGroups,
+		byID:     byID,
+		points:   buildClusterPoints(segments),
+		segments: segments,
+	}, nil
+}
+
+// markProblems finds broken links and immediately propagates each problem to
+// every dependent manifest.
+func markProblems(
+	entries map[backup.BackupID]*Entry,
+	children map[backup.BackupID][]*Entry,
+) {
+	// A structurally invalid manifest poisons its whole tail.
+	for _, entry := range entries {
+		if err := entry.Manifest.Validate(); err != nil {
+			propagateProblem(entry, &Problem{
+				Kind:     ProblemInvalidManifest,
+				BackupID: string(entry.Manifest.BackupID),
+				Detail:   fmt.Sprintf("manifest validation failed: %v", err),
+			}, children)
+		}
+	}
+
+	// Orphan and vclock mismatch belong to one entry and poison its whole tail.
+	for _, entry := range entries {
+		previousID := entry.Manifest.PreviousBackupID
+		parent := entries[previousID]
+		if previousID != "" && parent == nil {
+			propagateProblem(entry, &Problem{
+				Kind:     ProblemOrphan,
+				BackupID: string(entry.Manifest.BackupID),
+				Detail:   fmt.Sprintf("previous backup %q not found", previousID),
+			}, children)
+		}
+		if parent == nil {
+			continue
+		}
+
+		for _, problem := range vclockProblems(entry, entries) {
+			propagateProblem(entry, problem, children)
+		}
+	}
+
+	// A fork poisons every branch, not the common parent before the fork.
+	for previousID, forks := range children {
+		if len(forks) < 2 {
+			continue
+		}
+
+		ids := make([]string, 0, len(forks))
+
+		for _, entry := range forks {
+			ids = append(ids, string(entry.Manifest.BackupID))
+		}
+
+		detail := fmt.Sprintf(
+			"previous backup %q has multiple children: %s",
+			previousID,
+			strings.Join(ids, ", "),
+		)
+
+		for _, entry := range forks {
+			propagateProblem(entry, &Problem{
+				Kind:     ProblemFork,
+				BackupID: string(entry.Manifest.BackupID),
+				Detail:   detail,
+			}, children)
+		}
+	}
+}
+
+// propagateProblem attaches a problem to its source and creates an inherited
+// copy for each descendant. All writes affect the Entries stored in groups.
+func propagateProblem(
+	source *Entry,
+	problem *Problem,
+	children map[backup.BackupID][]*Entry,
+) {
+	source.Problems = append(source.Problems, problem)
+
+	// Guard against cycles in previous_backup_id to keep Build finite.
+	visited := map[backup.BackupID]bool{source.Manifest.BackupID: true}
+	pending := append([]*Entry(nil), children[source.Manifest.BackupID]...)
+
+	for len(pending) > 0 {
+		child := pending[0]
+		pending = pending[1:]
+		childID := child.Manifest.BackupID
+
+		if visited[childID] {
+			continue
+		}
+
+		visited[childID] = true
+
+		child.Problems = append(child.Problems, &Problem{
+			Kind:      problem.Kind,
+			BackupID:  string(childID),
+			Inherited: true,
+			Detail:    problem.Detail,
+		})
+
+		pending = append(pending, children[childID]...)
+	}
+}
+
+// vclockProblems flags an incremental shard whose vclock_begin does not continue
+// the vclock_end of the nearest ancestor carrying the same shard.
+func vclockProblems(entry *Entry, entries map[backup.BackupID]*Entry) []*Problem {
+	replicasets := make([]string, 0, len(entry.Manifest.Shards))
+
+	for replicasetUUID := range entry.Manifest.Shards {
+		replicasets = append(replicasets, replicasetUUID)
+	}
+
+	slices.Sort(replicasets)
+
+	var problems []*Problem
+	for _, replicasetUUID := range replicasets {
+		current := entry.Manifest.Shards[replicasetUUID].Instance
+		if current == nil || current.Artifact.Type != backup.BackupTypeIncremental {
+			continue
+		}
+
+		// Find the nearest ancestor manifest that carries this shard.
+		ancestor, previous := nearestShardAncestor(entry, replicasetUUID, entries)
+		if previous == nil {
+			// No ancestor carries this shard: nothing to stitch against.
+			continue
+		}
+
+		if maps.Equal(current.VclockBegin, previous.VclockEnd) {
+			continue
+		}
+
+		problems = append(problems, &Problem{
+			Kind:     ProblemVclockMismatch,
+			BackupID: string(entry.Manifest.BackupID),
+			Detail: fmt.Sprintf(
+				"replicaset %q vclock_begin %v does not match backup %q vclock_end %v",
+				replicasetUUID,
+				current.VclockBegin,
+				ancestor.Manifest.BackupID,
+				previous.VclockEnd,
+			),
+		})
+	}
+
+	return problems
+}
+
+// nearestShardAncestor walks previous_backup_id backwards and returns the first
+// ancestor carrying the given shard as an instance, skipping degraded ancestors.
+// Returns nil when none exists.
+func nearestShardAncestor(
+	entry *Entry,
+	replicasetUUID string,
+	entries map[backup.BackupID]*Entry,
+) (*Entry, *backup.ShardInstance) {
+	visited := map[backup.BackupID]bool{entry.Manifest.BackupID: true}
+	current := entry
+
+	for {
+		previousID := current.Manifest.PreviousBackupID
+		if previousID == "" {
+			return nil, nil
+		}
+
+		ancestor := entries[previousID]
+		if ancestor == nil || visited[previousID] {
+			return nil, nil
+		}
+
+		visited[previousID] = true
+
+		if instance := ancestor.Manifest.Shards[replicasetUUID].Instance; instance != nil {
+			return ancestor, instance
+		}
+
+		current = ancestor
+	}
+}
+
+// orderGroups puts each full first, follows its children, and then orders the
+// groups from oldest full backup to newest.
+func orderGroups(
+	byBase map[backup.BackupID]*Group,
+	children map[backup.BackupID][]*Entry,
+) []Group {
+	groups := make([]Group, 0, len(byBase))
+
+	for baseID, group := range byBase {
+		orderGroup(group, baseID, children)
+		groups = append(groups, *group)
+	}
+
+	slices.SortFunc(groups, func(left, right Group) int {
+		if len(left.Entries) == 0 || len(right.Entries) == 0 {
+			return len(left.Entries) - len(right.Entries)
+		}
+		return compareEntries(left.Entries[0], right.Entries[0])
+	})
+
+	return groups
+}
+
+// orderGroup walks the declared full first and follows previous_backup_id
+// links. Disconnected tails are appended afterwards for verify diagnostics.
+func orderGroup(
+	group *Group,
+	baseID backup.BackupID,
+	children map[backup.BackupID][]*Entry,
+) {
+	slices.SortFunc(group.Entries, compareEntries)
+	ordered := make([]*Entry, 0, len(group.Entries))
+	visited := make(map[backup.BackupID]bool, len(group.Entries))
+	members := make(map[backup.BackupID]bool, len(group.Entries))
+
+	for _, entry := range group.Entries {
+		members[entry.Manifest.BackupID] = true
+	}
+
+	var appendTree func(*Entry)
+	appendTree = func(entry *Entry) {
+		id := entry.Manifest.BackupID
+
+		if visited[id] || entry.Manifest.BaseFullBackupID != baseID {
+			return
+		}
+
+		visited[id] = true
+		ordered = append(ordered, entry)
+
+		for _, child := range children[id] {
+			appendTree(child)
+		}
+	}
+
+	for _, entry := range group.Entries {
+		if entry.Manifest.BackupID == baseID {
+			appendTree(entry)
+			break
+		}
+	}
+
+	// Append disconnected tails root-first (an entry whose previous is not a group
+	// member is a tail root), keeping parents before children in Problems().
+	for _, entry := range group.Entries {
+		if members[entry.Manifest.PreviousBackupID] {
+			continue
+		}
+
+		appendTree(entry)
+	}
+
+	group.Entries = ordered
+}

--- a/lib/backup/chain/build_test.go
+++ b/lib/backup/chain/build_test.go
@@ -1,0 +1,376 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+)
+
+func TestBuildEmpty(t *testing.T) {
+	chain, err := Build(nil)
+	require.NoError(t, err)
+	require.Empty(t, chain.Groups())
+	require.Nil(t, chain.Latest())
+	require.Empty(t, chain.Manifests())
+	require.Empty(t, chain.Problems())
+}
+
+func TestBuildGroupsOldestToNewest(t *testing.T) {
+	fullA := manifestFixture("full-a", "", "full-a",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	incA := manifestFixture("inc-a", "full-a", "full-a",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	fullB := manifestFixture("full-b", "", "full-b",
+		backup.BackupTypeFull, 30, 0, 10, nil)
+	incB := manifestFixture("inc-b", "full-b", "full-b",
+		backup.BackupTypeIncremental, 40, 10, 20, nil)
+
+	chain := buildFixtureChain(t, incA, fullB, incB, fullA)
+	groups := chain.Groups()
+	require.Len(t, groups, 2)
+	require.Equal(t, []backup.BackupID{"full-a", "inc-a"}, entryIDs(groups[0].Entries))
+	require.Equal(t, []backup.BackupID{"full-b", "inc-b"}, entryIDs(groups[1].Entries))
+	require.Empty(t, chain.Problems())
+}
+
+func TestBuildKeepsBrokenTailInDeclaredGroup(t *testing.T) {
+	fullA := manifestFixture("full-a", "", "full-a", backup.BackupTypeFull, 10, 0, 10, nil)
+	incA := manifestFixture("inc-a", "full-a", "full-a",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	brokenA := manifestFixture("broken-a", "missing", "full-a",
+		backup.BackupTypeIncremental, 25, 20, 30, nil)
+	fullB := manifestFixture("full-b", "", "full-b",
+		backup.BackupTypeFull, 30, 0, 10, nil)
+	incB := manifestFixture("inc-b", "full-b", "full-b",
+		backup.BackupTypeIncremental, 40, 10, 20, nil)
+
+	chain := buildFixtureChain(t, incB, brokenA, fullA, fullB, incA)
+	groups := chain.Groups()
+	require.Equal(t, []backup.BackupID{"full-a", "inc-a", "broken-a"}, entryIDs(groups[0].Entries))
+	require.Equal(t, []backup.BackupID{"full-b", "inc-b"}, entryIDs(groups[1].Entries))
+
+	broken := entriesByID(groups[0].Entries)["broken-a"]
+	requireProblems(t, broken, problemExpectation{
+		kind:           ProblemOrphan,
+		backupID:       "broken-a",
+		detailContains: []string{"missing"},
+	})
+}
+
+func TestBuildLatestUsesNewestGroup(t *testing.T) {
+	fullA := manifestFixture("full-a", "", "full-a",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	incA := manifestFixture("inc-a", "full-a", "full-a",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	fullB := manifestFixture("full-b", "", "full-b",
+		backup.BackupTypeFull, 30, 0, 10, nil)
+	incB := manifestFixture("inc-b", "full-b", "full-b",
+		backup.BackupTypeIncremental, 40, 10, 20, nil)
+
+	chain := buildFixtureChain(t, incB, fullA, incA, fullB)
+	require.Equal(t, backup.BackupID("inc-b"), chain.Latest().Manifest.BackupID)
+}
+
+func TestBuildLatestReturnsProblematicHead(t *testing.T) {
+	// The chain head is a problematic entry.
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	clean := manifestFixture("inc", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	orphanHead := manifestFixture("orphan", "missing", "orphan",
+		backup.BackupTypeFull, 30, 0, 30, nil)
+
+	chain := buildFixtureChain(t, full, clean, orphanHead)
+	latest := chain.Latest()
+	require.Equal(t, backup.BackupID("orphan"), latest.Manifest.BackupID)
+	require.NotEmpty(t, latest.Problems)
+}
+
+func TestBuildOrderFollowsBackupIDNotCreationTime(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 100, 0, 10, nil)
+	// inc-z sorts last by backup_id but was created earliest (CreationTime=50).
+	head := manifestFixture("inc-z", "full", "full",
+		backup.BackupTypeIncremental, 50, 10, 20, nil)
+
+	chain := buildFixtureChain(t, head, full)
+	require.Equal(t, backup.BackupID("inc-z"), chain.Latest().Manifest.BackupID)
+	require.Equal(t,
+		[]backup.BackupID{"full", "inc-z"},
+		entryIDs(chain.Groups()[0].Entries),
+	)
+}
+
+func TestBuildRejectsDuplicateBackupID(t *testing.T) {
+	first := manifestFixture("duplicate", "", "duplicate",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	second := manifestFixture("duplicate", "", "other",
+		backup.BackupTypeFull, 20, 0, 10, nil)
+
+	_, err := Build([]*backup.ClusterManifest{&first, &second})
+	require.ErrorContains(t, err, `duplicate backup_id "duplicate"`)
+}
+
+func TestBuildMarksOrphanAndDescendants(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	orphan := manifestFixture("orphan", "missing", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	child := manifestFixture("child", "orphan", "full",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+
+	chain := buildFixtureChain(t, orphan, child, full)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	require.Empty(t, entries["full"].Problems)
+	requireProblems(t, entries["orphan"], problemExpectation{
+		kind:           ProblemOrphan,
+		backupID:       "orphan",
+		detailContains: []string{"missing"},
+	})
+	requireProblems(t, entries["child"], problemExpectation{
+		kind:           ProblemOrphan,
+		backupID:       "child",
+		inherited:      true,
+		detailContains: []string{"missing"},
+	})
+
+	problems := chain.Problems()
+	require.Len(t, problems, 2)
+	require.Equal(t, entries["orphan"].Problems[0], problems[0])
+	require.Equal(t, entries["child"].Problems[0], problems[1])
+}
+
+func TestBuildMarksBothForkTails(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	first := manifestFixture("first", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	second := manifestFixture("second", "full", "full",
+		backup.BackupTypeIncremental, 21, 10, 20, nil)
+	firstChild := manifestFixture("first-child", "first", "full",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+	secondChild := manifestFixture("second-child", "second", "full",
+		backup.BackupTypeIncremental, 31, 20, 30, nil)
+
+	chain := buildFixtureChain(t, secondChild, first, full, firstChild, second)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	require.Empty(t, entries["full"].Problems)
+	for _, id := range []string{"first", "second"} {
+		requireProblems(t, entries[backup.BackupID(id)], problemExpectation{
+			kind:           ProblemFork,
+			backupID:       id,
+			detailContains: []string{"full", "first", "second"},
+		})
+	}
+	for _, id := range []string{"first-child", "second-child"} {
+		requireProblems(t, entries[backup.BackupID(id)], problemExpectation{
+			kind:           ProblemFork,
+			backupID:       id,
+			inherited:      true,
+			detailContains: []string{"full", "first", "second"},
+		})
+	}
+}
+
+func TestBuildMarksNonMonotonicForkTails(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	head := manifestFixture("inc-b", "full", "full",
+		backup.BackupTypeIncremental, 30, 10, 20, nil)
+	stale := manifestFixture("inc-a", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+
+	chain := buildFixtureChain(t, full, head, stale)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	require.Empty(t, entries["full"].Problems)
+	for _, id := range []string{"inc-a", "inc-b"} {
+		requireProblems(t, entries[backup.BackupID(id)], problemExpectation{
+			kind:           ProblemFork,
+			backupID:       id,
+			detailContains: []string{"full", "inc-a", "inc-b"},
+		})
+	}
+}
+
+func TestBuildMarksVclockMismatchOnOneShardAndDescendant(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	broken := manifestFixture("broken", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	broken.Shards[replicasetB].Instance.VclockBegin = backup.Vclock{2: 9}
+	child := manifestFixture("child", "broken", "full",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+
+	chain := buildFixtureChain(t, full, broken, child)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	require.Empty(t, entries["full"].Problems)
+	requireProblems(t, entries["broken"], problemExpectation{
+		kind:           ProblemVclockMismatch,
+		backupID:       "broken",
+		detailContains: []string{replicasetB, "map[2:9]", "map[2:10]"},
+	})
+
+	// Only replicasetB is mismatched: the problem detail must not mention replicasetA.
+	require.NotContains(t, entries["broken"].Problems[0].Detail, replicasetA)
+	requireProblems(t, entries["child"], problemExpectation{
+		kind:           ProblemVclockMismatch,
+		backupID:       "child",
+		inherited:      true,
+		detailContains: []string{replicasetB, "map[2:9]", "map[2:10]"},
+	})
+}
+
+func TestBuildMarksVclockMismatchOnBothShards(t *testing.T) {
+	// Both replicasets have mismatched vclock_begin — two separate Problems.
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	broken := manifestFixture("broken", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	broken.Shards[replicasetA].Instance.VclockBegin = backup.Vclock{1: 9}
+	broken.Shards[replicasetB].Instance.VclockBegin = backup.Vclock{2: 9}
+
+	chain := buildFixtureChain(t, full, broken)
+	problems := entriesByID(chain.Groups()[0].Entries)["broken"].Problems
+	require.Len(t, problems, 2)
+	require.Equal(t, ProblemVclockMismatch, problems[0].Kind)
+	require.Equal(t, ProblemVclockMismatch, problems[1].Kind)
+	// Each problem names a different replicaset.
+	mentionedReplicasets := []string{problems[0].Detail, problems[1].Detail}
+	require.Contains(t, mentionedReplicasets[0]+mentionedReplicasets[1], replicasetA)
+	require.Contains(t, mentionedReplicasets[0]+mentionedReplicasets[1], replicasetB)
+}
+
+func TestBuildSkipsVclockCheckForFullBackup(t *testing.T) {
+	// A full backup's vclock_begin is never compared with the previous manifest:
+	// a full is a chain root, not a delta.
+	prev := manifestFixture("prev", "", "prev",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	// next is declared as a full with an arbitrary vclock_begin that would fail
+	// an incremental check against prev's vclock_end.
+	next := manifestFixture("next", "prev", "next",
+		backup.BackupTypeFull, 20, 0, 20, nil)
+
+	chain := buildFixtureChain(t, prev, next)
+	for _, group := range chain.Groups() {
+		for _, entry := range group.Entries {
+			require.Empty(t, entry.Problems)
+		}
+	}
+}
+
+func TestBuildManifestsIncludesProblematic(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	orphan := manifestFixture("orphan", "missing", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+
+	chain := buildFixtureChain(t, full, orphan)
+	require.Equal(t,
+		[]backup.BackupID{"full", "orphan"},
+		manifestIDs(chain.Manifests()),
+	)
+	require.Len(t, chain.Problems(), 1)
+}
+
+func TestBuildMarksInvalidManifestAndDescendant(t *testing.T) {
+	full := manifestFixture("full", "", "full",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	invalid := manifestFixture("invalid", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	invalid.SchemaVersion = 0
+	child := manifestFixture("child", "invalid", "full",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+
+	chain := buildFixtureChain(t, full, invalid, child)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	require.Empty(t, entries["full"].Problems)
+	requireProblems(t, entries["invalid"], problemExpectation{
+		kind:           ProblemInvalidManifest,
+		backupID:       "invalid",
+		detailContains: []string{"schema_version"},
+	})
+	requireProblems(t, entries["child"], problemExpectation{
+		kind:           ProblemInvalidManifest,
+		backupID:       "child",
+		inherited:      true,
+		detailContains: []string{"schema_version"},
+	})
+}
+
+func TestBuildStitchesShardAcrossHoleByLastCarryingManifest(t *testing.T) {
+	// M2 is a hole for replicasetB (shard error). M3's replicasetB vclock_begin
+	// must be stitched against M1 (the last manifest carrying the shard), not
+	// against the hole in M2, and must not raise a false mismatch.
+	m1 := manifestFixture("m1", "", "m1",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	m2 := manifestFixture("m2", "m1", "m1",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	makeShardHole(&m2)
+	m3 := manifestFixture("m3", "m2", "m1",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+	// replicasetB in M3 continues from M1's vclock_end (10), across the M2 hole.
+	m3.Shards[replicasetB].Instance.VclockBegin = backup.Vclock{2: 10}
+
+	chain := buildFixtureChain(t, m1, m2, m3)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	// replicasetA is continuous through all three; replicasetB stitches over the
+	// hole. Neither must be flagged.
+	require.Empty(t, entries["m3"].Problems)
+}
+
+func TestBuildDetectsRealMismatchAcrossHole(t *testing.T) {
+	// Same shape, but M3's replicasetB does not line up with M1's vclock_end:
+	// stitching across the hole must catch the real mismatch.
+	m1 := manifestFixture("m1", "", "m1",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	m2 := manifestFixture("m2", "m1", "m1",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	makeShardHole(&m2)
+	m3 := manifestFixture("m3", "m2", "m1",
+		backup.BackupTypeIncremental, 30, 20, 30, nil)
+	// replicasetB in M3 claims to continue from 99, which matches neither M1 nor M2.
+	m3.Shards[replicasetB].Instance.VclockBegin = backup.Vclock{2: 99}
+
+	chain := buildFixtureChain(t, m1, m2, m3)
+	entries := entriesByID(chain.Groups()[0].Entries)
+	requireProblems(t, entries["m3"], problemExpectation{
+		kind:           ProblemVclockMismatch,
+		backupID:       "m3",
+		detailContains: []string{replicasetB, "m1"},
+	})
+}
+
+func TestBuildHandlesCycleInPreviousBackupID(t *testing.T) {
+	// A cycle in previous_backup_id must not hang Build. Because both entries
+	// resolve their previous_backup_id to an existing entry, neither is marked
+	// as an orphan. The cycle itself is not currently detected as a Problem.
+	a := manifestFixture("a", "b", "a",
+		backup.BackupTypeFull, 10, 0, 10, nil)
+	b := manifestFixture("b", "a", "a",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+
+	chain := buildFixtureChain(t, a, b)
+	require.Len(t, chain.Manifests(), 2)
+}
+
+type problemExpectation struct {
+	kind           ProblemKind
+	backupID       string
+	inherited      bool
+	detailContains []string
+}
+
+func requireProblems(t *testing.T, entry *Entry, expected ...problemExpectation) {
+	t.Helper()
+	require.Len(t, entry.Problems, len(expected))
+	for i, want := range expected {
+		problem := entry.Problems[i]
+		require.Equal(t, want.kind, problem.Kind)
+		require.Equal(t, want.backupID, problem.BackupID)
+		require.Equal(t, want.inherited, problem.Inherited)
+		for _, part := range want.detailContains {
+			require.Contains(t, problem.Detail, part)
+		}
+	}
+}

--- a/lib/backup/chain/chain.go
+++ b/lib/backup/chain/chain.go
@@ -1,0 +1,161 @@
+package chain
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/tarantool/tt/lib/backup"
+)
+
+// Chain is the in-memory view of all manifests in one storage.
+type Chain struct {
+	// groups are ordered from oldest full backup to newest.
+	groups []Group
+	// byID indexes group entries by backup_id for linking and PlanFor traversal.
+	byID map[backup.BackupID]*Entry
+	// points are ordered by their effective recovery timestamp.
+	points []ClusterPoint
+	// segments are time-ordered runs of points; the gap between two of them
+	// carries why the chain is not stitched across it, which Resolve reports.
+	segments []segment
+}
+
+// segment is a contiguous run of cluster points with uniform topology plus the
+// reason it is separated from the previous segment.
+type segment struct {
+	points    []ClusterPoint
+	gapBefore gapKind
+}
+
+// gapKind classifies the separation between two adjacent segments.
+type gapKind int
+
+const (
+	gapNone     gapKind = iota // first segment: no predecessor
+	gapTopology                // composition or master changed
+	gapBroken                  // problematic entry or unrelated full backup
+)
+
+// status maps a gap to the resolve status reported when a target time falls in it.
+func (g gapKind) status() Status {
+	if g == gapTopology {
+		return StatusTopologyBoundary
+	}
+
+	return StatusChainBroken
+}
+
+// Groups returns backup groups from oldest full backup to newest.
+func (c *Chain) Groups() []Group {
+	groups := make([]Group, len(c.groups))
+	for i, group := range c.groups {
+		entries := make([]*Entry, len(group.Entries))
+		for j, entry := range group.Entries {
+			entries[j] = copyEntry(entry)
+		}
+		groups[i].Entries = entries
+	}
+
+	return groups
+}
+
+// Latest returns the last entry in chain order, regardless of its Problems.
+func (c *Chain) Latest() *Entry {
+	var latest *Entry
+	for _, entry := range c.byID {
+		if latest == nil || compareEntries(latest, entry) < 0 {
+			latest = entry
+		}
+	}
+
+	if latest == nil {
+		return nil
+	}
+
+	return copyEntry(latest)
+}
+
+// Manifests returns every loaded manifest, including problematic ones.
+func (c *Chain) Manifests() []*backup.ClusterManifest {
+	manifests := make([]*backup.ClusterManifest, 0)
+	for _, group := range c.groups {
+		for _, entry := range group.Entries {
+			manifests = append(manifests, entry.Manifest)
+		}
+	}
+
+	return manifests
+}
+
+// Problems returns a flat list of all own and inherited entry problems.
+func (c *Chain) Problems() []*Problem {
+	problems := make([]*Problem, 0)
+	for _, group := range c.groups {
+		for _, entry := range group.Entries {
+			problems = append(problems, entry.Problems...)
+		}
+	}
+
+	return problems
+}
+
+// ClusterPoints returns cluster recovery points ordered by effective timestamp.
+func (c *Chain) ClusterPoints() []ClusterPoint {
+	points := make([]ClusterPoint, len(c.points))
+	copy(points, c.points)
+	return points
+}
+
+// copyEntry shares the manifest pointer but clones Problems so callers cannot
+// mutate the chain's state.
+func copyEntry(entry *Entry) *Entry {
+	return &Entry{
+		Manifest: entry.Manifest,
+		Problems: append([]*Problem(nil), entry.Problems...),
+	}
+}
+
+// compareEntries orders entries lexicographically by backup_id.
+func compareEntries(left, right *Entry) int {
+	return cmp.Compare(left.Manifest.BackupID, right.Manifest.BackupID)
+}
+
+// topologyEqual reports whether two adjacent manifests have the same replicaset
+// set and the same master on each.
+func topologyEqual(a, b *backup.ClusterManifest) bool {
+	if len(a.Topology.Replicasets) != len(b.Topology.Replicasets) {
+		return false
+	}
+
+	for uuid := range a.Topology.Replicasets {
+		if _, ok := b.Topology.Replicasets[uuid]; !ok {
+			return false
+		}
+
+		// The master is the instance that was actually backed up.
+		shardA := a.Shards[uuid]
+		shardB := b.Shards[uuid]
+		if shardA.Instance == nil || shardB.Instance == nil {
+			continue
+		}
+
+		if shardA.Instance.InstanceUUID != shardB.Instance.InstanceUUID {
+			return false
+		}
+	}
+
+	return true
+}
+
+// replicasetUUIDs returns the sorted replicaset UUIDs of a manifest.
+func replicasetUUIDs(m *backup.ClusterManifest) []string {
+	uuids := make([]string, 0, len(m.Topology.Replicasets))
+
+	for uuid := range m.Topology.Replicasets {
+		uuids = append(uuids, uuid)
+	}
+
+	slices.Sort(uuids)
+
+	return uuids
+}

--- a/lib/backup/chain/helpers_test.go
+++ b/lib/backup/chain/helpers_test.go
@@ -1,0 +1,254 @@
+package chain
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+	"github.com/tarantool/tt/lib/backup/storage"
+)
+
+const (
+	replicasetA = "11111111-1111-1111-1111-111111111111"
+	replicasetB = "22222222-2222-2222-2222-222222222222"
+	masterA     = "aaaaaaaa-0000-0000-0000-000000000001"
+	masterB     = "bbbbbbbb-0000-0000-0000-000000000001"
+)
+
+type memoryStorage struct {
+	objects map[string][]byte
+	listErr error
+	getErr  map[string]error
+	// getMisses[key] > 0: the next Get misses (gc race that resolves on retry).
+	getMisses map[string]int
+	// phantom keys are listed but never readable (gc-deleted for good).
+	phantom map[string]bool
+}
+
+func newMemoryStorage() *memoryStorage {
+	return &memoryStorage{
+		objects:   make(map[string][]byte),
+		getErr:    make(map[string]error),
+		getMisses: make(map[string]int),
+		phantom:   make(map[string]bool),
+	}
+}
+
+func (s *memoryStorage) List(_ context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+
+	objects := make([]storage.ObjectInfo, 0)
+	for key, data := range s.objects {
+		if strings.HasPrefix(key, prefix) {
+			objects = append(objects, storage.ObjectInfo{Key: key, Size: int64(len(data))})
+		}
+	}
+	for key := range s.phantom {
+		if strings.HasPrefix(key, prefix) {
+			objects = append(objects, storage.ObjectInfo{Key: key})
+		}
+	}
+	slices.SortFunc(objects, func(a, b storage.ObjectInfo) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return objects, nil
+}
+
+func (s *memoryStorage) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	if err := s.getErr[key]; err != nil {
+		return nil, err
+	}
+	if s.phantom[key] {
+		return nil, storage.ErrKeyNotFound
+	}
+	if s.getMisses[key] > 0 {
+		s.getMisses[key]--
+		return nil, storage.ErrKeyNotFound
+	}
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ErrKeyNotFound
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *memoryStorage) Put(_ context.Context, key string, r io.Reader, _ int64) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read data: %w", err)
+	}
+	s.objects[key] = data
+	return nil
+}
+
+func (s *memoryStorage) Delete(_ context.Context, key string) error {
+	delete(s.objects, key)
+	return nil
+}
+
+func (s *memoryStorage) addManifest(t *testing.T, manifest backup.ClusterManifest) {
+	t.Helper()
+	s.objects[storage.ManifestKey(string(manifest.BackupID))] = encodeManifest(t, manifest)
+}
+
+func encodeManifest(t *testing.T, manifest backup.ClusterManifest) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(data, &object))
+	if manifest.PreviousBackupID == "" {
+		object["previous_backup_id"] = nil
+	}
+
+	data, err = json.Marshal(object)
+	require.NoError(t, err)
+	return data
+}
+
+func manifestFixture(
+	id, previous, base string,
+	backupType backup.BackupType,
+	createdAt, vclockBegin, vclockEnd int64,
+	points map[string][]backup.RecoveryPoint,
+) backup.ClusterManifest {
+	manifest := backup.ClusterManifest{
+		SchemaVersion:    backup.SchemaVersion,
+		BackupID:         backup.BackupID(id),
+		PreviousBackupID: backup.BackupID(previous),
+		BaseFullBackupID: backup.BackupID(base),
+		Status:           backup.StatusOK,
+		CreationTime:     time.Unix(createdAt, 0).UTC(),
+		CreationDuration: time.Second,
+		Shards:           make(map[string]backup.Shard, 2),
+		Topology: backup.Topology{Replicasets: map[string][]backup.TopologyInstance{
+			replicasetA: {{InstanceUUID: masterA}},
+			replicasetB: {{InstanceUUID: masterB}},
+		}},
+		Warnings: []backup.Warning{},
+	}
+
+	addShard(&manifest, replicasetA, masterA, 1,
+		backupType, vclockBegin, vclockEnd, points[replicasetA])
+	addShard(&manifest, replicasetB, masterB, 2,
+		backupType, vclockBegin, vclockEnd, points[replicasetB])
+	return manifest
+}
+
+func addShard(
+	manifest *backup.ClusterManifest,
+	replicasetUUID, instanceUUID string,
+	replicaID uint32,
+	backupType backup.BackupType,
+	vclockBegin, vclockEnd int64,
+	points []backup.RecoveryPoint,
+) {
+	manifest.Shards[replicasetUUID] = backup.Shard{Instance: &backup.ShardInstance{
+		InstanceUUID: instanceUUID,
+		InstanceName: instanceUUID,
+		Hostname:     "localhost",
+		VclockBegin:  backup.Vclock{replicaID: uint64(vclockBegin)},
+		VclockEnd:    backup.Vclock{replicaID: uint64(vclockEnd)},
+		Artifact: backup.Artifact{
+			Path:           storage.ArchiveKey(string(manifest.BackupID), replicasetUUID),
+			SizeBytes:      100,
+			ChecksumSHA256: strings.Repeat("a", 64),
+			Compression:    "zstd",
+			Files:          []string{"00000000000000000000.xlog"},
+			RecoveryPoints: append(
+				make([]backup.RecoveryPoint, 0, len(points)),
+				points...,
+			),
+			Type: backupType,
+		},
+	}}
+}
+
+func recoveryPoint(name string, replicaID uint32,
+	lsn uint64, timestamp int64,
+) backup.RecoveryPoint {
+	return backup.RecoveryPoint{
+		UUID:      name,
+		ReplicaID: replicaID,
+		LSN:       lsn,
+		Timestamp: timestamp,
+	}
+}
+
+// makeShardHole turns replicasetB into a degraded hole (error instead of
+// instance), keeping the replicaset in topology.
+func makeShardHole(manifest *backup.ClusterManifest) {
+	const reason = "replicasetB unreachable"
+	manifest.Shards[replicasetB] = backup.Shard{Error: reason}
+	manifest.Status = backup.StatusDegraded
+	manifest.Warnings = append(manifest.Warnings,
+		backup.NewShardUnreachableWarning(replicasetB))
+}
+
+func buildFixtureChain(t *testing.T, manifests ...backup.ClusterManifest) *Chain {
+	t.Helper()
+
+	pointers := make([]*backup.ClusterManifest, len(manifests))
+	for i := range manifests {
+		pointers[i] = &manifests[i]
+	}
+	chain, err := Build(pointers)
+	require.NoError(t, err)
+	return chain
+}
+
+func findPoint(t *testing.T, chain *Chain, name string) ClusterPoint {
+	t.Helper()
+	for _, point := range chain.ClusterPoints() {
+		if point.Name == name {
+			return point
+		}
+	}
+	t.Fatalf("cluster point %q not found", name)
+	return ClusterPoint{}
+}
+
+func problemKinds(problems []*Problem) []ProblemKind {
+	kinds := make([]ProblemKind, 0, len(problems))
+	for _, problem := range problems {
+		kinds = append(kinds, problem.Kind)
+	}
+	return kinds
+}
+
+func entriesByID(entries []*Entry) map[backup.BackupID]*Entry {
+	result := make(map[backup.BackupID]*Entry, len(entries))
+	for _, entry := range entries {
+		result[entry.Manifest.BackupID] = entry
+	}
+	return result
+}
+
+func entryIDs(entries []*Entry) []backup.BackupID {
+	ids := make([]backup.BackupID, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, entry.Manifest.BackupID)
+	}
+	return ids
+}
+
+func manifestIDs(manifests []*backup.ClusterManifest) []backup.BackupID {
+	ids := make([]backup.BackupID, 0, len(manifests))
+	for _, manifest := range manifests {
+		ids = append(ids, manifest.BackupID)
+	}
+	return ids
+}

--- a/lib/backup/chain/load_test.go
+++ b/lib/backup/chain/load_test.go
@@ -1,0 +1,130 @@
+package chain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+	"github.com/tarantool/tt/lib/backup/storage"
+)
+
+func TestLoadEmptyStorage(t *testing.T) {
+	chain, err := Load(t.Context(), newMemoryStorage())
+	require.NoError(t, err)
+	require.Empty(t, chain.Groups())
+	require.Nil(t, chain.Latest())
+	require.Empty(t, chain.Manifests())
+	require.Empty(t, chain.Problems())
+}
+
+func TestLoadBuildsMarkedChain(t *testing.T) {
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	incremental := manifestFixture(
+		"incremental", "full", "full", backup.BackupTypeIncremental, 20, 10, 20, nil,
+	)
+	store.addManifest(t, incremental)
+	store.addManifest(t, full)
+
+	chain, err := Load(t.Context(), store)
+	require.NoError(t, err)
+	require.Len(t, chain.Groups(), 1)
+	require.Equal(t,
+		[]backup.BackupID{"full", "incremental"},
+		entryIDs(chain.Groups()[0].Entries),
+	)
+	require.Empty(t, chain.Problems())
+	require.Equal(t, backup.BackupID("incremental"), chain.Latest().Manifest.BackupID)
+}
+
+func TestLoadReturnsMarkedProblems(t *testing.T) {
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	orphan := manifestFixture(
+		"orphan", "missing", "full", backup.BackupTypeIncremental, 20, 10, 20, nil,
+	)
+	store.addManifest(t, full)
+	store.addManifest(t, orphan)
+
+	chain, err := Load(t.Context(), store)
+	require.NoError(t, err)
+	require.Equal(t, ProblemOrphan, chain.Latest().Problems[0].Kind)
+	problems := chain.Problems()
+	require.Len(t, problems, 1)
+	require.Equal(t, ProblemOrphan, problems[0].Kind)
+}
+
+func TestLoadRetriesOnVanishedManifest(t *testing.T) {
+	// GET misses once (gc race) then succeeds on retry: Load recovers.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	incremental := manifestFixture(
+		"incremental", "full", "full", backup.BackupTypeIncremental, 20, 10, 20, nil,
+	)
+	store.addManifest(t, full)
+	store.addManifest(t, incremental)
+	store.getMisses[storage.ManifestKey("incremental")] = 1
+
+	chain, err := Load(t.Context(), store)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]backup.BackupID{"full", "incremental"},
+		entryIDs(chain.Groups()[0].Entries),
+	)
+}
+
+func TestLoadFailsWhenManifestStaysVanished(t *testing.T) {
+	// A phantom key is listed but never readable: a second miss is a real error.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.phantom[storage.ManifestKey("ghost")] = true
+
+	_, err := Load(t.Context(), store)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "vanished")
+}
+
+func TestLoadRejectsInvalidManifest(t *testing.T) {
+	store := newMemoryStorage()
+	store.objects[storage.ManifestKey("broken")] = []byte("{")
+
+	_, err := Load(t.Context(), store)
+	require.Error(t, err)
+}
+
+func TestLoadMarksInvalidManifest(t *testing.T) {
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+
+	invalid := manifestFixture("invalid", "full", "full",
+		backup.BackupTypeIncremental, 20, 10, 20, nil)
+	invalid.SchemaVersion = 0
+	store.objects[storage.ManifestKey("invalid")] = encodeManifest(t, invalid)
+
+	chain, err := Load(t.Context(), store)
+	require.NoError(t, err)
+	require.Contains(t, problemKinds(chain.Problems()), ProblemInvalidManifest)
+}
+
+func TestLoadReturnsListError(t *testing.T) {
+	wantErr := errors.New("list failed")
+	store := newMemoryStorage()
+	store.listErr = wantErr
+
+	_, err := Load(t.Context(), store)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestLoadReturnsGetError(t *testing.T) {
+	wantErr := errors.New("get failed")
+	store := newMemoryStorage()
+	key := storage.ManifestKey("full")
+	store.objects[key] = []byte("{}")
+	store.getErr[key] = wantErr
+
+	_, err := Load(t.Context(), store)
+	require.ErrorIs(t, err, wantErr)
+}

--- a/lib/backup/chain/plan_test.go
+++ b/lib/backup/chain/plan_test.go
@@ -1,0 +1,92 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+)
+
+func TestPlanForFullOnly(t *testing.T) {
+	// Point inside a full: plan is the full alone, TrimTo set.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 20,
+		clusterPointFixture("target", 15, 15))
+	chain := buildFixtureChain(t, full)
+
+	plan, err := chain.PlanFor(findPoint(t, chain, "target"))
+	require.NoError(t, err)
+	require.Equal(t, "target", plan.Point.Name)
+	require.Equal(t,
+		[]backup.BackupID{"full"},
+		manifestIDs(plan.Shards[replicasetA].Backups),
+	)
+	require.Equal(t, &Position{ReplicaID: 1, LSN: 15}, plan.Shards[replicasetA].TrimTo)
+	require.Equal(t, &Position{ReplicaID: 2, LSN: 15}, plan.Shards[replicasetB].TrimTo)
+}
+
+func TestPlanForFullAndIncrementals(t *testing.T) {
+	// Point inside an incremental: plan is full + incremental, TrimTo on the last.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		clusterPointFixture("target", 18, 18))
+	chain := buildFixtureChain(t, full, incremental)
+
+	plan, err := chain.PlanFor(findPoint(t, chain, "target"))
+	require.NoError(t, err)
+	require.Equal(t, "target", plan.Point.Name)
+	require.Equal(t,
+		[]backup.BackupID{"full", "inc"},
+		manifestIDs(plan.Shards[replicasetA].Backups),
+	)
+	require.Equal(t, &Position{ReplicaID: 1, LSN: 18}, plan.Shards[replicasetA].TrimTo)
+	require.Equal(t,
+		[]backup.BackupID{"full", "inc"},
+		manifestIDs(plan.Shards[replicasetB].Backups),
+	)
+	require.Equal(t, &Position{ReplicaID: 2, LSN: 18}, plan.Shards[replicasetB].TrimTo)
+}
+
+func TestPlanForTrimToNilWhenPointAtManifestEnd(t *testing.T) {
+	// Point at vclock_end exactly: no trimming, TrimTo nil.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 20,
+		clusterPointFixture("target", 20, 15))
+	chain := buildFixtureChain(t, full)
+
+	plan, err := chain.PlanFor(findPoint(t, chain, "target"))
+	require.NoError(t, err)
+	require.Nil(t, plan.Shards[replicasetA].TrimTo)
+	require.Nil(t, plan.Shards[replicasetB].TrimTo)
+}
+
+func TestPlanForSkipsShardHole(t *testing.T) {
+	// M2 is a hole for replicasetB: its plan skips M2, shorter than replicasetA's.
+	m1 := manifestFixture("m1", "", "m1", backup.BackupTypeFull, 10, 0, 10, nil)
+	m2 := manifestFixture("m2", "m1", "m1", backup.BackupTypeIncremental, 20, 10, 20, nil)
+	makeShardHole(&m2)
+	m3 := manifestFixture("m3", "m2", "m1", backup.BackupTypeIncremental, 30, 20, 30,
+		clusterPointFixture("target", 25, 25))
+	m3.Shards[replicasetB].Instance.VclockBegin = backup.Vclock{2: 10}
+
+	chain := buildFixtureChain(t, m1, m2, m3)
+	plan, err := chain.PlanFor(findPoint(t, chain, "target"))
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]backup.BackupID{"m1", "m2", "m3"},
+		manifestIDs(plan.Shards[replicasetA].Backups),
+	)
+	require.Equal(t,
+		[]backup.BackupID{"m1", "m3"},
+		manifestIDs(plan.Shards[replicasetB].Backups),
+	)
+}
+
+func TestPlanForRejectsForeignPoint(t *testing.T) {
+	chain := buildFixtureChain(t, manifestFixture(
+		"full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("known", 8, 8),
+	))
+
+	_, err := chain.PlanFor(ClusterPoint{Name: "foreign"})
+	require.ErrorContains(t, err, "foreign")
+}

--- a/lib/backup/chain/points.go
+++ b/lib/backup/chain/points.go
@@ -1,0 +1,214 @@
+package chain
+
+import (
+	"slices"
+	"time"
+)
+
+// buildSegments partitions groups into time-ordered segments and records, for
+// each, why it is separated from the previous one.
+func buildSegments(groups []Group) []segment {
+	var segments []segment
+	for g := range groups {
+		groupSegments := segmentsFromGroup(groups[g])
+		if len(groupSegments) == 0 {
+			continue
+		}
+
+		if len(segments) > 0 {
+			groupSegments[0].gapBefore = gapBroken
+		}
+
+		segments = append(segments, groupSegments...)
+	}
+
+	slices.SortFunc(segments, func(a, b segment) int {
+		return a.points[0].Timestamp.Compare(b.points[0].Timestamp)
+	})
+
+	return segments
+}
+
+// buildClusterPoints flattens segments into a single time-ordered point slice.
+func buildClusterPoints(segments []segment) []ClusterPoint {
+	var points []ClusterPoint
+	for _, seg := range segments {
+		points = append(points, seg.points...)
+	}
+
+	slices.SortFunc(points, func(a, b ClusterPoint) int {
+		return a.Timestamp.Compare(b.Timestamp)
+	})
+
+	return points
+}
+
+// segmentsFromGroup splits one group into topology segments, carrying each
+// segment's separation reason.
+func segmentsFromGroup(group Group) []segment {
+	runs := splitIntoRuns(group.Entries)
+
+	var segments []segment
+	pendingGap := gapNone
+
+	for _, run := range runs {
+		points := pointsFromSegment(run.entries)
+		if len(points) == 0 {
+			pendingGap = maxGap(pendingGap, run.gapBefore)
+			continue
+		}
+
+		gap := run.gapBefore
+		if len(segments) == 0 {
+			// First point-bearing segment: only a carried-over gap matters.
+			gap = pendingGap
+		} else {
+			gap = maxGap(gap, pendingGap)
+		}
+
+		segments = append(segments, segment{points: points, gapBefore: gap})
+
+		pendingGap = gapNone
+	}
+
+	return segments
+}
+
+// maxGap returns the more severe gap: break outranks boundary outranks none.
+func maxGap(a, b gapKind) gapKind {
+	if a == gapBroken || b == gapBroken {
+		return gapBroken
+	}
+
+	if a == gapTopology || b == gapTopology {
+		return gapTopology
+	}
+
+	return gapNone
+}
+
+// run is a contiguous sequence of clean entries with uniform topology plus its
+// separation reason from the previous run.
+type run struct {
+	entries   []*Entry
+	gapBefore gapKind
+}
+
+// splitIntoRuns partitions ordered entries into runs of clean, same-topology
+// entries.
+func splitIntoRuns(entries []*Entry) []run {
+	var runs []run
+	var current []*Entry
+
+	nextGap := gapNone
+
+	flush := func() {
+		if len(current) > 0 {
+			runs = append(runs, run{entries: current, gapBefore: nextGap})
+			current = nil
+			nextGap = gapNone
+		}
+	}
+
+	for _, entry := range entries {
+		if len(entry.Problems) > 0 {
+			flush()
+			nextGap = gapBroken
+			continue
+		}
+
+		if len(current) > 0 && !topologyEqual(current[len(current)-1].Manifest, entry.Manifest) {
+			flush()
+			nextGap = gapTopology
+		}
+
+		current = append(current, entry)
+	}
+
+	flush()
+
+	return runs
+}
+
+// shardEntry is one recovery point's position and effective timestamp on a
+// single replicaset.
+type shardEntry struct {
+	position  Position
+	timestamp time.Time
+}
+
+// collectShardEntries maps each recovery point name to its first-seen shard
+// entry per replicaset across the segment's entries.
+func collectShardEntries(entries []*Entry) map[string]map[string]shardEntry {
+	pointShards := make(map[string]map[string]shardEntry)
+
+	for _, entry := range entries {
+		for _, replicasetUUID := range replicasetUUIDs(entry.Manifest) {
+			shard := entry.Manifest.Shards[replicasetUUID]
+			if shard.Instance == nil {
+				continue
+			}
+
+			for _, rp := range shard.Instance.Artifact.RecoveryPoints {
+				name := rp.UUID
+				if _, ok := pointShards[name]; !ok {
+					pointShards[name] = make(map[string]shardEntry)
+				}
+
+				if _, seen := pointShards[name][replicasetUUID]; !seen {
+					pointShards[name][replicasetUUID] = shardEntry{
+						position:  Position{ReplicaID: rp.ReplicaID, LSN: rp.LSN},
+						timestamp: time.Unix(rp.Timestamp, 0).UTC(),
+					}
+				}
+			}
+		}
+	}
+
+	return pointShards
+}
+
+// pointsFromSegment collects cluster points from one topology-homogeneous
+// segment: a name becomes a point only when present on every replicaset in the
+// segment's topology.
+func pointsFromSegment(entries []*Entry) []ClusterPoint {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	uuids := replicasetUUIDs(entries[0].Manifest)
+	required := len(uuids)
+	segmentTopology := entries[0].Manifest.Topology
+	pointShards := collectShardEntries(entries)
+
+	var points []ClusterPoint
+	for name, byReplicaset := range pointShards {
+		if len(byReplicaset) < required {
+			continue
+		}
+
+		shards := make(map[string]Position, required)
+		minTS := time.Time{}
+
+		for _, replicasetUUID := range uuids {
+			se := byReplicaset[replicasetUUID]
+			shards[replicasetUUID] = se.position
+			if minTS.IsZero() || se.timestamp.Before(minTS) {
+				minTS = se.timestamp
+			}
+		}
+
+		points = append(points, ClusterPoint{
+			Name:      name,
+			Timestamp: minTS,
+			Topology:  segmentTopology,
+			Shards:    shards,
+		})
+	}
+
+	slices.SortFunc(points, func(a, b ClusterPoint) int {
+		return a.Timestamp.Compare(b.Timestamp)
+	})
+
+	return points
+}

--- a/lib/backup/chain/points_test.go
+++ b/lib/backup/chain/points_test.go
@@ -1,0 +1,185 @@
+package chain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+)
+
+func TestClusterPointsJoinReplicasetsByName(t *testing.T) {
+	// Same point name on both shards -> one ClusterPoint.
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("point", 1, 100, 11)},
+			replicasetB: {recoveryPoint("point", 2, 200, 12)},
+		})
+
+	points := buildFixtureChain(t, manifest).ClusterPoints()
+	require.Len(t, points, 1)
+	require.Equal(t, "point", points[0].Name)
+	require.Equal(t, time.Unix(11, 0).UTC(), points[0].Timestamp)
+	require.Equal(t, Position{ReplicaID: 1, LSN: 100}, points[0].Shards[replicasetA])
+	require.Equal(t, Position{ReplicaID: 2, LSN: 200}, points[0].Shards[replicasetB])
+}
+
+func TestClusterPointsDropIncompletePoint(t *testing.T) {
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("partial", 1, 100, 11)},
+			// replicasetB has no recovery points at all.
+		})
+
+	require.Empty(t, buildFixtureChain(t, manifest).ClusterPoints())
+}
+
+func TestClusterPointsMultiplePointsInOneManifest(t *testing.T) {
+	// Two names present on all shards → two ClusterPoints.
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {
+				recoveryPoint("first", 1, 100, 10),
+				recoveryPoint("second", 1, 200, 20),
+			},
+			replicasetB: {
+				recoveryPoint("first", 2, 100, 11),
+				recoveryPoint("second", 2, 200, 21),
+			},
+		})
+
+	points := buildFixtureChain(t, manifest).ClusterPoints()
+	require.Len(t, points, 2)
+	require.Equal(t, "first", points[0].Name)
+	require.Equal(t, "second", points[1].Name)
+}
+
+func TestClusterPointsOrderedByTimestamp(t *testing.T) {
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {
+				recoveryPoint("later", 1, 200, 20),
+				recoveryPoint("earlier", 1, 100, 10),
+			},
+			replicasetB: {
+				recoveryPoint("later", 2, 200, 21),
+				recoveryPoint("earlier", 2, 100, 11),
+			},
+		})
+
+	points := buildFixtureChain(t, manifest).ClusterPoints()
+	require.Len(t, points, 2)
+	require.Equal(t, "earlier", points[0].Name)
+	require.Equal(t, "later", points[1].Name)
+	require.True(t, points[0].Timestamp.Before(points[1].Timestamp))
+}
+
+func TestClusterPointsDoNotCrossTopologyBoundary(t *testing.T) {
+	// "point" is on all shards of each manifest, but a topology boundary between
+	// them prevents cross-manifest stitching: two points, not one.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("point", 100, 8))
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		clusterPointFixture("point", 200, 18))
+	changeMaster(&incremental, replicasetA, "aaaaaaaa-0000-0000-0000-000000000002")
+
+	points := buildFixtureChain(t, full, incremental).ClusterPoints()
+	require.Len(t, points, 2)
+	require.Equal(t, time.Unix(8, 0).UTC(), points[0].Timestamp)
+	require.Equal(t, time.Unix(18, 0).UTC(), points[1].Timestamp)
+}
+
+func TestClusterPointsExcludeProblematicEntries(t *testing.T) {
+	// A problematic entry is excluded from stitching even with valid points.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	broken := manifestFixture("broken", "full", "full", backup.BackupTypeIncremental, 20, 9, 20,
+		clusterPointFixture("point", 18, 18))
+
+	require.Empty(t, buildFixtureChain(t, full, broken).ClusterPoints())
+}
+
+func changeMaster(manifest *backup.ClusterManifest, replicasetUUID, instanceUUID string) {
+	shard := manifest.Shards[replicasetUUID]
+	shard.Instance.InstanceUUID = instanceUUID
+	manifest.Shards[replicasetUUID] = shard
+	manifest.Topology.Replicasets[replicasetUUID] = []backup.TopologyInstance{{
+		InstanceUUID: instanceUUID,
+	}}
+}
+
+func addReplica(manifest *backup.ClusterManifest, replicasetUUID, replicaInstanceUUID string) {
+	instances := manifest.Topology.Replicasets[replicasetUUID]
+	instances = append(instances, backup.TopologyInstance{InstanceUUID: replicaInstanceUUID})
+	manifest.Topology.Replicasets[replicasetUUID] = instances
+}
+
+func TestClusterPointsDropPointWhenShardIsHole(t *testing.T) {
+	// replicasetB is a hole across the segment: "point" on replicasetA alone is
+	// not cluster-wide, since the topology still requires both.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("point", 1, 100, 11)},
+		})
+	makeShardHole(&full)
+
+	require.Empty(t, buildFixtureChain(t, full).ClusterPoints())
+}
+
+func TestClusterPointsStitchAcrossManifestsInSegment(t *testing.T) {
+	// One name may come from different replicasets in different manifests of a
+	// segment and still stitch into one point.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("point", 1, 100, 10)},
+		})
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		map[string][]backup.RecoveryPoint{
+			replicasetB: {recoveryPoint("point", 2, 200, 12)},
+		})
+
+	points := buildFixtureChain(t, full, incremental).ClusterPoints()
+	require.Len(t, points, 1)
+	require.Equal(t, "point", points[0].Name)
+	require.Equal(t, time.Unix(10, 0).UTC(), points[0].Timestamp)
+	require.Equal(t, Position{ReplicaID: 1, LSN: 100}, points[0].Shards[replicasetA])
+	require.Equal(t, Position{ReplicaID: 2, LSN: 200}, points[0].Shards[replicasetB])
+}
+
+func TestClusterPointsCarrySegmentTopology(t *testing.T) {
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 20, 0, 20,
+		clusterPointFixture("point", 100, 8))
+
+	points := buildFixtureChain(t, full).ClusterPoints()
+	require.Len(t, points, 1)
+	require.Equal(t, full.Topology, points[0].Topology)
+}
+
+func TestClusterPointsAcrossTopologyBoundaryCarryDifferentTopologies(t *testing.T) {
+	// Points on either side of a boundary carry their own segment's topology.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("before", 100, 8))
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		clusterPointFixture("after", 200, 18))
+	changeMaster(&incremental, replicasetA, "aaaaaaaa-0000-0000-0000-000000000002")
+
+	chain := buildFixtureChain(t, full, incremental)
+	before := findPoint(t, chain, "before")
+	after := findPoint(t, chain, "after")
+
+	require.Equal(t, full.Topology, before.Topology)
+	require.Equal(t, incremental.Topology, after.Topology)
+	require.NotEqual(t, before.Topology, after.Topology)
+}
+
+func TestClusterPointsIgnoreReplicaSetChange(t *testing.T) {
+	// Adding a non-master replica is not a topology boundary.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("point", 100, 8))
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		clusterPointFixture("point", 200, 18))
+	addReplica(&incremental, replicasetA, "aaaaaaaa-0000-0000-0000-000000000099")
+
+	points := buildFixtureChain(t, full, incremental).ClusterPoints()
+	require.Len(t, points, 1)
+	require.Equal(t, "point", points[0].Name)
+}

--- a/lib/backup/chain/resolve_test.go
+++ b/lib/backup/chain/resolve_test.go
@@ -1,0 +1,141 @@
+package chain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/lib/backup"
+)
+
+func TestResolveExactPoint(t *testing.T) {
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 30, 0, 30,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("point", 1, 10, 10)},
+			replicasetB: {recoveryPoint("point", 2, 10, 11)},
+		})
+
+	resolution := buildFixtureChain(t, manifest).Resolve(time.Unix(10, 0).UTC())
+	require.Equal(t, StatusOK, resolution.Status)
+	require.Equal(t, "point", resolution.Point.Name)
+	require.Nil(t, resolution.Before)
+	require.Nil(t, resolution.After)
+}
+
+func TestResolveLatestPointNotLaterThanT(t *testing.T) {
+	// T between two points resolves to the earlier one ("not later than T").
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 30, 0, 30,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {
+				recoveryPoint("before", 1, 10, 10),
+				recoveryPoint("after", 1, 20, 20),
+			},
+			replicasetB: {
+				recoveryPoint("before", 2, 10, 11),
+				recoveryPoint("after", 2, 20, 21),
+			},
+		})
+
+	resolution := buildFixtureChain(t, manifest).Resolve(time.Unix(15, 0).UTC())
+	require.Equal(t, StatusOK, resolution.Status)
+	require.Equal(t, "before", resolution.Point.Name)
+	require.Nil(t, resolution.Before)
+	require.Nil(t, resolution.After)
+}
+
+func TestResolveBetweenPoints(t *testing.T) {
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 30, 0, 30,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {
+				recoveryPoint("before", 1, 10, 10),
+				recoveryPoint("after", 1, 20, 20),
+			},
+			replicasetB: {
+				recoveryPoint("before", 2, 10, 11),
+				recoveryPoint("after", 2, 20, 21),
+			},
+		})
+
+	// T=9 is before every point.
+	resolution := buildFixtureChain(t, manifest).Resolve(time.Unix(9, 0).UTC())
+	require.Equal(t, StatusNoRecoveryPoint, resolution.Status)
+	require.Nil(t, resolution.Point)
+	require.Equal(t, "before", resolution.After.Name)
+	require.Nil(t, resolution.Before)
+}
+
+func TestResolveTAfterLastPoint(t *testing.T) {
+	// T past all coverage → out_of_range with the last point as a hint.
+	manifest := manifestFixture("full", "", "full", backup.BackupTypeFull, 30, 0, 30,
+		map[string][]backup.RecoveryPoint{
+			replicasetA: {recoveryPoint("point", 1, 10, 10)},
+			replicasetB: {recoveryPoint("point", 2, 10, 11)},
+		})
+
+	resolution := buildFixtureChain(t, manifest).Resolve(time.Unix(100, 0).UTC())
+	require.Equal(t, StatusOutOfRange, resolution.Status)
+	require.Nil(t, resolution.Point)
+	require.Equal(t, "point", resolution.Before.Name)
+	require.Nil(t, resolution.After)
+}
+
+func TestResolveEmptyChain(t *testing.T) {
+	resolution := buildFixtureChain(t).Resolve(time.Unix(10, 0).UTC())
+	require.Equal(t, StatusOutOfRange, resolution.Status)
+	require.Nil(t, resolution.Point)
+}
+
+func clusterPointFixture(name string, lsn uint64,
+	timestamp int64,
+) map[string][]backup.RecoveryPoint {
+	return map[string][]backup.RecoveryPoint{
+		replicasetA: {recoveryPoint(name, 1, lsn, timestamp)},
+		replicasetB: {recoveryPoint(name, 2, lsn, timestamp+1)},
+	}
+}
+
+func TestResolveTopologyBoundaryGap(t *testing.T) {
+	// T falls in the gap across a topology boundary: report the boundary and both
+	// neighbors, without silently returning the earlier point.
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("before", 100, 10))
+	incremental := manifestFixture("inc", "full", "full", backup.BackupTypeIncremental, 20, 10, 20,
+		clusterPointFixture("after", 200, 30))
+	changeMaster(&incremental, replicasetA, "aaaaaaaa-0000-0000-0000-000000000002")
+
+	chain := buildFixtureChain(t, full, incremental)
+	resolution := chain.Resolve(time.Unix(20, 0).UTC())
+	require.Equal(t, StatusTopologyBoundary, resolution.Status)
+	require.Nil(t, resolution.Point)
+	require.Equal(t, "before", resolution.Before.Name)
+	require.Equal(t, "after", resolution.After.Name)
+}
+
+func TestResolveChainBrokenGapBetweenGroups(t *testing.T) {
+	// Two unrelated fulls form two segments split by a chain break; T between them
+	// reports chain_broken with Point = last point before the break.
+	fullA := manifestFixture("full-a", "", "full-a", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("early", 100, 10))
+	fullB := manifestFixture("full-b", "", "full-b", backup.BackupTypeFull, 40, 0, 10,
+		clusterPointFixture("late", 200, 40))
+
+	chain := buildFixtureChain(t, fullA, fullB)
+	resolution := chain.Resolve(time.Unix(25, 0).UTC())
+	require.Equal(t, StatusChainBroken, resolution.Status)
+	require.Equal(t, "early", resolution.Point.Name)
+	require.Equal(t, "early", resolution.Before.Name)
+	require.Equal(t, "late", resolution.After.Name)
+}
+
+func TestResolveOKWithinSegmentIgnoresLaterGap(t *testing.T) {
+	// A point ≤ T in the same segment resolves OK despite a later gapped segment.
+	fullA := manifestFixture("full-a", "", "full-a", backup.BackupTypeFull, 10, 0, 10,
+		clusterPointFixture("early", 100, 10))
+	fullB := manifestFixture("full-b", "", "full-b", backup.BackupTypeFull, 40, 0, 10,
+		clusterPointFixture("late", 200, 40))
+
+	chain := buildFixtureChain(t, fullA, fullB)
+	resolution := chain.Resolve(time.Unix(10, 0).UTC())
+	require.Equal(t, StatusOK, resolution.Status)
+	require.Equal(t, "early", resolution.Point.Name)
+}

--- a/lib/backup/chain/status_test.go
+++ b/lib/backup/chain/status_test.go
@@ -1,0 +1,30 @@
+package chain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusEncoding(t *testing.T) {
+	tests := []struct {
+		status Status
+		name   string
+	}{
+		{StatusOK, "ok"},
+		{StatusTopologyBoundary, "topology_boundary"},
+		{StatusNoRecoveryPoint, "no_recovery_point"},
+		{StatusChainBroken, "chain_broken"},
+		{StatusOutOfRange, "out_of_range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.name, tt.status.String())
+			data, err := json.Marshal(tt.status)
+			require.NoError(t, err)
+			require.JSONEq(t, `"`+tt.name+`"`, string(data))
+		})
+	}
+}

--- a/lib/backup/chain/types.go
+++ b/lib/backup/chain/types.go
@@ -1,0 +1,103 @@
+// Package chain builds recovery chains from backup manifests.
+package chain
+
+import (
+	"time"
+
+	"github.com/tarantool/tt/lib/backup"
+)
+
+// Status describes the result of resolving a requested recovery time.
+type Status int
+
+const (
+	StatusOK Status = iota
+	StatusTopologyBoundary
+	StatusNoRecoveryPoint
+	StatusChainBroken
+	StatusOutOfRange
+)
+
+// ProblemKind identifies a manifest's place in a broken chain.
+type ProblemKind int
+
+const (
+	ProblemOrphan ProblemKind = iota
+	ProblemFork
+	ProblemVclockMismatch
+	ProblemInvalidManifest
+)
+
+// Problem is a chain problem attached to one manifest.
+type Problem struct {
+	// Kind classifies the problem.
+	Kind ProblemKind
+	// BackupID identifies the manifest whose recovery path is affected.
+	BackupID string
+	// Inherited reports that the problem originated in an ancestor.
+	Inherited bool
+	// Detail identifies the missing, conflicting, or mismatched link.
+	Detail string
+}
+
+// Entry is one manifest and the chain problems that make it unusable.
+type Entry struct {
+	// Manifest is the original cluster manifest.
+	Manifest *backup.ClusterManifest
+	// Problems is empty only when this manifest is usable for recovery.
+	Problems []*Problem
+}
+
+// Group is a cascade-deletion unit rooted at one full backup.
+type Group struct {
+	// Entries starts with the full backup and follows previous_backup_id.
+	Entries []*Entry
+}
+
+// Position is a recovery position inside one replicaset.
+type Position struct {
+	// ReplicaID is the source instance identifier in the replicaset.
+	ReplicaID uint32
+	// LSN is the xlog position on that replica.
+	LSN uint64
+}
+
+// ClusterPoint joins equally named points from every replicaset in a segment.
+type ClusterPoint struct {
+	// Name is the manager-generated common point name.
+	Name string
+	// Timestamp is the earliest timestamp among the shard points.
+	Timestamp time.Time
+	// Topology of the segment this point was stitched in, constant within it.
+	// Consumers compare it against the live cluster; chain does not.
+	Topology backup.Topology
+	// Shards maps a replicaset UUID to its position at this point.
+	Shards map[string]Position
+}
+
+// Resolution is the result of resolving a requested recovery time.
+type Resolution struct {
+	// Status explains whether Point can be used.
+	Status Status
+	// Point is selected for StatusOK, or the last healthy point before a break.
+	Point *ClusterPoint
+	// Before and After are nearest points around an unresolved target time.
+	Before *ClusterPoint
+	After  *ClusterPoint
+}
+
+// ShardPlan is an ordered backup path for one replicaset.
+type ShardPlan struct {
+	// Backups starts with a full backup and continues with incrementals.
+	Backups []*backup.ClusterManifest
+	// TrimTo limits the final incremental to the requested position.
+	TrimTo *Position
+}
+
+// Plan describes all backups required to recover one cluster point.
+type Plan struct {
+	// Point is the recovery target.
+	Point ClusterPoint
+	// Shards maps a replicaset UUID to the backup path needed for it.
+	Shards map[string]ShardPlan
+}

--- a/lib/backup/fixtures_test.go
+++ b/lib/backup/fixtures_test.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,35 +24,9 @@ var (
 func mustDecodeClusterManifest(t *testing.T, data []byte) ClusterManifest {
 	t.Helper()
 
-	type clusterManifestJSON struct {
-		SchemaVersion    int              `json:"schema_version"`
-		BackupID         BackupID         `json:"backup_id"`
-		PreviousBackupID BackupID         `json:"previous_backup_id"`
-		BaseFullBackupID BackupID         `json:"base_full_backup_id"`
-		Status           Status           `json:"status"`
-		CreationTime     time.Time        `json:"creation_time"`
-		CreationDuration string           `json:"creation_duration"`
-		Shards           map[string]Shard `json:"shards"`
-		Topology         Topology         `json:"topology"`
-		Warnings         []Warning        `json:"warnings"`
-	}
-
-	var raw clusterManifestJSON
-	require.NoError(t, json.Unmarshal(data, &raw))
-	duration, err := time.ParseDuration(raw.CreationDuration)
-	require.NoError(t, err)
-	return ClusterManifest{
-		SchemaVersion:    raw.SchemaVersion,
-		BackupID:         raw.BackupID,
-		PreviousBackupID: raw.PreviousBackupID,
-		BaseFullBackupID: raw.BaseFullBackupID,
-		Status:           raw.Status,
-		CreationTime:     raw.CreationTime,
-		CreationDuration: duration,
-		Shards:           raw.Shards,
-		Topology:         raw.Topology,
-		Warnings:         raw.Warnings,
-	}
+	var manifest ClusterManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	return manifest
 }
 
 func mustDecodeFragment(t *testing.T, data []byte) Fragment {

--- a/lib/backup/testdata/cluster_manifest.json
+++ b/lib/backup/testdata/cluster_manifest.json
@@ -5,7 +5,7 @@
   "base_full_backup_id": "20260312T120000Z",
   "status": "OK",
   "creation_time": "2026-03-12T12:00:02.456Z",
-  "creation_duration": "2.3s",
+  "creation_duration": 2300000000,
   "shards": {
     "11111111-1111-1111-1111-111111111111": {
       "instance": {


### PR DESCRIPTION
Build cluster recovery points from manifest segments and resolve a
target time to the nearest point not later than it. Report topology
boundaries and chain breaks when the time falls into a gap, and mark
orphan, fork, and vclock-mismatch problems per shard.

Closes TNTP-8391