### PR TITLE
cli/manifest/pack: tt package pack and the .tt archive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,10 @@ linters:
             # cli/manifest/build filters component files with gitignore-syntax
             # include/exclude patterns via go-git's matcher.
             - "github.com/go-git/go-git/v5/plumbing/format/gitignore"
+            # cli/manifest/pack compresses the .tt archive as tar+zstd.
+            - "github.com/klauspost/compress/zstd"
+            # cli/manifest/pack drives the build before archiving its result.
+            - "github.com/tarantool/tt/cli/manifest/build"
         test:
           files:
             - "$test"
@@ -116,3 +120,5 @@ linters:
             - "github.com/stretchr/testify"
             - "github.com/tarantool/tt/cli/manifest"
             - "github.com/tarantool/go-luarocks"
+            # cli/manifest/pack tests decompress the archive they just wrote.
+            - "github.com/klauspost/compress/zstd"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and `--locked` fails on a stale lock instead of re-resolving.
 - `tt package fetch`: materialize `.rocks/` strictly from the lock, without
   re-resolving or running component build backends.
+- `tt package pack`: run the full build and assemble the result into a
+  reproducible `.tt` archive (`tar.zst`) at
+  `_build/pack/<package>-<version>-<token>.tt`, printing the path to stdout. By
+  default the archive is self-contained: it carries `_runtime/` (Tarantool, tt,
+  and TCM when `[platform].tcm` is set) and the whole dependency closure, so
+  installing it needs no network. `--without-deps` drops both and leaves the
+  `bundled_*_version` lock fields empty. Runtime components are taken from
+  `<user cache>/tt/runtimes/<component>/<flavor>/<version>/`, falling back to
+  the active tt environment when it satisfies `[platform]`, with a warning.
+  Archives are byte-reproducible for a given commit; set `SOURCE_DATE_EPOCH` to
+  pin the build timestamp explicitly.
 - `tt pack`: support nested `.packignore` at the root of tt environment.
 - `tt status`: add `--format` option to support JSON and YAML output formats
 for machine-readable output.

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tarantool/tt/cli/manifest/build"
+	"github.com/tarantool/tt/cli/manifest/pack"
 	manifestrocks "github.com/tarantool/tt/cli/manifest/rocks"
 	oldrocks "github.com/tarantool/tt/cli/rocks"
 	ttversion "github.com/tarantool/tt/cli/version"
@@ -22,12 +24,13 @@ var errNoTarantool = errors.New("tarantool executable not found in PATH")
 
 // Shared flags for the package subcommands.
 var (
-	packageProduct string
-	packageLocked  bool
+	packageProduct     string
+	packageLocked      bool
+	packageWithoutDeps bool
 )
 
 // NewPackageCmd creates the `tt package` command group: the manifest build
