### PR TITLE
cli/manifest/build/backend: shell, make and c/lua-c build backends

### DIFF
--- a/cli/manifest/build/backend/backend.go
+++ b/cli/manifest/build/backend/backend.go
@@ -1,0 +1,189 @@
+// Package backend runs a single component build backend and places the
+// resulting artifacts in TT_OUTPUT_DIR.
+//
+// A component with a native part (or a generation step) is built by one of
+// four isolated executors selected by the [components.<name>.build] backend
+// field: shell (argv-style execve), make (make -C -f target), and a shared cc
+// driver serving both c and lua-c. Each executor receives the parsed
+// manifest.Build block, an absolute working directory, and the Env contract.
+// None of them order components, lay out install namespaces, resolve the lock,
+// or run lifecycle hooks — that orchestration is the caller's job (RFC 0010
+// task 06); a backend only runs one tool and writes into TT_OUTPUT_DIR.
+//
+// The process environment is assembled on the exec.Cmd, never via os.Chdir or
+// os.Setenv: the seven TT_* contract variables are applied last so a stray
+// [build].env pair cannot redirect e.g. TT_OUTPUT_DIR. The cc driver reuses
+// go-luarocks' per-OS flag derivation through the rocks adapter's Flags seam,
+// so -fPIC / -I<include> / -shared-vs-bundle / .so are not duplicated here.
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+
+	lrbuild "github.com/tarantool/go-luarocks/build"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// Backend build names. They mirror the closed enum validated at manifest parse
+// time (cli/manifest/validate.go); manifest keeps its own copies unexported, so
+// the dispatch vocabulary is redeclared here.
+const (
+	// BackendShell runs an arbitrary command argv-style (no shell parsing).
+	BackendShell = "shell"
+	// BackendMake drives make against a component-supplied Makefile.
+	BackendMake = "make"
+	// BackendC compiles a stored-proc C module (loaded via box.schema.func).
+	BackendC = "c"
+	// BackendLuaC compiles a Lua C extension (exports luaopen_<module>).
+	BackendLuaC = "lua-c"
+)
+
+// dirPerm is the mode used when creating output directories.
+const dirPerm os.FileMode = 0o750
+
+// ErrMissingHeaders reports that the Tarantool development headers are not
+// configured (flags.LuaIncDir is empty), so a c / lua-c component cannot be
+// compiled. The cc driver returns it before invoking the compiler, mirroring
+// the go-luarocks builtin backend's fail-fast on missing headers.
+var ErrMissingHeaders = errors.New(
+	"tarantool development headers not found: cannot compile c/lua-c component")
+
+// Env is the guaranteed environment contract handed to every backend. The
+// caller (RFC 0010 task 06) fully resolves OutputDir — including the install
+// namespace — before calling; the backend is namespace-agnostic and only ever
+// writes into OutputDir, creating it if absent.
+type Env struct {
+	// OutputDir is where native artifacts are placed (TT_OUTPUT_DIR). It must
+	// be an absolute path.
+	OutputDir string
+	// ProjectRoot is the package root (TT_PROJECT_ROOT).
+	ProjectRoot string
+	// Package is the package name (TT_PACKAGE).
+	Package string
+	// Component is the component name (TT_COMPONENT_NAME).
+	Component string
+	// Version is the package version (TT_VERSION).
+	Version string
+	// OS is the target platform OS (TT_PLATFORM_OS); empty defaults to
+	// runtime.GOOS, which also selects the [build].platforms.<os> overlay.
+	OS string
+	// Arch is the target platform architecture (TT_PLATFORM_ARCH); empty
+	// defaults to runtime.GOARCH.
+	Arch string
+	// Extra carries the [build].env pairs supplied by the manifest.
+	Extra map[string]string
+}
+
+// platformOS returns env.OS, defaulting to the host runtime.GOOS when empty so
+// an unset field never silently disables the per-OS overlay.
+func (e Env) platformOS() string {
+	if e.OS == "" {
+		return runtime.GOOS
+	}
+
+	return e.OS
+}
+
+// platformArch returns env.Arch, defaulting to the host runtime.GOARCH.
+func (e Env) platformArch() string {
+	if e.Arch == "" {
+		return runtime.GOARCH
+	}
+
+	return e.Arch
+}
+
+// environ builds the child process environment: os.Environ() first, then the
+// [build].env pairs in sorted key order, then the seven TT_* contract
+// variables last. exec.Cmd resolves duplicate keys last-wins, so the contract
+// variables are authoritative — a [build].env key cannot shadow TT_OUTPUT_DIR.
+// This is the only place the process environment is assembled; a backend never
+// re-reads manifest.Build.Env.
+func (e Env) environ() []string {
+	out := os.Environ()
+
+	keys := make([]string, 0, len(e.Extra))
+	for k := range e.Extra {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		out = append(out, k+"="+e.Extra[k])
+	}
+
+	return append(out,
+		"TT_OUTPUT_DIR="+e.OutputDir,
+		"TT_PROJECT_ROOT="+e.ProjectRoot,
+		"TT_PACKAGE="+e.Package,
+		"TT_COMPONENT_NAME="+e.Component,
+		"TT_VERSION="+e.Version,
+		"TT_PLATFORM_OS="+e.platformOS(),
+		"TT_PLATFORM_ARCH="+e.platformArch(),
+	)
+}
+
+// Backend builds one component into env.OutputDir.
+type Backend interface {
+	// Run builds b in cwd (an absolute path) with the env contract, placing
+	// artifacts in env.OutputDir. It returns a plain error on failure; mapping
+	// that to a process exit code is the caller's concern.
+	Run(ctx context.Context, b manifest.Build, cwd string, env Env) error
+}
+
+// New returns the Backend for the named build backend. flags supplies the
+// compile/link toolchain and is consumed only by c / lua-c; showOutput streams
+// child stdout/stderr when true, otherwise output is buffered and printed only
+// on failure. c and lua-c share one cc driver — the driver is identical and
+// only the later load path differs. An unknown name is an error.
+func New(name string, flags lrbuild.Flags, showOutput bool) (Backend, error) {
+	switch name {
+	case BackendShell:
+		return shellBackend{showOutput: showOutput}, nil
+	case BackendMake:
+		return makeBackend{showOutput: showOutput}, nil
+	case BackendC, BackendLuaC:
+		return ccBackend{flags: flags, showOutput: showOutput}, nil
+	default:
+		return nil, fmt.Errorf("unknown build backend %q", name)
+	}
+}
+
+// requireAbsPaths asserts the absolute-path contract for cwd and outputDir. A
+// relative cwd would be double-applied (make -C <cwd> plus cmd.Dir=cwd) and a
+// relative outputDir would diverge between MkdirAll and the child's -o write,
+// so both are rejected rather than papered over.
+func requireAbsPaths(cwd, outputDir string) error {
+	if !filepath.IsAbs(cwd) {
+		return fmt.Errorf("cwd must be an absolute path, got %q", cwd)
+	}
+
+	if !filepath.IsAbs(outputDir) {
+		return fmt.Errorf("output directory must be an absolute path, got %q", outputDir)
+	}
+
+	return nil
+}
+
+// run builds and runs one subprocess with the assembled contract environment.
+// It never mutates the tt process cwd or environment: the environment is set on
+// the exec.Cmd and util.RunCommand sets cmd.Dir. exec.CommandContext keeps ctx
+// cancellation working.
+func run(
+	ctx context.Context, cwd string, env Env, showOutput bool, name string, args ...string,
+) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = env.environ()
+
+	return util.RunCommand(cmd, cwd, showOutput)
+}

