### PR TITLE
test: run `mage integration` in docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
     && mv etcd-${ETCD_VERSION}-linux-amd64/etcd* /usr/local/bin/
 # install tt build requirements
 RUN  apt -y update \
-    && apt -y install git gcc make cmake unzip zip gdb libssl-dev \
+    && apt -y install git gcc make cmake unzip zip gdb libssl-dev bash-completion \
     && apt-get --allow-releaseinfo-change update \
     && apt-get -y -f install \
         build-essential ninja-build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# setup Python
+RUN apt update \
+    && apt install -y software-properties-common wget curl tar \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt update 
+
+RUN apt install -y python3.10 python3.10-dev python3.10-distutils python3.10-venv
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3.10 get-pip.py
+
+# setup Go
+ENV GO_VERSION=1.25.7
+ENV ETCD_VERSION=v3.5.9 
+ENV GOLANGCI_LINT_VERSION=v1.63.4
+ENV GO_OS=linux
+ENV GO_ARCH=amd64
+
+RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+# setup test environment
+RUN curl -L https://my.tech.vk.com/download/tarantool/3/installer.sh | bash \
+    && apt-get -y install tarantool tarantool-dev
+
+RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+    && tar xzvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+    && mv etcd-${ETCD_VERSION}-linux-amd64/etcd* /usr/local/bin/
+# install tt build requirements
+RUN  apt -y update \
+    && apt -y install git gcc make cmake unzip zip gdb libssl-dev \
+    && apt-get --allow-releaseinfo-change update \
+    && apt-get -y -f install \
+        build-essential ninja-build \
+        lua5.1 luarocks lcov \
+        ruby-dev liblz4-dev  autoconf \
+        automake libtool zsh fish \
+    && luarocks install luacheck 0.26.1 \
+    && gem install coveralls-lcov \
+    && pip3 install tarantool 
+
+COPY ./ /tt
+
+WORKDIR /tt
+# setup test environment
+RUN go install github.com/magefile/mage@latest \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+ENV PATH="${PATH}:/root/go/bin:/go/bin:/tt"
+RUN git submodule update --init --recursive
+RUN mage build
+RUN pip3 install -r test/requirements.txt
+# Stop Mono server
+RUN systemctl kill mono-xsp4 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-
     && mv etcd-${ETCD_VERSION}-linux-amd64/etcd* /usr/local/bin/
 # install tt build requirements
 RUN  apt -y update \
-    && apt -y install git gcc make cmake unzip zip gdb libssl-dev bash-completion \
+    && apt -y install git gcc make cmake unzip zip rsync gdb libssl-dev bash-completion \
     && apt-get --allow-releaseinfo-change update \
     && apt-get -y -f install \
         build-essential ninja-build \
@@ -56,3 +56,5 @@ RUN mage build
 RUN pip3 install -r test/requirements.txt
 # Stop Mono server
 RUN systemctl kill mono-xsp4 || true