-// pipeline (build and fetch; pack and install are not implemented yet).
+// pipeline (build, fetch and pack; install is not implemented yet).
 func NewPackageCmd() *cobra.Command {
 	packageCmd := &cobra.Command{
 		Use:   "package",
@@ -39,6 +42,7 @@ func NewPackageCmd() *cobra.Command {
 	packageCmd.AddCommand(
 		newPackageBuildCmd(),
 		newPackageFetchCmd(),
+		newPackagePackCmd(),
 	)
 
 	return packageCmd
@@ -84,6 +88,120 @@ func newPackageFetchCmd() *cobra.Command {
 		"product to fetch (default: the product marked default)")
 
 	return fetchCmd
+}
+
+// newPackagePackCmd wires `tt package pack`.
+func newPackagePackCmd() *cobra.Command {
+	packCmd := &cobra.Command{
+		Use:   "pack",
+		Short: "Build a manifest package and pack it into a .tt archive",
+		Long: "Run the full build and assemble its result into a reproducible " +
+			".tt archive. By default the archive is self-contained: it carries " +
+			"_runtime/ (Tarantool, tt and TCM when [platform].tcm is set) and the " +
+			"whole dependency closure in .rocks/, so installing it needs no " +
+			"network. --without-deps drops both. A separate tt package build " +
+			"beforehand is not needed. The archive path is printed to stdout.",
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPackagePack(); err != nil {
+				log.Error(err.Error())
+				os.Exit(pack.ExitCode(err))
+			}
+		},
+	}
+
+	packCmd.Flags().StringVar(&packageProduct, "product", "",
+		"product to pack (default: the product marked default)")
+	packCmd.Flags().BoolVar(&packageLocked, "locked", false,
+		"fail if the lock is out of date instead of re-resolving it")
+	packCmd.Flags().BoolVar(&packageWithoutDeps, "without-deps", false,
+		"pack without _runtime/ and without foreign dependencies in .rocks/")
+
+	return packCmd
+}
+
+// runPackagePack assembles pack.Options from the environment, packs, and prints
+// the resulting archive path to stdout so it can be piped.
+func runPackagePack() error {
+	projectDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	projectDir, err = filepath.Abs(projectDir)
+	if err != nil {
+		return err
+	}
+
+	tntInfo, err := tarantoolInfo()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	result, err := pack.Run(ctx, pack.Options{
+		ProjectDir:  projectDir,
+		Product:     packageProduct,
+		Locked:      packageLocked,
+		WithoutDeps: packageWithoutDeps,
+		Build: build.Options{
+			TtVersion:  "tt " + ttversion.GetVersion(true, false),
+			Tarantool:  tntInfo,
+			ShowOutput: cmdCtx.Cli.Verbose,
+		},
+		Runtime: runtimeRequest(ctx, tntInfo),
+		Warn:    func(msg string) { log.Warn(msg) },
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(result.Path)
+
+	return nil
+}
+
+// runtimeRequest describes where pack may take the _runtime/ components from:
+// the runtime cache first, the active tt environment as a fallback.
+//
+// TcmCli carries no version and nothing probes the binary, so the active TCM is
+// deliberately not offered as a fallback: passing the path without a version
+// would make pack report "the active tcm does not satisfy it" having never
+// looked at its version. With [platform].tcm set, the cache is the only source.
+func runtimeRequest(ctx context.Context, tntInfo manifestrocks.TarantoolInfo) pack.RuntimeOptions {
+	selfPath, err := os.Executable()
+	if err != nil {
+		// Without a path to ourselves the tt component can still come from the
+		// cache; pack reports a proper error if neither source has a match.
+		selfPath = ""
+	}
+
+	return pack.RuntimeOptions{
+		CacheDir:               runtimeCacheDir(),
+		ActiveTarantool:        tntInfo.Executable,
+		ActiveTarantoolVersion: tntInfo.Version,
+		ActiveTarantoolFlavor:  pack.DetectTarantoolFlavor(ctx, tntInfo.Executable),
+		ActiveTt:               selfPath,
+		// The short form is the bare "x.y.z"; the long form is a human-readable
+		// sentence that no version constraint can match.
+		ActiveTtVersion: ttversion.GetVersion(true, false),
+		// tt publishes no CE/EE marker through its version, so the flavor stays
+		// undetermined and only satisfies the [ce] default.
+		ActiveTtFlavor: "",
+	}
+}
+
+// runtimeCacheDir returns the runtime cache root, <user cache>/tt/runtimes.
+// RFC 0010 leaves the exact path an open item and `tt runtime install` is a v1
+// command; until then this is the directory a user populates by hand.
+func runtimeCacheDir() string {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(base, "tt", "runtimes")
 }
 
 // runPackageCmd runs a package build/fetch and maps failures to exit codes:

--- a/cli/manifest/build/build.go
+++ b/cli/manifest/build/build.go
@@ -93,19 +93,47 @@ func (o Options) builtAt() time.Time {
 	return o.Now
 }
 
-// Run executes the build (or fetch) described by opts. It returns an *ExitError
-// for the failures that carry a dedicated exit code (stale --locked,
-// version.lua collision, backend failure) and a plain error otherwise;
-// ExitCode maps either to a process exit code.
+// Result reports what a build produced. Callers that only drive the build for
+// its side effects ignore it; tt package pack consumes it to assemble the
+// archive without re-reading and re-deriving the same state from disk.
+type Result struct {
+	// Manifest is the parsed and validated app.manifest.toml.
+	Manifest *manifest.Manifest
+	// Lock is the lock the build resolved against, already gated. Its
+	// bundled_*_version fields are whatever was on disk; pack fills them.
+	Lock *manifest.Lock
+	// Version is the derived package version, with Flavor set from
+	// [platform].tarantool.
+	Version version.Version
+	// Product is the name of the product that was built, with the default
+	// already selected.
+	Product string
+	// Tree is the absolute path of the materialized .rocks/ tree.
+	Tree string
+}
+
+// Run executes the build (or fetch) described by opts, discarding the result.
+// It returns an *ExitError for the failures that carry a dedicated exit code
+// (stale --locked, version.lua collision, backend failure) and a plain error
+// otherwise; ExitCode maps either to a process exit code.
 func Run(ctx context.Context, opts Options) error {
+	_, err := RunResult(ctx, opts)
+
+	return err
+}
+
+// RunResult is Run, additionally reporting the manifest, lock, version and tree
+// the build worked with. A fetch run reports the manifest, lock and tree; it
+// derives no version and runs no backends.
+func RunResult(ctx context.Context, opts Options) (*Result, error) {
 	man, err := readManifest(opts.ProjectDir, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	productName, product, err := selectProduct(man, opts.Product)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	tree := filepath.Join(opts.ProjectDir, rocksDirName)
@@ -117,7 +145,7 @@ func Run(ctx context.Context, opts Options) error {
 	}))
 
 	if opts.FetchOnly {
-		return runFetch(ctx, adapter, opts.ProjectDir, productName)
+		return runFetch(ctx, adapter, opts.ProjectDir, man, tree, productName)
 	}
 
 	return runBuild(ctx, opts, man, adapter, tree, productName, product)
@@ -153,35 +181,40 @@ func readManifest(projectDir string, opts Options) (*manifest.Manifest, error) {
 // runFetch materializes the product's locked closure into the tree without
 // resolving or running backends — tt package fetch.
 func runFetch(
-	ctx context.Context, adapter *rocks.Adapter, projectDir, productName string,
-) error {
+	ctx context.Context, adapter *rocks.Adapter, projectDir string,
+	man *manifest.Manifest, tree, productName string,
+) (*Result, error) {
 	lock, err := loadLock(projectDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	prod, ok := lock.Products[productName]
 	if !ok {
-		return exitErrorf(exitStateError,
+		return nil, exitErrorf(exitStateError,
 			"lock has no closure for product %q; run tt package build", productName)
 	}
 
 	rockClient, err := adapter.Client(client.BackendNative)
 	if err != nil {
-		return fmt.Errorf("rocks client: %w", err)
+		return nil, fmt.Errorf("rocks client: %w", err)
 	}
 
-	return materialize(ctx, rockClient, projectDir, prod)
+	if err := materialize(ctx, rockClient, projectDir, prod); err != nil {
+		return nil, err
+	}
+
+	return &Result{Manifest: man, Lock: lock, Product: productName, Tree: tree}, nil
 }
 
 // runBuild runs the full build cycle.
 func runBuild(
 	ctx context.Context, opts Options, man *manifest.Manifest,
 	adapter *rocks.Adapter, tree, productName string, product manifest.Product,
-) error {
+) (*Result, error) {
 	components, err := selectComponents(product, opts.Component)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Version is derived before pre_build so the hook sees TT_VERSION, and
@@ -189,21 +222,21 @@ func runBuild(
 	// version.Derive spawns git internally and takes no context.
 	ver, err := version.Derive(opts.ProjectDir) //nolint:contextcheck // Derive has no ctx.
 	if err != nil {
-		return fmt.Errorf("deriving version: %w", err)
+		return nil, fmt.Errorf("deriving version: %w", err)
 	}
 
 	ver.Flavor = man.Platform.Tarantool.EffectiveFlavor()
 
 	preErr := runHook(ctx, man, ver, hookPreBuild, opts.ProjectDir, opts.ShowOutput)
 	if preErr != nil {
-		return exitErrorf(exitBackendError, "pre_build hook: %w", preErr)
+		return nil, exitErrorf(exitBackendError, "pre_build hook: %w", preErr)
 	}
 
 	engine := resolve.NewEngine(adapter, opts.ProjectDir, opts.TtVersion)
 
 	lock, warnings, err := gateLock(ctx, engine, man, opts.ProjectDir, opts.Locked)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	opts.emit(warnings)
@@ -212,36 +245,47 @@ func runBuild(
 	if !ok {
 		// A hash-fresh lock can still lack the product if it was hand-edited or
 		// truncated (IsStale only checks the manifest and path-dep hashes).
-		return exitErrorf(exitStateError, "lock has no closure for product %q", productName)
+		return nil, exitErrorf(exitStateError,
+			"lock has no closure for product %q", productName)
 	}
 
 	rockClient, err := adapter.Client(client.BackendNative)
 	if err != nil {
-		return fmt.Errorf("rocks client: %w", err)
+		return nil, fmt.Errorf("rocks client: %w", err)
 	}
 
 	matErr := materialize(ctx, rockClient, opts.ProjectDir, prod)
 	if matErr != nil {
-		return matErr
+		return nil, matErr
 	}
 
 	backendErr := runBackends(ctx, opts, man, adapter, tree, components, ver)
 	if backendErr != nil {
-		return backendErr
+		return nil, backendErr
 	}
 
 	laidOut, err := layoutComponents(opts.ProjectDir, tree, man, components)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	vluaErr := writeVersionLua(tree, man.Package.Name,
 		man.Package.GenerateVersionLuaValue(), ver, opts.builtAt(), laidOut)
 	if vluaErr != nil {
-		return vluaErr
+		return nil, vluaErr
 	}
 
-	return runPostBuild(ctx, opts, man, ver)
+	if err := runPostBuild(ctx, opts, man, ver); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Manifest: man,
+		Lock:     lock,
+		Version:  ver,
+		Product:  productName,
+		Tree:     tree,
+	}, nil
 }
 
 // runBackends runs the build backend of every selected component that declares

--- a/cli/manifest/pack/archive.go
+++ b/cli/manifest/pack/archive.go
@@ -1,0 +1,212 @@
+package pack
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/tarantool/tt/cli/util"
+)
+
+// Archive entry modes. Reproducibility beats preserving the source tree's
+// permissions, so every entry is normalized to one of two modes; the only bit
+// that survives from disk is the executable bit, which _runtime/ binaries and
+// component scripts need.
+const (
+	archiveFileMode = 0o644
+	archiveExecMode = 0o755
+	archiveDirMode  = 0o755
+)
+
+// archiveModTime is the timestamp stamped on every entry. The Unix epoch is the
+// usual reproducible-build choice; the zero time.Time is year 1, which tar
+// stores as a large negative stamp that some extractors reject.
+var archiveModTime = time.Unix(0, 0).UTC()
+
+// writeArchive packs the staging directory into destPath as tar+zstd and
+// returns the archive's sha256, lowercase hex.
+//
+// The archive is reproducible: identical staged content yields a byte-identical
+// file. That rules out cli/pack.WriteTarArchive, whose tar.FileInfoHeader
+// stamps each entry's real mtime, uid and gid — three inputs that change
+// between runs on the same content. Here every header is normalized (epoch
+// mtime, root:root, fixed mode) and entries are emitted in lexical order, which
+// filepath.WalkDir already guarantees.
+func writeArchive(stageDir, destPath string) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(destPath), dirPerm); err != nil {
+		return "", fmt.Errorf("creating archive directory: %w", err)
+	}
+
+	destFile, err := os.Create(destPath) //nolint:gosec // Path is derived from the manifest.
+	if err != nil {
+		return "", fmt.Errorf("creating archive: %w", err)
+	}
+
+	// Close errors matter on the write path: a swallowed zstd or tar Close
+	// silently truncates the frame and yields a corrupt archive that only fails
+	// at install time. The successful path checks every close; the failure paths
+	// discard them, since the original error already explains the failure and
+	// removing the partial archive is best-effort cleanup.
+	if err := writeArchiveTo(stageDir, destFile); err != nil {
+		_ = destFile.Close()
+		_ = os.Remove(destPath)
+
+		return "", err
+	}
+
+	if err := destFile.Close(); err != nil {
+		_ = os.Remove(destPath)
+
+		return "", fmt.Errorf("closing archive: %w", err)
+	}
+
+	sum, err := util.FileSHA256Hex(destPath)
+	if err != nil {
+		return "", fmt.Errorf("checksumming archive: %w", err)
+	}
+
+	return sum, nil
+}
+
+// writeArchiveTo streams stageDir into w as tar+zstd, closing both the tar and
+// the zstd writer in the right order (tar first, so its trailer is compressed).
+func writeArchiveTo(stageDir string, w io.Writer) error {
+	zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		return fmt.Errorf("creating zstd writer: %w", err)
+	}
+
+	tw := tar.NewWriter(zw)
+
+	if err := walkIntoTar(stageDir, tw); err != nil {
+		// Both closes are best-effort here; the walk error is the real one.
+		_ = tw.Close()
+		_ = zw.Close()
+
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		_ = zw.Close()
+
+		return fmt.Errorf("closing tar stream: %w", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("closing zstd stream: %w", err)
+	}
+
+	return nil
+}
+
+// walkIntoTar writes every entry under root into tw with a normalized header.
+func walkIntoTar(root string, tw *tar.Writer) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		if rel == "." {
+			return nil
+		}
+
+		// Archive paths are slash-separated regardless of host separator.
+		name := filepath.ToSlash(rel)
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		switch {
+		case d.IsDir():
+			return tw.WriteHeader(dirHeader(name))
+		case info.Mode().IsRegular():
+			return writeRegular(tw, path, name, info)
+		default:
+			// Symlinks and everything else are skipped: the staging tree is
+			// assembled by copying file contents, so nothing else should appear.
+			return nil
+		}
+	})
+}
+
+// dirHeader builds a normalized header for a directory entry.
+func dirHeader(name string) *tar.Header {
+	return &tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     name + "/",
+		Mode:     archiveDirMode,
+		ModTime:  archiveModTime,
+		Format:   tar.FormatPAX,
+	}
+}
+
+// writeRegular writes one regular file's header and contents.
+func writeRegular(tw *tar.Writer, path, name string, info fs.FileInfo) error {
+	mode := int64(archiveFileMode)
+	if info.Mode().Perm()&0o100 != 0 {
+		mode = archiveExecMode
+	}
+
+	header := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Mode:     mode,
+		Size:     info.Size(),
+		ModTime:  archiveModTime,
+		Format:   tar.FormatPAX,
+	}
+
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+
+	src, err := os.Open(path) //nolint:gosec // Path comes from our own staging tree.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+
+	if _, err := io.Copy(tw, src); err != nil {
+		return fmt.Errorf("archiving %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// isReservedName reports whether a path inside the archive would collide with a
+// name tt owns. The check is on the first path segment, so both "VERSION" and
+// ".rocks/share/..." are caught.
+//
+// The comparison is case-insensitive because the staging tree is a real
+// directory on the host filesystem, and on a case-insensitive one (APFS by
+// default, NTFS) an include entry named "version" opens the already-staged
+// VERSION file and truncates it. Matching only the exact case would let a
+// manifest silently overwrite tt's own metadata inside the archive.
+//
+// "." and ".." are reserved too: "." resolves to the project root, which
+// contains the staging directory, and copying it would recurse into itself.
+func isReservedName(name string) bool {
+	top, _, _ := strings.Cut(filepath.ToSlash(name), "/")
+
+	switch strings.ToLower(top) {
+	case manifestFileName, lockFileName, strings.ToLower(versionFileName),
+		runtimeDirName, rocksDirName, buildDirName, ".", "..", "":
+		return true
+	default:
+		return false
+	}
+}

--- a/cli/manifest/pack/archive_test.go
+++ b/cli/manifest/pack/archive_test.go
@@ -1,0 +1,195 @@
+package pack
+
+import (
+	"archive/tar"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTree materializes a name->content map under dir, creating parents.
+func writeTree(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+
+	for name, content := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), dirPerm))
+		require.NoError(t, os.WriteFile(path, []byte(content), filePerm))
+	}
+}
+
+// readArchive decompresses an archive and returns its entries by name.
+func readArchive(t *testing.T, path string) map[string]string {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	require.NoError(t, err, "archive must be valid zstd")
+
+	defer zr.Close()
+
+	entries := map[string]string{}
+	tr := tar.NewReader(zr)
+
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err, "archive must be a valid tar stream")
+
+		if header.Typeflag == tar.TypeDir {
+			entries[header.Name] = ""
+
+			continue
+		}
+
+		body, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		entries[header.Name] = string(body)
+	}
+
+	return entries
+}
+
+func TestWriteArchiveRoundTrip(t *testing.T) {
+	stage := t.TempDir()
+	writeTree(t, stage, map[string]string{
+		"VERSION":                             "1.0.0\n",
+		"app.manifest.toml":                   "manifest",
+		"README.md":                           "readme",
+		".rocks/share/tarantool/my-app/i.lua": "return 1",
+	})
+
+	dest := filepath.Join(t.TempDir(), "my-app-1.0.0-any.tt")
+
+	sum, err := writeArchive(stage, dest)
+	require.NoError(t, err)
+	assert.Len(t, sum, 64, "sha256 hex is 64 chars")
+
+	entries := readArchive(t, dest)
+	assert.Equal(t, "1.0.0\n", entries["VERSION"])
+	assert.Equal(t, "manifest", entries["app.manifest.toml"])
+	assert.Equal(t, "readme", entries["README.md"])
+	assert.Equal(t, "return 1", entries[".rocks/share/tarantool/my-app/i.lua"])
+
+	// Paths are slash-separated and carry no leading "./" or staging prefix.
+	for name := range entries {
+		assert.NotContains(t, name, "\\")
+		assert.False(t, filepath.IsAbs(name), "%q must be relative", name)
+		assert.NotContains(t, name, "..")
+	}
+}
+
+// TestWriteArchiveReproducible is the reason this package does not reuse
+// cli/pack.WriteTarArchive: tar.FileInfoHeader stamps real mtimes, so the same
+// content packed twice would differ. Identical content must yield an identical
+// archive byte for byte.
+func TestWriteArchiveReproducible(t *testing.T) {
+	files := map[string]string{
+		"VERSION":           "1.0.0\n",
+		"app.manifest.toml": "manifest",
+		"a/b/c.lua":         "return 1",
+	}
+
+	first := t.TempDir()
+	writeTree(t, first, files)
+
+	destA := filepath.Join(t.TempDir(), "a.tt")
+	sumA, err := writeArchive(first, destA)
+	require.NoError(t, err)
+
+	// A second tree with the same content but written later, so every mtime
+	// differs from the first tree's.
+	time.Sleep(10 * time.Millisecond)
+
+	second := t.TempDir()
+	writeTree(t, second, files)
+
+	now := time.Now().Add(2 * time.Hour)
+	require.NoError(t, os.Chtimes(filepath.Join(second, "VERSION"), now, now))
+
+	destB := filepath.Join(t.TempDir(), "b.tt")
+	sumB, err := writeArchive(second, destB)
+	require.NoError(t, err)
+
+	assert.Equal(t, sumA, sumB, "same content must yield the same checksum")
+
+	bytesA, err := os.ReadFile(destA)
+	require.NoError(t, err)
+	bytesB, err := os.ReadFile(destB)
+	require.NoError(t, err)
+	assert.Equal(t, bytesA, bytesB, "archives must be byte-identical")
+}
+
+// TestWriteArchivePreservesExecBit covers the one permission bit that survives
+// normalization: _runtime/ binaries are useless without it.
+func TestWriteArchivePreservesExecBit(t *testing.T) {
+	stage := t.TempDir()
+	writeTree(t, stage, map[string]string{"plain.lua": "x"})
+
+	binPath := filepath.Join(stage, "_runtime", "tt", "bin", "tt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), dirPerm))
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o755))
+
+	dest := filepath.Join(t.TempDir(), "x.tt")
+	_, err := writeArchive(stage, dest)
+	require.NoError(t, err)
+
+	modes := map[string]int64{}
+
+	f, err := os.Open(dest)
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	require.NoError(t, err)
+
+	defer zr.Close()
+
+	tr := tar.NewReader(zr)
+
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err)
+		modes[header.Name] = header.Mode
+
+		// Normalized ownership keeps the archive independent of who packed it.
+		assert.Zero(t, header.Uid)
+		assert.Zero(t, header.Gid)
+		assert.True(t, header.ModTime.Equal(archiveModTime),
+			"%q must carry the normalized mtime", header.Name)
+	}
+
+	assert.Equal(t, int64(archiveExecMode), modes["_runtime/tt/bin/tt"])
+	assert.Equal(t, int64(archiveFileMode), modes["plain.lua"])
+}
+
+// TestWriteArchiveNoPartialOnFailure guards the cleanup path: a failed write
+// must not leave a truncated archive that only fails later, at install time.
+func TestWriteArchiveNoPartialOnFailure(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "out.tt")
+
+	_, err := writeArchive(filepath.Join(t.TempDir(), "does-not-exist"), dest)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "no archive must be left behind")
+}

--- a/cli/manifest/pack/buildtime.go
+++ b/cli/manifest/pack/buildtime.go
@@ -1,0 +1,72 @@
+package pack
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// sourceDateEpochEnv is the cross-ecosystem convention for pinning a build
+// timestamp; honouring it lets a CI job make tt agree with everything else it
+// builds.
+const sourceDateEpochEnv = "SOURCE_DATE_EPOCH"
+
+// buildTime picks the timestamp stamped into the generated version.lua, and
+// with it whether the archive is reproducible at all.
+//
+// The wall clock would make every pack of the same commit produce a different
+// archive, which defeats the reproducible-archive guarantee the checksum rests
+// on. So the clock is pinned, in order: SOURCE_DATE_EPOCH when set, then the
+// HEAD commit's own timestamp, and only failing both the wall clock — the last
+// case being a tree with no git history, where reproducibility is unreachable
+// anyway.
+func buildTime(ctx context.Context, projectDir string) time.Time {
+	if epoch, ok := sourceDateEpoch(); ok {
+		return epoch
+	}
+
+	if commit, ok := commitTime(ctx, projectDir); ok {
+		return commit
+	}
+
+	return time.Now()
+}
+
+// sourceDateEpoch reads SOURCE_DATE_EPOCH as Unix seconds.
+func sourceDateEpoch() (time.Time, bool) {
+	raw := strings.TrimSpace(os.Getenv(sourceDateEpochEnv))
+	if raw == "" {
+		return time.Time{}, false
+	}
+
+	secs, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		// A malformed value is ignored rather than fatal: it is an ambient
+		// environment variable, not something this pack invocation asked for.
+		return time.Time{}, false
+	}
+
+	return time.Unix(secs, 0).UTC(), true
+}
+
+// commitTime returns the HEAD commit's author timestamp.
+func commitTime(ctx context.Context, projectDir string) (time.Time, bool) {
+	//nolint:gosec // Fixed program (git) with internally built args.
+	cmd := exec.CommandContext(ctx,
+		"git", "-C", projectDir, "log", "-1", "--format=%at")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	secs, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return time.Unix(secs, 0).UTC(), true
+}