--- a/cli/manifest/build/backend/backend_test.go
+++ b/cli/manifest/build/backend/backend_test.go
@@ -1,0 +1,147 @@
+package backend
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	lrbuild "github.com/tarantool/go-luarocks/build"
+)
+
+// lastEnvValue returns the value of the last KEY=VALUE entry for key, matching
+// how exec.Cmd resolves duplicate keys (last wins). It returns "" if absent.
+func lastEnvValue(environ []string, key string) string {
+	prefix := key + "="
+
+	value := ""
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, prefix) {
+			value = kv[len(prefix):]
+		}
+	}
+
+	return value
+}
+
+// indexOfEnv returns the index of the first entry equal to kv, or -1.
+func indexOfEnv(environ []string, kv string) int {
+	for i, e := range environ {
+		if e == kv {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestEnvironContract(t *testing.T) {
+	t.Parallel()
+
+	env := Env{
+		OutputDir:   "/out",
+		ProjectRoot: "/proj",
+		Package:     "pkg",
+		Component:   "comp",
+		Version:     "1.2.3",
+		OS:          "linux",
+		Arch:        "amd64",
+		Extra:       map[string]string{"FOO": "bar", "BAZ": "qux"},
+	}
+
+	got := env.environ()
+
+	// All seven contract variables are present with the Env values.
+	assert.Equal(t, "/out", lastEnvValue(got, "TT_OUTPUT_DIR"))
+	assert.Equal(t, "/proj", lastEnvValue(got, "TT_PROJECT_ROOT"))
+	assert.Equal(t, "pkg", lastEnvValue(got, "TT_PACKAGE"))
+	assert.Equal(t, "comp", lastEnvValue(got, "TT_COMPONENT_NAME"))
+	assert.Equal(t, "1.2.3", lastEnvValue(got, "TT_VERSION"))
+	assert.Equal(t, "linux", lastEnvValue(got, "TT_PLATFORM_OS"))
+	assert.Equal(t, "amd64", lastEnvValue(got, "TT_PLATFORM_ARCH"))
+
+	// [build].env is merged in.
+	assert.Equal(t, "bar", lastEnvValue(got, "FOO"))
+	assert.Equal(t, "qux", lastEnvValue(got, "BAZ"))
+}
+
+func TestEnvironContractVarWinsOverExtra(t *testing.T) {
+	t.Parallel()
+
+	env := Env{OutputDir: "/real", Extra: map[string]string{"TT_OUTPUT_DIR": "/fake"}}
+
+	got := env.environ()
+
+	// Both entries exist, but the contract var is emitted last so exec.Cmd's
+	// last-wins dedup makes it authoritative.
+	assert.Equal(t, "/real", lastEnvValue(got, "TT_OUTPUT_DIR"))
+	assert.Less(t,
+		indexOfEnv(got, "TT_OUTPUT_DIR=/fake"),
+		indexOfEnv(got, "TT_OUTPUT_DIR=/real"),
+		"the contract TT_OUTPUT_DIR must be emitted after the [build].env override")
+}
+
+func TestEnvironDefaultsPlatformToHost(t *testing.T) {
+	t.Parallel()
+
+	got := Env{}.environ()
+
+	assert.Equal(t, runtime.GOOS, lastEnvValue(got, "TT_PLATFORM_OS"))
+	assert.Equal(t, runtime.GOARCH, lastEnvValue(got, "TT_PLATFORM_ARCH"))
+}
+
+func TestNewDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want any
+	}{
+		{BackendShell, shellBackend{}},
+		{BackendMake, makeBackend{}},
+		{BackendC, ccBackend{}},
+		{BackendLuaC, ccBackend{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			be, err := New(tc.name, lrbuild.Flags{}, false)
+			require.NoError(t, err)
+			assert.IsType(t, tc.want, be)
+		})
+	}
+}
+
+func TestNewUnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	be, err := New("cmake", lrbuild.Flags{}, false)
+	require.Error(t, err)
+	assert.Nil(t, be)
+}
+
+func TestNewCcCarriesFlagsAndVerbosity(t *testing.T) {
+	t.Parallel()
+
+	flags := lrbuild.Flags{CC: "clang", Ext: ".so", LuaIncDir: "/inc"}
+
+	be, err := New(BackendC, flags, true)
+	require.NoError(t, err)
+
+	cc, ok := be.(ccBackend)
+	require.True(t, ok)
+	assert.Equal(t, flags, cc.flags)
+	assert.True(t, cc.showOutput)
+}
+
+func TestRequireAbsPaths(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, requireAbsPaths("/abs/cwd", "/abs/out"))
+	assert.Error(t, requireAbsPaths("rel/cwd", "/abs/out"))
+	assert.Error(t, requireAbsPaths("/abs/cwd", "rel/out"))
+}

