### PR TITLE
cli/manifest/build: tt package build and fetch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,9 @@ linters:
           - wrapcheck
           - err113
           - funlen
+          # Table-driven and fixture tests build partial structs on purpose;
+          # requiring every field spelled out is noise in tests.
+          - exhaustruct
 
   settings:
     varnamelen:
@@ -97,6 +100,12 @@ linters:
             # cli/manifest/resolve composes the model and the luarocks adapter
             # into the dependency-resolution engine.
             - "github.com/tarantool/tt/cli/manifest"
+            # cli/manifest/build/backend runs subprocesses through tt's shared
+            # helper rather than reinventing exec plumbing.
+            - "github.com/tarantool/tt/cli/util"
+            # cli/manifest/build filters component files with gitignore-syntax
+            # include/exclude patterns via go-git's matcher.
+            - "github.com/go-git/go-git/v5/plumbing/format/gitignore"
         test:
           files:
             - "$test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `tt package build`: build a manifest package (`app.manifest.toml`) into
+  `.rocks/` — resolve and lock dependencies, materialize the pinned closure,
+  run each component's build backend, lay component files out under their
+  install namespace and generate `version.lua`. `--product` selects the product
+  and `--locked` fails on a stale lock instead of re-resolving.
+- `tt package fetch`: materialize `.rocks/` strictly from the lock, without
+  re-resolving or running component build backends.
 - `tt pack`: support nested `.packignore` at the root of tt environment.
 - `tt status`: add `--format` option to support JSON and YAML output formats
 for machine-readable output.

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/tarantool/tt/cli/manifest/build"
+	manifestrocks "github.com/tarantool/tt/cli/manifest/rocks"
+	oldrocks "github.com/tarantool/tt/cli/rocks"
+	ttversion "github.com/tarantool/tt/cli/version"
+)
+
+// errNoTarantool reports that no tarantool executable was found; the manifest
+// build needs it to configure the rocks adapter (and to compile c/lua-c
+// components).
+var errNoTarantool = errors.New("tarantool executable not found in PATH")
+
+// Shared flags for the package subcommands.
+var (
+	packageProduct string
+	packageLocked  bool
+)
+
+// NewPackageCmd creates the `tt package` command group: the manifest build
+// pipeline (build and fetch; pack and install are not implemented yet).
+func NewPackageCmd() *cobra.Command {
+	packageCmd := &cobra.Command{
+		Use:   "package",
+		Short: "Manage tt manifest packages",
+		Long: "Build, fetch and pack Tarantool packages described by " +
+			"app.manifest.toml.",
+	}
+
+	packageCmd.AddCommand(
+		newPackageBuildCmd(),
+		newPackageFetchCmd(),
+	)
+
+	return packageCmd
+}
+
+// newPackageBuildCmd wires `tt package build [COMPONENT]`.
+func newPackageBuildCmd() *cobra.Command {
+	buildCmd := &cobra.Command{
+		Use:   "build [COMPONENT]",
+		Short: "Build a manifest package into .rocks/",
+		Long: "Resolve dependencies, materialize .rocks/, run component build " +
+			"backends and generate version.lua. With no argument every component " +
+			"of the product is built; a component name narrows the build to one.",
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runPackageCmd(args, false)
+		},
+	}
+
+	buildCmd.Flags().StringVar(&packageProduct, "product", "",
+		"product to build (default: the product marked default)")
+	buildCmd.Flags().BoolVar(&packageLocked, "locked", false,
+		"fail if the lock is out of date instead of re-resolving it")
+
+	return buildCmd
+}
+
+// newPackageFetchCmd wires `tt package fetch`.
+func newPackageFetchCmd() *cobra.Command {
+	fetchCmd := &cobra.Command{
+		Use:   "fetch",
+		Short: "Materialize .rocks/ from the lock without building",
+		Long: "Fetch and build the pinned dependency closure into .rocks/ " +
+			"strictly from the lock, without re-resolving or running component " +
+			"build backends.",
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runPackageCmd(nil, true)
+		},
+	}
+
+	fetchCmd.Flags().StringVar(&packageProduct, "product", "",
+		"product to fetch (default: the product marked default)")
+
+	return fetchCmd
+}
+
+// runPackageCmd runs a package build/fetch and maps failures to exit codes:
+// 1 for a state error (stale --locked, version.lua collision), 2 for a
+// component build backend failure.
+func runPackageCmd(args []string, fetchOnly bool) {
+	if err := runPackage(args, fetchOnly); err != nil {
+		log.Error(err.Error())
+		os.Exit(build.ExitCode(err))
+	}
+}
+
+// runPackage assembles build.Options from the environment and drives the build.
+func runPackage(args []string, fetchOnly bool) error {
+	projectDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	projectDir, err = filepath.Abs(projectDir)
+	if err != nil {
+		return err
+	}
+
+	tntInfo, err := tarantoolInfo()
+	if err != nil {
+		return err
+	}
+
+	component := ""
+	if len(args) == 1 {
+		component = args[0]
+	}
+
+	return build.Run(context.Background(), build.Options{
+		ProjectDir: projectDir,
+		Product:    packageProduct,
+		Component:  component,
+		Locked:     packageLocked,
+		FetchOnly:  fetchOnly,
+		TtVersion:  "tt " + ttversion.GetVersion(true, false),
+		Tarantool:  tntInfo,
+		ShowOutput: cmdCtx.Cli.Verbose,
+		Warn:       func(msg string) { log.Warn(msg) },
+	})
+}
+
+// tarantoolInfo gathers the Tarantool facts the rocks adapter needs from the
+// configured CLI context: the executable path, its version and its install
+// prefix.
+func tarantoolInfo() (manifestrocks.TarantoolInfo, error) {
+	if cmdCtx.Cli.TarantoolCli.Executable == "" {
+		return manifestrocks.TarantoolInfo{}, errNoTarantool
+	}
+
+	ver, err := cmdCtx.Cli.TarantoolCli.GetVersion()
+	if err != nil {
+		return manifestrocks.TarantoolInfo{}, err
+	}
+
+	prefix, err := oldrocks.GetTarantoolPrefix(&cmdCtx.Cli, cliOpts)
+	if err != nil {
+		return manifestrocks.TarantoolInfo{}, err
+	}
+
+	return manifestrocks.TarantoolInfo{
+		Executable: cmdCtx.Cli.TarantoolCli.Executable,
+		Prefix:     prefix,
+		Version:    ver.Str,
+	}, nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -203,6 +203,7 @@ After that tt will be able to manage the application using 'replicaset_example' 
 		NewInstallCmd(),
 		NewUninstallCmd(),
 		NewPackCmd(),
+		NewPackageCmd(),
 		NewInitCmd(),
 		NewDaemonCmd(),
 		NewCfgCmd(),

--- a/cli/manifest/build/backend/backend.go
+++ b/cli/manifest/build/backend/backend.go
@@ -7,8 +7,8 @@
 // driver serving both c and lua-c. Each executor receives the parsed
 // manifest.Build block, an absolute working directory, and the Env contract.
 // None of them order components, lay out install namespaces, resolve the lock,
-// or run lifecycle hooks — that orchestration is the caller's job (RFC 0010
-// task 06); a backend only runs one tool and writes into TT_OUTPUT_DIR.
+// or run lifecycle hooks — that orchestration is the caller's job; a backend
+// only runs one tool and writes into TT_OUTPUT_DIR.
 //
 // The process environment is assembled on the exec.Cmd, never via os.Chdir or
 // os.Setenv: the seven TT_* contract variables are applied last so a stray
@@ -58,9 +58,9 @@ var ErrMissingHeaders = errors.New(
 	"tarantool development headers not found: cannot compile c/lua-c component")
 
 // Env is the guaranteed environment contract handed to every backend. The
-// caller (RFC 0010 task 06) fully resolves OutputDir — including the install
-// namespace — before calling; the backend is namespace-agnostic and only ever
-// writes into OutputDir, creating it if absent.
+// caller fully resolves OutputDir — including the install namespace — before
+// calling; the backend is namespace-agnostic and only ever writes into
+// OutputDir, creating it if absent.
 type Env struct {
 	// OutputDir is where native artifacts are placed (TT_OUTPUT_DIR). It must
 	// be an absolute path.
@@ -102,13 +102,13 @@ func (e Env) platformArch() string {
 	return e.Arch
 }
 
-// environ builds the child process environment: os.Environ() first, then the
-// [build].env pairs in sorted key order, then the seven TT_* contract
-// variables last. exec.Cmd resolves duplicate keys last-wins, so the contract
-// variables are authoritative — a [build].env key cannot shadow TT_OUTPUT_DIR.
-// This is the only place the process environment is assembled; a backend never
-// re-reads manifest.Build.Env.
-func (e Env) environ() []string {
+// baseEnviron builds the shared prefix of every child environment: os.Environ()
+// first, then the [build].env pairs in sorted key order. The TT_* contract
+// variables are appended last by environ / hookEnviron so exec.Cmd's last-wins
+// resolution keeps them authoritative — a [build].env key cannot shadow
+// TT_OUTPUT_DIR. This is the only place the process environment is assembled; a
+// backend never re-reads manifest.Build.Env.
+func (e Env) baseEnviron() []string {
 	out := os.Environ()
 
 	keys := make([]string, 0, len(e.Extra))
@@ -122,11 +122,32 @@ func (e Env) environ() []string {
 		out = append(out, k+"="+e.Extra[k])
 	}
 
-	return append(out,
+	return out
+}
+
+// environ is the full component-build contract: baseEnviron plus the seven TT_*
+// variables, TT_OUTPUT_DIR / TT_COMPONENT_NAME included.
+func (e Env) environ() []string {
+	return append(e.baseEnviron(),
 		"TT_OUTPUT_DIR="+e.OutputDir,
 		"TT_PROJECT_ROOT="+e.ProjectRoot,
 		"TT_PACKAGE="+e.Package,
 		"TT_COMPONENT_NAME="+e.Component,
+		"TT_VERSION="+e.Version,
+		"TT_PLATFORM_OS="+e.platformOS(),
+		"TT_PLATFORM_ARCH="+e.platformArch(),
+	)
+}
+
+// hookEnviron is the reduced lifecycle-hook contract: baseEnviron plus the five
+// TT_* variables that exist before any component is built. TT_OUTPUT_DIR and
+// TT_COMPONENT_NAME are deliberately omitted — a pre_build / post_build hook
+// runs around all components and has no single output directory or component
+// name.
+func (e Env) hookEnviron() []string {
+	return append(e.baseEnviron(),
+		"TT_PROJECT_ROOT="+e.ProjectRoot,
+		"TT_PACKAGE="+e.Package,
 		"TT_VERSION="+e.Version,
 		"TT_PLATFORM_OS="+e.platformOS(),
 		"TT_PLATFORM_ARCH="+e.platformArch(),
@@ -175,15 +196,25 @@ func requireAbsPaths(cwd, outputDir string) error {
 	return nil
 }
 
-// run builds and runs one subprocess with the assembled contract environment.
-// It never mutates the tt process cwd or environment: the environment is set on
-// the exec.Cmd and util.RunCommand sets cmd.Dir. exec.CommandContext keeps ctx
-// cancellation working.
+// run builds and runs one subprocess with the full component-build contract
+// environment. It never mutates the tt process cwd or environment: the
+// environment is set on the exec.Cmd and util.RunCommand sets cmd.Dir.
+// exec.CommandContext keeps ctx cancellation working.
 func run(
 	ctx context.Context, cwd string, env Env, showOutput bool, name string, args ...string,
 ) error {
+	return runEnviron(ctx, cwd, env.environ(), showOutput, name, args...)
+}
+
+// runEnviron is the shared subprocess launcher: it takes the fully assembled
+// environment slice so the component path (run) and the hook path (RunHook) can
+// supply their respective contracts without duplicating exec wiring.
+func runEnviron(
+	ctx context.Context, cwd string, environ []string,
+	showOutput bool, name string, args ...string,
+) error {
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = env.environ()
+	cmd.Env = environ
 
 	return util.RunCommand(cmd, cwd, showOutput)
 }

--- a/cli/manifest/build/backend/hook.go
+++ b/cli/manifest/build/backend/hook.go
@@ -1,0 +1,48 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+var (
+	// errRelativeCwd reports a non-absolute hook working directory (rejected for
+	// the same double-application reason as a component build).
+	errRelativeCwd = errors.New("cwd must be an absolute path")
+	// errUnrunnableHookBackend reports a hook whose backend is neither shell nor
+	// make; the closed enum is enforced at manifest parse time.
+	errUnrunnableHookBackend = errors.New(
+		"hook backend is not runnable (only shell and make)")
+)
+
+// RunHook runs a lifecycle hook (pre_build / post_build) through the shell or
+// make backend. It reuses the component build machinery — the same argv
+// construction and the same last-wins environment assembly — but under the
+// reduced hook contract: TT_OUTPUT_DIR and TT_COMPONENT_NAME are not set (a
+// hook runs around all components, not inside one) and b.Output is ignored (a
+// hook has no single output directory to copy into).
+//
+// Only shell and make are valid hook backends; the closed enum is enforced at
+// manifest parse time (cli/manifest/validate.go), and any other backend here is
+// a programming error surfaced as a plain error rather than a panic. cwd must be
+// absolute for the same double-application reason as a component build.
+func RunHook(
+	ctx context.Context, hook manifest.Build, cwd string, env Env, showOutput bool,
+) error {
+	if !filepath.IsAbs(cwd) {
+		return fmt.Errorf("%w, got %q", errRelativeCwd, cwd)
+	}
+
+	switch hook.Backend {
+	case BackendShell:
+		return runEnviron(ctx, cwd, env.hookEnviron(), showOutput, hook.Command, hook.Args...)
+	case BackendMake:
+		return runEnviron(ctx, cwd, env.hookEnviron(), showOutput, "make", makeArgs(hook, cwd)...)
+	default:
+		return fmt.Errorf("%w: %q", errUnrunnableHookBackend, hook.Backend)
+	}
+}

--- a/cli/manifest/build/backend/hook_test.go
+++ b/cli/manifest/build/backend/hook_test.go
@@ -1,0 +1,91 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func TestRunHook_shellReducedContract(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	out := filepath.Join(cwd, "out.txt")
+
+	hook := manifest.Build{
+		Backend: BackendShell,
+		Command: "sh",
+		Args: []string{"-c",
+			`printf '%s|%s|%s|%s|%s' ` +
+				`"$TT_PACKAGE" "$TT_VERSION" "$TT_PROJECT_ROOT" ` +
+				`"${TT_OUTPUT_DIR-unset}" "${TT_COMPONENT_NAME-unset}" > out.txt`},
+	}
+	env := Env{
+		ProjectRoot: "/proj",
+		Package:     "my-app",
+		Version:     "1.2.3",
+		Extra:       map[string]string{"FOO": "bar"},
+	}
+
+	require.NoError(t, RunHook(context.Background(), hook, cwd, env, false))
+
+	data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	// TT_PACKAGE / TT_VERSION / TT_PROJECT_ROOT are set; the per-component
+	// TT_OUTPUT_DIR and TT_COMPONENT_NAME are not exported at all.
+	assert.Equal(t, "my-app|1.2.3|/proj|unset|unset", string(data))
+}
+
+func TestRunHook_shellExtraEnvExported(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+
+	hook := manifest.Build{
+		Backend: BackendShell,
+		Command: "sh",
+		Args:    []string{"-c", `printf '%s' "$FOO" > out.txt`},
+		Env:     map[string]string{"FOO": "bar"},
+	}
+	env := Env{ProjectRoot: cwd, Package: "p", Version: "1", Extra: map[string]string{"FOO": "bar"}}
+
+	require.NoError(t, RunHook(context.Background(), hook, cwd, env, false))
+
+	data, err := os.ReadFile(filepath.Join(cwd, "out.txt")) //nolint:gosec // temp path
+	require.NoError(t, err)
+	assert.Equal(t, "bar", string(data))
+}
+
+func TestRunHook_nonZeroExitIsError(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	hook := manifest.Build{Backend: BackendShell, Command: "sh", Args: []string{"-c", "exit 3"}}
+
+	err := RunHook(context.Background(), hook, cwd, Env{ProjectRoot: cwd}, false)
+	assert.Error(t, err)
+}
+
+func TestRunHook_rejectsNonHookBackend(t *testing.T) {
+	t.Parallel()
+
+	err := RunHook(context.Background(),
+		manifest.Build{Backend: BackendC}, t.TempDir(), Env{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not runnable")
+}
+
+func TestRunHook_requiresAbsCwd(t *testing.T) {
+	t.Parallel()
+
+	err := RunHook(context.Background(),
+		manifest.Build{Backend: BackendShell, Command: "true"}, "rel/dir", Env{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute path")
+}

--- a/cli/manifest/build/build.go
+++ b/cli/manifest/build/build.go
@@ -1,0 +1,344 @@
+// Package build is the orchestration layer of the tt manifest pipeline: it runs
+// the full build cycle of a package (tt package build) and its fetch-only slice
+// (tt package fetch). It stitches together the manifest model, version
+// derivation, the resolver, the rocks adapter and the component build
+// backends, and materializes the project's .rocks/ tree.
+//
+// The cycle, in order: derive the version, run pre_build, gate the
+// lock (resolve and rewrite unless --locked), materialize the pinned closure
+// into .rocks/, run each component's build backend, lay the component files out
+// under their install namespace, generate version.lua, then run post_build.
+// tt package fetch is the same materialization step in isolation: strictly from
+// the lock, without resolving or running backends.
+//
+// The build always works in project scope: <ProjectDir>/.rocks/. Selecting the
+// product, choosing versions, deriving flags and archiving are neighbouring
+// packages' jobs; this package only drives the cycle.
+package build
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/tarantool/go-luarocks/client"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/build/backend"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+// rocksDirName is the project-scope tree root the build materializes into.
+const rocksDirName = ".rocks"
+
+// Options configures one build (or fetch) run.
+type Options struct {
+	// ProjectDir is the directory holding app.manifest.toml; the build works in
+	// its .rocks/ subtree. Required and must be absolute.
+	ProjectDir string
+	// Product selects the product to build; empty picks the default (or the
+	// only) product.
+	Product string
+	// Component narrows the build to a single component of the product; empty
+	// builds every component of the product.
+	Component string
+	// Locked gates the lock: a stale lock is a hard error instead of being
+	// re-resolved and rewritten. Ignored by fetch.
+	Locked bool
+	// FetchOnly runs tt package fetch: materialize .rocks/ from the lock only,
+	// skipping hooks, resolution, component backends, layout and version.lua.
+	FetchOnly bool
+	// TtVersion is the "tt x.y.z" string stamped into a freshly written lock's
+	// generated_by field.
+	TtVersion string
+	// Tarantool carries the Tarantool facts the rocks adapter needs.
+	Tarantool rocks.TarantoolInfo
+	// Servers overrides the rock-server list; nil uses the adapter default.
+	Servers []string
+	// ShowOutput streams child (backend / hook) output when true.
+	ShowOutput bool
+	// Now stamps version.lua's built_at; the zero value uses the wall clock.
+	Now time.Time
+	// Logger receives the adapter's structured operation logs; nil disables it.
+	Logger *slog.Logger
+	// Warn receives non-fatal diagnostics (parse/validation/resolution
+	// warnings). The library never logs directly; the CLI sets this to route
+	// them through tt's logger. Nil drops them.
+	Warn func(string)
+}
+
+// emit surfaces non-fatal diagnostics through the Warn sink, if any.
+func (o Options) emit(warnings []string) {
+	if o.Warn == nil {
+		return
+	}
+
+	for _, w := range warnings {
+		o.Warn(w)
+	}
+}
+
+// builtAt returns the version.lua timestamp: Options.Now, or the wall clock when
+// unset.
+func (o Options) builtAt() time.Time {
+	if o.Now.IsZero() {
+		return time.Now()
+	}
+
+	return o.Now
+}
+
+// Run executes the build (or fetch) described by opts. It returns an *ExitError
+// for the failures that carry a dedicated exit code (stale --locked,
+// version.lua collision, backend failure) and a plain error otherwise;
+// ExitCode maps either to a process exit code.
+func Run(ctx context.Context, opts Options) error {
+	man, err := readManifest(opts.ProjectDir, opts)
+	if err != nil {
+		return err
+	}
+
+	productName, product, err := selectProduct(man, opts.Product)
+	if err != nil {
+		return err
+	}
+
+	tree := filepath.Join(opts.ProjectDir, rocksDirName)
+	adapter := rocks.New(rocks.BuildConfig(opts.Tarantool, rocks.ConfigOptions{
+		Tree:       tree,
+		WorkingDir: opts.ProjectDir,
+		Servers:    opts.Servers,
+		Logger:     opts.Logger,
+	}))
+
+	if opts.FetchOnly {
+		return runFetch(ctx, adapter, opts.ProjectDir, productName)
+	}
+
+	return runBuild(ctx, opts, man, adapter, tree, productName, product)
+}
+
+// readManifest reads, parses and validates app.manifest.toml from projectDir,
+// surfacing parse and validation warnings through opts.
+func readManifest(projectDir string, opts Options) (*manifest.Manifest, error) {
+	path := filepath.Join(projectDir, manifestFileName)
+
+	data, err := os.ReadFile(path) //nolint:gosec // Reads the caller's own manifest.
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", manifestFileName, err)
+	}
+
+	man, warnings, err := manifest.ParseManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", manifestFileName, err)
+	}
+
+	opts.emit(warnings)
+
+	validationWarnings, err := man.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+
+	opts.emit(validationWarnings)
+
+	return man, nil
+}
+
+// runFetch materializes the product's locked closure into the tree without
+// resolving or running backends — tt package fetch.
+func runFetch(
+	ctx context.Context, adapter *rocks.Adapter, projectDir, productName string,
+) error {
+	lock, err := loadLock(projectDir)
+	if err != nil {
+		return err
+	}
+
+	prod, ok := lock.Products[productName]
+	if !ok {
+		return exitErrorf(exitStateError,
+			"lock has no closure for product %q; run tt package build", productName)
+	}
+
+	rockClient, err := adapter.Client(client.BackendNative)
+	if err != nil {
+		return fmt.Errorf("rocks client: %w", err)
+	}
+
+	return materialize(ctx, rockClient, projectDir, prod)
+}
+
+// runBuild runs the full build cycle.
+func runBuild(
+	ctx context.Context, opts Options, man *manifest.Manifest,
+	adapter *rocks.Adapter, tree, productName string, product manifest.Product,
+) error {
+	components, err := selectComponents(product, opts.Component)
+	if err != nil {
+		return err
+	}
+
+	// Version is derived before pre_build so the hook sees TT_VERSION, and
+	// before the tree is touched so a hook-generated file does not flip .dirty.
+	// version.Derive spawns git internally and takes no context.
+	ver, err := version.Derive(opts.ProjectDir) //nolint:contextcheck // Derive has no ctx.
+	if err != nil {
+		return fmt.Errorf("deriving version: %w", err)
+	}
+
+	ver.Flavor = man.Platform.Tarantool.EffectiveFlavor()
+
+	preErr := runHook(ctx, man, ver, hookPreBuild, opts.ProjectDir, opts.ShowOutput)
+	if preErr != nil {
+		return exitErrorf(exitBackendError, "pre_build hook: %w", preErr)
+	}
+
+	engine := resolve.NewEngine(adapter, opts.ProjectDir, opts.TtVersion)
+
+	lock, warnings, err := gateLock(ctx, engine, man, opts.ProjectDir, opts.Locked)
+	if err != nil {
+		return err
+	}
+
+	opts.emit(warnings)
+
+	prod, ok := lock.Products[productName]
+	if !ok {
+		// A hash-fresh lock can still lack the product if it was hand-edited or
+		// truncated (IsStale only checks the manifest and path-dep hashes).
+		return exitErrorf(exitStateError, "lock has no closure for product %q", productName)
+	}
+
+	rockClient, err := adapter.Client(client.BackendNative)
+	if err != nil {
+		return fmt.Errorf("rocks client: %w", err)
+	}
+
+	matErr := materialize(ctx, rockClient, opts.ProjectDir, prod)
+	if matErr != nil {
+		return matErr
+	}
+
+	backendErr := runBackends(ctx, opts, man, adapter, tree, components, ver)
+	if backendErr != nil {
+		return backendErr
+	}
+
+	laidOut, err := layoutComponents(opts.ProjectDir, tree, man, components)
+	if err != nil {
+		return err
+	}
+
+	vluaErr := writeVersionLua(tree, man.Package.Name,
+		man.Package.GenerateVersionLuaValue(), ver, opts.builtAt(), laidOut)
+	if vluaErr != nil {
+		return vluaErr
+	}
+
+	return runPostBuild(ctx, opts, man, ver)
+}
+
+// runBackends runs the build backend of every selected component that declares
+// one, in the product's component order, placing artifacts in the component's
+// lib namespace directory. A backend failure is exit code 2.
+func runBackends(
+	ctx context.Context, opts Options, man *manifest.Manifest,
+	adapter *rocks.Adapter, tree string, components []string, ver version.Version,
+) error {
+	flags := adapter.Flags()
+
+	for _, name := range components {
+		component := man.Components[name]
+		if component.Build == nil {
+			continue
+		}
+
+		executor, err := backend.New(component.Build.Backend, flags, opts.ShowOutput)
+		if err != nil {
+			return fmt.Errorf("component %q: %w", name, err)
+		}
+
+		namespace := component.EffectiveNamespace(man.Package.Name)
+		env := backend.Env{
+			OutputDir:   componentOutputDir(tree, namespace),
+			ProjectRoot: opts.ProjectDir,
+			Package:     man.Package.Name,
+			Component:   name,
+			Version:     ver.SemVer,
+			OS:          "",
+			Arch:        "",
+			Extra:       component.Build.Env,
+		}
+
+		cwd := backendCwd(opts.ProjectDir, component)
+
+		runErr := executor.Run(ctx, *component.Build, cwd, env)
+		if runErr != nil {
+			return exitErrorf(exitBackendError, "building component %q: %w", name, runErr)
+		}
+	}
+
+	return nil
+}
+
+// layoutComponents lays every selected component out under its namespace and
+// returns the union of destination paths written, for the version.lua collision
+// check.
+func layoutComponents(
+	projectDir, tree string, man *manifest.Manifest, components []string,
+) ([]string, error) {
+	var laidOut []string
+
+	for _, name := range components {
+		component := man.Components[name]
+		compAbsPath := resolveDir(projectDir, component.Path)
+
+		written, err := layoutComponent(tree, man.Package.Name, component, compAbsPath)
+		if err != nil {
+			return nil, err
+		}
+
+		laidOut = append(laidOut, written...)
+	}
+
+	return laidOut, nil
+}
+
+// runPostBuild runs the post_build hook after all components are built.
+func runPostBuild(
+	ctx context.Context, opts Options, man *manifest.Manifest, ver version.Version,
+) error {
+	err := runHook(ctx, man, ver, hookPostBuild, opts.ProjectDir, opts.ShowOutput)
+	if err != nil {
+		return exitErrorf(exitBackendError, "post_build hook: %w", err)
+	}
+
+	return nil
+}
+
+// componentOutputDir is a component's native artifact directory:
+// <tree>/lib/tarantool/<namespace>/, flat when the namespace is empty. It
+// matches TT_OUTPUT_DIR in the backend contract.
+func componentOutputDir(tree, namespace string) string {
+	if namespace == "" {
+		return filepath.Join(tree, libTarantool)
+	}
+
+	return filepath.Join(tree, libTarantool, namespace)
+}
+
+// backendCwd is the working directory for a component's build: the build block's
+// cwd override, or the component's path, resolved against the project root.
+func backendCwd(projectDir string, component manifest.Component) string {
+	if component.Build != nil && component.Build.Cwd != "" {
+		return resolveDir(projectDir, component.Build.Cwd)
+	}
+
+	return resolveDir(projectDir, component.Path)
+}

--- a/cli/manifest/build/build_e2e_test.go
+++ b/cli/manifest/build/build_e2e_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package build
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// e2eManifest is my-app with a real lua-c native component: fast_hash.c is
+// compiled by the cc driver against the Tarantool headers.
+const e2eManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0,<4.0.0'
+tt = '>=3.1.0'
+
+[components.lua]
+path = '.'
+include = ['*.lua']
+
+[components.native]
+path = 'native/'
+
+[components.native.build]
+backend = 'lua-c'
+module = 'fast_hash'
+sources = ['fast_hash.c']
+
+[products.default]
+components = ['lua', 'native']
+default = true
+`
+
+// fastHashC is a minimal Lua C extension exporting luaopen_fast_hash.
+const fastHashC = `#include <lua.h>
+
+static int l_hash(lua_State *L) {
+	lua_pushinteger(L, 42);
+	return 1;
+}
+
+int luaopen_fast_hash(lua_State *L) {
+	lua_pushcfunction(L, l_hash);
+	return 1;
+}
+`
+
+// tarantoolInfoForTest derives the Tarantool facts from a live binary, skipping
+// the test when tarantool or its development headers are unavailable.
+func tarantoolInfoForTest(t *testing.T) rocks.TarantoolInfo {
+	t.Helper()
+
+	exe, err := exec.LookPath("tarantool")
+	if err != nil {
+		t.Skip("tarantool not found in PATH")
+	}
+
+	out, err := exec.Command(exe, "--version").Output()
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	require.GreaterOrEqual(t, len(lines), 3, "unexpected tarantool --version output")
+
+	version := lines[0][strings.LastIndex(lines[0], " ")+1:]
+
+	prefix := ""
+	prefixRe := regexp.MustCompile(`-DCMAKE_INSTALL_PREFIX=(\S+)`)
+	if m := prefixRe.FindStringSubmatch(lines[2]); m != nil {
+		prefix = m[1]
+	}
+
+	info := rocks.TarantoolInfo{Executable: exe, Prefix: prefix, Version: version}
+	if _, err := os.Stat(filepath.Join(info.IncludeDir(), "lua.h")); err != nil {
+		t.Skipf("Tarantool headers not found under %s", info.IncludeDir())
+	}
+
+	return info
+}
+
+func TestRunE2E_compilesNativeComponent(t *testing.T) {
+	info := tarantoolInfoForTest(t)
+
+	dir := setupProject(t, e2eManifest, map[string]string{
+		"init.lua":           "-- init",
+		"native/fast_hash.c": fastHashC,
+	})
+
+	opts := dryOptions(dir)
+	opts.Tarantool = info
+	require.NoError(t, Run(context.Background(), opts))
+
+	tree := filepath.Join(dir, ".rocks")
+	so := filepath.Join(tree, "lib/tarantool/my-app/fast_hash.so")
+
+	fi, err := os.Stat(so)
+	require.NoError(t, err, "compiled artifact must exist")
+	assert.Positive(t, fi.Size(), "compiled artifact must be non-empty")
+
+	assert.FileExists(t, filepath.Join(tree, "share/tarantool/my-app/init.lua"))
+	assert.FileExists(t, filepath.Join(tree, "share/tarantool/my-app/version.lua"))
+}

--- a/cli/manifest/build/errors.go
+++ b/cli/manifest/build/errors.go
@@ -1,0 +1,87 @@
+package build
+
+import (
+	"errors"
+	"fmt"
+)
+
+// File names the build reads and writes in the project root.
+const (
+	manifestFileName = "app.manifest.toml"
+	lockFileName     = "app.manifest.lock"
+)
+
+// Process exit codes the build maps failures to: a usage or state error (stale
+// lock under --locked, version.lua collision, bad manifest) exits 1; a
+// component build backend that fails exits 2.
+const (
+	exitStateError   = 1
+	exitBackendError = 2
+)
+
+var (
+	// errLockStale reports that the lock no longer matches the manifest while
+	// --locked forbids rewriting it. It carries exit code 1.
+	errLockStale = errors.New("lock is out of date")
+	// errNoLock reports that an operation requiring a lock found none:
+	// tt package fetch (which never resolves) or a --locked build.
+	errNoLock = errors.New("no lock file")
+	// errVersionLuaCollision reports that a component laid a file at the path
+	// the build generates version.lua into. It carries exit code 1.
+	errVersionLuaCollision = errors.New("version.lua collision")
+	// errUnknownProduct reports that --product named a product the manifest
+	// does not define.
+	errUnknownProduct = errors.New("unknown product")
+	// errNoDefaultProduct reports that no product could be selected: several
+	// products exist and none is marked default (should be caught by Validate,
+	// but the build fails safe).
+	errNoDefaultProduct = errors.New("no default product")
+	// errUnknownComponent reports that a component argument names a component
+	// the selected product does not build.
+	errUnknownComponent = errors.New("unknown component")
+	// errNoProducts reports that the manifest defines no products at all.
+	errNoProducts = errors.New("manifest defines no products")
+	// errUnknownSource reports a lock dependency whose source is neither
+	// registry nor path.
+	errUnknownSource = errors.New("unknown dependency source")
+	// errAmbiguousRockspec reports a path dependency directory that ships more
+	// than one rockspec, so which one to build is ambiguous.
+	errAmbiguousRockspec = errors.New("multiple rockspecs in path dependency")
+)
+
+// ExitError wraps an error with the process exit code the CLI should return.
+// The build produces it for the two codes above; ExitCode reads it back.
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+// Error renders the wrapped error.
+func (e *ExitError) Error() string { return e.Err.Error() }
+
+// Unwrap exposes the wrapped error to errors.Is / errors.As.
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// exitErrorf wraps a formatted error with an exit code. It is the exit-code
+// analogue of fmt.Errorf, so the format string carries the message (and any %w
+// wrap) rather than a static sentinel.
+//
+//nolint:err113 // Formatting helper, mirrors fmt.Errorf; callers pass %w wraps.
+func exitErrorf(code int, format string, args ...any) *ExitError {
+	return &ExitError{Code: code, Err: fmt.Errorf(format, args...)}
+}
+
+// ExitCode returns the process exit code for err: the code carried by an
+// ExitError in its chain, or 1 for any other non-nil error. A nil error is 0.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	var exit *ExitError
+	if errors.As(err, &exit) {
+		return exit.Code
+	}
+
+	return exitStateError
+}

--- a/cli/manifest/build/filter.go
+++ b/cli/manifest/build/filter.go
@@ -1,0 +1,88 @@
+package build
+
+import (
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// defaultInclude is the include set applied when a component declares none: the
+// pure-Lua sources and any pre-built shared objects that ship in the component
+// tree. A component that declares its own include list replaces this default
+// wholesale, rather than adding to it.
+func defaultInclude() []string {
+	return []string{"*.lua", "*.so"}
+}
+
+// defaultExclude is always applied, ahead of the component's own exclude list.
+// These entries are packaging hazards or tt-internal state that must never land
+// in a component regardless of what the manifest says: build scratch, the rocks
+// tree, the runtime bundle, vendored deps, VCS/hidden files and the manifest
+// itself. A component's exclude patterns extend this list; they do not replace
+// it, so no manifest can accidentally ship .rocks/ or app.manifest.toml.
+func defaultExclude() []string {
+	return []string{
+		"test/",
+		"tests/",
+		"_build/",
+		".rocks/",
+		"_runtime/",
+		"vendor/",
+		".*", // Hidden files and directories (.git, .rocks is also caught above).
+		manifestFileName,
+	}
+}
+
+// fileFilter decides which files of a component are laid out. A file is kept
+// when it matches the include allowlist and is not caught by the exclude
+// denylist; directories are consulted only for pruning (excluded subtrees are
+// skipped whole). Both matchers use gitignore syntax evaluated from the
+// component's path root.
+type fileFilter struct {
+	include gitignore.Matcher
+	exclude gitignore.Matcher
+}
+
+// newFileFilter builds the filter for one component: its include list (or the
+// default when empty) as the allowlist, and defaultExclude followed by the
+// component's own exclude patterns as the denylist. Patterns are anchored at
+// the component root (a nil gitignore domain).
+func newFileFilter(component manifest.Component) fileFilter {
+	include := component.Include
+	if len(include) == 0 {
+		include = defaultInclude()
+	}
+
+	// defaultExclude returns a fresh slice, so appending the component's own
+	// patterns onto it neither mutates the defaults nor drops them.
+	exclude := append(defaultExclude(), component.Exclude...)
+
+	return fileFilter{
+		include: gitignore.NewMatcher(parsePatterns(include)),
+		exclude: gitignore.NewMatcher(parsePatterns(exclude)),
+	}
+}
+
+// parsePatterns parses each gitignore line at the tree root (nil domain).
+func parsePatterns(lines []string) []gitignore.Pattern {
+	out := make([]gitignore.Pattern, 0, len(lines))
+	for _, line := range lines {
+		out = append(out, gitignore.ParsePattern(line, nil))
+	}
+
+	return out
+}
+
+// keepFile reports whether the file at rel (path components relative to the
+// component root) is laid out: included by the allowlist and not excluded.
+func (f fileFilter) keepFile(rel []string) bool {
+	return f.include.Match(rel, false) && !f.exclude.Match(rel, false)
+}
+
+// pruneDir reports whether the directory at rel is an excluded subtree that the
+// walk should skip entirely. The include allowlist never prunes directories — a
+// directory itself rarely matches a file glob like *.lua, yet its files may —
+// so only the exclude denylist gates pruning.
+func (f fileFilter) pruneDir(rel []string) bool {
+	return f.exclude.Match(rel, true)
+}

--- a/cli/manifest/build/filter_test.go
+++ b/cli/manifest/build/filter_test.go
@@ -1,0 +1,76 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func TestFileFilter_defaultsKeepLuaAndSo(t *testing.T) {
+	t.Parallel()
+
+	f := newFileFilter(manifest.Component{})
+
+	assert.True(t, f.keepFile([]string{"init.lua"}))
+	assert.True(t, f.keepFile([]string{"lib", "foo.lua"}))
+	assert.True(t, f.keepFile([]string{"fast_hash.so"}))
+	assert.False(t, f.keepFile([]string{"README.md"}))
+	assert.False(t, f.keepFile([]string{"fast_hash.c"}))
+}
+
+func TestFileFilter_defaultExcludesAlwaysApply(t *testing.T) {
+	t.Parallel()
+
+	// A component whose include list would otherwise match everything still
+	// cannot ship the hazardous defaults.
+	f := newFileFilter(manifest.Component{Include: []string{"*"}})
+
+	assert.False(t, f.keepFile([]string{".hidden"}))
+	assert.False(t, f.keepFile([]string{manifestFileName}))
+	assert.True(t, f.pruneDir([]string{"test"}))
+	assert.True(t, f.pruneDir([]string{"tests"}))
+	assert.True(t, f.pruneDir([]string{"_build"}))
+	assert.True(t, f.pruneDir([]string{".rocks"}))
+	assert.True(t, f.pruneDir([]string{"_runtime"}))
+	assert.True(t, f.pruneDir([]string{"vendor"}))
+	assert.True(t, f.pruneDir([]string{".git"}))
+}
+
+func TestFileFilter_customIncludeReplacesDefault(t *testing.T) {
+	t.Parallel()
+
+	// A component narrowing to these two patterns no longer picks up a *.so at
+	// the root. An unanchored *.lua matches .lua files at any depth (gitignore
+	// basename matching).
+	f := newFileFilter(manifest.Component{Include: []string{"*.lua", "lib/*.lua"}})
+
+	assert.True(t, f.keepFile([]string{"init.lua"}))
+	assert.True(t, f.keepFile([]string{"lib", "helper.lua"}))
+	assert.True(t, f.keepFile([]string{"lib", "inner", "deep.lua"}))
+	assert.False(t, f.keepFile([]string{"prebuilt.so"}))
+}
+
+func TestFileFilter_anchoredIncludeIsDepthLimited(t *testing.T) {
+	t.Parallel()
+
+	// A slashed pattern is anchored to the component root: lib/*.lua matches
+	// files directly under lib/, not deeper and not at the root.
+	f := newFileFilter(manifest.Component{Include: []string{"lib/*.lua"}})
+
+	assert.True(t, f.keepFile([]string{"lib", "helper.lua"}))
+	assert.False(t, f.keepFile([]string{"lib", "inner", "deep.lua"}))
+	assert.False(t, f.keepFile([]string{"init.lua"}))
+}
+
+func TestFileFilter_customExcludeExtendsDefault(t *testing.T) {
+	t.Parallel()
+
+	f := newFileFilter(manifest.Component{Exclude: []string{"*.bak"}})
+
+	assert.False(t, f.keepFile([]string{"old.lua.bak"}))
+	// The defaults are still in force alongside the custom pattern.
+	assert.False(t, f.keepFile([]string{".hidden.lua"}))
+	assert.True(t, f.keepFile([]string{"init.lua"}))
+}

--- a/cli/manifest/build/hooks.go
+++ b/cli/manifest/build/hooks.go
@@ -1,0 +1,67 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/build/backend"
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+// Hook names, matching the manifest's [hooks.<name>] tables.
+const (
+	hookPreBuild  = "pre_build"
+	hookPostBuild = "post_build"
+)
+
+// runHook runs the named lifecycle hook if the manifest declares it, under the
+// reduced hook contract (TT_PACKAGE, TT_VERSION and friends, but no per-
+// component TT_OUTPUT_DIR / TT_COMPONENT_NAME). An absent hook is a no-op. The
+// hook runs in its own cwd (default: the project root), so pre_build can
+// generate files anywhere in the tree before components are gathered.
+func runHook(
+	ctx context.Context, man *manifest.Manifest, ver version.Version,
+	name, projectDir string, showOutput bool,
+) error {
+	hook, ok := man.Hooks[name]
+	if !ok {
+		return nil
+	}
+
+	env := backend.Env{
+		OutputDir:   "",
+		ProjectRoot: projectDir,
+		Package:     man.Package.Name,
+		Component:   "",
+		Version:     ver.SemVer,
+		OS:          "",
+		Arch:        "",
+		Extra:       hook.Env,
+	}
+
+	cwd := resolveDir(projectDir, hook.Cwd)
+
+	err := backend.RunHook(ctx, hook, cwd, env, showOutput)
+	if err != nil {
+		return fmt.Errorf("%s hook: %w", name, err)
+	}
+
+	return nil
+}
+
+// resolveDir resolves a manifest-supplied directory against the project root: an
+// empty value defaults to the root, an absolute value is used verbatim, and a
+// relative value is joined onto the root. The result is always absolute (the
+// backend contract requires it) as long as projectDir is.
+func resolveDir(projectDir, dir string) string {
+	switch {
+	case dir == "":
+		return projectDir
+	case filepath.IsAbs(dir):
+		return dir
+	default:
+		return filepath.Join(projectDir, dir)
+	}
+}

--- a/cli/manifest/build/layout.go
+++ b/cli/manifest/build/layout.go
@@ -1,0 +1,172 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Rocks-tree layout roots. Component .lua files land under the share subtree and
+// compiled .so modules under the lib subtree, mirroring where Tarantool's
+// require and box.schema.func look. The namespace segment is appended to these
+// (empty namespace => flat, no segment).
+const (
+	shareTarantool = "share/tarantool"
+	libTarantool   = "lib/tarantool"
+)
+
+// sharedObjectExt selects the lib subtree; every other kept file goes to share.
+const sharedObjectExt = ".so"
+
+// filePerm / dirPerm are the modes for laid-out files and their parents. Source
+// permissions are preserved when readable; these are the fallbacks.
+const (
+	filePerm os.FileMode = 0o644
+	dirPerm  os.FileMode = 0o750
+)
+
+// layoutComponent copies one component's files into the rocks tree under its
+// namespace. Files are taken from the component's path, filtered by
+// include/exclude (see fileFilter), and split by extension: .so into
+// <tree>/lib/tarantool/<namespace>/, everything else into
+// <tree>/share/tarantool/<namespace>/, each keeping its path relative to the
+// component root. An empty namespace yields a flat layout with no namespace
+// segment.
+//
+// It returns the absolute destination paths it wrote, in deterministic walk
+// order, so the caller can detect a component that laid down a file colliding
+// with the generated version.lua.
+func layoutComponent(
+	tree, pkgName string, component manifest.Component, compAbsPath string,
+) ([]string, error) {
+	filter := newFileFilter(component)
+	namespace := component.EffectiveNamespace(pkgName)
+
+	var written []string
+
+	walkErr := filepath.WalkDir(compAbsPath, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := relComponents(compAbsPath, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		// The component root itself is never a candidate and never pruned.
+		if len(rel) == 0 {
+			return nil
+		}
+
+		if entry.IsDir() {
+			if filter.pruneDir(rel) {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if !entry.Type().IsRegular() || !filter.keepFile(rel) {
+			return nil
+		}
+
+		dst := destPath(tree, namespace, rel)
+
+		copyErr := copyFile(path, dst)
+		if copyErr != nil {
+			return fmt.Errorf("laying out %s: %w", filepath.Join(rel...), copyErr)
+		}
+
+		written = append(written, dst)
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("component %q: %w", component.Path, walkErr)
+	}
+
+	return written, nil
+}
+
+// relComponents returns path split into slash-separated components relative to
+// root. The component root itself yields an empty slice.
+func relComponents(root, path string) ([]string, error) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, fmt.Errorf("relativizing %q: %w", path, err)
+	}
+
+	if rel == "." {
+		return nil, nil
+	}
+
+	return strings.Split(filepath.ToSlash(rel), "/"), nil
+}
+
+// destPath builds the absolute destination for a kept file: the share or lib
+// subtree (by .so extension), the namespace segment when non-empty, then the
+// file's path relative to the component root.
+func destPath(tree, namespace string, rel []string) string {
+	sub := shareTarantool
+	if strings.HasSuffix(rel[len(rel)-1], sharedObjectExt) {
+		sub = libTarantool
+	}
+
+	parts := []string{tree, sub}
+	if namespace != "" {
+		parts = append(parts, namespace)
+	}
+
+	parts = append(parts, rel...)
+
+	return filepath.Join(parts...)
+}
+
+// copyFile copies src to dst, creating dst's parent directory and preserving
+// the source's permission bits (falling back to filePerm when unreadable).
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src) //nolint:gosec // Copies the caller's own component files.
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+
+	defer func() { _ = srcFile.Close() }()
+
+	mode := filePerm
+
+	info, statErr := srcFile.Stat()
+	if statErr == nil && info.Mode().Perm() != 0 {
+		mode = info.Mode().Perm()
+	}
+
+	mkErr := os.MkdirAll(filepath.Dir(dst), dirPerm)
+	if mkErr != nil {
+		return fmt.Errorf("create destination dir: %w", mkErr)
+	}
+
+	//nolint:gosec // dst is derived from the manifest's own component tree.
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	if copyErr != nil {
+		_ = dstFile.Close()
+
+		return fmt.Errorf("copy contents: %w", copyErr)
+	}
+
+	closeErr := dstFile.Close()
+	if closeErr != nil {
+		return fmt.Errorf("close destination: %w", closeErr)
+	}
+
+	return nil
+}

--- a/cli/manifest/build/layout_test.go
+++ b/cli/manifest/build/layout_test.go
@@ -1,0 +1,114 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// writeFile creates path (with parents) and writes content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// seedComponentTree lays down a representative component tree under root and
+// returns root.
+func seedComponentTree(t *testing.T, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, "init.lua"), "-- init")
+	writeFile(t, filepath.Join(root, "lib", "foo.lua"), "-- foo")
+	writeFile(t, filepath.Join(root, "prebuilt.so"), "so")
+	writeFile(t, filepath.Join(root, "README.md"), "readme")
+	writeFile(t, filepath.Join(root, "fast_hash.c"), "int main(){}")
+	writeFile(t, filepath.Join(root, "test", "spec.lua"), "-- test")
+	writeFile(t, filepath.Join(root, ".hidden.lua"), "-- hidden")
+	writeFile(t, filepath.Join(root, manifestFileName), "manifest")
+}
+
+// relSet returns the tree-relative slash paths of files present under tree.
+func relSet(t *testing.T, tree string) []string {
+	t.Helper()
+	var out []string
+	require.NoError(t, filepath.Walk(tree, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			rel, relErr := filepath.Rel(tree, path)
+			require.NoError(t, relErr)
+			out = append(out, filepath.ToSlash(rel))
+		}
+		return nil
+	}))
+	sort.Strings(out)
+	return out
+}
+
+func TestLayoutComponent_defaultNamespaceSplitsByExt(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	tree := filepath.Join(project, ".rocks")
+	seedComponentTree(t, project)
+
+	written, err := layoutComponent(tree, "my-app", manifest.Component{Path: "."}, project)
+	require.NoError(t, err)
+
+	// .lua goes to share, .so to lib, both under the my-app namespace; the
+	// README, C source, test/, hidden and manifest files are all filtered out.
+	assert.ElementsMatch(t, []string{
+		"lib/tarantool/my-app/prebuilt.so",
+		"share/tarantool/my-app/init.lua",
+		"share/tarantool/my-app/lib/foo.lua",
+	}, relSet(t, tree))
+
+	// Returned destinations are the absolute paths written.
+	assert.Contains(t, written, filepath.Join(tree, "share/tarantool/my-app/init.lua"))
+	assert.Len(t, written, 3)
+}
+
+func TestLayoutComponent_emptyNamespaceIsFlat(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	tree := filepath.Join(project, ".rocks")
+	seedComponentTree(t, project)
+
+	empty := ""
+	component := manifest.Component{Path: ".", Namespace: &empty}
+	_, err := layoutComponent(tree, "my-app", component, project)
+	require.NoError(t, err)
+
+	// No namespace segment: artifacts land directly under lib/ and share/.
+	assert.ElementsMatch(t, []string{
+		"lib/tarantool/prebuilt.so",
+		"share/tarantool/init.lua",
+		"share/tarantool/lib/foo.lua",
+	}, relSet(t, tree))
+}
+
+func TestLayoutComponent_subdirComponentPath(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	tree := filepath.Join(project, ".rocks")
+	writeFile(t, filepath.Join(project, "native", "fast_hash.so"), "so")
+	writeFile(t, filepath.Join(project, "native", "fast_hash.c"), "int main(){}")
+
+	compPath := filepath.Join(project, "native")
+	_, err := layoutComponent(tree, "my-app", manifest.Component{Path: "native/"}, compPath)
+	require.NoError(t, err)
+
+	// Paths are relative to the component root, not the project root.
+	assert.ElementsMatch(t, []string{
+		"lib/tarantool/my-app/fast_hash.so",
+	}, relSet(t, tree))
+}

--- a/cli/manifest/build/lockgate.go
+++ b/cli/manifest/build/lockgate.go
@@ -1,0 +1,116 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// resolver is the slice of resolve.Engine the lock gate drives: report whether
+// a lock is stale and (re)resolve a manifest into a fresh lock. *resolve.Engine
+// satisfies it; tests substitute a fake so the gate's --locked branching can be
+// exercised without a registry.
+type resolver interface {
+	IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, string, error)
+	Resolve(ctx context.Context, man *manifest.Manifest) (*manifest.Lock, []string, error)
+}
+
+// loadLock reads and parses the lock next to the manifest. It never resolves —
+// this is the tt package fetch path, which materializes strictly from the lock.
+// A missing lock is errNoLock (exit 1): there is nothing to fetch from.
+func loadLock(projectDir string) (*manifest.Lock, error) {
+	path := filepath.Join(projectDir, lockFileName)
+
+	data, err := os.ReadFile(path) //nolint:gosec // Reads the caller's own lock.
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, exitErrorf(exitStateError, "%w: %s not found", errNoLock, lockFileName)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", lockFileName, err)
+	}
+
+	lock, err := manifest.ParseLock(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", lockFileName, err)
+	}
+
+	return lock, nil
+}
+
+// gateLock resolves the lock per the --locked gate and reports whether the lock
+// was rewritten:
+//
+//   - No lock on disk: --locked fails (errLockStale, exit 1); otherwise resolve
+//     fresh and write it.
+//   - Lock present and stale: --locked fails with the staleness reason (exit 1);
+//     otherwise re-resolve and rewrite.
+//   - Lock present and fresh: use it as is, no rewrite.
+//
+// This is what separates build from fetch: an unflagged build silently updates
+// the lock, while fetch (loadLock) never resolves.
+func gateLock(
+	ctx context.Context, res resolver, man *manifest.Manifest, projectDir string, locked bool,
+) (*manifest.Lock, []string, error) {
+	path := filepath.Join(projectDir, lockFileName)
+
+	data, readErr := os.ReadFile(path) //nolint:gosec // Reads the caller's own lock.
+	if errors.Is(readErr, os.ErrNotExist) {
+		if locked {
+			return nil, nil, exitErrorf(exitStateError,
+				"%w: %s not found and --locked forbids resolving", errLockStale, lockFileName)
+		}
+
+		return resolveAndWrite(ctx, res, man, path)
+	}
+
+	if readErr != nil {
+		return nil, nil, fmt.Errorf("reading %s: %w", lockFileName, readErr)
+	}
+
+	lock, err := manifest.ParseLock(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing %s: %w", lockFileName, err)
+	}
+
+	stale, reason, err := res.IsStale(man, lock)
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking lock staleness: %w", err)
+	}
+
+	if !stale {
+		return lock, nil, nil
+	}
+
+	if locked {
+		return nil, nil, exitErrorf(exitStateError, "%w: %s (--locked)", errLockStale, reason)
+	}
+
+	return resolveAndWrite(ctx, res, man, path)
+}
+
+// resolveAndWrite resolves man into a fresh lock and writes it to path.
+func resolveAndWrite(
+	ctx context.Context, res resolver, man *manifest.Manifest, path string,
+) (*manifest.Lock, []string, error) {
+	lock, warnings, err := res.Resolve(ctx, man)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
+	out, err := lock.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshaling %s: %w", lockFileName, err)
+	}
+
+	writeErr := os.WriteFile(path, out, filePerm)
+	if writeErr != nil {
+		return nil, nil, fmt.Errorf("writing %s: %w", lockFileName, writeErr)
+	}
+
+	return lock, warnings, nil
+}

--- a/cli/manifest/build/lockgate_test.go
+++ b/cli/manifest/build/lockgate_test.go
@@ -1,0 +1,144 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// fakeResolver drives the lock gate without a registry.
+type fakeResolver struct {
+	stale         bool
+	reason        string
+	fresh         *manifest.Lock
+	resolveCalled bool
+}
+
+func (f *fakeResolver) IsStale(*manifest.Manifest, *manifest.Lock) (bool, string, error) {
+	return f.stale, f.reason, nil
+}
+
+func (f *fakeResolver) Resolve(
+	context.Context, *manifest.Manifest,
+) (*manifest.Lock, []string, error) {
+	f.resolveCalled = true
+	return f.fresh, nil, nil
+}
+
+// freshLock is a minimal, round-trippable lock the fake resolver returns.
+func freshLock() *manifest.Lock {
+	return &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: "0.1",
+		GeneratedBy:     "tt test",
+		ManifestHash:    "sha256:new",
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+			}},
+		},
+	}
+}
+
+// writeLock marshals lock into projectDir.
+func writeLock(t *testing.T, projectDir string, lock *manifest.Lock) {
+	t.Helper()
+	data, err := lock.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, lockFileName), data, 0o600))
+}
+
+func lockOnDisk(t *testing.T, projectDir string) *manifest.Lock {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(projectDir, lockFileName)) //nolint:gosec // temp path
+	require.NoError(t, err)
+	lock, err := manifest.ParseLock(data)
+	require.NoError(t, err)
+	return lock
+}
+
+func TestGateLock_noLockResolvesAndWrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r := &fakeResolver{fresh: freshLock()}
+
+	lock, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, false)
+	require.NoError(t, err)
+	assert.True(t, r.resolveCalled)
+	assert.Contains(t, lock.Products, "default")
+	// The freshly resolved lock is persisted.
+	assert.Equal(t, "sha256:new", lockOnDisk(t, dir).ManifestHash)
+}
+
+func TestGateLock_noLockUnderLockedFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	r := &fakeResolver{fresh: freshLock()}
+
+	_, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, true)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errLockStale))
+	assert.Equal(t, exitStateError, ExitCode(err))
+	assert.False(t, r.resolveCalled)
+}
+
+func TestGateLock_freshLockReused(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existing := freshLock()
+	existing.ManifestHash = "sha256:existing"
+	writeLock(t, dir, existing)
+
+	r := &fakeResolver{stale: false}
+	lock, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, true)
+	require.NoError(t, err)
+	assert.False(t, r.resolveCalled)
+	assert.Equal(t, "sha256:existing", lock.ManifestHash)
+}
+
+func TestGateLock_staleUnlockedRewrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existing := freshLock()
+	existing.ManifestHash = "sha256:existing"
+	writeLock(t, dir, existing)
+
+	r := &fakeResolver{stale: true, reason: "manifest changed", fresh: freshLock()}
+	_, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, false)
+	require.NoError(t, err)
+	assert.True(t, r.resolveCalled)
+	assert.Equal(t, "sha256:new", lockOnDisk(t, dir).ManifestHash)
+}
+
+func TestGateLock_staleLockedFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeLock(t, dir, freshLock())
+
+	r := &fakeResolver{stale: true, reason: "manifest changed"}
+	_, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, true)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errLockStale))
+	assert.Contains(t, err.Error(), "manifest changed")
+	assert.False(t, r.resolveCalled)
+}
+
+func TestLoadLock_missingIsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadLock(t.TempDir())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoLock))
+}

--- a/cli/manifest/build/materialize.go
+++ b/cli/manifest/build/materialize.go
@@ -1,0 +1,99 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/tarantool/go-luarocks/client"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Lock dependency sources (mirrors the closed set the resolver writes).
+const (
+	sourceRegistry = "registry"
+	sourcePath     = "path"
+)
+
+// rockClient is the slice of go-luarocks' *client.Rocks the materializer drives:
+// fetch-and-build a pinned registry rock into the tree, or build a path
+// dependency's rockspec in place. *client.Rocks satisfies it; tests fake it so
+// the lock walk is exercised without a registry or a compiler.
+type rockClient interface {
+	Install(ctx context.Context, name string, opts client.InstallOpts) error
+	Build(ctx context.Context, specPath string, opts client.BuildOpts) error
+}
+
+// materialize realizes a product's pinned closure into the rocks tree, in the
+// lock's topological order so every dependency is present before the rock that
+// needs it. This is the whole of tt package fetch and step 4 of tt package
+// build.
+//
+// Registry rocks are installed at their exact locked version with dependency
+// resolution off (DepsNone): the closure is already complete and ordered, so no
+// rock re-resolves its own deps. Path dependencies are built from the single
+// rockspec in their directory; a leaf path dependency that ships no rockspec is
+// nothing to build and is skipped.
+func materialize(
+	ctx context.Context, client rockClient, projectDir string, prod manifest.LockProduct,
+) error {
+	for _, dep := range prod.Dependencies {
+		depErr := materializeDep(ctx, client, projectDir, dep)
+		if depErr != nil {
+			return depErr
+		}
+	}
+
+	return nil
+}
+
+// materializeDep materializes one locked dependency.
+func materializeDep(
+	ctx context.Context, rockClient rockClient, projectDir string, dep manifest.LockDependency,
+) error {
+	switch dep.Source {
+	case sourceRegistry:
+		opts := client.InstallOpts{Version: dep.Version, Servers: nil, Deps: client.DepsNone}
+
+		installErr := rockClient.Install(ctx, dep.Name, opts)
+		if installErr != nil {
+			return fmt.Errorf("installing %s %s: %w", dep.Name, dep.Version, installErr)
+		}
+
+		return nil
+	case sourcePath:
+		return materializePathDep(ctx, rockClient, projectDir, dep)
+	default:
+		return fmt.Errorf("dependency %q: %w %q", dep.Name, errUnknownSource, dep.Source)
+	}
+}
+
+// materializePathDep builds a path dependency from the rockspec in its
+// directory. A directory with no rockspec is a leaf pinned by content hash with
+// nothing to build; more than one rockspec is ambiguous and is an error.
+func materializePathDep(
+	ctx context.Context, rockClient rockClient, projectDir string, dep manifest.LockDependency,
+) error {
+	dir := filepath.Join(projectDir, dep.Path)
+
+	specs, err := filepath.Glob(filepath.Join(dir, "*.rockspec"))
+	if err != nil {
+		return fmt.Errorf("path dependency %q: %w", dep.Name, err)
+	}
+
+	switch len(specs) {
+	case 0:
+		return nil
+	case 1:
+		buildErr := rockClient.Build(ctx, specs[0], client.BuildOpts{Keep: false})
+		if buildErr != nil {
+			return fmt.Errorf("building path dependency %q: %w", dep.Name, buildErr)
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("path dependency %q: %w (%d in %s)",
+			dep.Name, errAmbiguousRockspec, len(specs), dir)
+	}
+}

--- a/cli/manifest/build/materialize_test.go
+++ b/cli/manifest/build/materialize_test.go
@@ -1,0 +1,104 @@
+package build
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-luarocks/client"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// fakeRockClient records the Install/Build calls the materializer makes.
+type fakeRockClient struct {
+	installs []installCall
+	builds   []string
+	err      error
+}
+
+type installCall struct {
+	name string
+	opts client.InstallOpts
+}
+
+func (f *fakeRockClient) Install(_ context.Context, name string, opts client.InstallOpts) error {
+	f.installs = append(f.installs, installCall{name: name, opts: opts})
+	return f.err
+}
+
+func (f *fakeRockClient) Build(_ context.Context, specPath string, _ client.BuildOpts) error {
+	f.builds = append(f.builds, specPath)
+	return f.err
+}
+
+func TestMaterialize_registryDepsPinnedNoDeps(t *testing.T) {
+	t.Parallel()
+
+	rc := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+		{Name: "metrics", Version: "1.5.0-1", Source: sourceRegistry},
+	}}
+
+	require.NoError(t, materialize(context.Background(), rc, t.TempDir(), prod))
+
+	require.Len(t, rc.installs, 2)
+	// Order is preserved (topological), each pinned to the exact version with
+	// dependency resolution off.
+	assert.Equal(t, "checks", rc.installs[0].name)
+	assert.Equal(t, "3.1.0-1", rc.installs[0].opts.Version)
+	assert.Equal(t, client.DepsNone, rc.installs[0].opts.Deps)
+	assert.Equal(t, "metrics", rc.installs[1].name)
+	assert.Empty(t, rc.builds)
+}
+
+func TestMaterialize_pathDepBuildsRockspec(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "vendor", "mylib", "mylib-scm-1.rockspec"), "-- spec")
+
+	rc := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "mylib", Source: sourcePath, Path: "vendor/mylib"},
+	}}
+
+	require.NoError(t, materialize(context.Background(), rc, project, prod))
+
+	require.Len(t, rc.builds, 1)
+	assert.Equal(t, filepath.Join(project, "vendor", "mylib", "mylib-scm-1.rockspec"), rc.builds[0])
+	assert.Empty(t, rc.installs)
+}
+
+func TestMaterialize_leafPathDepIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "vendor", "leaf", "leaf.lua"), "-- leaf")
+
+	rc := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "leaf", Source: sourcePath, Path: "vendor/leaf"},
+	}}
+
+	require.NoError(t, materialize(context.Background(), rc, project, prod))
+	assert.Empty(t, rc.builds)
+	assert.Empty(t, rc.installs)
+}
+
+func TestMaterialize_unknownSource(t *testing.T) {
+	t.Parallel()
+
+	rc := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "weird", Source: "http"},
+	}}
+
+	err := materialize(context.Background(), rc, t.TempDir(), prod)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnknownSource)
+}

--- a/cli/manifest/build/product.go
+++ b/cli/manifest/build/product.go
@@ -1,0 +1,58 @@
+package build
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// selectProduct picks the product the build acts on. A non-empty name selects
+// that product (errUnknownProduct if it does not exist). With no name: a single
+// product is used implicitly; otherwise the one flagged default is chosen
+// (errNoDefaultProduct if none is, which Validate normally rejects first). It
+// returns the product name so callers can index the lock's per-product closure.
+func selectProduct(man *manifest.Manifest, name string) (string, manifest.Product, error) {
+	if len(man.Products) == 0 {
+		return "", manifest.Product{}, errNoProducts
+	}
+
+	if name != "" {
+		product, ok := man.Products[name]
+		if !ok {
+			return "", manifest.Product{}, fmt.Errorf("%w: %q", errUnknownProduct, name)
+		}
+
+		return name, product, nil
+	}
+
+	if len(man.Products) == 1 {
+		for only, product := range man.Products {
+			return only, product, nil
+		}
+	}
+
+	for chosen, product := range man.Products {
+		if product.Default {
+			return chosen, product, nil
+		}
+	}
+
+	return "", manifest.Product{}, errNoDefaultProduct
+}
+
+// selectComponents returns the component names the build processes for product:
+// every component of the product, or the single named one when component is
+// non-empty (errUnknownComponent if that name is not in the product).
+func selectComponents(product manifest.Product, component string) ([]string, error) {
+	if component == "" {
+		return product.Components, nil
+	}
+
+	if slices.Contains(product.Components, component) {
+		return []string{component}, nil
+	}
+
+	return nil, fmt.Errorf("%w: %q is not a component of the selected product",
+		errUnknownComponent, component)
+}

--- a/cli/manifest/build/product_test.go
+++ b/cli/manifest/build/product_test.go
@@ -1,0 +1,98 @@
+package build
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func multiProductManifest() *manifest.Manifest {
+	return &manifest.Manifest{
+		Package: manifest.Package{Name: "my-app"},
+		Components: map[string]manifest.Component{
+			"lua":    {Path: "."},
+			"native": {Path: "native/"},
+			"extra":  {Path: "extra/"},
+		},
+		Products: map[string]manifest.Product{
+			"default": {Components: []string{"lua", "native"}, Default: true},
+			"minimal": {Components: []string{"lua"}},
+		},
+	}
+}
+
+func TestSelectProduct_default(t *testing.T) {
+	t.Parallel()
+
+	name, product, err := selectProduct(multiProductManifest(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "default", name)
+	assert.Equal(t, []string{"lua", "native"}, product.Components)
+}
+
+func TestSelectProduct_named(t *testing.T) {
+	t.Parallel()
+
+	name, product, err := selectProduct(multiProductManifest(), "minimal")
+	require.NoError(t, err)
+	assert.Equal(t, "minimal", name)
+	assert.Equal(t, []string{"lua"}, product.Components)
+}
+
+func TestSelectProduct_unknown(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := selectProduct(multiProductManifest(), "nope")
+	assert.True(t, errors.Is(err, errUnknownProduct))
+}
+
+func TestSelectProduct_singleImplicitDefault(t *testing.T) {
+	t.Parallel()
+
+	man := &manifest.Manifest{
+		Components: map[string]manifest.Component{"lua": {Path: "."}},
+		Products: map[string]manifest.Product{
+			"solo": {Components: []string{"lua"}},
+		},
+	}
+	name, _, err := selectProduct(man, "")
+	require.NoError(t, err)
+	assert.Equal(t, "solo", name)
+}
+
+func TestSelectProduct_noProducts(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := selectProduct(&manifest.Manifest{}, "")
+	assert.True(t, errors.Is(err, errNoProducts))
+}
+
+func TestSelectComponents_all(t *testing.T) {
+	t.Parallel()
+
+	product := manifest.Product{Components: []string{"lua", "native"}}
+	got, err := selectComponents(product, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"lua", "native"}, got)
+}
+
+func TestSelectComponents_one(t *testing.T) {
+	t.Parallel()
+
+	product := manifest.Product{Components: []string{"lua", "native"}}
+	got, err := selectComponents(product, "native")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"native"}, got)
+}
+
+func TestSelectComponents_unknown(t *testing.T) {
+	t.Parallel()
+
+	product := manifest.Product{Components: []string{"lua"}}
+	_, err := selectComponents(product, "native")
+	assert.True(t, errors.Is(err, errUnknownComponent))
+}

--- a/cli/manifest/build/run_test.go
+++ b/cli/manifest/build/run_test.go
@@ -1,0 +1,289 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// baseManifest is a one-product my-app: a pure-Lua component and a "native"
+// component whose .so is produced by a shell backend (so the full orchestration
+// runs without a compiler, Tarantool or a registry). It covers every cycle step
+// except the live cc compile, which lives in the build-tagged e2e test.
+const baseManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0,<4.0.0'
+tt = '>=3.1.0'
+
+[components.lua]
+path = '.'
+include = ['*.lua']
+
+[components.native]
+path = 'native/'
+
+[components.native.build]
+backend = 'shell'
+command = 'sh'
+args = ['-c', 'echo built > fast_hash.so']
+output = ['fast_hash.so']
+
+[products.default]
+components = ['lua', 'native']
+default = true
+`
+
+// setupProject writes a manifest, a VERSION file (so version.Derive is
+// deterministic without git) and the given extra files into a fresh temp dir.
+func setupProject(t *testing.T, manifest string, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, manifestFileName), manifest)
+	writeFile(t, filepath.Join(dir, "VERSION"), "1.2.3\n")
+	for name, content := range files {
+		writeFile(t, filepath.Join(dir, name), content)
+	}
+
+	return dir
+}
+
+// dryOptions builds Options that need neither a compiler nor a network: the
+// dummy Tarantool facts are enough for shell/make backends and a dependency-free
+// closure.
+func dryOptions(dir string) Options {
+	return Options{
+		ProjectDir: dir,
+		TtVersion:  "tt test",
+		Tarantool:  rocks.TarantoolInfo{Prefix: "/nonexistent", Version: "3.0.0"},
+	}
+}
+
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		require.NoError(t, err)
+	}
+	return err == nil
+}
+
+func TestRun_fullBuild(t *testing.T) {
+	t.Parallel()
+
+	dir := setupProject(t, baseManifest, map[string]string{
+		"init.lua":     "-- init",
+		"lib/foo.lua":  "-- foo",
+		"native/x.txt": "keep native dir",
+	})
+
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	tree := filepath.Join(dir, ".rocks")
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/init.lua")))
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/lib/foo.lua")))
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/version.lua")))
+	// Default namespace places the native artifact under my-app.
+	assert.True(t, exists(t, filepath.Join(tree, "lib/tarantool/my-app/fast_hash.so")))
+	// The lock was written.
+	assert.True(t, exists(t, filepath.Join(dir, lockFileName)))
+
+	vluaPath := filepath.Join(tree, "share/tarantool/my-app/version.lua")
+	data, err := os.ReadFile(vluaPath) //nolint:gosec // temp path
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `version  = "1.2.3"`)
+}
+
+func TestRun_productSelectsComponentSet(t *testing.T) {
+	t.Parallel()
+
+	const manifest = baseManifest + `
+[products.minimal]
+components = ['lua']
+`
+	dir := setupProject(t, manifest, map[string]string{"init.lua": "-- init"})
+
+	opts := dryOptions(dir)
+	opts.Product = "minimal"
+	require.NoError(t, Run(context.Background(), opts))
+
+	tree := filepath.Join(dir, ".rocks")
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/init.lua")))
+	// The native component is not part of the minimal product.
+	assert.False(t, exists(t, filepath.Join(tree, "lib/tarantool/my-app/fast_hash.so")))
+}
+
+func TestRun_emptyNamespaceIsFlat(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0,<4.0.0'
+tt = '>=3.1.0'
+
+[components.native]
+path = 'native/'
+namespace = ''
+
+[components.native.build]
+backend = 'shell'
+command = 'sh'
+args = ['-c', 'echo built > fast_hash.so']
+output = ['fast_hash.so']
+
+[products.default]
+components = ['native']
+default = true
+`
+	dir := setupProject(t, manifest, map[string]string{"native/x.txt": "x"})
+
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	tree := filepath.Join(dir, ".rocks")
+	// Empty namespace: the artifact lands flat under lib/tarantool.
+	assert.True(t, exists(t, filepath.Join(tree, "lib/tarantool/fast_hash.so")))
+	assert.False(t, exists(t, filepath.Join(tree, "lib/tarantool/my-app/fast_hash.so")))
+}
+
+func TestRun_lockedGate(t *testing.T) {
+	t.Parallel()
+
+	dir := setupProject(t, baseManifest, map[string]string{
+		"init.lua":           "-- init",
+		"native/fast_hash.c": "int x;",
+	})
+
+	// First build writes the lock.
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	// --locked on a fresh lock builds fine.
+	locked := dryOptions(dir)
+	locked.Locked = true
+	require.NoError(t, Run(context.Background(), locked))
+
+	// Change the manifest so the lock goes stale, then --locked must fail (1).
+	writeFile(t, filepath.Join(dir, manifestFileName), baseManifest+"\n# drift\n")
+	err := Run(context.Background(), locked)
+	require.Error(t, err)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+func TestRun_versionLuaCollision(t *testing.T) {
+	t.Parallel()
+
+	dir := setupProject(t, baseManifest, map[string]string{
+		"init.lua":           "-- init",
+		"version.lua":        "-- shipped by the component",
+		"native/fast_hash.c": "int x;",
+	})
+
+	// The lua component (include *.lua) lays version.lua into the package
+	// namespace, colliding with the generated one.
+	err := Run(context.Background(), dryOptions(dir))
+	require.Error(t, err)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+func TestRun_generateVersionLuaDisabled(t *testing.T) {
+	t.Parallel()
+
+	const manifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+generate_version_lua = false
+
+[platform]
+tarantool = '>=3.0.0,<4.0.0'
+tt = '>=3.1.0'
+
+[components.lua]
+path = '.'
+include = ['*.lua']
+
+[products.default]
+components = ['lua']
+default = true
+`
+	dir := setupProject(t, manifest, map[string]string{"init.lua": "-- init"})
+
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	tree := filepath.Join(dir, ".rocks")
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/init.lua")))
+	assert.False(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/version.lua")))
+}
+
+func TestRun_preBuildGeneratedFileIncluded(t *testing.T) {
+	t.Parallel()
+
+	const manifest = baseManifest + `
+[hooks.pre_build]
+backend = 'shell'
+command = 'sh'
+args = ['-c', 'echo generated > generated.lua']
+`
+	dir := setupProject(t, manifest, map[string]string{
+		"init.lua":           "-- init",
+		"native/fast_hash.c": "int x;",
+	})
+
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	// pre_build ran before component gathering, so its output is laid out.
+	tree := filepath.Join(dir, ".rocks")
+	assert.True(t, exists(t, filepath.Join(tree, "share/tarantool/my-app/generated.lua")))
+}
+
+func TestRun_fetchMaterializesWithoutBackends(t *testing.T) {
+	t.Parallel()
+
+	dir := setupProject(t, baseManifest, map[string]string{
+		"init.lua":           "-- init",
+		"native/fast_hash.c": "int x;",
+	})
+
+	// Build first so a lock exists.
+	require.NoError(t, Run(context.Background(), dryOptions(dir)))
+
+	tree := filepath.Join(dir, ".rocks")
+	so := filepath.Join(tree, "lib/tarantool/my-app/fast_hash.so")
+	vlua := filepath.Join(tree, "share/tarantool/my-app/version.lua")
+	require.NoError(t, os.Remove(so))
+	require.NoError(t, os.Remove(vlua))
+
+	// Fetch runs materialization only; with no deps it neither rebuilds the
+	// native artifact nor regenerates version.lua.
+	opts := dryOptions(dir)
+	opts.FetchOnly = true
+	require.NoError(t, Run(context.Background(), opts))
+
+	assert.False(t, exists(t, so))
+	assert.False(t, exists(t, vlua))
+}
+
+func TestRun_fetchWithoutLockFails(t *testing.T) {
+	t.Parallel()
+
+	dir := setupProject(t, baseManifest, map[string]string{"init.lua": "-- init"})
+
+	opts := dryOptions(dir)
+	opts.FetchOnly = true
+	err := Run(context.Background(), opts)
+	require.Error(t, err)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}

--- a/cli/manifest/build/versionlua.go
+++ b/cli/manifest/build/versionlua.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+// versionLuaName is the descriptor file dropped into the package's own share
+// namespace.
+const versionLuaName = "version.lua"
+
+// writeVersionLua generates version.lua at <tree>/share/tarantool/<package>/
+// unless package.generate_version_lua = false. It is written under the package
+// name, not a component namespace: it describes the package as a whole.
+//
+// A component that already laid a file at that exact path is a collision — two
+// sources claiming version.lua — and is a hard error (exit code 1 at the CLI).
+// laidOut is the set of destinations layoutComponent reported this run, so a
+// stale version.lua left by a previous build does not count as a collision: it
+// is simply overwritten.
+func writeVersionLua(
+	tree, pkgName string, generate bool, ver version.Version, builtAt time.Time,
+	laidOut []string,
+) error {
+	if !generate {
+		return nil
+	}
+
+	dst := filepath.Join(tree, shareTarantool, pkgName, versionLuaName)
+
+	if slices.Contains(laidOut, dst) {
+		return exitErrorf(exitStateError,
+			"%w: component ships %s at %s, which the build also generates",
+			errVersionLuaCollision, versionLuaName, dst)
+	}
+
+	content := version.GenerateVersionLua(ver, builtAt)
+
+	mkErr := os.MkdirAll(filepath.Dir(dst), dirPerm)
+	if mkErr != nil {
+		return fmt.Errorf("creating package share dir: %w", mkErr)
+	}
+
+	writeErr := os.WriteFile(dst, []byte(content), filePerm)
+	if writeErr != nil {
+		return fmt.Errorf("writing %s: %w", versionLuaName, writeErr)
+	}
+
+	return nil
+}

--- a/cli/manifest/build/versionlua_test.go
+++ b/cli/manifest/build/versionlua_test.go
@@ -1,0 +1,72 @@
+package build
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/version"
+)
+
+func TestWriteVersionLua_generates(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+	ver := version.Version{SemVer: "1.2.3", Commit: "abc1234", Flavor: "ce"}
+
+	err := writeVersionLua(tree, "my-app", true, ver, time.Unix(0, 0), nil)
+	require.NoError(t, err)
+
+	vlua := filepath.Join(tree, "share/tarantool/my-app/version.lua")
+	data, err := os.ReadFile(vlua) //nolint:gosec // temp path
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `version  = "1.2.3"`)
+	assert.Contains(t, string(data), `flavor   = "ce"`)
+}
+
+func TestWriteVersionLua_disabledWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+
+	err := writeVersionLua(tree, "my-app", false, version.Version{}, time.Unix(0, 0), nil)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(tree, "share/tarantool/my-app/version.lua"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestWriteVersionLua_collisionWithLaidOutFile(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+	dst := filepath.Join(tree, "share/tarantool/my-app/version.lua")
+
+	// A component laid a version.lua at the exact generated path this run.
+	err := writeVersionLua(tree, "my-app", true, version.Version{}, time.Unix(0, 0), []string{dst})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errVersionLuaCollision))
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+func TestWriteVersionLua_staleFileOverwritten(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+	dst := filepath.Join(tree, "share/tarantool/my-app/version.lua")
+	writeFile(t, dst, "-- stale from a previous build")
+
+	// The stale file is not in laidOut, so it is overwritten, not a collision.
+	err := writeVersionLua(tree, "my-app", true,
+		version.Version{SemVer: "9.9.9"}, time.Unix(0, 0), nil)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(dst) //nolint:gosec // temp path
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `version  = "9.9.9"`)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.23.2
 	github.com/fatih/color v1.18.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.8.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
@@ -79,7 +80,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-json-experiment/json v0.0.0-20251027170946-4849db3c2f7e // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/test/integration/completion/test_completion.py
+++ b/test/integration/completion/test_completion.py
@@ -31,6 +31,7 @@ tt_root_command: set[str] = set(
         "connect",
         "init",
         "pack",
+        "package",
         "start",
         "cat",
         "coredump",


### PR DESCRIPTION
Orchestrate the full package build cycle, stitching the earlier waves (model, version, resolver, rocks adapter, component backends) into one pass that materializes the project's .rocks/ tree. In order: derive the version, run pre_build, gate the lock (resolve and rewrite unless --locked), materialize the pinned closure, run each component's build backend, lay component files out under their install namespace, generate version.lua, then run post_build. tt package fetch is the same materialization step in isolation: strictly from the lock, no resolve and no backends.

Include/exclude uses go-git's gitignore matcher with the spec defaults (always-on hazard excludes plus the component's own patterns); .lua land under share/tarantool/<ns>/ and .so under lib/tarantool/<ns>/, flat when the namespace is empty. version.lua is generated under the package name and a component shipping one there is a collision (exit 1); a stale lock under --locked is exit 1; a component build backend failure is exit 2. Lifecycle hooks reuse the backend machinery through a new RunHook under the reduced contract (no TT_OUTPUT_DIR/TT_COMPONENT_NAME).

Filtering, layout, version.lua, product selection, the lock gate and materialization are unit-tested on fixtures; the live cc/Tarantool build of my-app is gated behind the integration tag.

Part of TNTP-8611