--- a/cli/manifest/pack/buildtime_test.go
+++ b/cli/manifest/pack/buildtime_test.go
@@ -1,0 +1,72 @@
+package pack
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitRepo makes a temp dir into a git repo with one commit and returns it.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"init.lua": "return 1"})
+
+	git(t, dir, "init", "-q")
+	git(t, dir, "add", "-A")
+	git(t, dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
+
+	return dir
+}
+
+// git runs one git command in dir and fails the test on a non-zero exit.
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}
+
+// TestBuildTimeIsDeterministic is the reproducibility guarantee at its source.
+// version.lua embeds built_at, so a wall-clock stamp makes the same commit pack
+// to a different archive every time and the checksum meaningless.
+func TestBuildTimeIsDeterministic(t *testing.T) {
+	dir := gitRepo(t)
+
+	first := buildTime(context.Background(), dir)
+	time.Sleep(1100 * time.Millisecond)
+	second := buildTime(context.Background(), dir)
+
+	assert.Equal(t, first, second, "the same commit must yield the same timestamp")
+	assert.False(t, first.IsZero())
+}
+
+// TestBuildTimeHonorsSourceDateEpoch lets CI pin the stamp explicitly.
+func TestBuildTimeHonorsSourceDateEpoch(t *testing.T) {
+	t.Setenv(sourceDateEpochEnv, "1700000000")
+
+	assert.Equal(t, time.Unix(1700000000, 0).UTC(), buildTime(context.Background(), gitRepo(t)))
+}
+
+func TestBuildTimeIgnoresMalformedEpoch(t *testing.T) {
+	t.Setenv(sourceDateEpochEnv, "not-a-number")
+
+	dir := gitRepo(t)
+	// Falls through to the commit timestamp rather than failing.
+	assert.Equal(t, buildTime(context.Background(), dir), buildTime(context.Background(), dir))
+}
+
+// TestBuildTimeOutsideGitFallsBack covers a tree with no history, where
+// reproducibility is unreachable and the wall clock is the honest answer.
+func TestBuildTimeOutsideGitFallsBack(t *testing.T) {
+	before := time.Now().Add(-time.Second)
+
+	got := buildTime(context.Background(), t.TempDir())
+
+	assert.False(t, got.Before(before), "expected a wall-clock stamp")
+}

--- a/cli/manifest/pack/errors.go
+++ b/cli/manifest/pack/errors.go
@@ -1,0 +1,72 @@
+package pack
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tarantool/tt/cli/manifest/build"
+)
+
+// File and directory names pack reads from the project and writes into the
+// archive. The archive-side names are the reserved set tt owns: [package]
+// include and license_files entries may not collide with them.
+const (
+	manifestFileName = "app.manifest.toml"
+	lockFileName     = "app.manifest.lock"
+	versionFileName  = "VERSION"
+	runtimeDirName   = "_runtime"
+	rocksDirName     = ".rocks"
+	buildDirName     = "_build"
+	// packSubDir is the _build subdirectory the archive is produced in.
+	packSubDir = "pack"
+	// archiveExt is the tt-native archive extension. The payload is tar+zstd.
+	archiveExt = ".tt"
+)
+
+// exitStateError is the exit code for a usage or state error, matching tt
+// package build so the two commands are indistinguishable to a CI script.
+//
+// Pack defines no code of its own beyond this one: a build backend failure
+// exits 2, but that error is raised inside cli/manifest/build and passes
+// through pack untouched, carrying its code with it.
+const exitStateError = 1
+
+var (
+	// errReservedName reports an include or license_files entry that would land
+	// on a name tt owns inside the archive.
+	errReservedName = errors.New("entry collides with a reserved archive name")
+	// errNoRuntime reports that no Tarantool or tt satisfying [platform] could
+	// be found to bundle into _runtime/.
+	errNoRuntime = errors.New("no runtime available to bundle")
+	// errBadConstraint reports a [platform] constraint tt cannot parse.
+	errBadConstraint = errors.New("unparseable version constraint")
+	// errFlatNamespace reports a --without-deps pack of a package that lays
+	// files flat in the rocks tree, where its own files cannot be separated
+	// from its dependencies'.
+	errFlatNamespace = errors.New("cannot pack a flat namespace without deps")
+	// errNoTarantoolLicense reports a bundled Tarantool whose LICENSE file is
+	// missing; shipping the binary without it is not permitted.
+	errNoTarantoolLicense = errors.New("bundled Tarantool has no LICENSE")
+	// errMissingInclude reports an include or license_files entry that matched
+	// nothing on disk.
+	errMissingInclude = errors.New("no such file")
+	// errEscapingPath reports an include or license_files entry that resolves
+	// outside the project directory.
+	errEscapingPath = errors.New("path escapes the project directory")
+)
+
+// ExitCode returns the process exit code for err, reusing the build package's
+// mapping so pack and build agree: a build run driven by pack surfaces its own
+// exit codes unchanged. A nil error is 0.
+func ExitCode(err error) int {
+	return build.ExitCode(err)
+}
+
+// stateErrorf wraps a formatted error as a state error (exit 1), using the
+// build package's ExitError so build.ExitCode reads it back through pack's
+// chain.
+//
+//nolint:err113 // Formatting helper, mirrors fmt.Errorf; callers pass %w wraps.
+func stateErrorf(format string, args ...any) error {
+	return &build.ExitError{Code: exitStateError, Err: fmt.Errorf(format, args...)}
+}

--- a/cli/manifest/pack/flavor.go
+++ b/cli/manifest/pack/flavor.go
@@ -1,0 +1,54 @@
+package pack
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+// enterpriseMarker is the word Tarantool Enterprise puts in its version banner:
+// "Tarantool Enterprise 3.2.0-0-g19607a903" against CE's "Tarantool 3.2.0".
+const enterpriseMarker = "Enterprise"
+
+// DetectTarantoolFlavor reports whether the Tarantool at path is a "ce" or "ee"
+// build, or "" when that cannot be determined.
+//
+// The flavor has to be read here because the shared version plumbing discards
+// it: cmdcontext.TarantoolCli.GetVersion keeps only the last whitespace-
+// separated token of the banner, which is the version number, so the
+// Enterprise marker never reaches a caller. Getting this wrong is not a
+// cosmetic error - it decides whether an [ee] manifest gets an EE runtime.
+func DetectTarantoolFlavor(ctx context.Context, path string) string {
+	if path == "" {
+		return ""
+	}
+
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	if err != nil {
+		return ""
+	}
+
+	return flavorFromBanner(string(out))
+}
+
+// flavorFromBanner classifies a Tarantool --version banner.
+func flavorFromBanner(banner string) string {
+	first, _, _ := strings.Cut(banner, "\n")
+
+	// A banner is at least "Tarantool <version>"; anything shorter is not a
+	// form this code understands, and saying so beats guessing "ce", which
+	// would let an unverified build satisfy a [ce] requirement.
+	const minBannerFields = 2
+
+	fields := strings.Fields(first)
+	if len(fields) < minBannerFields {
+		return ""
+	}
+
+	if slices.Contains(fields, enterpriseMarker) {
+		return flavorEE
+	}
+
+	return flavorCE
+}

--- a/cli/manifest/pack/flavor_test.go
+++ b/cli/manifest/pack/flavor_test.go
@@ -1,0 +1,157 @@
+package pack
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// flavored builds a constraint with an explicit flavor.
+func flavored(spec, flavor string) manifest.Constraint {
+	return manifest.Constraint{Version: spec, Flavor: flavor}
+}
+
+func TestFlavorFromBanner(t *testing.T) {
+	tests := []struct {
+		name   string
+		banner string
+		want   string
+	}{
+		{"community", "Tarantool 3.2.0-0-g19607a903\nTarget: Darwin\n", flavorCE},
+		{"enterprise", "Tarantool Enterprise 3.2.0-0-g19607a903\nTarget: Linux\n", flavorEE},
+		{"entrypoint community", "Tarantool 3.8.0-entrypoint-49-g97a3b38040\n", flavorCE},
+		{"unrecognized banner", "weird\n", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, flavorFromBanner(tt.banner))
+		})
+	}
+}
+
+// TestFindInCacheSeparatesFlavors is the core of the flavor fix: a [ce]
+// requirement must never resolve to an EE tree, and vice versa. Before the
+// cache grew a flavor level the two were indistinguishable.
+func TestFindInCacheSeparatesFlavors(t *testing.T) {
+	cache := fakeFlavorCache(t, flavorEE, map[string][]string{
+		runtimeTarantool: {"3.0.5"},
+	})
+
+	_, _, ok, err := findInCache(cache, runtimeTarantool, flavorCE, constraint(">=3.0.0"))
+	require.NoError(t, err)
+	assert.False(t, ok, "a ce requirement must not resolve to the ee tree")
+
+	dir, ver, ok, err := findInCache(cache, runtimeTarantool, flavorEE, constraint(">=3.0.0"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "3.0.5", ver)
+	assert.Equal(t, filepath.Join(cache, runtimeTarantool, flavorEE, "3.0.5"), dir)
+}
+
+// TestBundleRuntimeRejectsWrongFlavorFallback is the regression test for the
+// original defect: an [ee] manifest silently bundled the active CE Tarantool.
+func TestBundleRuntimeRejectsWrongFlavorFallback(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "BSD-2-Clause",
+	})
+
+	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: flavored(">=3.0.0,<4.0.0", flavorEE),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "3.0.5",
+		ActiveTarantoolFlavor:  flavorCE,
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoRuntime)
+	assert.Contains(t, err.Error(), "[ee]", "the error must name the wanted flavor")
+}
+
+// TestBundleRuntimeAcceptsMatchingFlavorFallback is the positive counterpart.
+func TestBundleRuntimeAcceptsMatchingFlavorFallback(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "Tarantool Enterprise",
+		"bin/tt":        "#!/bin/sh\n",
+	})
+
+	bundled, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: flavored(">=3.0.0,<4.0.0", flavorEE),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "3.0.5",
+		ActiveTarantoolFlavor:  flavorEE,
+		ActiveTt:               filepath.Join(prefix, "bin", "tt"),
+		ActiveTtVersion:        "2.4.0",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.5", bundled.Tarantool)
+}
+
+// TestBundleRuntimeUndeterminedFlavorOnlySatisfiesCE covers the safety rule for
+// a binary whose flavor could not be probed: usable for the [ce] default,
+// refused for [ee], where guessing would be a licensing error.
+func TestBundleRuntimeUndeterminedFlavorOnlySatisfiesCE(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "BSD-2-Clause",
+		"bin/tt":        "#!/bin/sh\n",
+	})
+
+	opts := func(flavor string) RuntimeOptions {
+		return RuntimeOptions{
+			CacheDir: filepath.Join(t.TempDir(), "empty"),
+			Platform: manifest.Platform{
+				Tarantool: flavored(">=3.0.0,<4.0.0", flavor),
+				Tt:        constraint(">=2.0.0,<3.0.0"),
+			},
+			ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+			ActiveTarantoolVersion: "3.0.5",
+			ActiveTarantoolFlavor:  "", // Undetermined.
+			ActiveTt:               filepath.Join(prefix, "bin", "tt"),
+			ActiveTtVersion:        "2.4.0",
+		}
+	}
+
+	_, err := bundleRuntime(t.TempDir(), opts(flavorCE))
+	require.NoError(t, err, "an undetermined flavor stands in for the ce default")
+
+	_, err = bundleRuntime(t.TempDir(), opts(flavorEE))
+	require.Error(t, err, "an undetermined flavor must never pass for ee")
+	assert.ErrorIs(t, err, errNoRuntime)
+}
+
+// TestSatisfiesFlavorOnlyConstraintNeedsAVersion closes the hole where a
+// constraint carrying only a flavor matched anything, including a binary whose
+// version was unknown - which then stamped an empty bundled_*_version.
+func TestSatisfiesFlavorOnlyConstraintNeedsAVersion(t *testing.T) {
+	flavorOnly := flavored("", flavorEE)
+
+	require.False(t, flavorOnly.IsZero(), "a flavor-only constraint is not zero")
+
+	got, err := satisfies("", flavorOnly)
+	require.NoError(t, err)
+	assert.False(t, got, "an undetermined version must satisfy nothing")
+
+	got, err = satisfies("3.0.5", flavorOnly)
+	require.NoError(t, err)
+	assert.True(t, got, "a known version still matches an unbounded range")
+}