--- a/cli/manifest/build/backend/cc.go
+++ b/cli/manifest/build/backend/cc.go
@@ -1,0 +1,121 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	lrbuild "github.com/tarantool/go-luarocks/build"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// initialArgsCap pre-sizes the cc argument slice to avoid early regrows.
+const initialArgsCap = 16
+
+// ccBackend is the shared cc driver for the c and lua-c backends. Both compile
+// b.Sources into one <module><Ext> shared library with the base per-OS flags
+// (from the injected lrbuild.Flags) plus the component's defines / include dirs
+// / library dirs / libraries and the per-OS overlay. The two backends differ
+// only in how the artifact is later loaded (require vs box.schema.func.create),
+// which is not this driver's concern.
+type ccBackend struct {
+	// flags is the compile/link toolchain derived once from the rocks adapter.
+	flags lrbuild.Flags
+	// showOutput streams child output when true.
+	showOutput bool
+}
+
+// ccArgs builds the cc argv, mirroring the go-luarocks builtin compileModule
+// token for token:
+//
+//	$CC <CFLAGS...> -D<define...> -I<incdir...> <LIBFLAG...> -o <out> \
+//	    <sources...> {-L<libdir> [-Wl,-rpath,<libdir> if GccRpath]}... \
+//	    -l<lib...> <LDFLAGS...>
+//
+// defines / include dirs / library dirs / libraries come from b, each merged
+// (append-only) with the b.Platforms[goos] overlay; library order is preserved
+// because link order matters. Each -L is immediately followed by its matching
+// -Wl,-rpath, entry when flags.GccRpath is set (interleaved per libdir). out is
+// the fully resolved artifact path; sources are emitted verbatim and resolved
+// against cwd by the child (cmd.Dir=cwd). It is a pure function so the argv is
+// testable without a compiler or Tarantool headers.
+func ccArgs(b manifest.Build, flags lrbuild.Flags, out, goos string) []string {
+	overlay := b.Platforms[goos]
+
+	defines := concat(b.Defines, overlay.Defines)
+	includeDirs := concat(b.IncludeDirs, overlay.IncludeDirs)
+	libraryDirs := concat(b.LibraryDirs, overlay.LibraryDirs)
+	libraries := concat(b.Libraries, overlay.Libraries)
+
+	args := make([]string, 0, initialArgsCap)
+	args = append(args, flags.CFLAGS...)
+
+	for _, d := range defines {
+		args = append(args, "-D"+d)
+	}
+
+	for _, inc := range includeDirs {
+		args = append(args, "-I"+inc)
+	}
+
+	args = append(args, flags.LIBFLAG...)
+	args = append(args, "-o", out)
+	args = append(args, b.Sources...)
+
+	for _, dir := range libraryDirs {
+		args = append(args, "-L"+dir)
+		if flags.GccRpath {
+			args = append(args, "-Wl,-rpath,"+dir)
+		}
+	}
+
+	for _, lib := range libraries {
+		args = append(args, "-l"+lib)
+	}
+
+	return append(args, flags.LDFLAGS...)
+}
+
+// concat returns base followed by extra in a fresh slice (an append-only
+// overlay merge that never mutates either input).
+func concat(base, extra []string) []string {
+	out := make([]string, 0, len(base)+len(extra))
+	out = append(out, base...)
+
+	return append(out, extra...)
+}
+
+// artifactName builds the compiled artifact's flat leaf filename from the
+// module name and the toolchain extension. module is used verbatim (a dotted
+// module yields a literal a.b<ext>, not slashed into subdirectories) and the
+// extension comes from flags.Ext, never a hardcoded ".so".
+func artifactName(module, ext string) string {
+	return module + ext
+}
+
+// Run compiles the c / lua-c component. It asserts the absolute-path contract,
+// fails fast when the Tarantool headers are unconfigured, creates OutputDir,
+// then runs one cc invocation producing <module><Ext> directly in OutputDir.
+// module is a flat leaf name, so a dotted module yields a literal a.b.so — it
+// is not slashed into subdirectories. c / lua-c ignore b.Output (the artifact
+// is the compiled library, not a copy list).
+func (c ccBackend) Run(ctx context.Context, b manifest.Build, cwd string, env Env) error {
+	if err := requireAbsPaths(cwd, env.OutputDir); err != nil {
+		return err
+	}
+
+	if c.flags.LuaIncDir == "" {
+		return ErrMissingHeaders
+	}
+
+	if err := os.MkdirAll(env.OutputDir, dirPerm); err != nil {
+		return fmt.Errorf("create output directory %q: %w", env.OutputDir, err)
+	}
+
+	out := filepath.Join(env.OutputDir, artifactName(b.Module, c.flags.Ext))
+	args := ccArgs(b, c.flags, out, env.platformOS())
+
+	return run(ctx, cwd, env, c.showOutput, c.flags.CC, args...)
+}

