### PR TITLE
cluster: add cluster topology command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `tt backup start` and `tt backup finalize`: add support for creating and
   finalizing local backup artifacts.
+- `tt cluster topology`: add cluster topology discovery from a file, etcd, or
+  Tarantool Config Storage with table and JSON output.
 
 ### Changed
 

--- a/cli/backup/aggregation.go
+++ b/cli/backup/aggregation.go
@@ -9,6 +9,7 @@ import (
 const artifactCompression = "zstd"
 
 // RecoveryPoint describes one engine recovery point returned by Tarantool.
+// box.backup.info() returns {timestamp, replica_id, lsn, label}.
 type RecoveryPoint struct {
 	Label     string  `json:"label"`
 	ReplicaID uint32  `json:"replica_id"`

--- a/cli/backup/boxbackup.go
+++ b/cli/backup/boxbackup.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -82,6 +81,7 @@ const instanceInfoExpr = `return {
 	replicaset_uuid = box.info.replicaset.uuid,
 	instance_uuid   = box.info.uuid,
 	instance_name   = box.info.name,
+	hostname        = box.info.hostname,
 	wal_dir         = box.cfg.wal_dir,
 	memtx_dir       = box.cfg.memtx_dir,
 	vinyl_dir       = box.cfg.vinyl_dir,
@@ -91,11 +91,6 @@ const instanceInfoExpr = `return {
 // from the instance (box.info/box.cfg) and augments them with the local
 // hostname (the command runs on the node).
 func GetInstanceInfo(conn connector.Connector) (*InstanceInfo, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine hostname: %w", err)
-	}
-
 	res, err := conn.Eval(instanceInfoExpr, []any{}, connector.RequestOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get instance info: %w", err)
@@ -108,6 +103,7 @@ func GetInstanceInfo(conn connector.Connector) (*InstanceInfo, error) {
 		ReplicasetUUID string `json:"replicaset_uuid"`
 		InstanceUUID   string `json:"instance_uuid"`
 		InstanceName   string `json:"instance_name"`
+		Hostname       string `json:"hostname"`
 		WalDir         string `json:"wal_dir"`
 		MemtxDir       string `json:"memtx_dir"`
 		VinylDir       string `json:"vinyl_dir"`
@@ -127,9 +123,9 @@ func GetInstanceInfo(conn connector.Connector) (*InstanceInfo, error) {
 		ReplicasetUUID: decoded.ReplicasetUUID,
 		InstanceUUID:   decoded.InstanceUUID,
 		InstanceName:   decoded.InstanceName,
+		Hostname:       decoded.Hostname,
 		WalDir:         decoded.WalDir,
 		MemtxDir:       decoded.MemtxDir,
 		VinylDir:       decoded.VinylDir,
-		Hostname:       hostname,
 	}, nil
 }

--- a/cli/backup/boxbackup_test.go
+++ b/cli/backup/boxbackup_test.go
@@ -218,6 +218,7 @@ func TestGetInstanceInfo(t *testing.T) {
 		"replicaset_uuid": testReplicasetUUID,
 		"instance_uuid":   testInstanceUUID,
 		"instance_name":   "router-001",
+		"hostname":        "node-1.example.com",
 		"wal_dir":         "/var/lib/tarantool/wal",
 		"memtx_dir":       "/var/lib/tarantool/memtx",
 		"vinyl_dir":       "/var/lib/tarantool/vinyl",
@@ -228,6 +229,7 @@ func TestGetInstanceInfo(t *testing.T) {
 	require.Equal(t, testReplicasetUUID, inst.ReplicasetUUID)
 	require.Equal(t, testInstanceUUID, inst.InstanceUUID)
 	require.Equal(t, "router-001", inst.InstanceName)
+	require.Equal(t, "node-1.example.com", inst.Hostname)
 	require.Equal(t, "/var/lib/tarantool/wal", inst.WalDir)
 	require.Equal(t, "/var/lib/tarantool/memtx", inst.MemtxDir)
 	require.Equal(t, "/var/lib/tarantool/vinyl", inst.VinylDir)

--- a/cli/backup/start_test.go
+++ b/cli/backup/start_test.go
@@ -50,8 +50,8 @@ func (m *mockEvaler) Eval(expr string, args []any,
 func (m *mockEvaler) Close() error { return nil }
 
 // Golden fixtures for the start command: fixed WAL payloads and an expected
-// instance_backup.json. hostname and checksum_sha256 are dynamic (node hostname
-// and the sha256 of the produced archive), so they are masked out in tests.
+// instance_backup.json. checksum_sha256 is dynamic (the sha256 of the
+// produced archive), so it is masked out in tests.
 var (
 	//go:embed testdata/start/snap.bin
 	goldenSnap []byte
@@ -175,6 +175,7 @@ func instanceMap(
 		"replicaset_uuid": testReplicasetUUID,
 		"instance_uuid":   testInstanceUUID,
 		"instance_name":   instanceName,
+		"hostname":        "node-1.example.com",
 		"wal_dir":         walDir,
 		"memtx_dir":       memtxDir,
 		"vinyl_dir":       "",
@@ -287,7 +288,7 @@ func TestStartBackup_fragmentFields(t *testing.T) {
 	require.Equal(t, golden.ReplicasetUUID, frag.ReplicasetUUID)
 	require.Equal(t, golden.InstanceUUID, frag.InstanceUUID)
 	require.Equal(t, golden.InstanceName, frag.InstanceName)
-	require.NotEmpty(t, frag.Hostname, "hostname must be the node's own hostname")
+	require.Equal(t, "node-1.example.com", frag.Hostname)
 	require.Equal(t, golden.Type, frag.Type)
 	require.Equal(t, golden.VclockBegin, frag.VclockBegin)
 	require.Equal(t, golden.VclockEnd, frag.VclockEnd)

--- a/cli/backup/types.go
+++ b/cli/backup/types.go
@@ -30,6 +30,13 @@ type Status string
 
 // BackupInfo is the decoded box.backup.info() result: files, vclocks, type
 // and recovery points of an open backup.
+//
+// Tarantool 3.8.0 returns:
+//   - vclock: the end vclock (max vclock to restore to);
+//   - prev_vclock: the begin vclock (only for incremental);
+//   - checkpoint_vclock: the begin vclock for full (cleared from output);
+//   - files: full paths to snap/xlog files;
+//   - recovery_points: {timestamp, replica_id, lsn, label}.
 type BackupInfo struct {
 	Files          []string          `json:"files"`
 	Type           BackupType        `json:"type"`

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -439,6 +439,33 @@ func NewClusterCmd() *cobra.Command {
 	integrity.RegisterWithIntegrityFlag(publish.Flags(), &clusterIntegrityPrivateKey)
 
 	clusterCmd.AddCommand(publish)
+
+	topology := &cobra.Command{
+		Use:   "topology -c <CLUSTER_CONFIG|URI> [flags]",
+		Short: "Show the current cluster topology",
+		Long: "Discover and print the current cluster topology by connecting to " +
+			"cluster nodes via net.box.\n\n" +
+			"The cluster configuration can be loaded from a file, etcd, or " +
+			"Tarantool Config Storage. It is used to determine the list of " +
+			"instances and their listen URIs. Each instance is contacted " +
+			"via net.box, the live topology is collected and merged into " +
+			"a single view.\n\n" +
+			"JSON output contains replicasets keyed by UUID and their instances " +
+			"(instance_uuid, instance_name, hostname, mode, status). If a replicaset " +
+			"is unreachable and its UUID is not configured, its name is used as " +
+			"the key. Unreachable instances have the status \"not reachable\".\n\n" +
+			clusterUriHelp,
+		Run:  RunModuleFunc(internalClusterTopologyModule),
+		Args: cobra.NoArgs,
+	}
+	addTarantoolConnectFlags(topology)
+	topology.Flags().StringVarP(&topologyConfigPath, "config", "c", "",
+		"path or URI of the cluster configuration")
+	topology.Flags().StringVar(&topologyFormat, "format", topologyFormatTable,
+		"output format: table or json")
+	topology.MarkFlagRequired("config")
+	clusterCmd.AddCommand(topology)
+
 	clusterCmd.AddCommand(newClusterReplicasetCmd())
 	clusterCmd.AddCommand(newClusterFailoverCmd())
 	clusterCmd.AddCommand(newClusterWorkerCmd())

--- a/cli/cmd/topology.go
+++ b/cli/cmd/topology.go
@@ -1,0 +1,551 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/apex/log"
+
+	clustercli "github.com/tarantool/tt/cli/cluster"
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/connect"
+	"github.com/tarantool/tt/cli/connector"
+	"github.com/tarantool/tt/cli/replicaset"
+	replicasetcmd "github.com/tarantool/tt/cli/replicaset/cmd"
+	libcluster "github.com/tarantool/tt/lib/cluster"
+	libconnect "github.com/tarantool/tt/lib/connect"
+)
+
+var (
+	topologyFormat           string
+	topologyConfigPath       string
+	topologyUnixConnectMutex sync.Mutex
+)
+
+const (
+	topologyStatusOK           = "OK"
+	topologyStatusNotReachable = "not reachable"
+	topologyFormatJSON         = "json"
+	topologyFormatTable        = "table"
+)
+
+type topologyOutput struct {
+	Replicasets map[string][]topologyInstanceOutput `json:"replicasets"`
+}
+
+type topologyInstanceOutput struct {
+	InstanceUUID string `json:"instance_uuid"`
+	InstanceName string `json:"instance_name"`
+	Hostname     string `json:"hostname"`
+	Mode         string `json:"mode"`
+	Status       string `json:"status"`
+}
+
+// hostnameExpr fetches the instance UUID and the hostname of the node.
+const hostnameExpr = `return box.info.uuid, box.info.hostname`
+
+type topologyDiscoveryResult struct {
+	topology     *replicaset.Replicasets
+	instanceUUID string
+	hostname     string
+	connected    bool
+}
+
+func discoverInstanceTopology(
+	clusterConfig libcluster.ClusterConfig,
+	instName string,
+	configDir string,
+	connectCtx connect.ConnectCtx,
+) topologyDiscoveryResult {
+	instConfig := libcluster.Instantiate(clusterConfig, instName)
+	advertiseData, _ := instConfig.Get([]string{"iproto", "advertise", "client"})
+	uri, _ := advertiseData.(string)
+	if uri == "" {
+		listenData, _ := instConfig.Get([]string{"iproto", "listen"})
+		if listen, ok := listenData.([]any); ok && len(listen) > 0 {
+			endpoint, _ := listen[0].(map[any]any)
+			uri, _ = endpoint["uri"].(string)
+		}
+	}
+	if uri == "" {
+		log.Warnf("instance %q: no client URI found, skipping", instName)
+		return topologyDiscoveryResult{}
+	}
+
+	groupName, rsName, _ := libcluster.FindInstance(clusterConfig, instName)
+	uri = renderConfigTemplate(uri, instName, rsName, groupName)
+
+	network, address := parseListenURI(uri, configDir)
+	connOpts := makeConnOpts(network, address, connectCtx)
+	conn, err := connectTopologyInstance(connOpts)
+	if err != nil {
+		log.Warnf("instance %q: failed to connect: %s", instName, err)
+		return topologyDiscoveryResult{}
+	}
+	defer conn.Close()
+
+	result := topologyDiscoveryResult{connected: true}
+	hostData, err := conn.Eval(hostnameExpr, []any{}, connector.RequestOpts{})
+	if err == nil && len(hostData) >= 2 {
+		result.instanceUUID, _ = hostData[0].(string)
+		result.hostname, _ = hostData[1].(string)
+	}
+
+	orchestrator, err := replicaset.EvalOrchestrator(conn)
+	if err != nil {
+		log.Warnf("instance %q: failed to determine orchestrator: %s", instName, err)
+		return result
+	}
+
+	discoverer, err := replicasetcmd.MakeInstanceOrchestrator(orchestrator, conn)
+	if err != nil {
+		log.Warnf("instance %q: failed to create orchestrator: %s", instName, err)
+		return result
+	}
+
+	replicasets, err := discoverer.Discovery(replicaset.SkipCache)
+	if err != nil {
+		log.Warnf("instance %q: discovery failed: %s", instName, err)
+		return result
+	}
+
+	result.topology = &replicasets
+	return result
+}
+
+func connectTopologyInstance(opts connector.ConnectOpts) (connector.Connector, error) {
+	if opts.Network == connector.UnixNetwork {
+		topologyUnixConnectMutex.Lock()
+		defer topologyUnixConnectMutex.Unlock()
+	}
+
+	return connector.Connect(opts) //nolint:wrapcheck
+}
+
+func discoverInstancesParallel(
+	instanceNames []string,
+	discover func(string) topologyDiscoveryResult,
+) ([]replicaset.Replicasets, map[string]string, map[string]bool) {
+	results := make([]topologyDiscoveryResult, len(instanceNames))
+	var wg sync.WaitGroup
+
+	for i, instName := range instanceNames {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			results[i] = discover(instName)
+		}()
+	}
+
+	wg.Wait()
+
+	topologies := make([]replicaset.Replicasets, 0, len(results))
+	hostnames := map[string]string{}
+	reachable := map[string]bool{}
+	for i, result := range results {
+		if result.topology != nil {
+			topologies = append(topologies, *result.topology)
+		}
+		if result.connected {
+			reachable[instanceNames[i]] = true
+			if result.instanceUUID != "" {
+				reachable[result.instanceUUID] = true
+				hostnames[result.instanceUUID] = result.hostname
+			}
+		}
+	}
+
+	return topologies, hostnames, reachable
+}
+
+// internalClusterTopologyModule is an entrypoint for cluster topology command.
+func internalClusterTopologyModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
+	switch topologyFormat {
+	case topologyFormatJSON, topologyFormatTable, "":
+	default:
+		return fmt.Errorf("unsupported format: %s (use table or json)", topologyFormat)
+	}
+
+	clusterConfig, configDir, err := loadTopologyConfig(cmdCtx, topologyConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load topology config: %w", err)
+	}
+
+	instanceNames := libcluster.Instances(clusterConfig)
+	if len(instanceNames) == 0 {
+		return fmt.Errorf("no instances found in the cluster config")
+	}
+
+	connectCtx := connect.ConnectCtx{
+		Username:    replicasetUser,
+		Password:    replicasetPassword,
+		SslKeyFile:  replicasetSslKeyFile,
+		SslCertFile: replicasetSslCertFile,
+		SslCaFile:   replicasetSslCaFile,
+		SslCiphers:  replicasetSslCiphers,
+	}
+
+	allTopologies, hostnames, reachable := discoverInstancesParallel(
+		instanceNames,
+		func(instName string) topologyDiscoveryResult {
+			return discoverInstanceTopology(
+				clusterConfig,
+				instName,
+				configDir,
+				connectCtx,
+			)
+		},
+	)
+
+	configTopology := topologyFromConfig(clusterConfig)
+	allTopologies = append(
+		[]replicaset.Replicasets{configTopology},
+		allTopologies...,
+	)
+	merged := mergeReplicasets(allTopologies)
+
+	if err := printTopology(merged, hostnames, reachable); err != nil {
+		return fmt.Errorf("failed to print topology: %w", err)
+	}
+
+	return nil
+}
+
+func loadTopologyConfig(
+	cmdCtx *cmdcontext.CmdCtx,
+	source string,
+) (libcluster.ClusterConfig, string, error) {
+	dataCollectors, err := createDataCollectors(cmdCtx.Integrity)
+	if err != nil {
+		return libcluster.ClusterConfig{}, "",
+			fmt.Errorf("failed to create data collectors: %w", err)
+	}
+	collectors := libcluster.NewCollectorFactory(dataCollectors)
+
+	if uriOpts, err := libconnect.CreateUriOpts(source); err == nil {
+		connOpts := libcluster.ConnectOpts{
+			Username: replicasetUser,
+			Password: replicasetPassword,
+		}
+		collector, closeConnection, err := libcluster.CreateCollector(
+			collectors, connOpts, uriOpts,
+		)
+		if err != nil {
+			return libcluster.ClusterConfig{}, "",
+				fmt.Errorf("failed to connect to cluster config storage: %w", err)
+		}
+		defer closeConnection()
+
+		config, err := collector.Collect()
+		if err != nil {
+			return libcluster.ClusterConfig{}, "",
+				fmt.Errorf("failed to collect cluster config: %w", err)
+		}
+
+		clusterConfig, err := libcluster.MakeClusterConfig(config)
+		if err != nil {
+			return libcluster.ClusterConfig{}, "",
+				fmt.Errorf("failed to parse cluster config: %w", err)
+		}
+
+		return clusterConfig, ".", nil
+	}
+
+	clusterConfig, err := clustercli.GetClusterConfig(collectors, source)
+	if err != nil {
+		return libcluster.ClusterConfig{}, "",
+			fmt.Errorf("failed to load cluster config %q: %w", source, err)
+	}
+
+	return clusterConfig, filepath.Dir(source), nil
+}
+
+func printTopology(
+	merged replicaset.Replicasets,
+	hostnames map[string]string,
+	reachable map[string]bool,
+) error {
+	switch topologyFormat {
+	case topologyFormatJSON:
+		topology := replicasetsToTopology(merged, hostnames, reachable)
+		return printTopologyJSON(topology) //nolint:wrapcheck
+	default:
+		return printTopologyTable(merged, hostnames, reachable) //nolint:wrapcheck
+	}
+}
+
+func topologyFromConfig(clusterConfig libcluster.ClusterConfig) replicaset.Replicasets {
+	var topology replicaset.Replicasets
+
+	groupNames := make([]string, 0, len(clusterConfig.Groups))
+	for groupName := range clusterConfig.Groups {
+		groupNames = append(groupNames, groupName)
+	}
+	sort.Strings(groupNames)
+
+	for _, groupName := range groupNames {
+		group := clusterConfig.Groups[groupName]
+		replicasetNames := make([]string, 0, len(group.Replicasets))
+		for replicasetName := range group.Replicasets {
+			replicasetNames = append(replicasetNames, replicasetName)
+		}
+		sort.Strings(replicasetNames)
+
+		for _, replicasetName := range replicasetNames {
+			configuredReplicaset := group.Replicasets[replicasetName]
+			rs := replicaset.Replicaset{Alias: replicasetName}
+
+			instanceNames := make([]string, 0, len(configuredReplicaset.Instances))
+			for instanceName := range configuredReplicaset.Instances {
+				instanceNames = append(instanceNames, instanceName)
+			}
+			sort.Strings(instanceNames)
+
+			for _, instanceName := range instanceNames {
+				instanceConfig := libcluster.Instantiate(clusterConfig, instanceName)
+				instanceUUIDData, _ := instanceConfig.Get([]string{"database", "instance_uuid"})
+				replicasetUUID, _ := instanceConfig.Get([]string{
+					"database", "replicaset_uuid",
+				})
+				if rs.UUID == "" {
+					rs.UUID, _ = replicasetUUID.(string)
+				}
+				instanceUUID, _ := instanceUUIDData.(string)
+				rs.Instances = append(rs.Instances, replicaset.Instance{
+					Alias: instanceName,
+					UUID:  instanceUUID,
+				})
+			}
+
+			topology.Replicasets = append(topology.Replicasets, rs)
+		}
+	}
+
+	return topology
+}
+
+// renderConfigTemplate replaces Tarantool config template variables in a URI.
+func renderConfigTemplate(uri, instName, rsName, groupName string) string {
+	uri = strings.ReplaceAll(uri, "{{ instance_name }}", instName)
+	uri = strings.ReplaceAll(uri, "{{ replicaset_name }}", rsName)
+	uri = strings.ReplaceAll(uri, "{{ group_name }}", groupName)
+
+	return uri
+}
+
+// parseListenURI parses a Tarantool listen URI and returns the network type
+// and address.
+func parseListenURI(uri, configDir string) (string, string) {
+	network, address := libconnect.ParseBaseURI(uri)
+
+	if network == connector.UnixNetwork && strings.HasPrefix(address, "./") {
+		address = filepath.Join(configDir, address)
+	}
+
+	return network, address
+}
+
+// mergeReplicasets merges per-instance discovery results into a single
+// Replicasets. Runtime UUIDs are merged into the aliases loaded from config.
+func mergeReplicasets(all []replicaset.Replicasets) replicaset.Replicasets {
+	var merged replicaset.Replicasets
+
+	for _, rs := range all {
+		if merged.Orchestrator == replicaset.OrchestratorUnknown {
+			merged.Orchestrator = rs.Orchestrator
+		}
+
+		if merged.State == replicaset.StateUnknown {
+			merged.State = rs.State
+		}
+
+		for _, r := range rs.Replicasets {
+			found := false
+
+			for i := range merged.Replicasets {
+				if (merged.Replicasets[i].UUID != "" &&
+					merged.Replicasets[i].UUID == r.UUID) ||
+					(merged.Replicasets[i].Alias != "" &&
+						merged.Replicasets[i].Alias == r.Alias) {
+
+					if merged.Replicasets[i].UUID == "" {
+						merged.Replicasets[i].UUID = r.UUID
+					}
+					mergeInstances(&merged.Replicasets[i], r.Instances)
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				merged.Replicasets = append(merged.Replicasets, r)
+			}
+		}
+	}
+
+	return merged
+}
+
+// mergeInstances merges a source instance list into a replicaset, updating
+// missing fields (URI, Mode) for already-known instances.
+func mergeInstances(rs *replicaset.Replicaset, sources []replicaset.Instance) {
+	for _, src := range sources {
+		found := false
+
+		for i := range rs.Instances {
+			if (rs.Instances[i].UUID != "" && rs.Instances[i].UUID == src.UUID) ||
+				(rs.Instances[i].Alias != "" && rs.Instances[i].Alias == src.Alias) {
+
+				if rs.Instances[i].UUID == "" {
+					rs.Instances[i].UUID = src.UUID
+				}
+				if rs.Instances[i].URI == "" {
+					rs.Instances[i].URI = src.URI
+				}
+
+				if rs.Instances[i].Mode == replicaset.ModeUnknown {
+					rs.Instances[i].Mode = src.Mode
+				}
+
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			rs.Instances = append(rs.Instances, src)
+		}
+	}
+}
+
+func replicasetsToTopology(
+	replicasets replicaset.Replicasets,
+	hostnames map[string]string,
+	reachable map[string]bool,
+) topologyOutput {
+	topology := topologyOutput{
+		Replicasets: make(map[string][]topologyInstanceOutput,
+			len(replicasets.Replicasets)),
+	}
+
+	for _, rs := range replicasets.Replicasets {
+		instances := make([]topologyInstanceOutput, 0, len(rs.Instances))
+		for _, inst := range rs.Instances {
+			status := topologyStatusNotReachable
+			if reachable[inst.UUID] || reachable[inst.Alias] {
+				status = topologyStatusOK
+			}
+			instances = append(instances, topologyInstanceOutput{
+				InstanceUUID: inst.UUID,
+				InstanceName: inst.Alias,
+				Hostname:     lookupHostname(inst.UUID, hostnames),
+				Mode:         formatMode(inst.Mode),
+				Status:       status,
+			})
+		}
+		replicasetID := rs.UUID
+		if replicasetID == "" {
+			replicasetID = rs.Alias
+		}
+		topology.Replicasets[replicasetID] = instances
+	}
+
+	return topology
+}
+
+// lookupHostname returns the hostname for the instance UUID.
+func lookupHostname(uuid string, hostnames map[string]string) string {
+	if h, ok := hostnames[uuid]; ok {
+		return h
+	}
+
+	return ""
+}
+
+// formatMode returns a human-readable string for the instance mode.
+func formatMode(mode replicaset.Mode) string {
+	if mode == replicaset.ModeRead {
+		return "ro"
+	}
+	return mode.String()
+}
+
+func printTopologyJSON(topology topologyOutput) error {
+	data, err := json.MarshalIndent(topology, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal topology: %w", err)
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+// printTopologyTable prints the topology as a human-readable table.
+func printTopologyTable(
+	replicasets replicaset.Replicasets,
+	hostnames map[string]string,
+	reachable map[string]bool,
+) error {
+	if len(replicasets.Replicasets) == 0 {
+		log.Warn("No replicasets found.")
+		return nil
+	}
+
+	log.Info("Active cluster topology\n")
+
+	for _, rs := range replicasets.Replicasets {
+		alias := rs.Alias
+		if alias == "" {
+			alias = rs.UUID
+		}
+		replicasetReachable := false
+		for _, inst := range rs.Instances {
+			if reachable[inst.UUID] || reachable[inst.Alias] {
+				replicasetReachable = true
+				break
+			}
+		}
+		replicasetHeader := alias
+		if rs.UUID != "" {
+			replicasetHeader = fmt.Sprintf("%s (%s)", alias, rs.UUID)
+		}
+		if !replicasetReachable {
+			replicasetHeader += "  " + topologyStatusNotReachable
+		}
+		log.Info(replicasetHeader)
+
+		instances := make([]replicaset.Instance, len(rs.Instances))
+		copy(instances, rs.Instances)
+		sort.SliceStable(instances, func(i, j int) bool {
+			if (instances[i].Mode == replicaset.ModeRW) !=
+				(instances[j].Mode == replicaset.ModeRW) {
+
+				return instances[i].Mode == replicaset.ModeRW
+			}
+			return instances[i].Alias < instances[j].Alias
+		})
+
+		for _, inst := range instances {
+			name := inst.Alias
+			if name == "" {
+				name = inst.UUID
+			}
+			hostname := lookupHostname(inst.UUID, hostnames)
+			mode := formatMode(inst.Mode)
+			status := topologyStatusNotReachable
+			if reachable[inst.UUID] || reachable[inst.Alias] {
+				status = topologyStatusOK
+			}
+			log.Infof("    %s %s  %s  %s  %s",
+				name, inst.UUID, hostname, mode, status)
+		}
+	}
+	return nil
+}

--- a/cli/cmd/topology_test.go
+++ b/cli/cmd/topology_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/cmdcontext"
+	"github.com/tarantool/tt/cli/replicaset"
+	libcluster "github.com/tarantool/tt/lib/cluster"
+)
+
+func TestDiscoverInstancesParallel(t *testing.T) {
+	instanceNames := []string{"instance-1", "instance-2", "instance-3"}
+	started := make(chan struct{}, len(instanceNames))
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	var topologies []replicaset.Replicasets
+	var hostnames map[string]string
+	var reachable map[string]bool
+	go func() {
+		topologies, hostnames, reachable = discoverInstancesParallel(
+			instanceNames,
+			func(instName string) topologyDiscoveryResult {
+				started <- struct{}{}
+				<-release
+				return topologyDiscoveryResult{
+					topology: &replicaset.Replicasets{
+						Replicasets: []replicaset.Replicaset{{Alias: instName}},
+					},
+					instanceUUID: instName,
+					hostname:     instName + "-host",
+					connected:    true,
+				}
+			},
+		)
+		close(done)
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	allStarted := true
+	for range instanceNames {
+		select {
+		case <-started:
+		case <-timer.C:
+			allStarted = false
+		}
+		if !allStarted {
+			break
+		}
+	}
+	close(release)
+	<-done
+
+	require.True(t, allStarted)
+	require.Len(t, topologies, len(instanceNames))
+	for i, instName := range instanceNames {
+		assert.Equal(t, instName, topologies[i].Replicasets[0].Alias)
+		assert.Equal(t, instName+"-host", hostnames[instName])
+		assert.True(t, reachable[instName])
+	}
+}
+
+func TestLoadTopologyConfigFromFile(t *testing.T) {
+	path := "../cluster/testdata/app/config.yaml"
+
+	config, configDir, err := loadTopologyConfig(&cmdcontext.CmdCtx{}, path)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(path), configDir)
+	assert.ElementsMatch(t, []string{"b", "c"}, libcluster.Instances(config))
+}
+
+func TestReplicasetsToTopology(t *testing.T) {
+	replicasets := replicaset.Replicasets{
+		Replicasets: []replicaset.Replicaset{
+			{
+				UUID:  "rs-uuid-1",
+				Alias: "replicaset-1",
+				Instances: []replicaset.Instance{
+					{
+						UUID:  "inst-uuid-1",
+						Alias: "instance-1",
+						URI:   "host-1:3301",
+						Mode:  replicaset.ModeRW,
+					},
+					{
+						UUID:  "inst-uuid-2",
+						Alias: "instance-2",
+						URI:   "host-2:3302",
+						Mode:  replicaset.ModeUnknown,
+					},
+					{
+						UUID:  "inst-uuid-3",
+						Alias: "instance-3",
+						URI:   "host-3:3303",
+						Mode:  replicaset.ModeRead,
+					},
+				},
+			},
+		},
+	}
+	hostnames := map[string]string{
+		"inst-uuid-1": "node-1.example.com",
+		"inst-uuid-2": "node-2.example.com",
+	}
+	reachable := map[string]bool{
+		"inst-uuid-1": true,
+		"inst-uuid-2": true,
+	}
+
+	topology := replicasetsToTopology(replicasets, hostnames, reachable)
+
+	assert.Len(t, topology.Replicasets, 1)
+
+	instances := topology.Replicasets["rs-uuid-1"]
+	assert.Len(t, instances, 3)
+
+	assert.Equal(t, "inst-uuid-1", instances[0].InstanceUUID)
+	assert.Equal(t, "instance-1", instances[0].InstanceName)
+	assert.Equal(t, "node-1.example.com", instances[0].Hostname)
+	assert.Equal(t, "rw", instances[0].Mode)
+	assert.Equal(t, topologyStatusOK, instances[0].Status)
+
+	assert.Equal(t, "inst-uuid-2", instances[1].InstanceUUID)
+	assert.Equal(t, "instance-2", instances[1].InstanceName)
+	assert.Equal(t, "node-2.example.com", instances[1].Hostname)
+	assert.Equal(t, "unknown", instances[1].Mode)
+	assert.Equal(t, topologyStatusOK, instances[1].Status)
+
+	assert.Equal(t, "inst-uuid-3", instances[2].InstanceUUID)
+	assert.Equal(t, "instance-3", instances[2].InstanceName)
+	assert.Equal(t, "ro", instances[2].Mode)
+	assert.Equal(t, topologyStatusNotReachable, instances[2].Status)
+}

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -49,8 +49,8 @@ func makeApplicationOrchestrator(
 	return orchestrator, err
 }
 
-// makeInstanceOrchestrator creates an orchestrator for the single instance.
-func makeInstanceOrchestrator(orchestratorType replicaset.Orchestrator,
+// MakeInstanceOrchestrator creates an orchestrator for the single instance.
+func MakeInstanceOrchestrator(orchestratorType replicaset.Orchestrator,
 	conn connector.Connector,
 ) (replicasetOrchestrator, error) {
 	var (

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -48,7 +48,7 @@ func Promote(ctx PromoteCtx) error {
 			return err
 		}
 	} else {
-		if orchestrator, err = makeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
+		if orchestrator, err = MakeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
 			return err
 		}
 	}

--- a/cli/replicaset/cmd/roles.go
+++ b/cli/replicaset/cmd/roles.go
@@ -63,7 +63,7 @@ func RolesChange(ctx RolesChangeCtx, changeRoleAction replicaset.RolesChangerAct
 			return err
 		}
 	} else {
-		if orchestrator, err = makeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
+		if orchestrator, err = MakeInstanceOrchestrator(orchestratorType, ctx.Conn); err != nil {
 			return err
 		}
 	}

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -34,7 +34,7 @@ func getReplicasets(ctx DiscoveryCtx) (replicaset.Replicasets, error) {
 		orchestrator, err = makeApplicationOrchestrator(orchestratorType,
 			ctx.RunningCtx, nil, nil)
 	} else {
-		orchestrator, err = makeInstanceOrchestrator(orchestratorType, ctx.Conn)
+		orchestrator, err = MakeInstanceOrchestrator(orchestratorType, ctx.Conn)
 	}
 
 	if err != nil {

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -62,7 +62,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 			return err
 		}
 	} else {
-		if orchestrator, err = makeInstanceOrchestrator(
+		if orchestrator, err = MakeInstanceOrchestrator(
 			orchestratorType, ctx.Conn); err != nil {
 			return err
 		}

--- a/lib/connect/uri.go
+++ b/lib/connect/uri.go
@@ -161,6 +161,9 @@ func ParseBaseURI(uri string) (string, string) {
 	case uriLen >= 7 && uri[0:7] == "unix://":
 		network = UnixNetwork
 		address = uri[7:]
+	case uriLen >= 6 && uri[0:6] == "unix/:":
+		network = UnixNetwork
+		address = uri[6:]
 	case uriLen >= 6 && uri[0:6] == "tcp://":
 		network = TCPNetwork
 		address = uri[6:]

--- a/lib/connect/uri_test.go
+++ b/lib/connect/uri_test.go
@@ -219,8 +219,11 @@ func TestParseBaseURI(t *testing.T) {
 		{"/path/to/socket", connect.UnixNetwork, "/path/to/socket"},
 		{"unix:///path/to/socket", connect.UnixNetwork, "/path/to/socket"},
 		{"unix://..//path/to/socket", connect.UnixNetwork, "..//path/to/socket"},
+		{"unix/:./instance-001.iproto", connect.UnixNetwork, "./instance-001.iproto"},
+		{"unix/:/var/run/tt.sock", connect.UnixNetwork, "/var/run/tt.sock"},
+		{"unix/:instance.sock", connect.UnixNetwork, "instance.sock"},
 		{"..//path", connect.UnixNetwork, "..//path"},
-		{"some_uri", connect.TCPNetwork, "some_uri"}, // Keeps unchanged
+		{"some_uri", connect.TCPNetwork, "some_uri"}, // Keeps unchanged.
 	}
 
 	for _, tc := range cases {

--- a/magefile.go
+++ b/magefile.go
@@ -363,7 +363,12 @@ func (Lint) GolangDiff() error {
 func (Lint) Python() error {
 	fmt.Println("Running Python Ruff...")
 
-	if err := sh.RunV(pythonExecutableName, "-m", "ruff", "check", "test"); err != nil {
+	args := []string{"-m", "ruff", "check", "test"}
+	if fixFlag() {
+		args = append(args, "--fix")
+	}
+
+	if err := sh.RunV(pythonExecutableName, args...); err != nil {
 		return err
 	}
 

--- a/test/integration/cluster/test_cluster_topology.py
+++ b/test/integration/cluster/test_cluster_topology.py
@@ -1,0 +1,483 @@
+import json
+import os
+import shutil
+
+import pytest
+
+from utils import get_tarantool_version, run_command_and_get_output, wait_file
+
+tarantool_major_version, _ = get_tarantool_version()
+
+# The cconfig test app lives in the replicaset test directory.
+CCONFIG_APP_NAME = "test_ccluster_app"
+CCONFIG_APP_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "replicaset",
+    CCONFIG_APP_NAME,
+)
+
+INSTANCES = [f"instance-00{i}" for i in range(1, 6)]
+
+# Expected modes for a fully running cluster: masters are rw, replicas are ro.
+EXPECTED_MODES = {
+    "instance-001": "rw",
+    "instance-002": "ro",
+    "instance-003": "ro",
+    "instance-004": "rw",
+    "instance-005": "rw",
+}
+
+
+@pytest.fixture
+def ccluster_app(request, tt_cmd, tmpdir_with_cfg, port_factory):
+    """Start the centralized-config cluster app and tear it down after."""
+    tmpdir = tmpdir_with_cfg
+    app_path = os.path.join(tmpdir, CCONFIG_APP_NAME)
+    shutil.copytree(CCONFIG_APP_DIR, app_path)
+
+    transport = getattr(request, "param", "unix")
+    assert transport in ("unix", "tcp")
+
+    config_path = os.path.join(app_path, "config.yaml")
+    with open(config_path) as config_file:
+        config = config_file.read()
+
+    config = config.replace(
+        "  listen:\n    - uri: 'unix/:./{{ instance_name }}.iproto'\n",
+        "",
+    )
+    for instance in INSTANCES:
+        if transport == "unix":
+            uri = f"unix/:./{instance}.iproto"
+        else:
+            uri = f"127.0.0.1:{port_factory()}"
+
+        instance_marker = f"          {instance}:\n"
+        instance_iproto = (
+            instance_marker
+            + "            iproto:\n"
+            + "              listen:\n"
+            + f"                - uri: '{uri}'\n"
+        )
+        assert instance_marker in config
+        config = config.replace(instance_marker, instance_iproto, 1)
+
+    with open(config_path, "w") as config_file:
+        config_file.write(config)
+
+    rc, _ = run_command_and_get_output(
+        [tt_cmd, "start", CCONFIG_APP_NAME],
+        cwd=tmpdir,
+    )
+    assert rc == 0
+    for inst in INSTANCES:
+        assert wait_file(os.path.join(tmpdir, CCONFIG_APP_NAME), f"ready-{inst}", []) != ""
+
+    yield tmpdir
+
+    run_command_and_get_output(
+        [tt_cmd, "stop", "-y", CCONFIG_APP_NAME],
+        cwd=tmpdir,
+    )
+
+
+def _topology_cmd(tt_cmd, config_path, tmpdir, fmt=None):
+    """Build and run a topology command, return (rc, output)."""
+    cmd = [
+        tt_cmd,
+        "cluster",
+        "topology",
+        "-c",
+        config_path,
+        "-u",
+        "client",
+        "-p",
+        "secret",
+    ]
+    if fmt:
+        cmd += ["--format", fmt]
+    return run_command_and_get_output(cmd, cwd=tmpdir)
+
+
+def _parse_json_output(output):
+    """Extract and parse JSON from combined stdout+stderr output.
+
+    The JSON payload is printed to stdout while log messages go to stderr;
+    they may be interleaved in the combined output. Scan for the first '{'
+    that begins a valid JSON object and decode it.
+    """
+    decoder = json.JSONDecoder()
+    search_from = 0
+    while True:
+        idx = output.find("{", search_from)
+        if idx == -1:
+            raise ValueError("no JSON object found in output")
+        try:
+            obj, _ = decoder.raw_decode(output[idx:])
+            return obj
+        except json.JSONDecodeError:
+            search_from = idx + 1
+
+
+def _instance_names_from_json(data):
+    """Collect all instance names from a parsed topology JSON."""
+    names = set()
+    for instances in data["replicasets"].values():
+        for inst in instances:
+            names.add(inst["instance_name"])
+    return names
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+def test_topology_table(tt_cmd, ccluster_app):
+    """tt cluster topology -c <config.yaml> — table output."""
+    tmpdir = ccluster_app
+    config_path = os.path.join(tmpdir, CCONFIG_APP_NAME, "config.yaml")
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir)
+    assert rc == 0
+
+    # Two replicasets.
+    assert "replicaset-001" in out
+    assert "replicaset-002" in out
+
+    # All instances present.
+    assert "instance-001" in out
+    assert "instance-002" in out
+    assert "instance-003" in out
+    assert "instance-004" in out
+    assert "instance-005" in out
+
+    # Mode is shown: rw for masters, ro for replicas.
+    lines = out.splitlines()
+    inst001 = [line for line in lines if "instance-001" in line and "rw" in line]
+    assert inst001, "instance-001 rw line not found"
+
+    inst002 = [line for line in lines if "instance-002" in line and "ro" in line]
+    assert inst002, "instance-002 ro line not found"
+
+    for instance in INSTANCES:
+        instance_lines = [line for line in lines if instance in line]
+        assert len(instance_lines) == 1
+        assert "OK" in instance_lines[0]
+        assert "not reachable" not in instance_lines[0]
+
+    # No 'M' marker in the output.
+    assert "M instance" not in out
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+@pytest.mark.parametrize(
+    "ccluster_app",
+    ["unix", "tcp"],
+    indirect=True,
+    ids=["unix-per-instance", "tcp-per-instance"],
+)
+def test_topology_json(tt_cmd, ccluster_app):
+    """tt cluster topology -c <config.yaml> --format json."""
+    tmpdir = ccluster_app
+    config_path = os.path.join(tmpdir, CCONFIG_APP_NAME, "config.yaml")
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir, fmt="json")
+    assert rc == 0
+
+    data = _parse_json_output(out)
+    assert "replicasets" in data
+    replicasets = data["replicasets"]
+    assert len(replicasets) == 2
+
+    names = _instance_names_from_json(data)
+    assert names == {
+        "instance-001",
+        "instance-002",
+        "instance-003",
+        "instance-004",
+        "instance-005",
+    }
+
+    for rs_uuid, instances in replicasets.items():
+        assert rs_uuid, "replicaset UUID must be non-empty"
+        assert len(instances) > 0
+        for inst in instances:
+            assert inst["instance_uuid"], "instance_uuid must be non-empty"
+            assert inst["instance_name"], "instance_name must be non-empty"
+            assert inst["hostname"], "hostname must be non-empty"
+            assert inst["mode"] == EXPECTED_MODES[inst["instance_name"]]
+            assert inst["status"] == "OK"
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+@pytest.mark.parametrize("config_storage_type", ["etcd", "tcs"])
+def test_topology_config_storage(
+    tt_cmd,
+    ccluster_app,
+    config_storage_type,
+    request,
+):
+    tmpdir = ccluster_app
+    app_path = os.path.join(tmpdir, CCONFIG_APP_NAME)
+    config_path = os.path.join(app_path, "config.yaml")
+    with open(config_path) as config_file:
+        config = config_file.read()
+
+    for instance in INSTANCES:
+        listen = (
+            "            iproto:\n"
+            "              listen:\n"
+            f"                - uri: 'unix/:./{instance}.iproto'\n"
+        )
+        advertise = (
+            "            iproto:\n"
+            "              listen:\n"
+            f"                - uri: 'unix/:/nonexistent/{instance}.iproto'\n"
+            "              advertise:\n"
+            f"                client: 'unix/:{app_path}/{instance}.iproto'\n"
+        )
+        assert listen in config
+        config = config.replace(listen, advertise, 1)
+
+    config_storage = request.getfixturevalue(config_storage_type)
+    connection = config_storage.conn()
+    if config_storage_type == "etcd":
+        connection.put("/prefix/config/all", config)
+    else:
+        connection.call("config.storage.put", "/prefix/config/all", config)
+
+    credentials = f"{config_storage.connection_username}:{config_storage.connection_password}@"
+    uri = f"http://{credentials}{config_storage.host}:{config_storage.port}/prefix?timeout=5"
+
+    try:
+        if config_storage_type == "etcd":
+            config_storage.enable_auth()
+
+        rc, out = _topology_cmd(tt_cmd, uri, tmpdir, fmt="json")
+    finally:
+        if config_storage_type == "etcd":
+            config_storage.disable_auth()
+
+    assert rc == 0, out
+    data = _parse_json_output(out)
+    assert _instance_names_from_json(data) == set(INSTANCES)
+    assert len(data["replicasets"]) == 2
+    assert "replicaset-001" not in data["replicasets"]
+    assert "replicaset-002" not in data["replicasets"]
+    for instances in data["replicasets"].values():
+        for instance in instances:
+            assert instance["instance_uuid"]
+            assert instance["hostname"]
+            assert instance["mode"] == EXPECTED_MODES[instance["instance_name"]]
+            assert instance["status"] == "OK"
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+def test_topology_unreachable_instance_included(tt_cmd, ccluster_app):
+    tmpdir = ccluster_app
+    config_path = os.path.join(tmpdir, CCONFIG_APP_NAME, "config.yaml")
+
+    # Stop one instance from replicaset-001.
+    rc, out = run_command_and_get_output(
+        [tt_cmd, "stop", "-y", f"{CCONFIG_APP_NAME}:instance-003"],
+        cwd=tmpdir,
+    )
+    assert rc == 0, out
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir)
+    assert rc == 0
+    assert "replicaset-001" in out
+    assert "instance-001" in out
+    assert "instance-002" in out
+
+    lines = out.splitlines()
+
+    # Find first non error line (greetings).
+    greetings_position = lines.index("   • Active cluster topology")
+
+    topo_lines = "\n".join(lines[greetings_position + 1 :])
+
+    unreachable = [line for line in topo_lines.splitlines() if "instance-003" in line]
+    assert len(unreachable) == 1
+    assert "not reachable" in unreachable[0]
+    replicaset_lines = [line for line in topo_lines.splitlines() if "replicaset-001" in line]
+    assert len(replicaset_lines) == 1
+    assert "not reachable" not in replicaset_lines[0]
+    for instance in ("instance-001", "instance-002", "instance-004", "instance-005"):
+        instance_lines = [line for line in topo_lines.splitlines() if instance in line]
+        assert len(instance_lines) == 1
+        assert "OK" in instance_lines[0]
+        assert "not reachable" not in instance_lines[0]
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir, fmt="json")
+    assert rc == 0
+    data = _parse_json_output(out)
+    assert _instance_names_from_json(data) == set(INSTANCES)
+    instances = {
+        instance["instance_name"]: instance
+        for replicas in data["replicasets"].values()
+        for instance in replicas
+    }
+    assert instances["instance-003"]["status"] == "not reachable"
+    assert instances["instance-003"]["instance_uuid"]
+    assert instances["instance-003"]["hostname"] == ""
+    assert instances["instance-003"]["mode"] == "unknown"
+    for instance in ("instance-001", "instance-002", "instance-004", "instance-005"):
+        assert instances[instance]["status"] == "OK"
+        assert instances[instance]["instance_uuid"]
+        assert instances[instance]["hostname"]
+        assert instances[instance]["mode"] == EXPECTED_MODES[instance]
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+def test_topology_unreachable_replicaset_included(tt_cmd, ccluster_app):
+    tmpdir = ccluster_app
+    config_path = os.path.join(tmpdir, CCONFIG_APP_NAME, "config.yaml")
+
+    # Stop all instances of replicaset-002.
+    rc, out = run_command_and_get_output(
+        [tt_cmd, "stop", "-y", f"{CCONFIG_APP_NAME}:instance-004"],
+        cwd=tmpdir,
+    )
+    assert rc == 0, out
+    rc, out = run_command_and_get_output(
+        [tt_cmd, "stop", "-y", f"{CCONFIG_APP_NAME}:instance-005"],
+        cwd=tmpdir,
+    )
+    assert rc == 0, out
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir)
+    assert rc == 0
+    lines = out.splitlines()
+    greetings_position = lines.index("   • Active cluster topology")
+    topology_lines = lines[greetings_position + 1 :]
+
+    assert any("replicaset-001" in line for line in topology_lines)
+    reachable_replicaset_lines = [line for line in topology_lines if "replicaset-001" in line]
+    assert len(reachable_replicaset_lines) == 1
+    assert "not reachable" not in reachable_replicaset_lines[0]
+    replicaset_lines = [line for line in topology_lines if "replicaset-002" in line]
+    assert len(replicaset_lines) == 1
+    assert "not reachable" in replicaset_lines[0]
+    for instance in ("instance-004", "instance-005"):
+        instance_lines = [line for line in topology_lines if instance in line]
+        assert len(instance_lines) == 1
+        assert "not reachable" in instance_lines[0]
+    for instance in ("instance-001", "instance-002", "instance-003"):
+        instance_lines = [line for line in topology_lines if instance in line]
+        assert len(instance_lines) == 1
+        assert "OK" in instance_lines[0]
+        assert "not reachable" not in instance_lines[0]
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir, fmt="json")
+    assert rc == 0
+    data = _parse_json_output(out)
+    names = _instance_names_from_json(data)
+    assert names == set(INSTANCES)
+    assert len(data["replicasets"]) == 2
+    assert "replicaset-002" in data["replicasets"]
+    assert {
+        instance["instance_name"]: (
+            instance["instance_uuid"],
+            instance["mode"],
+            instance["status"],
+        )
+        for instance in data["replicasets"]["replicaset-002"]
+    } == {
+        "instance-004": ("", "unknown", "not reachable"),
+        "instance-005": ("", "unknown", "not reachable"),
+    }
+    reachable_rs_ids = [rid for rid in data["replicasets"] if rid != "replicaset-002"]
+    assert len(reachable_rs_ids) == 1
+    assert reachable_rs_ids[0], "reachable replicaset UUID must be non-empty"
+    reachable_instances = {
+        instance["instance_name"]: instance
+        for replicaset_id, instances in data["replicasets"].items()
+        if replicaset_id != "replicaset-002"
+        for instance in instances
+    }
+    assert set(reachable_instances) == {"instance-001", "instance-002", "instance-003"}
+    for name, instance in reachable_instances.items():
+        assert instance["instance_uuid"]
+        assert instance["hostname"]
+        assert instance["mode"] == EXPECTED_MODES[name]
+        assert instance["status"] == "OK"
+
+
+@pytest.mark.skipif(
+    tarantool_major_version < 3,
+    reason="centralized config requires Tarantool 3.x",
+)
+def test_topology_unreachable_cluster_included(tt_cmd, ccluster_app):
+    tmpdir = ccluster_app
+    config_path = os.path.join(tmpdir, CCONFIG_APP_NAME, "config.yaml")
+
+    rc, out = run_command_and_get_output(
+        [tt_cmd, "stop", "-y", CCONFIG_APP_NAME],
+        cwd=tmpdir,
+    )
+    assert rc == 0, out
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir)
+    assert rc == 0, out
+    lines = out.splitlines()
+    greetings_position = lines.index("   • Active cluster topology")
+    topology_lines = lines[greetings_position + 1 :]
+
+    for replicaset in ("replicaset-001", "replicaset-002"):
+        replicaset_lines = [line for line in topology_lines if replicaset in line]
+        assert len(replicaset_lines) == 1
+        assert "not reachable" in replicaset_lines[0]
+    for instance in INSTANCES:
+        instance_lines = [line for line in topology_lines if instance in line]
+        assert len(instance_lines) == 1
+        assert "not reachable" in instance_lines[0]
+
+    rc, out = _topology_cmd(tt_cmd, config_path, tmpdir, fmt="json")
+    assert rc == 0, out
+    data = _parse_json_output(out)
+    assert set(data["replicasets"]) == {"replicaset-001", "replicaset-002"}
+    assert _instance_names_from_json(data) == set(INSTANCES)
+    for instances in data["replicasets"].values():
+        for instance in instances:
+            assert instance["instance_uuid"] == ""
+            assert instance["hostname"] == ""
+            assert instance["mode"] == "unknown"
+            assert instance["status"] == "not reachable"
+
+
+def test_topology_no_config(tt_cmd, tmpdir_with_cfg):
+    rc, out = run_command_and_get_output(
+        [tt_cmd, "cluster", "topology"],
+        cwd=tmpdir_with_cfg,
+    )
+    assert rc != 0
+    assert "required flag" in out or "config" in out.lower()
+
+
+def test_topology_bad_format(tt_cmd, tmpdir_with_cfg):
+    rc, out = run_command_and_get_output(
+        [
+            tt_cmd,
+            "cluster",
+            "topology",
+            "-c",
+            "/dev/null",
+            "--format",
+            "yaml",
+        ],
+        cwd=tmpdir_with_cfg,
+    )
+    assert rc != 0
+    assert "unsupported format" in out


### PR DESCRIPTION
The tt cluster topology command has been added. It shows the current cluster topology based on the cluster manifest (Tarantool 3.0) with a bypass of all instances for the current status. The credits are also taken from the cluster manifest.

Part of TNTP-8609
