### PR TITLE
test: fix two flaky integration tests

### DIFF
--- a/.cspell_project-words.txt
+++ b/.cspell_project-words.txt
@@ -32,6 +32,7 @@ finalizer*
 flightrec
 getfixturevalue
 GKTTBACKUPTEST
+gofumpt
 golangci
 heywoodlh
 iconfig

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -830,7 +830,6 @@ type instanceProc struct {
 
 // Stop the Instances.
 func Stop(runs []InstanceCtx) error {
-
 	// Request an interruption for each process.
 	// This is done in advance to enable parallel termination.
 	procsToWait := make([]instanceProc, 0, len(runs))

--- a/test/integration/cluster/test_cluster_publish.py
+++ b/test/integration/cluster/test_cluster_publish.py
@@ -740,7 +740,7 @@ def test_cluster_publish_config_no_auth(
             tt_cmd,
             "cluster",
             "publish",
-            f"{instance.endpoint}/prefix?timeout=0.1",
+            f"{instance.endpoint}/prefix?timeout=5",
             "src.yaml",
         ]
         instance_process = subprocess.Popen(
@@ -775,7 +775,7 @@ def test_cluster_publish_config_bad_auth(
         tt_cmd,
         "cluster",
         "publish",
-        f"http://invalid_user:invalid_pass@{instance.endpoint}/prefix?timeout=0.1",
+        f"http://invalid_user:invalid_pass@{instance.endpoint}/prefix?timeout=5",
         "src.yaml",
     ]
     instance_process = subprocess.Popen(

--- a/test/integration/cluster/test_cluster_roles_add.py
+++ b/test/integration/cluster/test_cluster_roles_add.py
@@ -72,7 +72,7 @@ def test_cluster_rs_roles_add_no_auth(
             "roles",
             "add",
             "-f",
-            f"{instance.endpoint}/prefix?timeout=0.1",
+            f"{instance.endpoint}/prefix?timeout=5",
             "role",
             "-G",
         ]
@@ -100,7 +100,7 @@ def test_cluster_rs_roles_add_bad_auth(
         "rs",
         "roles",
         "add",
-        f"http://invalid_user:invalid:pass@{instance.endpoint}/prefix?timeout=0.1",
+        f"http://invalid_user:invalid:pass@{instance.endpoint}/prefix?timeout=5",
         "role",
         "-G",
     ]

--- a/test/integration/cluster/test_cluster_roles_remove.py
+++ b/test/integration/cluster/test_cluster_roles_remove.py
@@ -75,7 +75,7 @@ def test_cluster_rs_roles_remove_no_auth(
             "roles",
             "remove",
             "-f",
-            f"{instance.endpoint}/prefix?timeout=0.1",
+            f"{instance.endpoint}/prefix?timeout=5",
             "role",
             "-G",
         ]
@@ -103,7 +103,7 @@ def test_cluster_rs_roles_remove_bad_auth(
         "rs",
         "roles",
         "remove",
-        f"http://invalid_user:invalid:pass@{instance.endpoint}/prefix?timeout=0.1",
+        f"http://invalid_user:invalid:pass@{instance.endpoint}/prefix?timeout=5",
         "role",
         "-G",
     ]

--- a/test/integration/restart/test_restart.py
+++ b/test/integration/restart/test_restart.py
@@ -75,7 +75,9 @@ def wait_pid_files_changed(tt_app, instances, orig_status):
                 return False
         return True
 
-    return utils.wait_event(5, all_pids_changed)
+    # A restarted instance writes its PID file only once it has been spawned,
+    # which a loaded CI runner can drag out well past a few seconds.
+    return utils.wait_event(30, all_pids_changed)
 
 
 def check_restart(tt, tt_app, target, input, is_confirm, *args):
@@ -98,8 +100,10 @@ def check_restart(tt, tt_app, target, input, is_confirm, *args):
     discarding_msg = "Restart is cancelled."
     if is_confirm:
         assert discarding_msg not in out
-        # Make sure all involved PIDs are updated.
-        wait_pid_files_changed(tt_app, target_instances, orig_status)
+        # Make sure all involved PIDs are updated. A timeout here must fail
+        # loudly: otherwise the checks below race the instance start and report
+        # a bare "NOT RUNNING" instead.
+        assert wait_pid_files_changed(tt_app, target_instances, orig_status)
     else:
         # Check the discarding message.
         assert discarding_msg in out


### PR DESCRIPTION
Two integration tests raced a deadline that a loaded CI runner could blow
past. Both were observed failing on unrelated PRs, and both re-ran green on
an unchanged tree, so neither was a real product failure.

Related to TNTP-8611