--- a/cli/manifest/build/backend/cc_integration_test.go
+++ b/cli/manifest/build/backend/cc_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package backend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	luarocks "github.com/tarantool/go-luarocks"
+	lrbuild "github.com/tarantool/go-luarocks/build"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// integrationFlags derives real toolchain flags with includeDir wired in so the
+// header preflight passes and cc receives -I<includeDir>. includeDir comes from
+// requireHostToolchain, so it points at the host's real Tarantool headers.
+func integrationFlags(includeDir string) lrbuild.Flags {
+	cfg := luarocks.Config{}
+	cfg.Tarantool.IncludeDir = includeDir
+
+	return lrbuild.DeriveFlags(cfg)
+}
+
+// writeSource writes body to name under dir, failing the test on error.
+func writeSource(t *testing.T, dir, name, body string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+}
+
+func TestCcCompilesSingleSource(t *testing.T) {
+	tc := requireHostToolchain(t)
+
+	cwd := t.TempDir()
+	out := t.TempDir()
+
+	writeSource(t, cwd, "answer.c", "int answer(void) { return 42; }\n")
+
+	flags := integrationFlags(tc.IncludeDir)
+	b := manifest.Build{Backend: BackendC, Module: "answer", Sources: []string{"answer.c"}}
+
+	err := ccBackend{flags: flags}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "answer"+flags.Ext))
+}
+
+func TestCcCompilesMultiSource(t *testing.T) {
+	tc := requireHostToolchain(t)
+
+	cwd := t.TempDir()
+	out := t.TempDir()
+
+	writeSource(t, cwd, "part_a.c", "int a(void) { return 1; }\n")
+	// part_b references a from part_a, so a passing link proves both objects
+	// end up in one .so; the prototype avoids an implicit-declaration error.
+	writeSource(t, cwd, "part_b.c", "int a(void);\nint b(void) { return a() + 1; }\n")
+
+	flags := integrationFlags(tc.IncludeDir)
+	b := manifest.Build{
+		Backend: BackendLuaC,
+		Module:  "parts",
+		Sources: []string{"part_a.c", "part_b.c"},
+	}
+
+	err := ccBackend{flags: flags}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "parts"+flags.Ext))
+}
+
+// TestCcCompilesAgainstTarantoolHeaders proves the include-dir wiring works
+// against the real Tarantool C module API: the source includes <module.h> and
+// exports a luaopen_ entry point, so it compiles only when -I<IncludeDir>
+// actually resolves the headers requireHostToolchain validated. This is the
+// payoff of checking the headers exist — a compile a stub source cannot do.
+func TestCcCompilesAgainstTarantoolHeaders(t *testing.T) {
+	tc := requireHostToolchain(t)
+
+	cwd := t.TempDir()
+	out := t.TempDir()
+
+	src := "#include <module.h>\n" +
+		"int luaopen_headercheck(lua_State *L) { (void)L; return 0; }\n"
+	writeSource(t, cwd, "headercheck.c", src)
+
+	flags := integrationFlags(tc.IncludeDir)
+	b := manifest.Build{
+		Backend: BackendLuaC,
+		Module:  "headercheck",
+		Sources: []string{"headercheck.c"},
+	}
+
+	err := ccBackend{flags: flags}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "headercheck"+flags.Ext))
+}