--- a/cli/manifest/pack/pack.go
+++ b/cli/manifest/pack/pack.go
@@ -1,0 +1,288 @@
+// Package pack implements tt package pack: it runs the manifest build and
+// then assembles its result into a reproducible .tt archive (tar+zstd).
+//
+// Two packing modes exist. The default, with-deps, produces a self-contained
+// archive carrying _runtime/ (Tarantool, tt and optionally TCM) and the full
+// dependency closure in .rocks/, so installing it is a plain extraction with no
+// network. The --without-deps mode drops both, leaving the package's own
+// namespace subtrees; installing that archive extracts it and refetches the
+// dependencies from the registry using the lock's pins.
+package pack
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/build"
+)
+
+// Options configures one pack run. The build-facing fields mirror
+// build.Options, which pack drives before archiving.
+type Options struct {
+	// ProjectDir is the directory holding app.manifest.toml. Required and must
+	// be absolute.
+	ProjectDir string
+	// Product selects the product to pack; empty picks the default.
+	Product string
+	// Locked gates the lock: a stale lock is a hard error.
+	Locked bool
+	// WithoutDeps drops _runtime/ and foreign dependencies from the archive.
+	WithoutDeps bool
+	// OutputDir overrides where the archive is written; empty uses
+	// <ProjectDir>/_build/pack.
+	OutputDir string
+	// Build carries the remaining build knobs (Tarantool facts, servers, output
+	// streaming, logger) through to build.RunResult.
+	//
+	// Pack owns some of these and overwrites whatever is set here: ProjectDir,
+	// Product, Locked, Component and FetchOnly come from the fields above, and
+	// Now is pinned by buildTime unless already set. Warn is taken over only
+	// when Options.Warn is non-nil.
+	Build build.Options
+	// Runtime describes where the runtime components come from. Ignored when
+	// WithoutDeps is set.
+	Runtime RuntimeOptions
+	// Warn receives non-fatal diagnostics; nil drops them.
+	Warn func(string)
+}
+
+// Result reports what pack produced.
+type Result struct {
+	// Path is the absolute path of the archive.
+	Path string
+	// SHA256 is the archive's checksum, lowercase hex.
+	SHA256 string
+	// Token is the platform token in the archive name.
+	Token string
+	// Bundled reports the runtime versions written into the lock; zero in
+	// --without-deps mode.
+	Bundled BundledVersions
+}
+
+// Run builds the project and packs it into an archive. It returns an
+// *build.ExitError for failures carrying a dedicated exit code; ExitCode maps
+// any error to a process exit code.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	built, err := runBuild(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	stageDir, cleanup, err := makeStageDir(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	bundled, err := runtimeInto(stageDir, opts, built.Manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	lockBytes, err := lockWithBundled(built.Lock, bundled)
+	if err != nil {
+		return nil, err
+	}
+
+	man := built.Manifest
+	namespaces, hasFlat := packageNamespaces(man, built.Product)
+
+	if err := stage(stageDir, stageRequest{
+		ProjectDir:       opts.ProjectDir,
+		Manifest:         man,
+		LockBytes:        lockBytes,
+		Version:          built.Version.SemVer,
+		Tree:             built.Tree,
+		WithDeps:         !opts.WithoutDeps,
+		Namespaces:       namespaces,
+		HasFlatNamespace: hasFlat,
+	}); err != nil {
+		return nil, err
+	}
+
+	native, err := hasNativeArtifacts(stageDir)
+	if err != nil {
+		return nil, err
+	}
+
+	token := platformToken(!opts.WithoutDeps, native)
+	dest := filepath.Join(outputDir(opts),
+		archiveName(man.Package.Name, built.Version.SemVer, token))
+
+	sum, err := writeArchive(stageDir, dest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{Path: dest, SHA256: sum, Token: token, Bundled: bundled}, nil
+}
+
+// runBuild drives the full build cycle pack is defined to include, so a clean
+// tree needs no separate tt package build.
+func runBuild(ctx context.Context, opts Options) (*build.Result, error) {
+	buildOpts := opts.Build
+	buildOpts.ProjectDir = opts.ProjectDir
+	buildOpts.Product = opts.Product
+	buildOpts.Locked = opts.Locked
+	buildOpts.FetchOnly = false
+	buildOpts.Component = ""
+
+	// Only take over the build's warning sink when pack has one of its own;
+	// otherwise a caller who configured Build.Warn and left Options.Warn nil
+	// would lose every build diagnostic.
+	if opts.Warn != nil {
+		buildOpts.Warn = opts.Warn
+	}
+
+	// Pin version.lua's built_at, without which the same commit packs to a
+	// different archive every time. A caller that set Now explicitly keeps it.
+	if buildOpts.Now.IsZero() {
+		buildOpts.Now = buildTime(ctx, opts.ProjectDir)
+	}
+
+	built, err := build.RunResult(ctx, buildOpts)
+	if err != nil {
+		// Build failures already carry their exit code (2 for a backend
+		// failure); pass them through untouched.
+		return nil, err
+	}
+
+	return built, nil
+}
+
+// makeStageDir creates the staging tree and returns a cleanup that removes it.
+func makeStageDir(opts Options) (string, func(), error) {
+	base := filepath.Join(opts.ProjectDir, buildDirName, packSubDir)
+	if err := os.MkdirAll(base, dirPerm); err != nil {
+		return "", nil, fmt.Errorf("creating %s: %w", base, err)
+	}
+
+	dir, err := os.MkdirTemp(base, "stage-")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating staging directory: %w", err)
+	}
+
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// runtimeInto bundles _runtime/ unless the archive is --without-deps.
+//
+// The [platform] constraints are taken from the manifest here rather than from
+// the caller: they are only known once the build has parsed it, and leaving the
+// field to the CLI to fill made an unset Platform silently bundle nothing.
+func runtimeInto(
+	stageDir string, opts Options, man *manifest.Manifest,
+) (BundledVersions, error) {
+	if opts.WithoutDeps {
+		return BundledVersions{}, nil
+	}
+
+	req := opts.Runtime
+	req.Warn = opts.Warn
+	req.Platform = man.Platform
+
+	return bundleRuntime(stageDir, req)
+}
+
+// lockWithBundled stamps the bundled runtime versions into a copy of the lock
+// and marshals it. In --without-deps mode the fields stay empty, which is what
+// tells an installer the archive carries no runtime.
+func lockWithBundled(lock *manifest.Lock, bundled BundledVersions) ([]byte, error) {
+	if lock == nil {
+		return nil, stateErrorf("build produced no lock")
+	}
+
+	// Lock.Marshal has a value receiver, so this copy leaves the build's lock
+	// (and the on-disk file) untouched: bundled_* live only in the archive.
+	stamped := *lock
+	stamped.BundledTarantool = bundled.Tarantool
+	stamped.BundledTt = bundled.Tt
+	stamped.BundledTcm = bundled.Tcm
+
+	out, err := stamped.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling lock: %w", err)
+	}
+
+	return out, nil
+}
+
+// outputDir picks where the archive lands.
+func outputDir(opts Options) string {
+	if opts.OutputDir != "" {
+		return opts.OutputDir
+	}
+
+	return filepath.Join(opts.ProjectDir, buildDirName, packSubDir)
+}
+
+// packageNamespaces lists the rocks-tree namespaces the package itself owns,
+// which is what --without-deps keeps. Every component of the product
+// contributes its effective namespace.
+func packageNamespaces(man *manifest.Manifest, productName string) ([]string, bool) {
+	seen := map[string]bool{}
+
+	var namespaces []string
+
+	add := func(ns string) {
+		if seen[ns] {
+			return
+		}
+
+		seen[ns] = true
+		namespaces = append(namespaces, ns)
+	}
+
+	// The package name is always owned: version.lua is generated under it even
+	// when no component lays anything there.
+	add(man.Package.Name)
+
+	product, ok := man.Products[productName]
+	if !ok {
+		return namespaces, false
+	}
+
+	flat := false
+
+	for _, name := range product.Components {
+		component, ok := man.Components[name]
+		if !ok {
+			continue
+		}
+
+		ns := component.EffectiveNamespace(man.Package.Name)
+		if ns == "" {
+			flat = true
+		}
+
+		add(ns)
+	}
+
+	return namespaces, flat
+}
+
+// hasNativeArtifacts reports whether the staged tree carries any compiled
+// module, which pins an otherwise universal archive to the host platform.
+func hasNativeArtifacts(stageDir string) (bool, error) {
+	found := false
+
+	err := filepath.WalkDir(stageDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() && filepath.Ext(path) == ".so" {
+			found = true
+		}
+
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("scanning for native artifacts: %w", err)
+	}
+
+	return found, nil
+}

--- a/cli/manifest/pack/pack_test.go
+++ b/cli/manifest/pack/pack_test.go
@@ -1,0 +1,190 @@
+package pack
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// TestLockWithBundledStampsVersions covers the lock side of a with-deps pack:
+// the resolver leaves bundled_* empty and pack fills them in.
+func TestLockWithBundledStampsVersions(t *testing.T) {
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		GeneratedBy:     "tt 3.0.0",
+		ManifestHash:    "sha256:abc",
+	}
+
+	out, err := lockWithBundled(lock, BundledVersions{
+		Tarantool: "3.0.5", Tt: "3.2.0", Tcm: "1.5.2",
+	})
+	require.NoError(t, err)
+
+	parsed, err := manifest.ParseLock(out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "3.0.5", parsed.BundledTarantool)
+	assert.Equal(t, "3.2.0", parsed.BundledTt)
+	assert.Equal(t, "1.5.2", parsed.BundledTcm)
+
+	// The build's lock is untouched: bundled_* exist only inside the archive,
+	// never in the project's app.manifest.lock on disk.
+	assert.Empty(t, lock.BundledTarantool)
+	assert.Empty(t, lock.BundledTt)
+	assert.Empty(t, lock.BundledTcm)
+}
+
+// TestLockWithBundledWithoutDeps pins the --without-deps contract: empty
+// bundled_* are what tell an installer the archive carries no runtime.
+func TestLockWithBundledWithoutDeps(t *testing.T) {
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+	}
+
+	out, err := lockWithBundled(lock, BundledVersions{})
+	require.NoError(t, err)
+
+	parsed, err := manifest.ParseLock(out)
+	require.NoError(t, err)
+
+	assert.Empty(t, parsed.BundledTarantool)
+	assert.Empty(t, parsed.BundledTt)
+	assert.Empty(t, parsed.BundledTcm)
+}
+
+// TestLockWithBundledPreservesClosure guards the nested [lock.products.<name>]
+// round-trip: stamping bundled_* must not drop the resolved dependency set.
+func TestLockWithBundledPreservesClosure(t *testing.T) {
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "inspect", Version: "3.1.3", Source: "registry", Checksum: "md5:abc"},
+			}},
+		},
+	}
+
+	out, err := lockWithBundled(lock, BundledVersions{Tarantool: "3.0.5"})
+	require.NoError(t, err)
+
+	parsed, err := manifest.ParseLock(out)
+	require.NoError(t, err)
+
+	require.Contains(t, parsed.Products, "default")
+	require.Len(t, parsed.Products["default"].Dependencies, 1)
+	assert.Equal(t, "inspect", parsed.Products["default"].Dependencies[0].Name)
+	assert.Equal(t, "3.0.5", parsed.BundledTarantool)
+}
+
+func TestLockWithBundledRejectsNilLock(t *testing.T) {
+	_, err := lockWithBundled(nil, BundledVersions{})
+	require.Error(t, err)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+func TestPackageNamespaces(t *testing.T) {
+	parse := func(t *testing.T, toml string) *manifest.Manifest {
+		t.Helper()
+
+		man, _, err := manifest.ParseManifest([]byte(toml))
+		require.NoError(t, err)
+
+		return man
+	}
+
+	base := `manifest_version = "0.1"
+
+[package]
+name = "my-app"
+
+[platform]
+tarantool = ">=3.0.0,<4.0.0"
+tt = ">=2.0.0,<3.0.0"
+`
+
+	t.Run("default namespace is the package name", func(t *testing.T) {
+		man := parse(t, base+`
+[components.main]
+path = "."
+
+[products.default]
+components = ["main"]
+default = true
+`)
+		ns, flat := packageNamespaces(man, "default")
+		assert.Equal(t, []string{"my-app"}, ns)
+		assert.False(t, flat)
+	})
+
+	t.Run("explicit namespace is owned too", func(t *testing.T) {
+		man := parse(t, base+`
+[components.main]
+path = "."
+
+[components.roles]
+path = "roles"
+namespace = "app"
+
+[products.default]
+components = ["main", "roles"]
+default = true
+`)
+		ns, flat := packageNamespaces(man, "default")
+		assert.ElementsMatch(t, []string{"my-app", "app"}, ns)
+		assert.False(t, flat)
+	})
+
+	t.Run("unknown product still owns the package name", func(t *testing.T) {
+		man := parse(t, base+`
+[components.main]
+path = "."
+
+[products.default]
+components = ["main"]
+default = true
+`)
+		ns, flat := packageNamespaces(man, "nope")
+		assert.Equal(t, []string{"my-app"}, ns)
+		assert.False(t, flat)
+	})
+}
+
+func TestHasNativeArtifacts(t *testing.T) {
+	t.Run("pure lua tree is universal", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTree(t, dir, map[string]string{
+			".rocks/share/tarantool/my-app/init.lua": "return 1",
+			"README.md":                              "readme",
+		})
+
+		native, err := hasNativeArtifacts(dir)
+		require.NoError(t, err)
+		assert.False(t, native)
+	})
+
+	t.Run("a shared object pins the platform", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTree(t, dir, map[string]string{
+			".rocks/lib/tarantool/my-app/fast.so": "native",
+		})
+
+		native, err := hasNativeArtifacts(dir)
+		require.NoError(t, err)
+		assert.True(t, native)
+	})
+}
+
+// TestOutputDir pins where the archive lands: RFC 0010 puts it in _build/pack.
+func TestOutputDir(t *testing.T) {
+	assert.Equal(t, filepath.Join("/proj", "_build", "pack"),
+		outputDir(Options{ProjectDir: "/proj"}))
+	assert.Equal(t, "/elsewhere",
+		outputDir(Options{ProjectDir: "/proj", OutputDir: "/elsewhere"}))
+}