+
+#RUN sysctl -w net.ipv6.conf.all.disable_ipv6=0

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ To run full set of tests:
 mage testfull
 ```
 
+To run integration test in containersed environment see `/test/docker/README.md`.
+
 ### Commit changes
 
 The project uses [pre-commit](https://pre-commit.com/) to check code before committing.

--- a/TEMP_run_local_tests.md
+++ b/TEMP_run_local_tests.md
@@ -1,7 +1,10 @@
 # build image 
 sudo docker build -t tt_test .
 # run
-sudo docker run -it --name tt_test_run tt_test /bin/bash
+docker network create --ipv6 --subnet fd01::/64 my-ipv6-network
+sudo docker run -it --security-opt seccomp=unconfined  --network my-ipv6-network --name tt_test_run tt_test /bin/bash
+
+
 container cmd:
 mage integration
 

--- a/TEMP_run_local_tests.md
+++ b/TEMP_run_local_tests.md
@@ -1,0 +1,10 @@
+# build image 
+sudo docker build -t tt_test .
+# run
+sudo docker run -it --name tt_test_run tt_test /bin/bash
+container cmd:
+mage integration
+
+# delete tmp
+sudo docker rm tt_test_run 
+sudo docker rmi tt_test

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM tt_integration_test_base
+COPY . /tt
+
+WORKDIR /tt
+RUN git submodule update --init --recursive
+ENV PATH="${PATH}:/root/go/bin:/go/bin:/tt"
+RUN mage build

--- a/test/docker/Dockerfile_base
+++ b/test/docker/Dockerfile_base
@@ -1,24 +1,28 @@
 FROM ubuntu:22.04
+# default tarantool version
+ARG TARANTOOL_VERSION=3.0.2
+
+# versions of test environment
+ENV GO_VERSION=1.25.7
+ENV ETCD_VERSION=v3.5.9 
+ENV GOLANGCI_LINT_VERSION=v1.63.4
+ENV TARANTOOL_VERSION=${TARANTOOL_VERSION}
+ENV GO_OS=linux
+ENV GO_ARCH=amd64
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 # setup Python
 RUN apt update \
-    && apt install -y software-properties-common wget curl tar \
+    && apt install -y software-properties-common curl tar \
     && add-apt-repository ppa:deadsnakes/ppa -y \
     && apt update 
 
 RUN apt install -y python3.10 python3.10-dev python3.10-distutils python3.10-venv
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3.10 get-pip.py
+RUN curl -O https://bootstrap.pypa.io/get-pip.py && python3.10 get-pip.py
 
 # setup Go
-ENV GO_VERSION=1.25.7
-ENV ETCD_VERSION=v3.5.9 
-ENV GOLANGCI_LINT_VERSION=v1.63.4
-ENV GO_OS=linux
-ENV GO_ARCH=amd64
-
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
@@ -26,9 +30,10 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz -o g
 ENV PATH="/usr/local/go/bin:${PATH}"
 # setup test environment
 RUN curl -L https://my.tech.vk.com/download/tarantool/3/installer.sh | bash \
-    && apt-get -y install tarantool tarantool-dev
+    && apt-get -y install tarantool=${TARANTOOL_VERSION}-1 \
+    && apt-get -y install tarantool-dev=${TARANTOOL_VERSION}-1
 
-RUN wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+RUN curl -L -O --retry 5 --retry-delay 5 --fail https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && tar xzvf etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
     && mv etcd-${ETCD_VERSION}-linux-amd64/etcd* /usr/local/bin/
 # install tt build requirements
@@ -44,17 +49,12 @@ RUN  apt -y update \
     && gem install coveralls-lcov \
     && pip3 install tarantool 
 
-COPY ./ /tt
-
-WORKDIR /tt
 # setup test environment
 RUN go install github.com/magefile/mage@latest \
     && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
-ENV PATH="${PATH}:/root/go/bin:/go/bin:/tt"
-RUN git submodule update --init --recursive
-RUN mage build
-RUN pip3 install -r test/requirements.txt
 # Stop Mono server
 RUN systemctl kill mono-xsp4 || true
 
-#RUN sysctl -w net.ipv6.conf.all.disable_ipv6=0
+COPY ./test/requirements.txt /tt/test/requirements.txt
+WORKDIR /tt
+RUN pip3 install -r /tt/test/requirements.txt

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -1,0 +1,9 @@
+# Running integration tests in a containerized environment
+
+The final image `tt_integration_test` includes all the necessary components to run the test. At the moment, only `mage integration` is functional.
+1. Create a base image that contains all necessary infrastructure (Tarantool, Etcd, etc.). `docker build -f ./test/docker/Dockerfile_base -t tt_integration_test_base .` The default Tarantool version is 3.0.2. If you need a different version, use the `--build-arg` flag to specify the desired version. Example: `docker build --build-arg TARANTOOL_VERSION=3.8.0 -f ./test/docker/Dockerfile_base -t tt_integration_test_base .`.
+2. Create an image that contains the current state of TT source files. This image is used for testing. Example: `docker build -f ./test/docker/Dockerfile -t tt_integration_test .`.
+3. Create a subnet for the tests, as the tests require IPv6. Example: `sudo docker build -f ./test/docker/Dockerfile -t tt_integration_test .`.
+4. Launch the test container with the following command: `docker run -it --security-opt seccomp=unconfined  --network my-ipv6-network --name tt_test_run tt_integration_test /bin/bash`.
+The `seccomp=unconfined` option is used to execute the unshare system call in the tests. 
+5) Run the `mage integration` test in container terminal.


### PR DESCRIPTION
Now the setting up of integration test environment is too complex. I suggest pack it into container.
Here i've packed into container `mage integration`.

`mage integration` runs in `tarantool 3.0.2` environment OK.
<img width="1232" height="139" alt="image" src="https://github.com/user-attachments/assets/22166eae-365c-437f-aed2-fecd4f69c18b" />
[tarantool 3_8 integration errors.log](https://github.com/user-attachments/files/30151887/tarantool.3_8.integration.errors.log)

I wants to attention that tt fails some tests in `tarantool 3.8` environment. See attached files or run this test with tarantool 3.8.0 (see test/docker/readme.md to setup this case). 
<img width="1231" height="244" alt="image" src="https://github.com/user-attachments/assets/81a29df8-370b-4bf8-9d97-e3be23028ab6" />