--- a/cli/manifest/build/backend/cc_test.go
+++ b/cli/manifest/build/backend/cc_test.go
@@ -1,0 +1,235 @@
+package backend
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	luarocks "github.com/tarantool/go-luarocks"
+	lrbuild "github.com/tarantool/go-luarocks/build"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// indexOf returns the index of the first occurrence of tok in args, or -1.
+func indexOf(args []string, tok string) int {
+	for i, a := range args {
+		if a == tok {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// linuxFlags is a hand-built lrbuild.Flags fixture mirroring flags.go for
+// linux: -shared LIBFLAG and GccRpath on, so placement can be asserted without
+// depending on the host OS.
+func linuxFlags() lrbuild.Flags {
+	return lrbuild.Flags{
+		CC:        "cc",
+		CFLAGS:    []string{"-O2", "-fPIC", "-I/tt/include"},
+		LDFLAGS:   []string{"-Wl,--as-needed"},
+		LIBFLAG:   []string{"-shared"},
+		LuaIncDir: "/tt/include",
+		Ext:       ".so",
+		GccRpath:  true,
+	}
+}
+
+// darwinFlags is a hand-built lrbuild.Flags fixture mirroring flags.go for
+// darwin: the -bundle LIBFLAG list and GccRpath off.
+func darwinFlags() lrbuild.Flags {
+	return lrbuild.Flags{
+		CC:        "cc",
+		CFLAGS:    []string{"-O2", "-fPIC", "-I/tt/include"},
+		LDFLAGS:   []string{"-Wl,--as-needed"},
+		LIBFLAG:   []string{"-bundle", "-undefined", "dynamic_lookup", "-all_load"},
+		LuaIncDir: "/tt/include",
+		Ext:       ".so",
+		GccRpath:  false,
+	}
+}
+
+// sampleBuild carries base lists plus distinct linux/darwin overlays so the
+// overlay-selection and append-only-merge behavior is observable.
+func sampleBuild() manifest.Build {
+	return manifest.Build{
+		Backend:     BackendC,
+		Module:      "mymod",
+		Sources:     []string{"a.c", "b.c"},
+		Defines:     []string{"BASE=1"},
+		IncludeDirs: []string{"/inc/base"},
+		LibraryDirs: []string{"/lib/base"},
+		Libraries:   []string{"m", "z"},
+		Platforms: map[string]manifest.BuildOverlay{
+			"linux": {
+				Defines:     []string{"LIN"},
+				IncludeDirs: []string{"/inc/lin"},
+				LibraryDirs: []string{"/lib/lin"},
+				Libraries:   []string{"linlib"},
+			},
+			"darwin": {
+				Defines:     []string{"DARW"},
+				IncludeDirs: []string{"/inc/dar"},
+				LibraryDirs: []string{"/lib/dar"},
+				Libraries:   []string{"darlib"},
+			},
+		},
+	}
+}
+
+func TestCcArgsLinuxPlacement(t *testing.T) {
+	t.Parallel()
+
+	args := ccArgs(sampleBuild(), linuxFlags(), "/out/mymod.so", "linux")
+
+	want := []string{
+		// CFLAGS.
+		"-O2", "-fPIC", "-I/tt/include",
+		// defines: base then linux overlay.
+		"-DBASE=1", "-DLIN",
+		// include dirs: base then linux overlay.
+		"-I/inc/base", "-I/inc/lin",
+		// per-OS shared-link flag.
+		"-shared",
+		// output.
+		"-o", "/out/mymod.so",
+		// sources, emitted verbatim.
+		"a.c", "b.c",
+		// library dirs with interleaved rpath (GccRpath=true), base then overlay.
+		"-L/lib/base", "-Wl,-rpath,/lib/base",
+		"-L/lib/lin", "-Wl,-rpath,/lib/lin",
+		// libraries: base order preserved, then overlay.
+		"-lm", "-lz", "-llinlib",
+		// LDFLAGS.
+		"-Wl,--as-needed",
+	}
+	assert.Equal(t, want, args)
+}
+
+func TestCcArgsDarwinPlacement(t *testing.T) {
+	t.Parallel()
+
+	args := ccArgs(sampleBuild(), darwinFlags(), "/out/mymod.so", "darwin")
+
+	want := []string{
+		// CFLAGS.
+		"-O2", "-fPIC", "-I/tt/include",
+		// defines: base then darwin overlay.
+		"-DBASE=1", "-DDARW",
+		// include dirs: base then darwin overlay.
+		"-I/inc/base", "-I/inc/dar",
+		// per-OS shared-link flag (bundle list on darwin).
+		"-bundle", "-undefined", "dynamic_lookup", "-all_load",
+		// output.
+		"-o", "/out/mymod.so",
+		// sources.
+		"a.c", "b.c",
+		// library dirs, no rpath (GccRpath=false on darwin), base then overlay.
+		"-L/lib/base",
+		"-L/lib/dar",
+		// libraries: base order preserved, then overlay.
+		"-lm", "-lz", "-ldarlib",
+		// LDFLAGS.
+		"-Wl,--as-needed",
+	}
+	assert.Equal(t, want, args)
+}
+
+func TestCcArgsSingleSource(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{Backend: BackendC, Module: "solo", Sources: []string{"solo.c"}}
+	args := ccArgs(b, linuxFlags(), "/out/solo.so", "linux")
+
+	// -o <out> immediately precedes the single source.
+	i := indexOf(args, "-o")
+	require.GreaterOrEqual(t, i, 0)
+	require.Less(t, i+2, len(args))
+	assert.Equal(t, "/out/solo.so", args[i+1])
+	assert.Equal(t, "solo.c", args[i+2])
+}
+
+func TestCcArgsMultiSourceOrder(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{
+		Backend: BackendC,
+		Module:  "multi",
+		Sources: []string{"one.c", "two.c", "three.c"},
+	}
+	args := ccArgs(b, linuxFlags(), "/out/multi.so", "linux")
+
+	i := indexOf(args, "-o")
+	require.GreaterOrEqual(t, i, 0)
+	require.Less(t, i+4, len(args))
+	// All sources follow -o <out> in the given order.
+	assert.Equal(t, []string{"one.c", "two.c", "three.c"}, args[i+2:i+5])
+}
+
+func TestCcArgsHostParityWithDeriveFlags(t *testing.T) {
+	t.Parallel()
+
+	cfg := luarocks.Config{}
+	cfg.Tarantool.IncludeDir = "/opt/tt/include/tarantool"
+	flags := lrbuild.DeriveFlags(cfg)
+
+	b := manifest.Build{Backend: BackendC, Module: "m", Sources: []string{"m.c"}}
+	args := ccArgs(b, flags, "/out/m.so", runtime.GOOS)
+
+	// The real DeriveFlags CFLAGS appear as the leading tokens.
+	require.GreaterOrEqual(t, len(args), len(flags.CFLAGS))
+	assert.Equal(t, flags.CFLAGS, args[:len(flags.CFLAGS)])
+
+	// Host-independent invariants derived by go-luarocks.
+	assert.Contains(t, args, "-fPIC")
+	assert.Contains(t, args, "-I/opt/tt/include/tarantool")
+
+	// The derived LIBFLAG appears immediately before "-o".
+	oi := indexOf(args, "-o")
+	require.GreaterOrEqual(t, oi, len(flags.LIBFLAG))
+	assert.Equal(t, flags.LIBFLAG, args[oi-len(flags.LIBFLAG):oi])
+
+	// The artifact extension is the derived one, not a hardcoded ".so".
+	assert.Equal(t, flags.Ext, ".so")
+}
+
+func TestArtifactName(t *testing.T) {
+	t.Parallel()
+
+	// The extension comes from flags.Ext, so a non-".so" ext must be honored;
+	// a regression hardcoding ".so" would fail this.
+	assert.Equal(t, "fast_hash.dylib", artifactName("fast_hash", ".dylib"))
+	assert.Equal(t, "m.so", artifactName("m", ".so"))
+	// A dotted module stays a flat leaf name (not slashed into subdirectories).
+	assert.Equal(t, "a.b.so", artifactName("a.b", ".so"))
+}
+
+func TestCcMissingHeadersPreflight(t *testing.T) {
+	t.Parallel()
+
+	// A CC that would fail loudly if invoked, proving the preflight returns
+	// before exec: LuaIncDir is empty, so ErrMissingHeaders comes back instead
+	// of a run failure from the bogus compiler.
+	be := ccBackend{flags: lrbuild.Flags{CC: "/nonexistent/cc", Ext: ".so"}}
+
+	b := manifest.Build{Backend: BackendC, Module: "m", Sources: []string{"m.c"}}
+	err := be.Run(context.Background(), b, t.TempDir(), Env{OutputDir: t.TempDir()})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingHeaders)
+}
+
+func TestCcRejectsRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	be := ccBackend{flags: linuxFlags()}
+	b := manifest.Build{Backend: BackendC, Module: "m", Sources: []string{"m.c"}}
+
+	err := be.Run(context.Background(), b, "rel/cwd", Env{OutputDir: t.TempDir()})
+	require.Error(t, err)
+}

--- a/cli/manifest/build/backend/host_test.go
+++ b/cli/manifest/build/backend/host_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/version"
+)
+
+// minTarantoolMajor is the lowest Tarantool major version tt v3 supports. The
+// cc / lua-c integration tests compile against its C module headers, so an
+// older Tarantool is skipped rather than exercised.
+const minTarantoolMajor = 3
+
+// hostToolchain is the set of native build prerequisites the cc / lua-c
+// integration tests need, resolved and validated by requireHostToolchain.
+type hostToolchain struct {
+	// CC is the resolved C compiler (honors $CC, else "cc").
+	CC string
+	// Tarantool is the resolved tarantool binary.
+	Tarantool string
+	// Version is the parsed tarantool version.
+	Version version.Version
+	// IncludeDir is the directory holding module.h (the C module API header) —
+	// the -I passed to cc.
+	IncludeDir string
+}
+
+// requireHostToolchain resolves and validates the host build prerequisites for
+// the cc / lua-c integration tests: a C compiler, a supported Tarantool binary,
+// and its C module headers. When any prerequisite is missing it SKIPS the
+// calling test with a specific reason (it never fails), so the integration suite
+// stays green on a host without the native toolchain while still exercising it
+// wherever it is present. The returned toolchain carries the real Tarantool
+// include dir, so callers compile against the actual headers, not a stub.
+func requireHostToolchain(t *testing.T) hostToolchain {
+	t.Helper()
+
+	// Resolve the compiler the same way DeriveFlags does: $CC, else "cc".
+	ccName := os.Getenv("CC")
+	if ccName == "" {
+		ccName = "cc"
+	}
+
+	cc, err := exec.LookPath(ccName)
+	if err != nil {
+		t.Skipf("C compiler %q not found in PATH: %v", ccName, err)
+	}
+
+	tarantoolBin, err := exec.LookPath("tarantool")
+	if err != nil {
+		t.Skipf("tarantool not found in PATH: %v", err)
+	}
+
+	// Reuse tt's own version parsing (tarantool --version, last token of line 1).
+	tntCli := cmdcontext.TarantoolCli{Executable: tarantoolBin}
+
+	ver, err := tntCli.GetVersion()
+	if err != nil {
+		t.Skipf("cannot determine tarantool version from %q: %v", tarantoolBin, err)
+	}
+
+	if ver.Major < minTarantoolMajor {
+		t.Skipf("tarantool %s is too old: need >= %d.0", ver.Str, minTarantoolMajor)
+	}
+
+	includeDir := tarantoolIncludeDir(tarantoolBin)
+	if includeDir == "" {
+		t.Skipf("tarantool C module headers (module.h) not found for %q", tarantoolBin)
+	}
+
+	t.Logf("host toolchain: cc=%s tarantool=%s (%s) include=%s",
+		cc, tarantoolBin, ver.Str, includeDir)
+
+	return hostToolchain{
+		CC:         cc,
+		Tarantool:  tarantoolBin,
+		Version:    ver,
+		IncludeDir: includeDir,
+	}
+}
+
+// tarantoolIncludeDir locates the directory holding Tarantool's module.h for the
+// given tarantool binary, or "" when none is found. It derives the install
+// prefix from the binary path — both as found on PATH and with symlinks
+// resolved, to cover layouts like Homebrew's bin -> Cellar — and probes
+// <prefix>/include/tarantool, matching tt's TarantoolInfo.IncludeDir.
+func tarantoolIncludeDir(tarantoolBin string) string {
+	seen := make(map[string]struct{})
+
+	for _, bin := range candidateBinPaths(tarantoolBin) {
+		prefix := filepath.Dir(filepath.Dir(bin))
+		if _, dup := seen[prefix]; dup {
+			continue
+		}
+
+		seen[prefix] = struct{}{}
+
+		includeDir := filepath.Join(prefix, "include", "tarantool")
+		if _, err := os.Stat(filepath.Join(includeDir, "module.h")); err == nil {
+			return includeDir
+		}
+	}
+
+	return ""
+}
+
+// candidateBinPaths returns the binary path as given, plus its symlink-resolved
+// form when that differs, so prefix derivation works for both direct installs
+// and symlinked layouts. The as-given path is tried first on purpose: Homebrew's
+// headers live under the symlink prefix (/opt/homebrew), not the resolved Cellar
+// path bin/tarantool points into.
+func candidateBinPaths(bin string) []string {
+	paths := []string{bin}
+
+	if resolved, err := filepath.EvalSymlinks(bin); err == nil && resolved != bin {
+		paths = append(paths, resolved)
+	}
+
+	return paths
+}