--- a/cli/manifest/pack/runtime.go
+++ b/cli/manifest/pack/runtime.go
@@ -1,0 +1,477 @@
+package pack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Runtime component directory names inside _runtime/.
+const (
+	runtimeTarantool = "tarantool"
+	runtimeTt        = "tt"
+	runtimeTcm       = "tcm"
+)
+
+// Flavor tokens, matching manifest.Constraint.EffectiveFlavor.
+const (
+	flavorCE = "ce"
+	flavorEE = "ee"
+)
+
+// tarantoolLicenseNames are the file names a bundled Tarantool's license may
+// carry. Shipping the binary without one is refused.
+var tarantoolLicenseNames = []string{"LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"}
+
+// runtimeSource describes one resolved runtime component ready to be bundled.
+type runtimeSource struct {
+	// Name is the _runtime/ subdirectory: tarantool, tt or tcm.
+	Name string
+	// Version is the concrete version bundled, recorded in the lock's
+	// bundled_*_version field.
+	Version string
+	// Dir is a directory tree to copy wholesale (a runtime cache entry).
+	// Exactly one of Dir and Binary is set.
+	Dir string
+	// Binary is a single executable to copy into <name>/bin/.
+	Binary string
+	// Fallback marks a component resolved from the active tt environment
+	// rather than the runtime cache, which is worth warning about.
+	Fallback bool
+}
+
+// RuntimeOptions carries what bundleRuntime needs to find and place runtimes.
+type RuntimeOptions struct {
+	// CacheDir is the runtime cache root; entries live at
+	// <CacheDir>/<component>/<version>/.
+	CacheDir string
+	// Platform is the manifest's [platform] block, whose constraints select the
+	// versions to bundle. Run fills this from the built manifest; callers leave
+	// it zero.
+	Platform manifest.Platform
+	// ActiveTarantool / ActiveTt / ActiveTcm are the binaries of the running tt
+	// environment, used as the fallback when the cache has no match. The Flavor
+	// fields carry "ce", "ee", or "" when the flavor could not be determined;
+	// an unknown flavor is only ever accepted for a [ce] requirement.
+	ActiveTarantool        string
+	ActiveTarantoolVersion string
+	ActiveTarantoolFlavor  string
+	ActiveTt               string
+	ActiveTtVersion        string
+	ActiveTtFlavor         string
+	ActiveTcm              string
+	ActiveTcmVersion       string
+	// Warn receives the fallback diagnostics; nil drops them.
+	Warn func(string)
+}
+
+// BundledVersions reports the concrete versions that went into _runtime/, to be
+// stamped into the lock.
+type BundledVersions struct {
+	Tarantool string
+	Tt        string
+	Tcm       string
+}
+
+// bundleRuntime resolves and copies _runtime/ into stageDir, returning the
+// versions bundled. TCM is bundled only when [platform].tcm is set.
+//
+// Each component is resolved cache-first: the highest version in the runtime
+// cache satisfying the constraint wins. Failing that, the active tt
+// environment's own binary is accepted if it satisfies the constraint, with a
+// warning — the cache is the reproducible source, the active binary is a
+// convenience for v0 where no `tt runtime install` exists yet.
+func bundleRuntime(stageDir string, req RuntimeOptions) (BundledVersions, error) {
+	// [platform].tarantool and .tt are required by manifest validation, so an
+	// empty constraint here means the platform block never reached this call.
+	// Without the guard that mistake produces a with-deps archive carrying no
+	// _runtime/ at all - silently, and indistinguishable from --without-deps.
+	if req.Platform.Tarantool.IsZero() || req.Platform.Tt.IsZero() {
+		return BundledVersions{}, stateErrorf(
+			"%w: [platform].tarantool and [platform].tt are required to bundle a runtime",
+			errNoRuntime)
+	}
+
+	wanted := []struct {
+		name       string
+		constraint manifest.Constraint
+		binary     string
+		binVersion string
+		binFlavor  string
+	}{
+		{
+			runtimeTarantool, req.Platform.Tarantool,
+			req.ActiveTarantool, req.ActiveTarantoolVersion, req.ActiveTarantoolFlavor,
+		},
+		{
+			runtimeTt, req.Platform.Tt,
+			req.ActiveTt, req.ActiveTtVersion, req.ActiveTtFlavor,
+		},
+		// TCM is Enterprise-only and carries no flavor (manifest validation
+		// rejects one), so its effective flavor is never compared.
+		{runtimeTcm, req.Platform.Tcm, req.ActiveTcm, req.ActiveTcmVersion, ""},
+	}
+
+	var bundled BundledVersions
+
+	for _, w := range wanted {
+		if w.constraint.IsZero() {
+			// Only tcm is optional; tarantool and tt are required by Validate.
+			continue
+		}
+
+		src, err := resolveRuntime(req, w.name, w.constraint,
+			activeBinary{path: w.binary, version: w.binVersion, flavor: w.binFlavor})
+		if err != nil {
+			return BundledVersions{}, err
+		}
+
+		if src.Fallback && req.Warn != nil {
+			req.Warn(fmt.Sprintf(
+				"no %s %s in the runtime cache (%s); bundling the active %s %s instead",
+				w.name, w.constraint.Version, req.CacheDir, w.name, src.Version))
+		}
+
+		// A prerelease satisfies the constraint here on its core version alone
+		// (see coreVersion), so say so rather than letting a development build
+		// end up in a release archive unremarked.
+		if isPrerelease(src.Version) && req.Warn != nil {
+			req.Warn(fmt.Sprintf(
+				"bundling %s %s, a prerelease build, to satisfy %q",
+				w.name, src.Version, w.constraint.Version))
+		}
+
+		if err := placeRuntime(stageDir, src); err != nil {
+			return BundledVersions{}, err
+		}
+
+		switch w.name {
+		case runtimeTarantool:
+			bundled.Tarantool = src.Version
+		case runtimeTt:
+			bundled.Tt = src.Version
+		case runtimeTcm:
+			bundled.Tcm = src.Version
+		}
+	}
+
+	return bundled, nil
+}
+
+// activeBinary describes the running tt environment's copy of one component,
+// the fallback source when the cache has no match.
+type activeBinary struct {
+	// path is the executable; empty means the component was not found.
+	path string
+	// version is its reported version; empty means it could not be determined,
+	// which never satisfies a constraint.
+	version string
+	// flavor is "ce", "ee", or "" for undetermined.
+	flavor string
+}
+
+// resolveRuntime picks the source for one runtime component: cache first,
+// active binary second. Both must match the constraint's flavor as well as its
+// version - bundling a CE build for an [ee] requirement produces an archive
+// that is wrong in a way nothing downstream detects.
+func resolveRuntime(
+	req RuntimeOptions, name string, constraint manifest.Constraint,
+	active activeBinary,
+) (runtimeSource, error) {
+	flavor := constraint.EffectiveFlavor()
+
+	dir, ver, ok, err := findInCache(req.CacheDir, name, flavor, constraint)
+	if err != nil {
+		return runtimeSource{}, err
+	}
+
+	if ok {
+		return runtimeSource{Name: name, Version: ver, Dir: dir}, nil
+	}
+
+	usable, err := activeUsable(active, flavor, constraint)
+	if err != nil {
+		return runtimeSource{}, err
+	}
+
+	if usable {
+		return runtimeSource{
+			Name:     name,
+			Version:  normalizeVersion(active.version),
+			Binary:   active.path,
+			Fallback: true,
+		}, nil
+	}
+
+	return runtimeSource{}, stateErrorf(
+		"%w: no %s satisfying %s found in the runtime cache %s, and the active "+
+			"%s (%s) does not satisfy it; place a matching build under %s",
+		errNoRuntime, name, constraint.String(), req.CacheDir, name,
+		describeActive(active),
+		filepath.Join(req.CacheDir, name, flavor, "<version>"))
+}
+
+// activeUsable reports whether the active binary may stand in for the cache.
+// An undetermined flavor is accepted only for a [ce] requirement: ce is the
+// default and overwhelmingly the common case, whereas silently treating an
+// unverified build as Enterprise would be a licensing error, not just a bug.
+func activeUsable(
+	active activeBinary, flavor string, constraint manifest.Constraint,
+) (bool, error) {
+	if active.path == "" {
+		return false, nil
+	}
+
+	versionOK, err := satisfies(active.version, constraint)
+	if err != nil {
+		return false, err
+	}
+
+	if !versionOK {
+		return false, nil
+	}
+
+	switch active.flavor {
+	case flavor:
+		return true, nil
+	case "":
+		return flavor == flavorCE, nil
+	default:
+		return false, nil
+	}
+}
+
+// describeActive renders the active binary for an error message, saying plainly
+// which of the two checks could not be made rather than implying both ran.
+func describeActive(active activeBinary) string {
+	switch {
+	case active.path == "":
+		return "not found"
+	case active.version == "":
+		return active.path + ", version undetermined"
+	case active.flavor == "":
+		return active.version + ", flavor undetermined"
+	default:
+		return active.version + "[" + active.flavor + "]"
+	}
+}
+
+// findInCache returns the highest cached version of a component satisfying the
+// constraint. Cache entries are directories laid out as
+// <cache>/<component>/<flavor>/<version>/, so a CE and an EE build of the same
+// version can coexist and a [ce] requirement can never resolve to an EE tree.
+func findInCache(
+	cacheDir, name, flavor string, constraint manifest.Constraint,
+) (string, string, bool, error) {
+	if cacheDir == "" {
+		return "", "", false, nil
+	}
+
+	root := filepath.Join(cacheDir, name, flavor)
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		// A missing or unreadable cache is a miss, not a failure: the fallback
+		// may still supply the component, and an absent cache is the normal
+		// state in v0 where nothing populates it automatically.
+		return "", "", false, nil //nolint:nilerr // An unreadable cache is a miss.
+	}
+
+	var matches []string
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		ok, err := satisfies(e.Name(), constraint)
+		if err != nil {
+			return "", "", false, err
+		}
+
+		if ok {
+			matches = append(matches, e.Name())
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", "", false, nil
+	}
+
+	sortVersionsDesc(matches)
+
+	return filepath.Join(root, matches[0]), normalizeVersion(matches[0]), true, nil
+}
+
+// sortVersionsDesc sorts semantic versions highest-first, falling back to
+// reverse lexical order for anything unparseable.
+func sortVersionsDesc(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		vi, erri := version.NewVersion(normalizeVersion(versions[i]))
+		vj, errj := version.NewVersion(normalizeVersion(versions[j]))
+
+		if erri != nil || errj != nil {
+			return versions[i] > versions[j]
+		}
+
+		return vi.GreaterThan(vj)
+	})
+}
+
+// satisfies reports whether a concrete version meets the manifest constraint.
+// An empty constraint accepts anything.
+//
+// A constraint tt cannot parse is an error rather than a miss: degrading it to
+// a literal comparison would quietly bundle the wrong runtime, or nothing at
+// all, off a typo. An unparseable *version* is only a miss — cache directories
+// are user-created and a stray name should be skipped, not fatal.
+func satisfies(ver string, constraint manifest.Constraint) (bool, error) {
+	// An unknown version satisfies nothing, checked before the empty-spec case:
+	// a flavor-only constraint ("[ee]" with no range) otherwise accepted an
+	// undetermined version and stamped an empty bundled_*_version into the lock.
+	if strings.TrimSpace(ver) == "" {
+		return false, nil
+	}
+
+	spec := strings.TrimSpace(constraint.Version)
+	if spec == "" {
+		return true, nil
+	}
+
+	constraints, err := version.NewConstraint(spec)
+	if err != nil {
+		return false, stateErrorf(
+			"%w: %q (expected a comma-separated range like %q)",
+			errBadConstraint, spec, ">=3.0.0,<4.0.0")
+	}
+
+	parsed, err := version.NewVersion(coreVersion(ver))
+	if err != nil {
+		// Cache directories are user-created; a stray name that is not a version
+		// is skipped rather than failing the whole pack.
+		return false, nil //nolint:nilerr // An unparseable version is a miss.
+	}
+
+	return constraints.Check(parsed), nil
+}
+
+// coreVersion reduces a reported runtime version to its major.minor.patch core,
+// dropping any prerelease or build-metadata suffix.
+//
+// This is deliberately looser than semver's own rule, which excludes a
+// prerelease from a range that does not itself name one. That rule exists for
+// resolving dependencies, where an unreleased version is a hazard. Here the
+// version describes a binary the user already has installed, and every
+// Tarantool development build reports one - "3.8.0-entrypoint-49-g97a3b38040".
+// Under the strict rule such a build satisfies no ordinary constraint at all,
+// so [platform].tarantool = ">=3.0.0,<4.0.0" would reject a perfectly usable
+// 3.8.0. Matching on the core version treats that build as the 3.8.0 it is;
+// bundleRuntime warns separately when what it bundles is a prerelease.
+func coreVersion(ver string) string {
+	ver = normalizeVersion(ver)
+
+	// Cut build metadata first, then the prerelease: "3.8.0-rc1+deadbeef".
+	ver, _, _ = strings.Cut(ver, "+")
+	ver, _, _ = strings.Cut(ver, "-")
+
+	return ver
+}
+
+// isPrerelease reports whether a reported version carries a prerelease or
+// build-metadata suffix, i.e. whether coreVersion had to drop anything.
+func isPrerelease(ver string) bool {
+	return coreVersion(ver) != normalizeVersion(ver)
+}
+
+// normalizeVersion strips a leading "v" and surrounding whitespace, leaving the
+// version otherwise intact - the prerelease suffix is meaningful and is only
+// dropped for constraint checking, by coreVersion.
+func normalizeVersion(ver string) string {
+	return strings.TrimPrefix(strings.TrimSpace(ver), "v")
+}
+
+// placeRuntime copies one resolved component into <stage>/_runtime/<name>/.
+func placeRuntime(stageDir string, src runtimeSource) error {
+	dst := filepath.Join(stageDir, runtimeDirName, src.Name)
+
+	if src.Dir != "" {
+		if err := copyTree(src.Dir, dst); err != nil {
+			return fmt.Errorf("bundling %s: %w", src.Name, err)
+		}
+	} else if err := placeBinaryRuntime(dst, src); err != nil {
+		return err
+	}
+
+	if src.Name == runtimeTarantool {
+		return checkTarantoolLicense(dst, src)
+	}
+
+	return nil
+}
+
+// placeBinaryRuntime bundles a component resolved to a single executable, the
+// fallback shape. For Tarantool the interpreter alone is not enough: its Lua
+// modules live in <prefix>/share/tarantool, and a bundle missing them fails at
+// require time rather than at pack time, so they come along when present.
+func placeBinaryRuntime(dst string, src runtimeSource) error {
+	target := filepath.Join(dst, "bin", src.Name)
+	if err := copyFile(src.Binary, target); err != nil {
+		return fmt.Errorf("bundling %s: %w", src.Name, err)
+	}
+
+	if src.Name != runtimeTarantool {
+		return nil
+	}
+
+	prefix := filepath.Dir(filepath.Dir(src.Binary))
+
+	share := filepath.Join(prefix, "share", "tarantool")
+	if _, err := os.Stat(share); err != nil {
+		return nil //nolint:nilerr // No share tree to bundle.
+	}
+
+	if err := copyTree(share, filepath.Join(dst, "share", "tarantool")); err != nil {
+		return fmt.Errorf("bundling Tarantool share/: %w", err)
+	}
+
+	return nil
+}
+
+// checkTarantoolLicense enforces that a bundled Tarantool ships its LICENSE.
+// A cache entry is expected to carry one; the single-binary fallback cannot, so
+// the license is looked up next to the binary's install prefix.
+func checkTarantoolLicense(dst string, src runtimeSource) error {
+	for _, name := range tarantoolLicenseNames {
+		if _, err := os.Stat(filepath.Join(dst, name)); err == nil {
+			return nil
+		}
+	}
+
+	if src.Dir != "" {
+		return stateErrorf("%w: none of %s found in %s",
+			errNoTarantoolLicense, strings.Join(tarantoolLicenseNames, ", "), src.Dir)
+	}
+
+	// Fallback path: look beside the binary, i.e. <prefix>/bin/tarantool =>
+	// <prefix>/ and <prefix>/share/tarantool/.
+	prefix := filepath.Dir(filepath.Dir(src.Binary))
+	candidates := []string{prefix, filepath.Join(prefix, "share", "tarantool")}
+
+	for _, dir := range candidates {
+		for _, name := range tarantoolLicenseNames {
+			path := filepath.Join(dir, name)
+			if _, err := os.Stat(path); err == nil {
+				return copyFile(path, filepath.Join(dst, "LICENSE"))
+			}
+		}
+	}
+
+	return stateErrorf("%w: looked beside %s in %s", errNoTarantoolLicense,
+		src.Binary, strings.Join(candidates, ", "))
+}