--- a/cli/manifest/build/backend/make.go
+++ b/cli/manifest/build/backend/make.go
@@ -1,0 +1,52 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// defaultMakefile is the entrypoint used when b.Entrypoint is empty.
+const defaultMakefile = "Makefile"
+
+// makeBackend drives make against a component-supplied Makefile. tt never
+// parses the Makefile; the target sees TT_OUTPUT_DIR and the rest of the
+// contract through the environment.
+type makeBackend struct {
+	// showOutput streams child output when true.
+	showOutput bool
+}
+
+// makeArgs builds the make argv: make -C <cwd> -f <entrypoint> <make_target>
+// followed by b.Flags (e.g. -j4). entrypoint defaults to Makefile in cwd.
+func makeArgs(b manifest.Build, cwd string) []string {
+	entrypoint := b.Entrypoint
+	if entrypoint == "" {
+		entrypoint = defaultMakefile
+	}
+
+	args := []string{"-C", cwd, "-f", entrypoint, b.MakeTarget}
+
+	return append(args, b.Flags...)
+}
+
+// Run invokes make in cwd under the env contract. A non-zero exit is a build
+// error. On success, if b.Output is set the listed files are copied into
+// env.OutputDir (a make target usually writes into TT_OUTPUT_DIR itself, but
+// the copy is honored uniformly).
+func (m makeBackend) Run(ctx context.Context, b manifest.Build, cwd string, env Env) error {
+	if err := requireAbsPaths(cwd, env.OutputDir); err != nil {
+		return err
+	}
+
+	err := run(ctx, cwd, env, m.showOutput, "make", makeArgs(b, cwd)...)
+	if err != nil {
+		return err
+	}
+
+	if len(b.Output) == 0 {
+		return nil
+	}
+
+	return copyOutputs(env.OutputDir, cwd, b.Output)
+}