--- a/cli/manifest/pack/runtime_test.go
+++ b/cli/manifest/pack/runtime_test.go
@@ -1,0 +1,324 @@
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func constraint(spec string) manifest.Constraint {
+	return manifest.Constraint{Version: spec}
+}
+
+// fakeCache builds a runtime cache with the given component versions, all under
+// the ce flavor. Every tarantool entry gets a LICENSE, since bundling one
+// without it is refused.
+func fakeCache(t *testing.T, entries map[string][]string) string {
+	t.Helper()
+
+	return fakeFlavorCache(t, flavorCE, entries)
+}
+
+// fakeFlavorCache builds a runtime cache under one explicit flavor.
+func fakeFlavorCache(t *testing.T, flavor string, entries map[string][]string) string {
+	t.Helper()
+
+	cache := t.TempDir()
+
+	for component, versions := range entries {
+		for _, ver := range versions {
+			dir := filepath.Join(cache, component, flavor, ver)
+			files := map[string]string{
+				filepath.Join("bin", component): "#!/bin/sh\n",
+			}
+
+			if component == runtimeTarantool {
+				files["LICENSE"] = "BSD-2-Clause"
+			}
+
+			writeTree(t, dir, files)
+		}
+	}
+
+	return cache
+}
+
+// TestSatisfies uses the manifest's documented constraint syntax - a
+// comma-separated hashicorp range, as in testdata/my-app.toml's
+// ">=3.0.0,<4.0.0[ce]". Caret ranges are npm/cargo syntax and are rejected.
+func TestSatisfies(t *testing.T) {
+	tests := []struct {
+		name string
+		ver  string
+		spec string
+		want bool
+	}{
+		{"range matches", "3.2.0", ">=3.0.0,<4.0.0", true},
+		{"range rejects major bump", "4.0.0", ">=3.0.0,<4.0.0", false},
+		{"range rejects below floor", "2.11.0", ">=3.0.0,<4.0.0", false},
+		{"lower bound only", "3.1.0", ">=3.1.0", true},
+		{"empty constraint accepts anything", "3.0.5", "", true},
+		{"empty version never satisfies", "", ">=3.0.0", false},
+		{"leading v is tolerated", "v3.0.5", ">=3.0.0,<4.0.0", true},
+		{"exact pin", "3.0.5", "3.0.5", true},
+		{"unparseable version is a miss", "not-a-version", ">=3.0.0", false},
+		// Every Tarantool development build reports a prerelease suffix; under
+		// strict semver it would satisfy no ordinary range at all.
+		{"tarantool entrypoint build", "3.8.0-entrypoint-49-g97a3b38040",
+			">=3.0.0,<4.0.0", true},
+		{"prerelease still respects bounds", "4.0.0-entrypoint-1-gabc",
+			">=3.0.0,<4.0.0", false},
+		{"build metadata is dropped", "3.2.0+deadbeef", ">=3.0.0,<4.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := satisfies(tt.ver, constraint(tt.spec))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSatisfiesRejectsBadConstraint pins the no-silent-fallback rule: a typo in
+// [platform] must fail loudly rather than degrade to an exact-string match and
+// bundle the wrong runtime.
+func TestSatisfiesRejectsBadConstraint(t *testing.T) {
+	for _, spec := range []string{"^3.0", "~3.0.0.0", "not a constraint"} {
+		_, err := satisfies("3.0.5", constraint(spec))
+		require.Error(t, err, "constraint %q must be rejected", spec)
+		assert.ErrorIs(t, err, errBadConstraint)
+	}
+}
+
+// TestFindInCachePicksHighest is what makes the cache deterministic: with
+// several satisfying versions present, the highest wins, not the first read.
+func TestFindInCachePicksHighest(t *testing.T) {
+	cache := fakeCache(t, map[string][]string{
+		runtimeTarantool: {"3.0.1", "3.2.0", "3.10.0", "2.11.0", "4.0.0"},
+	})
+
+	dir, ver, ok, err := findInCache(cache, runtimeTarantool, flavorCE, constraint(">=3.0.0,<4.0.0"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "3.10.0", ver, "3.10.0 > 3.2.0 numerically, not lexically")
+	assert.Equal(t, filepath.Join(cache, runtimeTarantool, flavorCE, "3.10.0"), dir)
+}
+
+func TestFindInCacheMisses(t *testing.T) {
+	cache := fakeCache(t, map[string][]string{runtimeTarantool: {"2.11.0"}})
+
+	_, _, ok, err := findInCache(cache, runtimeTarantool, flavorCE, constraint(">=3.0.0,<4.0.0"))
+	require.NoError(t, err)
+	assert.False(t, ok, "no satisfying version")
+
+	_, _, ok, err = findInCache(cache, runtimeTt, flavorCE, constraint(">=2.0.0,<3.0.0"))
+	require.NoError(t, err)
+	assert.False(t, ok, "component absent from cache")
+
+	_, _, ok, err = findInCache("", runtimeTarantool, flavorCE, constraint(">=3.0.0,<4.0.0"))
+	require.NoError(t, err)
+	assert.False(t, ok, "no cache configured")
+}
+
+func TestBundleRuntimeFromCache(t *testing.T) {
+	cache := fakeCache(t, map[string][]string{
+		runtimeTarantool: {"3.0.5", "3.1.0"},
+		runtimeTt:        {"2.5.0"},
+	})
+	stageDir := t.TempDir()
+
+	var warnings []string
+
+	bundled, err := bundleRuntime(stageDir, RuntimeOptions{
+		CacheDir: cache,
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		Warn: func(msg string) { warnings = append(warnings, msg) },
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "3.1.0", bundled.Tarantool)
+	assert.Equal(t, "2.5.0", bundled.Tt)
+	assert.Empty(t, bundled.Tcm, "tcm unset in [platform] is not bundled")
+	assert.Empty(t, warnings, "the cache path must not warn")
+
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tarantool", "bin", "tarantool"))
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tarantool", "LICENSE"))
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tt", "bin", "tt"))
+	assert.NoDirExists(t, filepath.Join(stageDir, "_runtime", "tcm"))
+}
+
+func TestBundleRuntimeIncludesTcmWhenDeclared(t *testing.T) {
+	cache := fakeCache(t, map[string][]string{
+		runtimeTarantool: {"3.0.5"},
+		runtimeTt:        {"2.5.0"},
+		runtimeTcm:       {"1.5.2"},
+	})
+	stageDir := t.TempDir()
+
+	bundled, err := bundleRuntime(stageDir, RuntimeOptions{
+		CacheDir: cache,
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+			Tcm:       constraint(">=1.5.0,<2.0.0"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.5.2", bundled.Tcm)
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tcm", "bin", "tcm"))
+}
+
+// TestBundleRuntimeFallsBackToActive covers the v0 convenience path: with no
+// runtime cache yet, the active binary is accepted when it satisfies the
+// constraint — and the user is told the archive is not cache-reproducible.
+func TestBundleRuntimeFallsBackToActive(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "BSD-2-Clause",
+		"bin/tt":        "#!/bin/sh\n",
+	})
+
+	stageDir := t.TempDir()
+
+	var warnings []string
+
+	bundled, err := bundleRuntime(stageDir, RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "3.0.5",
+		ActiveTt:               filepath.Join(prefix, "bin", "tt"),
+		ActiveTtVersion:        "2.4.0",
+		Warn:                   func(msg string) { warnings = append(warnings, msg) },
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "3.0.5", bundled.Tarantool)
+	assert.Equal(t, "2.4.0", bundled.Tt)
+	assert.Len(t, warnings, 2, "each fallback must warn")
+
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tarantool", "bin", "tarantool"))
+	// The license is picked up from beside the binary's install prefix.
+	assert.FileExists(t, filepath.Join(stageDir, "_runtime", "tarantool", "LICENSE"))
+}
+
+// TestBundleRuntimeRejectsEmptyPlatform is a regression test. The [platform]
+// constraints reach bundleRuntime from the built manifest; when nothing filled
+// them, every component was skipped as "unset" and a with-deps pack produced an
+// archive with no _runtime/ at all - silently, and byte-comparable to
+// --without-deps. An empty platform must fail loudly instead.
+func TestBundleRuntimeRejectsEmptyPlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform manifest.Platform
+	}{
+		{"nothing set", manifest.Platform{}},
+		{"tarantool only", manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+		}},
+		{"tt only", manifest.Platform{Tt: constraint(">=2.0.0,<3.0.0")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stageDir := t.TempDir()
+
+			_, err := bundleRuntime(stageDir, RuntimeOptions{
+				CacheDir: fakeCache(t, map[string][]string{
+					runtimeTarantool: {"3.0.5"},
+					runtimeTt:        {"2.5.0"},
+				}),
+				Platform: tt.platform,
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errNoRuntime)
+			assert.NoDirExists(t, filepath.Join(stageDir, "_runtime"))
+		})
+	}
+}
+
+// TestBundleRuntimeRejectsUnsatisfiedActive guards against silently bundling
+// the wrong Tarantool: a fallback that misses the constraint is an error, not
+// a warning.
+func TestBundleRuntimeRejectsUnsatisfiedActive(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{"bin/tarantool": "#!/bin/sh\n"})
+
+	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "2.11.0",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoRuntime)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+func TestBundleRuntimeNoSourceAtAll(t *testing.T) {
+	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoRuntime)
+}
+
+// TestBundleRuntimeRequiresTarantoolLicense enforces the RFC rule that a
+// bundled Tarantool ships its LICENSE.
+func TestBundleRuntimeRequiresTarantoolLicense(t *testing.T) {
+	cache := t.TempDir()
+	writeTree(t, filepath.Join(cache, runtimeTarantool, flavorCE, "3.0.5"), map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+	})
+
+	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: cache,
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoTarantoolLicense)
+}
+
+func TestPlaceRuntimeKeepsExecutableBit(t *testing.T) {
+	src := t.TempDir()
+	binPath := filepath.Join(src, "bin", "tt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), dirPerm))
+	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o755))
+
+	stageDir := t.TempDir()
+	require.NoError(t, placeRuntime(stageDir, runtimeSource{
+		Name: runtimeTt, Version: "2.0.0", Dir: src,
+	}))
+
+	info, err := os.Stat(filepath.Join(stageDir, "_runtime", "tt", "bin", "tt"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode().Perm()&0o100, "the binary must stay executable")
+}

--- a/cli/manifest/pack/stage.go
+++ b/cli/manifest/pack/stage.go
@@ -1,0 +1,339 @@
+package pack
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Staging tree modes.
+const (
+	filePerm os.FileMode = 0o644
+	dirPerm  os.FileMode = 0o755
+)
+
+// stage assembles the archive tree under stageDir: the manifest, lock, VERSION,
+// license files, [package].include payload and the .rocks/ subtree, filtered by
+// packing mode. _runtime/ is added separately by bundleRuntime.
+//
+// Everything is copied into a staging directory rather than streamed straight
+// from the project, so the tar layer sees one flat, already-correct tree and
+// the mode filtering happens exactly once, in one place.
+func stage(stageDir string, req stageRequest) error {
+	if err := os.MkdirAll(stageDir, dirPerm); err != nil {
+		return fmt.Errorf("creating staging directory: %w", err)
+	}
+
+	if err := stageMetadata(stageDir, req); err != nil {
+		return err
+	}
+
+	if err := stagePayload(stageDir, req); err != nil {
+		return err
+	}
+
+	return stageRocks(stageDir, req)
+}
+
+// stageRequest carries everything stage needs to lay out the archive tree.
+type stageRequest struct {
+	// ProjectDir is the source project root.
+	ProjectDir string
+	// Manifest is the parsed manifest; its raw bytes go into the archive as-is.
+	Manifest *manifest.Manifest
+	// LockBytes is the marshaled lock, already carrying the bundled_* versions.
+	LockBytes []byte
+	// Version is the derived version string written to VERSION.
+	Version string
+	// Tree is the project's materialized .rocks/ directory.
+	Tree string
+	// WithDeps keeps foreign dependencies in .rocks/; false strips everything
+	// but the package's own namespace subtrees.
+	WithDeps bool
+	// Namespaces lists the rocks-tree namespaces the package itself owns. In
+	// --without-deps mode only these survive under share/ and lib/.
+	Namespaces []string
+	// HasFlatNamespace records that some component declares namespace = "",
+	// which --without-deps cannot express (see stageRocks).
+	HasFlatNamespace bool
+}
+
+// stageMetadata writes the three tt-owned metadata files.
+func stageMetadata(stageDir string, req stageRequest) error {
+	files := []struct {
+		name string
+		data []byte
+	}{
+		{manifestFileName, req.Manifest.Raw()},
+		{lockFileName, req.LockBytes},
+		{versionFileName, []byte(req.Version + "\n")},
+	}
+
+	for _, f := range files {
+		path := filepath.Join(stageDir, f.name)
+		if err := os.WriteFile(path, f.data, filePerm); err != nil {
+			return fmt.Errorf("staging %s: %w", f.name, err)
+		}
+	}
+
+	return nil
+}
+
+// stagePayload copies the license files and the [package].include entries into
+// the archive root, keeping each entry's path relative to the project.
+func stagePayload(stageDir string, req stageRequest) error {
+	pkg := req.Manifest.Package
+
+	for _, entry := range pkg.LicenseFiles {
+		if err := stageEntry(stageDir, req.ProjectDir, entry, "license_files"); err != nil {
+			return err
+		}
+	}
+
+	for _, entry := range pkg.Include {
+		if err := stageEntry(stageDir, req.ProjectDir, entry, "include"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// stageEntry copies one manifest-declared path into the staging tree. The entry
+// is rejected if it escapes the project, collides with a reserved archive name
+// or matches nothing — a silently dropped LICENSE is worse than a failed pack.
+func stageEntry(stageDir, projectDir, entry, field string) error {
+	clean := filepath.Clean(entry)
+	upward := clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator))
+
+	if filepath.IsAbs(clean) || upward {
+		return stateErrorf("%s entry %q: %w", field, entry, errEscapingPath)
+	}
+
+	if isReservedName(clean) {
+		return stateErrorf("%s entry %q: %w", field, entry, errReservedName)
+	}
+
+	src := filepath.Join(projectDir, clean)
+
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return stateErrorf("%s entry %q: %w", field, entry, errMissingInclude)
+		}
+
+		return fmt.Errorf("%s entry %q: %w", field, entry, err)
+	}
+
+	dst := filepath.Join(stageDir, clean)
+
+	if info.IsDir() {
+		return copyTree(src, dst)
+	}
+
+	return copyFile(src, dst)
+}
+
+// stageRocks copies the project's .rocks/ tree into the archive. In --with-deps
+// mode the tree is copied whole; in --without-deps mode only the package's own
+// namespace subtrees under share/tarantool/ and lib/tarantool/ survive, which
+// is what leaves the dependency closure to be refetched from the lock at
+// install time.
+func stageRocks(stageDir string, req stageRequest) error {
+	if _, err := os.Stat(req.Tree); os.IsNotExist(err) {
+		// A pure-metadata package need not have produced a tree.
+		return nil
+	}
+
+	dstRocks := filepath.Join(stageDir, rocksDirName)
+
+	if req.WithDeps {
+		return copyTree(req.Tree, dstRocks)
+	}
+
+	if req.HasFlatNamespace {
+		// A flat namespace (namespace = "") owns no subtree: its files sit
+		// directly among the tree roots, indistinguishable by path from a
+		// dependency's. Dropping them silently would lose the package's own code
+		// from an archive whose whole promise is to keep exactly that, so this is
+		// refused rather than quietly under-packing.
+		return stateErrorf(
+			"%w: a component with namespace = \"\" lays its files flat in the "+
+				"rocks tree, where they cannot be told apart from dependencies; "+
+				"pack it with the default --with-deps instead",
+			errFlatNamespace)
+	}
+
+	for _, sub := range []string{shareTarantool, libTarantool} {
+		for _, ns := range req.Namespaces {
+			if ns == "" {
+				continue
+			}
+
+			src := filepath.Join(req.Tree, filepath.FromSlash(sub), ns)
+			if _, err := os.Stat(src); os.IsNotExist(err) {
+				continue
+			}
+
+			dst := filepath.Join(dstRocks, filepath.FromSlash(sub), ns)
+			if err := copyTree(src, dst); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Rocks-tree layout roots, mirroring cli/manifest/build.
+const (
+	shareTarantool = "share/tarantool"
+	libTarantool   = "lib/tarantool"
+)
+
+// copyTree recursively copies src to dst, creating parents as needed. The
+// archive carries no link structure, so symlinks are dereferenced: a link to a
+// file is copied as that file, a link to a directory is descended into.
+//
+// The root is resolved up front because WalkDir does not follow a symlinked
+// root - it reports it as a plain symlink entry, which would otherwise send a
+// directory down the file-copy path. Package prefixes hit this routinely
+// (Homebrew's share/tarantool is a link into the Cellar).
+func copyTree(src, dst string) error {
+	if resolved, err := filepath.EvalSymlinks(src); err == nil {
+		src = resolved
+	}
+
+	// Refuse to copy a tree into itself. The staging directory lives inside the
+	// project (_build/pack/stage-*), so a payload entry naming an ancestor of it
+	// would have WalkDir descend into the copies it is creating, recursing until
+	// the path outgrows PATH_MAX. isReservedName rejects the entries that reach
+	// this today; the guard keeps the invariant independent of that list.
+	if within(dst, src) {
+		return stateErrorf("refusing to copy %s into its own subdirectory %s", src, dst)
+	}
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, dirPerm)
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Stat follows the link; a link to a directory becomes its own walk.
+			resolved, err := os.Stat(path)
+			if err != nil {
+				// A dangling link is skipped rather than failing the pack.
+				return nil //nolint:nilerr // A dangling symlink is not packable.
+			}
+
+			if resolved.IsDir() {
+				return copyTree(path, target)
+			}
+
+			return copyFile(path, target)
+		}
+
+		if !info.Mode().IsRegular() {
+			// Sockets, devices and pipes have no place in an archive.
+			return nil
+		}
+
+		return copyFile(path, target)
+	})
+}
+
+// within reports whether path is inside root (or is root itself). Both sides
+// are resolved first: on macOS EvalSymlinks turns /var into /private/var, so
+// comparing a resolved root against an unresolved path finds no relation even
+// when one contains the other.
+func within(path, root string) bool {
+	rel, err := filepath.Rel(resolveExisting(root), resolveExisting(path))
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || !strings.HasPrefix(rel, "..")
+}
+
+// resolveExisting resolves symlinks in the longest existing prefix of path and
+// re-appends the remainder, so a path that does not exist yet (the staging
+// directory) still normalizes the same way as one that does.
+func resolveExisting(path string) string {
+	path = filepath.Clean(path)
+
+	rest := ""
+	for cur := path; ; {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return path
+		}
+
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
+}
+
+// copyFile copies one file, creating the destination's parent and preserving
+// the executable bit (which _runtime/ binaries depend on).
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return err
+	}
+
+	// Stat, not Lstat: a symlinked binary in bin_dir must be copied as its
+	// target, since the archive carries no link structure.
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	perm := filePerm
+	if info.Mode().Perm()&0o100 != 0 {
+		perm = 0o755
+	}
+
+	in, err := os.Open(src) //nolint:gosec // Sources are project or runtime files.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	//nolint:gosec // The destination is inside our own staging tree.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+
+		return fmt.Errorf("copying %s: %w", src, err)
+	}
+
+	return out.Close()
+}