--- a/cli/manifest/build/backend/make_test.go
+++ b/cli/manifest/build/backend/make_test.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func TestMakeArgs(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{Backend: BackendMake, MakeTarget: "all", Flags: []string{"-j4", "V=1"}}
+
+	got := makeArgs(b, "/proj")
+	want := []string{"-C", "/proj", "-f", "Makefile", "all", "-j4", "V=1"}
+	assert.Equal(t, want, got)
+}
+
+func TestMakeArgsCustomEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{Backend: BackendMake, MakeTarget: "build", Entrypoint: "Makefile.tt"}
+
+	got := makeArgs(b, "/proj")
+	assert.Equal(t, []string{"-C", "/proj", "-f", "Makefile.tt", "build"}, got)
+}
+
+func TestMakeRunsTargetIntoOutputDir(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Skip("make not available")
+	}
+
+	cwd := t.TempDir()
+	out := t.TempDir()
+
+	makefile := "build:\n\tprintf x > $(TT_OUTPUT_DIR)/mod.so\n"
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "Makefile"), []byte(makefile), 0o600))
+
+	b := manifest.Build{Backend: BackendMake, MakeTarget: "build"}
+
+	err := makeBackend{}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "mod.so"))
+}
+
+func TestMakeCopiesDeclaredOutputs(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Skip("make not available")
+	}
+
+	cwd := t.TempDir()
+	out := t.TempDir()
+
+	// The target writes into cwd; the backend copies the declared output out.
+	makefile := "build:\n\tprintf x > libmod.so\n"
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "Makefile"), []byte(makefile), 0o600))
+
+	b := manifest.Build{Backend: BackendMake, MakeTarget: "build", Output: []string{"libmod.so"}}
+
+	err := makeBackend{}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "libmod.so"))
+}