--- a/cli/manifest/pack/stage_test.go
+++ b/cli/manifest/pack/stage_test.go
@@ -1,0 +1,337 @@
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// stagedNames lists every file staged under dir, slash-separated and sorted.
+func stagedNames(t *testing.T, dir string) []string {
+	t.Helper()
+
+	var names []string
+
+	require.NoError(t, filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		names = append(names, filepath.ToSlash(rel))
+
+		return nil
+	}))
+
+	sort.Strings(names)
+
+	return names
+}
+
+// testProject writes a minimal project tree and returns its dir and a parsed
+// manifest for it.
+func testProject(t *testing.T, extra map[string]string) (string, *manifest.Manifest) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	manifestTOML := `manifest_version = "0.1"
+
+[package]
+name = "my-app"
+include = ["README.md"]
+license_files = ["LICENSE"]
+
+[platform]
+tarantool = ">=3.0.0,<4.0.0"
+tt = ">=2.0.0,<3.0.0"
+
+[components.main]
+path = "."
+
+[products.default]
+components = ["main"]
+default = true
+`
+
+	files := map[string]string{
+		manifestFileName: manifestTOML,
+		"README.md":      "readme body",
+		"LICENSE":        "license body",
+	}
+	for k, v := range extra {
+		files[k] = v
+	}
+
+	writeTree(t, dir, files)
+
+	man, _, err := manifest.ParseManifest([]byte(manifestTOML))
+	require.NoError(t, err)
+
+	return dir, man
+}
+
+// testTree writes a .rocks tree with the package's own files plus a dependency.
+func testTree(t *testing.T, projectDir string) string {
+	t.Helper()
+
+	tree := filepath.Join(projectDir, ".rocks")
+	writeTree(t, tree, map[string]string{
+		"share/tarantool/my-app/init.lua":    "return 1",
+		"share/tarantool/my-app/version.lua": "return {}",
+		"share/tarantool/inspect/init.lua":   "dependency",
+		"lib/tarantool/my-app/fast.so":       "native",
+		"lib/tarantool/cjson/cjson.so":       "dependency native",
+	})
+
+	return tree
+}
+
+func baseRequest(projectDir string, man *manifest.Manifest, tree string) stageRequest {
+	return stageRequest{
+		ProjectDir: projectDir,
+		Manifest:   man,
+		LockBytes:  []byte("lock_version = \"0.1\"\n"),
+		Version:    "1.0.0",
+		Tree:       tree,
+		WithDeps:   true,
+		Namespaces: []string{"my-app"},
+	}
+}
+
+func TestStageWithDeps(t *testing.T) {
+	projectDir, man := testProject(t, nil)
+	tree := testTree(t, projectDir)
+	stageDir := t.TempDir()
+
+	require.NoError(t, stage(stageDir, baseRequest(projectDir, man, tree)))
+
+	assert.Equal(t, []string{
+		".rocks/lib/tarantool/cjson/cjson.so",
+		".rocks/lib/tarantool/my-app/fast.so",
+		".rocks/share/tarantool/inspect/init.lua",
+		".rocks/share/tarantool/my-app/init.lua",
+		".rocks/share/tarantool/my-app/version.lua",
+		"LICENSE",
+		"README.md",
+		"VERSION",
+		"app.manifest.lock",
+		"app.manifest.toml",
+	}, stagedNames(t, stageDir))
+
+	version, err := os.ReadFile(filepath.Join(stageDir, versionFileName))
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0\n", string(version))
+
+	// The manifest goes in verbatim, not re-serialized.
+	staged, err := os.ReadFile(filepath.Join(stageDir, manifestFileName))
+	require.NoError(t, err)
+	assert.Equal(t, string(man.Raw()), string(staged))
+}
+
+// TestStageWithoutDeps is the core of --without-deps: the package's own
+// namespace survives in .rocks/, every foreign dependency is dropped.
+func TestStageWithoutDeps(t *testing.T) {
+	projectDir, man := testProject(t, nil)
+	tree := testTree(t, projectDir)
+	stageDir := t.TempDir()
+
+	req := baseRequest(projectDir, man, tree)
+	req.WithDeps = false
+
+	require.NoError(t, stage(stageDir, req))
+
+	names := stagedNames(t, stageDir)
+
+	assert.Contains(t, names, ".rocks/share/tarantool/my-app/init.lua")
+	assert.Contains(t, names, ".rocks/lib/tarantool/my-app/fast.so")
+	assert.NotContains(t, names, ".rocks/share/tarantool/inspect/init.lua")
+	assert.NotContains(t, names, ".rocks/lib/tarantool/cjson/cjson.so")
+
+	// Metadata and license are unaffected by the mode.
+	assert.Contains(t, names, "app.manifest.toml")
+	assert.Contains(t, names, "app.manifest.lock")
+	assert.Contains(t, names, "VERSION")
+	assert.Contains(t, names, "LICENSE")
+}
+
+func TestStageMissingTreeIsNotFatal(t *testing.T) {
+	projectDir, man := testProject(t, nil)
+	stageDir := t.TempDir()
+
+	req := baseRequest(projectDir, man, filepath.Join(projectDir, ".rocks"))
+
+	require.NoError(t, stage(stageDir, req))
+	assert.Contains(t, stagedNames(t, stageDir), "app.manifest.toml")
+}
+
+// TestStageEntryRejections covers the three ways a manifest-declared payload
+// entry is refused. A silently dropped LICENSE is worse than a failed pack.
+func TestStageEntryRejections(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry string
+		want  error
+	}{
+		{"missing file", "NOPE.md", errMissingInclude},
+		{"reserved name", "VERSION", errReservedName},
+		{"reserved directory", ".rocks", errReservedName},
+		{"escaping path", "../outside.txt", errEscapingPath},
+		{"absolute path", "/etc/passwd", errEscapingPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			err := stageEntry(t.TempDir(), projectDir, tt.entry, "include")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.want)
+			assert.Equal(t, exitStateError, ExitCode(err))
+		})
+	}
+}
+
+// TestCopyTreeFollowsSymlinkedRoot is a regression test. WalkDir does not
+// follow a symlinked root, so it reported the link as a plain entry and the
+// directory went down the file-copy path, failing with "is a directory".
+// Package prefixes hit this routinely - Homebrew's share/tarantool is a link
+// into the Cellar, which broke bundling a fallback Tarantool's share/ tree.
+func TestCopyTreeFollowsSymlinkedRoot(t *testing.T) {
+	base := t.TempDir()
+
+	real := filepath.Join(base, "real")
+	writeTree(t, real, map[string]string{"a.lua": "a", "sub/b.lua": "b"})
+
+	link := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	dst := t.TempDir()
+	require.NoError(t, copyTree(link, dst))
+
+	assert.Equal(t, []string{"a.lua", "sub/b.lua"}, stagedNames(t, dst))
+}
+
+// TestCopyTreeDereferencesInnerSymlinks covers links found during the walk: the
+// archive carries no link structure, so each is copied as its target.
+func TestCopyTreeDereferencesInnerSymlinks(t *testing.T) {
+	base := t.TempDir()
+
+	src := filepath.Join(base, "src")
+	writeTree(t, src, map[string]string{"real.lua": "body", "d/inner.lua": "inner"})
+
+	require.NoError(t, os.Symlink(
+		filepath.Join(src, "real.lua"), filepath.Join(src, "link.lua")))
+	require.NoError(t, os.Symlink(
+		filepath.Join(src, "d"), filepath.Join(src, "linkdir")))
+	// A dangling link must be skipped, not fail the pack.
+	require.NoError(t, os.Symlink(
+		filepath.Join(src, "gone.lua"), filepath.Join(src, "dangling.lua")))
+
+	dst := t.TempDir()
+	require.NoError(t, copyTree(src, dst))
+
+	assert.Equal(t, []string{
+		"d/inner.lua", "link.lua", "linkdir/inner.lua", "real.lua",
+	}, stagedNames(t, dst))
+
+	body, err := os.ReadFile(filepath.Join(dst, "link.lua"))
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(body))
+}
+
+// TestStageEntrySelfCopyIsRejected is a regression test. The staging directory
+// lives inside the project at _build/pack/stage-*, so include = ["."] had
+// copyTree descend into the copies it was creating, dying at PATH_MAX with an
+// opaque "file name too long" for an entirely plausible manifest.
+func TestStageEntrySelfCopyIsRejected(t *testing.T) {
+	for _, entry := range []string{".", "_build", "_build/pack"} {
+		t.Run(entry, func(t *testing.T) {
+			projectDir := t.TempDir()
+			writeTree(t, projectDir, map[string]string{"init.lua": "x"})
+
+			stageDir := filepath.Join(projectDir, "_build", "pack", "stage-1")
+
+			err := stageEntry(stageDir, projectDir, entry, "include")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errReservedName)
+		})
+	}
+}
+
+// TestCopyTreeRefusesSelfNesting guards the invariant directly, independent of
+// which entries isReservedName happens to reject.
+func TestCopyTreeRefusesSelfNesting(t *testing.T) {
+	src := t.TempDir()
+	writeTree(t, src, map[string]string{"a.lua": "a"})
+
+	err := copyTree(src, filepath.Join(src, "_build", "pack", "stage-1"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to copy")
+}
+
+// TestStageReservedNameIsCaseInsensitive is a regression test. On a
+// case-insensitive filesystem (APFS, the dev platform) include = ["version"]
+// reopened the already-staged VERSION with O_TRUNC and replaced tt's own
+// metadata with the package's file — silent archive corruption.
+func TestStageReservedNameIsCaseInsensitive(t *testing.T) {
+	projectDir, man := testProject(t, map[string]string{"version": "NOT THE VERSION"})
+	man.Package.Include = []string{"version"}
+
+	err := stage(t.TempDir(), baseRequest(projectDir, man, filepath.Join(projectDir, ".rocks")))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errReservedName)
+}
+
+// TestStageWithoutDepsRejectsFlatNamespace is a regression test. A component
+// with namespace = "" lays its files at the rocks-tree root, where they cannot
+// be told apart from a dependency's; the filter used to skip it silently,
+// dropping the package's own code from an archive that promises to keep it.
+func TestStageWithoutDepsRejectsFlatNamespace(t *testing.T) {
+	projectDir, man := testProject(t, nil)
+	tree := testTree(t, projectDir)
+
+	req := baseRequest(projectDir, man, tree)
+	req.WithDeps = false
+	req.HasFlatNamespace = true
+
+	err := stage(t.TempDir(), req)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errFlatNamespace)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+// A flat namespace is fine with deps bundled: the whole tree is copied anyway.
+func TestStageWithDepsAllowsFlatNamespace(t *testing.T) {
+	projectDir, man := testProject(t, nil)
+	tree := testTree(t, projectDir)
+
+	req := baseRequest(projectDir, man, tree)
+	req.HasFlatNamespace = true
+
+	require.NoError(t, stage(t.TempDir(), req))
+}
+
+func TestStageEntryCopiesDirectory(t *testing.T) {
+	projectDir := t.TempDir()
+	writeTree(t, projectDir, map[string]string{
+		"doc/a.md":     "a",
+		"doc/sub/b.md": "b",
+	})
+
+	stageDir := t.TempDir()
+	require.NoError(t, stageEntry(stageDir, projectDir, "doc", "include"))
+
+	assert.Equal(t, []string{"doc/a.md", "doc/sub/b.md"}, stagedNames(t, stageDir))
+}

--- a/cli/manifest/pack/token.go
+++ b/cli/manifest/pack/token.go
@@ -1,0 +1,37 @@
+package pack
+
+import (
+	"runtime"
+)
+
+// anyToken is the platform token of a universal archive — one that runs on any
+// OS and architecture. Only a --without-deps archive of a product with no
+// native components earns it.
+const anyToken = "any"
+
+// hostToken returns the platform token of the machine pack runs on:
+// "<os>-<arch>", e.g. linux-amd64, linux-arm64, darwin-amd64, darwin-arm64.
+// Go's GOARCH names already match the RFC's token vocabulary for the four
+// supported pairs, so no translation table is needed.
+func hostToken() string {
+	return runtime.GOOS + "-" + runtime.GOARCH
+}
+
+// platformToken picks the token that goes into the archive file name.
+//
+// An archive is universal only when it carries neither a bundled runtime nor
+// any native artifact: bundling Tarantool pins the archive to a platform
+// because the binary is platform-specific, and a .so pins it for the same
+// reason. Every other archive is per-(os, arch) and takes the host token.
+func platformToken(withDeps, hasNative bool) string {
+	if withDeps || hasNative {
+		return hostToken()
+	}
+
+	return anyToken
+}
+
+// archiveName builds the archive file name: <package>-<version>-<token>.tt.
+func archiveName(pkg, version, token string) string {
+	return pkg + "-" + version + "-" + token + archiveExt
+}

--- a/cli/manifest/pack/token_test.go
+++ b/cli/manifest/pack/token_test.go
@@ -1,0 +1,96 @@
+package pack
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlatformToken(t *testing.T) {
+	host := runtime.GOOS + "-" + runtime.GOARCH
+
+	tests := []struct {
+		name      string
+		withDeps  bool
+		hasNative bool
+		want      string
+	}{
+		{
+			name:     "with-deps is always platform bound",
+			withDeps: true,
+			want:     host,
+		},
+		{
+			name:      "with-deps and native is platform bound",
+			withDeps:  true,
+			hasNative: true,
+			want:      host,
+		},
+		{
+			name:      "without-deps but native is platform bound",
+			hasNative: true,
+			want:      host,
+		},
+		{
+			name: "without-deps and pure lua is universal",
+			want: anyToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, platformToken(tt.withDeps, tt.hasNative))
+		})
+	}
+}
+
+func TestArchiveName(t *testing.T) {
+	assert.Equal(t, "my-app-1.0.0-linux-amd64.tt",
+		archiveName("my-app", "1.0.0", "linux-amd64"))
+	assert.Equal(t, "my-lib-2.1.0-any.tt",
+		archiveName("my-lib", "2.1.0", anyToken))
+	assert.Equal(t, "my-app-1.0.0-dev.3+gabc1234-linux-arm64.tt",
+		archiveName("my-app", "1.0.0-dev.3+gabc1234", "linux-arm64"))
+}
+
+func TestIsReservedName(t *testing.T) {
+	reserved := []string{
+		"app.manifest.toml",
+		"app.manifest.lock",
+		"VERSION",
+		"_runtime",
+		"_runtime/tarantool/bin/tarantool",
+		".rocks",
+		".rocks/share/tarantool/my-app/init.lua",
+	}
+	for _, name := range reserved {
+		assert.True(t, isReservedName(name), "%q must be reserved", name)
+	}
+
+	// The staging tree is a real directory, and on a case-insensitive
+	// filesystem (APFS, NTFS) "version" opens the staged VERSION and truncates
+	// it — so the reserved check is case-insensitive rather than exact.
+	caseVariants := []string{"version", "Version", "APP.MANIFEST.TOML", "_Runtime", ".Rocks"}
+	for _, name := range caseVariants {
+		assert.True(t, isReservedName(name), "%q must be reserved case-insensitively", name)
+	}
+
+	// "." is the project root, which contains the staging directory, and
+	// _build holds it — copying either would recurse into the copy in progress.
+	for _, name := range []string{".", "..", "", "_build", "_build/pack"} {
+		assert.True(t, isReservedName(name), "%q must be reserved", name)
+	}
+
+	allowed := []string{
+		"LICENSE",
+		"README.md",
+		"doc/index.md",
+		"runtime/thing.lua", // No leading underscore.
+		"app.manifest.yaml",
+		"versions.lua", // Only the exact name is reserved, not a prefix.
+	}
+	for _, name := range allowed {
+		assert.False(t, isReservedName(name), "%q must be allowed", name)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.8.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
+	github.com/klauspost/compress v1.18.4
 	github.com/magefile/mage v1.15.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-isatty v0.0.20
@@ -102,7 +103,6 @@ require (
 	github.com/kaptinlin/jsonschema v0.6.7 // indirect
 	github.com/kaptinlin/messageformat-go v0.4.7 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect


### PR DESCRIPTION
Adds `cli/manifest/pack` and wires `tt package pack`: it runs the full build and assembles the result into a reproducible `.tt` archive (tar+zstd) written to `_build/pack/<package>-<version>-<token>.tt`, with the path printed to stdout. Two modes — the default bundles `_runtime/` (Tarantool, tt, and TCM when `[platform].tcm` is set) plus the whole dependency closure in `.rocks/` so installing is a plain extraction; `--without-deps` drops both, keeping only the package's own namespace subtrees. The archive is byte-reproducible (normalized tar headers, `built_at` pinned to `SOURCE_DATE_EPOCH` or the HEAD commit time), and runtime components resolve cache-first from `<user cache>/tt/runtimes` with flavor-aware, licensing-safe constraints.

A preparatory commit adds `RunResult` to the build so pack consumes the manifest, gated lock, derived version, selected product, and tree directly instead of re-reading and re-deriving them from disk.

- cli/manifest/build: report the build result to callers
- cli/manifest/pack: tt package pack and the .tt archive

Part of TNTP-8612