--- a/cli/manifest/build/backend/output.go
+++ b/cli/manifest/build/backend/output.go
@@ -1,0 +1,68 @@
+package backend
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// copyOutputs copies each declared output from cwd into outputDir, flattened to
+// its basename (matching how the loader looks up <namespace>/<name>). It
+// creates outputDir first. A listed file that does not exist after the build is
+// an error — the build claimed an output it did not produce. Shared by the
+// shell and make backends and run only after a zero-exit build.
+func copyOutputs(outputDir, cwd string, outputs []string) error {
+	if err := os.MkdirAll(outputDir, dirPerm); err != nil {
+		return fmt.Errorf("create output directory %q: %w", outputDir, err)
+	}
+
+	for _, entry := range outputs {
+		src := filepath.Join(cwd, entry)
+		dst := filepath.Join(outputDir, filepath.Base(entry))
+
+		if err := copyFile(src, dst); err != nil {
+			return fmt.Errorf("copy declared output %q: %w", entry, err)
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies src to dst, preserving the source's permission bits and
+// creating dst's parent directory. It fails if src does not exist.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	mode := info.Mode().Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+
+		return err
+	}
+
+	return out.Close()
+}

--- a/cli/manifest/build/backend/shell.go
+++ b/cli/manifest/build/backend/shell.go
@@ -1,0 +1,36 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// shellBackend runs an arbitrary command argv-style: execve of b.Command with
+// b.Args, no shell parsing (a pipeline needs its own wrapper script). It is the
+// widest backend, for everything that is neither cc nor make.
+type shellBackend struct {
+	// showOutput streams child output when true.
+	showOutput bool
+}
+
+// Run executes b.Command with b.Args in cwd under the env contract. A non-zero
+// exit is a build error. On success, if b.Output is set the listed files are
+// copied into env.OutputDir; otherwise the command was expected to write there
+// itself.
+func (s shellBackend) Run(ctx context.Context, b manifest.Build, cwd string, env Env) error {
+	if err := requireAbsPaths(cwd, env.OutputDir); err != nil {
+		return err
+	}
+
+	err := run(ctx, cwd, env, s.showOutput, b.Command, b.Args...)
+	if err != nil {
+		return err
+	}
+
+	if len(b.Output) == 0 {
+		return nil
+	}
+
+	return copyOutputs(env.OutputDir, cwd, b.Output)
+}

--- a/cli/manifest/build/backend/shell_test.go
+++ b/cli/manifest/build/backend/shell_test.go
@@ -1,0 +1,84 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func TestShellWritesToOutputDir(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+
+	b := manifest.Build{
+		Backend: BackendShell,
+		Command: "sh",
+		Args:    []string{"-c", `printf hi > "$TT_OUTPUT_DIR/artifact.txt"`},
+	}
+
+	err := shellBackend{}.Run(context.Background(), b, t.TempDir(), Env{OutputDir: out})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(out, "artifact.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(got))
+}
+
+func TestShellCopiesDeclaredOutputs(t *testing.T) {
+	t.Parallel()
+
+	out := t.TempDir()
+	cwd := t.TempDir()
+
+	// The command writes into cwd; the declared output is copied (flat) out.
+	b := manifest.Build{
+		Backend: BackendShell,
+		Command: "sh",
+		Args:    []string{"-c", "printf x > artifact.so"},
+		Output:  []string{"artifact.so"},
+	}
+
+	err := shellBackend{}.Run(context.Background(), b, cwd, Env{OutputDir: out})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(out, "artifact.so"))
+}
+
+func TestShellNonZeroExitIsError(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{Backend: BackendShell, Command: "sh", Args: []string{"-c", "exit 1"}}
+
+	err := shellBackend{}.Run(context.Background(), b, t.TempDir(), Env{OutputDir: t.TempDir()})
+	require.Error(t, err)
+}
+
+func TestShellMissingDeclaredOutputIsError(t *testing.T) {
+	t.Parallel()
+
+	// The command succeeds but never produces the declared output.
+	b := manifest.Build{
+		Backend: BackendShell,
+		Command: "sh",
+		Args:    []string{"-c", "true"},
+		Output:  []string{"ghost.so"},
+	}
+
+	err := shellBackend{}.Run(context.Background(), b, t.TempDir(), Env{OutputDir: t.TempDir()})
+	require.Error(t, err)
+}
+
+func TestShellRejectsRelativeCwd(t *testing.T) {
+	t.Parallel()
+
+	b := manifest.Build{Backend: BackendShell, Command: "true"}
+
+	err := shellBackend{}.Run(context.Background(), b, "rel/dir", Env{OutputDir: t.TempDir()})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Four isolated executors behind one `Backend` interface, completing the manifest build layer for TNTP-8232:

- **shell** - runs the build command as an `execve` argv.
- **make** - `make -C <dir> -f <makefile> <target>`.
- **cc** - a shared C / lua-C driver.

Environment is assembled directly on the `exec.Cmd` (the `TT_*` contract vars are authoritative; no `os.Chdir` / `os.Setenv`), so executors stay side-effect free and safe to run concurrently. The `cc` driver mirrors the go-luarocks builtin backend through the rocks adapter's `DeriveFlags` seam, with a pure argv builder that is unit tested for both Linux and Darwin flag placement; the live `.so` compile is gated behind the `integration` tag.

Closes TNTP-8232
