### PR TITLE
cli/manifest/install: tt package install and joint resolution

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,9 @@ linters:
             - "github.com/klauspost/compress/zstd"
             # cli/manifest/pack drives the build before archiving its result.
             - "github.com/tarantool/tt/cli/manifest/build"
+            # cli/manifest/install refetches dependencies through the luarocks
+            # adapter and reuses the build package's exit-code machinery.
+            - "github.com/tarantool/tt/cli/manifest/rocks"
         test:
           files:
             - "$test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the active tt environment when it satisfies `[platform]`, with a warning.
   Archives are byte-reproducible for a given commit; set `SOURCE_DATE_EPOCH` to
   pin the build timestamp explicitly.
+- `tt package install`: unpack a `.tt` archive into a scope and bring the tree
+  to a runnable state. `--scope project` (default) accepts both archive modes; a
+  with-deps archive in the project scope is a plain offline extraction, while a
+  `--without-deps` archive additionally refetches its dependency closure from
+  the registry using the lock's pins. `--scope user`/`--scope system` accept
+  only `--without-deps` archives — a with-deps archive there is refused from the
+  archive header before anything is written. Several packages installed into one
+  project share a `.rocks/` tree, so a dependency they lock at different
+  versions is reconciled to the highest locked version satisfying every
+  package's constraints, or the install fails with a breakdown. Per-package
+  metadata (manifest, lock, VERSION) is recorded under `.rocks/manifests/<pkg>/`
+  for inventory and dependency refcounting. `--locked` refuses an archive whose
+  lock diverges from its manifest, `--upgrade` installs only a strictly higher
+  version, `--force` reinstalls over a collision, and `--yes` skips the
+  reconciliation prompt. Installing several archives at once exits 3 when some
+  succeed and some fail.
 - `tt pack`: support nested `.packignore` at the root of tt environment.
 - `tt status`: add `--format` option to support JSON and YAML output formats
 for machine-readable output.

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -11,9 +11,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tarantool/tt/cli/manifest/build"
+	"github.com/tarantool/tt/cli/manifest/install"
 	"github.com/tarantool/tt/cli/manifest/pack"
 	manifestrocks "github.com/tarantool/tt/cli/manifest/rocks"
 	oldrocks "github.com/tarantool/tt/cli/rocks"
+	"github.com/tarantool/tt/cli/util"
 	ttversion "github.com/tarantool/tt/cli/version"
 )
 
@@ -27,6 +29,14 @@ var (
 	packageProduct     string
 	packageLocked      bool
 	packageWithoutDeps bool
+)
+
+// Flags specific to `tt package install`.
+var (
+	packageScope   string
+	packageUpgrade bool
+	packageForce   bool
+	packageYes     bool
 )
 
 // NewPackageCmd creates the `tt package` command group: the manifest build
@@ -43,9 +53,95 @@ func NewPackageCmd() *cobra.Command {
 		newPackageBuildCmd(),
 		newPackageFetchCmd(),
 		newPackagePackCmd(),
+		newPackageInstallCmd(),
 	)
 
 	return packageCmd
+}
+
+// newPackageInstallCmd wires `tt package install ARCHIVE...`.
+func newPackageInstallCmd() *cobra.Command {
+	installCmd := &cobra.Command{
+		Use:   "install ARCHIVE...",
+		Short: "Install a .tt package archive into a scope",
+		Long: "Unpack a package archive into the chosen scope and bring the tree " +
+			"to a runnable state. A with-deps archive in the project scope is a " +
+			"plain offline extraction; otherwise the package is unpacked and its " +
+			"dependencies are refetched from the registry using the lock's pins. " +
+			"Several packages installed into one project share a .rocks/ tree, so a " +
+			"dependency they lock at different versions is reconciled to one both " +
+			"accept, or the install fails with an explanation.",
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPackageInstall(args); err != nil {
+				log.Error(err.Error())
+				os.Exit(install.ExitCode(err))
+			}
+		},
+	}
+
+	installCmd.Flags().StringVar(&packageScope, "scope", "project",
+		"install scope: project, user or system")
+	installCmd.Flags().BoolVar(&packageLocked, "locked", false,
+		"fail if the archive lock does not match its manifest")
+	installCmd.Flags().BoolVar(&packageUpgrade, "upgrade", false,
+		"install over an existing package only when the archive version is higher")
+	installCmd.Flags().BoolVar(&packageForce, "force", false,
+		"reinstall over an existing package (destructive)")
+	installCmd.Flags().BoolVarP(&packageYes, "yes", "y", false,
+		"skip the confirmation prompt when reconciling shared dependencies")
+
+	return installCmd
+}
+
+// runPackageInstall assembles install.Options from the environment and installs
+// every archive. Tarantool facts are gathered best-effort: an offline with-deps
+// install needs none, so a missing tarantool is only fatal when a dependency
+// must actually be refetched.
+func runPackageInstall(archives []string) error {
+	projectDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	projectDir, err = filepath.Abs(projectDir)
+	if err != nil {
+		return err
+	}
+
+	// Missing tarantool is tolerated here; refetch surfaces its own error only
+	// if the install actually reaches the registry.
+	tntInfo, _ := tarantoolInfo()
+
+	result, err := install.Run(context.Background(), install.Options{
+		ProjectDir: projectDir,
+		Scope:      install.Scope(packageScope),
+		Archives:   archives,
+		Locked:     packageLocked,
+		Upgrade:    packageUpgrade,
+		Force:      packageForce,
+		Yes:        packageYes,
+		Tarantool:  tntInfo,
+		Warn:       func(msg string) { log.Warn(msg) },
+		Confirm: func(prompt string) bool {
+			ok, askErr := util.AskConfirm(os.Stdin, prompt)
+
+			return askErr == nil && ok
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, one := range result.Installed {
+		if one.Skipped {
+			continue
+		}
+
+		fmt.Printf("installed %s %s into %s scope\n", one.Package, one.Version, one.Scope)
+	}
+
+	return nil
 }
 
 // newPackageBuildCmd wires `tt package build [COMPONENT]`.
@@ -193,8 +289,8 @@ func runtimeRequest(ctx context.Context, tntInfo manifestrocks.TarantoolInfo) pa
 }
 
 // runtimeCacheDir returns the runtime cache root, <user cache>/tt/runtimes.
-// RFC 0010 leaves the exact path an open item and `tt runtime install` is a v1
-// command; until then this is the directory a user populates by hand.
+// The exact path is not yet finalized and nothing populates it automatically
+// yet; until then this is the directory a user populates by hand.
 func runtimeCacheDir() string {
 	base, err := os.UserCacheDir()
 	if err != nil {

--- a/cli/manifest/install/archive.go
+++ b/cli/manifest/install/archive.go
@@ -1,0 +1,314 @@
+package install
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/util"
+)
+
+// File modes install writes with. Directories and executables get 0755, plain
+// files 0644 — the same two modes the pack writer normalized every entry to.
+const (
+	dirPerm  os.FileMode = 0o755
+	execPerm os.FileMode = 0o755
+	filePerm os.FileMode = 0o644
+	// execBit is the owner-executable bit tested to tell the two modes apart.
+	execBit = 0o100
+)
+
+// Archive is a read handle on a .tt package archive (tar+zstd). It is the read
+// counterpart of cli/manifest/pack's write-only archive writer: pack never
+// produced a reader, so install carries its own. Each method opens the file
+// afresh, so an Archive is cheap to hold and safe to reuse.
+type Archive struct {
+	path string
+}
+
+// OpenArchive returns a read handle on the archive at path. It only checks that
+// the file exists; the tar+zstd stream is validated lazily on the first read.
+func OpenArchive(archivePath string) (*Archive, error) {
+	_, err := os.Stat(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errBadArchive, err)
+	}
+
+	return &Archive{path: archivePath}, nil
+}
+
+// Path is the archive's filesystem path.
+func (a *Archive) Path() string { return a.path }
+
+// SHA256 returns the archive's checksum, lowercase hex — the same value
+// tt package pack reported when it wrote the file.
+func (a *Archive) SHA256() (string, error) {
+	sum, err := util.FileSHA256Hex(a.path)
+	if err != nil {
+		return "", fmt.Errorf("checksumming archive: %w", err)
+	}
+
+	return sum, nil
+}
+
+// Header is the tt-owned metadata read from an archive without extracting it:
+// the manifest, the lock and the declared version, plus whether the archive
+// bundles a runtime (a with-deps archive) — the facts install needs to decide
+// scope compatibility, collisions and reconciliation before touching disk.
+type Header struct {
+	// Manifest is the parsed app.manifest.toml.
+	Manifest *manifest.Manifest
+	// ManifestBytes is its raw bytes, kept for the --locked hash check.
+	ManifestBytes []byte
+	// Lock is the parsed app.manifest.lock.
+	Lock *manifest.Lock
+	// Version is the VERSION file's content, trimmed.
+	Version string
+	// WithDeps reports whether the archive carries _runtime/ and the full
+	// dependency closure (the default pack mode). A --without-deps archive has
+	// neither, and installing it refetches the closure from the registry.
+	WithDeps bool
+}
+
+// ReadHeader scans the archive once, reading the three tt-owned metadata members
+// into memory and noting whether a _runtime/ tree is present. It never writes to
+// disk, so a scope or runtime rejection happens before any extraction.
+func (a *Archive) ReadHeader() (*Header, error) {
+	manifestBytes, lockBytes, versionBytes, hasRuntime, err := a.readMetaMembers()
+	if err != nil {
+		return nil, err
+	}
+
+	if manifestBytes == nil {
+		return nil, fmt.Errorf("%w: missing %s", errBadArchive, manifestFileName)
+	}
+
+	if lockBytes == nil {
+		return nil, fmt.Errorf("%w: missing %s", errBadArchive, lockFileName)
+	}
+
+	man, _, err := manifest.ParseManifest(manifestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errBadArchive, err)
+	}
+
+	lock, err := manifest.ParseLock(lockBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errBadArchive, err)
+	}
+
+	return &Header{
+		Manifest:      man,
+		ManifestBytes: manifestBytes,
+		Lock:          lock,
+		Version:       strings.TrimSpace(string(versionBytes)),
+		WithDeps:      hasRuntime,
+	}, nil
+}
+
+// Extract writes archive entries into dstDir. For each entry mapEntry is given
+// the entry's slash-path and returns the destination path relative to dstDir and
+// whether to write it at all; returning ok=false skips the entry. This lets a
+// caller both filter (skip a dependency's subtree) and remap (strip the .rocks/
+// prefix for a user-scope tree). Every resolved destination is validated to stay
+// within dstDir; an escaping entry is a hard error and nothing more is written.
+func (a *Archive) Extract(dstDir string, mapEntry func(name string) (string, bool)) error {
+	err := os.MkdirAll(dstDir, dirPerm)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", dstDir, err)
+	}
+
+	return a.walk(func(hdr *tar.Header, reader io.Reader) (bool, error) {
+		name := path.Clean(filepath.ToSlash(hdr.Name))
+
+		rel, ok := name, true
+		if mapEntry != nil {
+			rel, ok = mapEntry(name)
+		}
+
+		if !ok || rel == "" {
+			return true, nil
+		}
+
+		dst, err := safeJoin(dstDir, rel)
+		if err != nil {
+			return false, err
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			return true, mkdirWrapped(dst)
+		case tar.TypeReg:
+			return true, writeFile(dst, reader, entryMode(hdr))
+		default:
+			// The pack writer emits only files and directories; anything else is
+			// skipped rather than trusted.
+			return true, nil
+		}
+	})
+}
+
+// readMetaMembers scans the archive once and returns the raw bytes of the three
+// tt-owned metadata members plus whether a _runtime/ tree is present.
+func (a *Archive) readMetaMembers() ([]byte, []byte, []byte, bool, error) {
+	var (
+		manifestBytes []byte
+		lockBytes     []byte
+		versionBytes  []byte
+		hasRuntime    bool
+	)
+
+	err := a.walk(func(hdr *tar.Header, reader io.Reader) (bool, error) {
+		name := path.Clean(filepath.ToSlash(hdr.Name))
+
+		if top, _, _ := strings.Cut(name, "/"); top == runtimeDirName {
+			hasRuntime = true
+		}
+
+		if hdr.Typeflag != tar.TypeReg {
+			return true, nil
+		}
+
+		data, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			return false, fmt.Errorf("%w: reading %s: %w", errBadArchive, name, readErr)
+		}
+
+		switch name {
+		case manifestFileName:
+			manifestBytes = data
+		case lockFileName:
+			lockBytes = data
+		case versionFileName:
+			versionBytes = data
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
+	return manifestBytes, lockBytes, versionBytes, hasRuntime, nil
+}
+
+// walk opens the archive, decompresses it and calls visit for each tar entry.
+// visit returns whether to continue and an error that stops the walk. The reader
+// passed to visit is valid only for that call.
+func (a *Archive) walk(visit func(*tar.Header, io.Reader) (bool, error)) error {
+	file, err := os.Open(a.path)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errBadArchive, err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	zstdReader, err := zstd.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("%w: opening zstd stream: %w", errBadArchive, err)
+	}
+
+	defer zstdReader.Close()
+
+	tarReader := tar.NewReader(zstdReader)
+
+	for {
+		hdr, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("%w: reading tar stream: %w", errBadArchive, err)
+		}
+
+		cont, err := visit(hdr, tarReader)
+		if err != nil {
+			return err
+		}
+
+		if !cont {
+			return nil
+		}
+	}
+}
+
+// entryMode is the file mode an archive entry is written with: 0755 when the
+// stored mode carries the executable bit (runtime binaries, scripts), 0644
+// otherwise. The pack writer already normalized modes to exactly these two.
+func entryMode(hdr *tar.Header) os.FileMode {
+	if hdr.Mode&execBit != 0 {
+		return execPerm
+	}
+
+	return filePerm
+}
+
+// mkdirWrapped creates dir and its parents, wrapping the external error.
+func mkdirWrapped(dir string) error {
+	err := os.MkdirAll(dir, dirPerm)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	return nil
+}
+
+// writeFile creates dst (and its parents) and copies reader into it with mode
+// perm.
+func writeFile(dst string, reader io.Reader, perm os.FileMode) error {
+	err := mkdirWrapped(filepath.Dir(dst))
+	if err != nil {
+		return err
+	}
+
+	// Path is validated by safeJoin; the archive is the user's own package.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", dst, err)
+	}
+
+	_, err = io.Copy(out, reader)
+	if err != nil {
+		_ = out.Close()
+
+		return fmt.Errorf("writing %s: %w", dst, err)
+	}
+
+	err = out.Close()
+	if err != nil {
+		return fmt.Errorf("closing %s: %w", dst, err)
+	}
+
+	return nil
+}
+
+// safeJoin joins a slash-separated archive entry name onto dstDir, refusing any
+// name that is absolute or climbs out of dstDir (a tar-slip attempt).
+func safeJoin(dstDir, name string) (string, error) {
+	if name == "" || name == "." {
+		return dstDir, nil
+	}
+
+	if path.IsAbs(name) || strings.HasPrefix(name, "../") ||
+		name == ".." || strings.Contains(name, "/../") {
+		return "", fmt.Errorf("%w: %q", errUnsafePath, name)
+	}
+
+	joined := filepath.Join(dstDir, filepath.FromSlash(name))
+
+	rel, err := filepath.Rel(dstDir, joined)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%w: %q", errUnsafePath, name)
+	}
+
+	return joined, nil
+}

--- a/cli/manifest/install/archive_internal_test.go
+++ b/cli/manifest/install/archive_internal_test.go
@@ -1,0 +1,141 @@
+package install
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadHeaderWithDeps reads the metadata of a with-deps archive and reports
+// it carries a runtime.
+func TestReadHeaderWithDeps(t *testing.T) {
+	t.Parallel()
+
+	path := archiveSpec{
+		name: "my-app", version: "1.0.0", withRuntime: "3.0.5",
+		lockDeps: []LockDep{{Name: "luasocket", Version: "3.0.4", Source: "registry"}},
+	}.build(t)
+
+	ar, err := OpenArchive(path)
+	require.NoError(t, err)
+
+	header, err := ar.ReadHeader()
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", header.Manifest.Package.Name)
+	assert.Equal(t, "1.0.0", header.Version)
+	assert.True(t, header.WithDeps)
+	assert.Equal(t, "3.0.5", header.Lock.BundledTarantool)
+}
+
+// TestReadHeaderWithoutDeps reports a runtime-less archive as without-deps.
+func TestReadHeaderWithoutDeps(t *testing.T) {
+	t.Parallel()
+
+	path := archiveSpec{name: "some-lib", version: "2.0.0"}.build(t)
+
+	ar, err := OpenArchive(path)
+	require.NoError(t, err)
+
+	header, err := ar.ReadHeader()
+	require.NoError(t, err)
+
+	assert.False(t, header.WithDeps)
+	assert.Empty(t, header.Lock.BundledTarantool)
+}
+
+// TestExtractProjectKeepsRocksPrefix extracts into a project root and checks the
+// .rocks/ prefix survives while root metadata does not leak into the tree.
+func TestExtractProjectKeepsRocksPrefix(t *testing.T) {
+	t.Parallel()
+
+	path := archiveSpec{
+		name: "my-app", version: "1.0.0", withRuntime: "3.0.5",
+		files: rockFiles("my-app", "1.0.0"),
+	}.build(t)
+
+	ar, err := OpenArchive(path)
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	mapper := extractMapper(ScopeProject, nil, true)
+	require.NoError(t, ar.Extract(root, mapper))
+
+	assert.FileExists(t, filepath.Join(root, ".rocks", "share", "tarantool", "my-app", "init.lua"))
+	assert.FileExists(t, filepath.Join(root, "_runtime", "tarantool", "bin", "tarantool"))
+
+	// Root metadata must not be laid into the tree.
+	assert.NoFileExists(t, filepath.Join(root, "app.manifest.toml"))
+	assert.NoFileExists(t, filepath.Join(root, "VERSION"))
+}
+
+// TestExtractSkipsDependency verifies a dependency in the skip set is not
+// written from the archive.
+func TestExtractSkipsDependency(t *testing.T) {
+	t.Parallel()
+
+	path := archiveSpec{
+		name: "my-app", version: "1.0.0", withRuntime: "3.0.5",
+		files: mergeFiles(rockFiles("my-app", "1.0.0"), rockFiles("luasocket", "3.0.4")),
+	}.build(t)
+
+	ar, err := OpenArchive(path)
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	skip := map[string]struct{}{"luasocket": {}}
+	require.NoError(t, ar.Extract(root, extractMapper(ScopeProject, skip, true)))
+
+	assert.FileExists(t, filepath.Join(root, ".rocks", "share", "tarantool", "my-app", "init.lua"))
+	assert.NoFileExists(t,
+		filepath.Join(root, ".rocks", "share", "tarantool", "luasocket", "init.lua"))
+}
+
+// TestExtractRejectsTraversal guards the tar-slip defense: an entry climbing out
+// of the destination is refused and nothing is written.
+func TestExtractRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	dst := filepath.Join(t.TempDir(), "evil.tt")
+	writeRawTarZst(t, dst, "../escape.txt", "pwned")
+
+	ar, err := OpenArchive(dst)
+	require.NoError(t, err)
+
+	root := t.TempDir()
+
+	err = ar.Extract(root, nil)
+	require.ErrorIs(t, err, errUnsafePath)
+
+	assert.NoFileExists(t, filepath.Join(filepath.Dir(root), "escape.txt"))
+}
+
+// writeRawTarZst writes a single-entry tar+zstd stream with an arbitrary (even
+// unsafe) name, for the traversal guard test.
+func writeRawTarZst(t *testing.T, dst, name, content string) {
+	t.Helper()
+
+	f, err := os.Create(dst) //nolint:gosec // Test writes to a temp path.
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, f.Close()) }()
+
+	zstdWriter, err := zstd.NewWriter(f)
+	require.NoError(t, err)
+
+	tarWriter := tar.NewWriter(zstdWriter)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: name, Mode: 0o644,
+		Size: int64(len(content)), Format: tar.FormatPAX,
+	}))
+
+	_, err = tarWriter.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, zstdWriter.Close())
+}

--- a/cli/manifest/install/errors.go
+++ b/cli/manifest/install/errors.go
@@ -1,0 +1,78 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tarantool/tt/cli/manifest/build"
+)
+
+// Names install reads from inside a .tt archive. They mirror the reserved set
+// tt writes at pack time.
+const (
+	manifestFileName = "app.manifest.toml"
+	lockFileName     = "app.manifest.lock"
+	versionFileName  = "VERSION"
+	runtimeDirName   = "_runtime"
+)
+
+// Process exit codes install maps failures to. A usage or state error (name
+// collision without --force/--upgrade, incompatible runtime, a with-deps
+// archive into user/system, a stale lock under --locked, an unreconcilable
+// shared dependency) exits 1. A multi-archive run where some targets installed
+// and some failed exits 3.
+const (
+	exitStateError   = 1
+	exitPartialError = 3
+)
+
+var (
+	// errUnknownScope reports a --scope value that is not project, user or
+	// system.
+	errUnknownScope = errors.New("unknown scope")
+	// errWithDepsScope reports a with-deps archive aimed at user or system,
+	// which accept only --without-deps archives. Caught from the archive header,
+	// before anything is written.
+	errWithDepsScope = errors.New(
+		"a with-deps archive can only be installed into the project scope")
+	// errNameCollision reports a package already installed in the scope while
+	// neither --force nor --upgrade was given.
+	errNameCollision = errors.New("package already installed")
+	// errLockStale reports that the archive's lock no longer matches its manifest
+	// while --locked forbids proceeding.
+	errLockStale = errors.New("lock is out of date")
+	// errRuntimeMismatch reports a bundled runtime whose version conflicts with
+	// the one the project's primary package (or an earlier install) already
+	// fixed.
+	errRuntimeMismatch = errors.New("bundled runtime is incompatible")
+	// errIncompatibleDeps reports a shared dependency no locked version can
+	// satisfy across all packages that require it.
+	errIncompatibleDeps = errors.New("incompatible shared dependency")
+	// errBadArchive reports a .tt archive that cannot be read as tar+zstd or that
+	// is missing a tt-owned member.
+	errBadArchive = errors.New("invalid archive")
+	// errUnsafePath reports an archive entry whose path escapes the destination
+	// directory (a tar-slip attempt).
+	errUnsafePath = errors.New("archive entry escapes destination")
+	// errPartialInstall reports a multi-archive run where some archives
+	// installed and some failed; it carries exit code 3.
+	errPartialInstall = errors.New("some archives failed to install")
+)
+
+// ExitError re-exports build.ExitError so install returns the same typed error
+// the build and pack commands do; ExitCode reads the code back through the
+// chain.
+type ExitError = build.ExitError
+
+// ExitCode returns the process exit code for err, reusing the build package's
+// mapping so build, pack and install all agree. A nil error is 0.
+func ExitCode(err error) int {
+	return build.ExitCode(err)
+}
+
+// stateErrorf wraps a formatted error as a state error (exit 1).
+//
+//nolint:err113 // Formatting helper, mirrors fmt.Errorf; callers pass %w wraps.
+func stateErrorf(format string, args ...any) error {
+	return &build.ExitError{Code: exitStateError, Err: fmt.Errorf(format, args...)}
+}

--- a/cli/manifest/install/extract.go
+++ b/cli/manifest/install/extract.go
@@ -1,0 +1,97 @@
+package install
+
+import "strings"
+
+// Path-segment counts for a rock's location under the .rocks/ tree:
+// share|lib / tarantool / <dep> is three deep, and the rock-manifest path
+// share/tarantool/rocks/<dep> is four.
+const (
+	rockPathDepth     = 3
+	rockManifestDepth = 4
+)
+
+// extractMapper builds the per-entry mapper Extract uses for one install. It
+// decides, for each archive entry, where it lands under the install-root and
+// whether it is written at all:
+//
+//   - the tt-owned root metadata (manifest, lock, VERSION) and payload files
+//     are never laid into the tree — a guest's manifest must not overwrite the
+//     project's own, and the metadata is recorded under manifests/ separately;
+//   - _runtime/ is written only for a project-scope install that is placing it
+//     for the first time (extractRuntime);
+//   - a dependency whose reconciled version stays what is already installed is
+//     skipped (skipNames);
+//   - for the user and system scopes the leading .rocks/ prefix is stripped so
+//     files land directly in the shared tree.
+func extractMapper(
+	scope Scope, skipNames map[string]struct{}, extractRuntime bool,
+) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		top, rest, _ := strings.Cut(name, "/")
+
+		switch top {
+		case runtimeDirName:
+			if scope != ScopeProject || !extractRuntime {
+				return "", false
+			}
+
+			return name, true
+		case rocksDirName:
+			return mapRocksEntry(scope, rest, skipNames)
+		default:
+			return "", false
+		}
+	}
+}
+
+// mapRocksEntry maps one entry under the archive's .rocks/ tree. rest is the
+// path with the .rocks/ prefix already stripped.
+func mapRocksEntry(scope Scope, rest string, skipNames map[string]struct{}) (string, bool) {
+	if rest == "" {
+		return "", false
+	}
+
+	// tt's own install state never travels inside an archive; ignore it if it
+	// somehow appears.
+	if top, _, _ := strings.Cut(rest, "/"); top == manifestsDirName {
+		return "", false
+	}
+
+	if dep, ok := rocksDepName(rest); ok {
+		if _, skip := skipNames[dep]; skip {
+			return "", false
+		}
+	}
+
+	if scope == ScopeProject {
+		return rocksDirName + "/" + rest, true
+	}
+
+	// user / system: the shared tree has no .rocks/ level.
+	return rest, true
+}
+
+// rocksDepName extracts the rock name owning a path under the .rocks/ tree:
+// share/tarantool/<dep>/…, lib/tarantool/<dep>/…, or the rock-manifest path
+// share/tarantool/rocks/<dep>/<version>/…. It returns false for anything that
+// is not inside a named rock's subtree.
+func rocksDepName(rest string) (string, bool) {
+	parts := strings.Split(rest, "/")
+	if len(parts) < rockPathDepth {
+		return "", false
+	}
+
+	if parts[1] != "tarantool" || (parts[0] != "share" && parts[0] != "lib") {
+		return "", false
+	}
+
+	if parts[2] == "rocks" {
+		if len(parts) < rockManifestDepth {
+			return "", false
+		}
+
+		return parts[3], true
+	}
+
+	return parts[2], true
+}

--- a/cli/manifest/install/helpers_internal_test.go
+++ b/cli/manifest/install/helpers_internal_test.go
@@ -1,0 +1,210 @@
+package install
+
+import (
+	"archive/tar"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// LockDep is a test-local shorthand for a resolved lock dependency.
+type LockDep = manifest.LockDependency
+
+// archiveSpec describes a .tt archive to fabricate for a test, without a build
+// or a real pack. It is the read side of what cli/manifest/pack writes.
+type archiveSpec struct {
+	// name is the package name written into the manifest.
+	name string
+	// version is the VERSION file content.
+	version string
+	// tarantoolConstraint / ttConstraint are the [platform] constraints; empty
+	// values fall back to permissive defaults.
+	tarantoolConstraint string
+	ttConstraint        string
+	// deps is the registry dependency map declared in [dependencies].
+	deps map[string]string
+	// lockDeps is the resolved dependency closure written into the lock.
+	lockDeps []manifest.LockDependency
+	// withRuntime bundles a fake _runtime/ and stamps bundled_* into the lock,
+	// marking the archive as with-deps. Bundled tarantool version; "" means
+	// --without-deps.
+	withRuntime string
+	// files are extra archive entries: archive-relative slash path -> content.
+	// Used to place package and dependency subtrees under .rocks/.
+	files map[string]string
+}
+
+// manifestTOML renders the spec's manifest.
+func (s archiveSpec) manifestTOML() string {
+	tnt := s.tarantoolConstraint
+	if tnt == "" {
+		tnt = ">=3.0.0,<4.0.0"
+	}
+
+	tt := s.ttConstraint
+	if tt == "" {
+		tt = ">=3.1.0"
+	}
+
+	out := "manifest_version = '0.1'\n\n[package]\nname = '" + s.name + "'\n\n" +
+		"[platform]\ntarantool = '" + tnt + "'\ntt = '" + tt + "'\n\n" +
+		"[products.default]\ncomponents = ['lua']\ndefault = true\n\n" +
+		"[components.lua]\npath = '.'\n"
+
+	if len(s.deps) == 0 {
+		return out
+	}
+
+	names := make([]string, 0, len(s.deps))
+	for n := range s.deps {
+		names = append(names, n)
+	}
+
+	sort.Strings(names)
+
+	var builder strings.Builder
+
+	builder.WriteString(out)
+	builder.WriteString("\n[dependencies]\n")
+
+	for _, n := range names {
+		builder.WriteString(n + " = '" + s.deps[n] + "'\n")
+	}
+
+	return builder.String()
+}
+
+// lockBytes builds the spec's lock, with manifest_hash matching the rendered
+// manifest so a --locked install passes by default.
+func (s archiveSpec) lockBytes(t *testing.T) []byte {
+	t.Helper()
+
+	lock := manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		GeneratedBy:     "tt 3.0.0",
+		ManifestHash:    manifest.HashBytes([]byte(s.manifestTOML())),
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: s.lockDeps},
+		},
+	}
+
+	if s.withRuntime != "" {
+		lock.BundledTarantool = s.withRuntime
+		lock.BundledTt = "3.2.0"
+	}
+
+	data, err := lock.Marshal()
+	require.NoError(t, err)
+
+	return data
+}
+
+// build writes the archive to a temp file and returns its path.
+func (s archiveSpec) build(t *testing.T) string {
+	t.Helper()
+
+	entries := map[string]string{
+		manifestFileName: s.manifestTOML(),
+		lockFileName:     string(s.lockBytes(t)),
+		versionFileName:  s.version + "\n",
+	}
+
+	if s.withRuntime != "" {
+		entries["_runtime/tarantool/bin/tarantool"] = "#!/bin/sh\n"
+	}
+
+	maps.Copy(entries, s.files)
+
+	dst := filepath.Join(t.TempDir(), s.name+".tt")
+	writeTarZst(t, dst, entries)
+
+	return dst
+}
+
+// writeTarZst writes entries as a tar+zstd stream, mirroring the pack writer's
+// normalized layout closely enough for the reader under test.
+func writeTarZst(t *testing.T, dst string, entries map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(dst) //nolint:gosec // Test writes to a temp path.
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, f.Close()) }()
+
+	zstdWriter, err := zstd.NewWriter(f)
+	require.NoError(t, err)
+
+	tarWriter := tar.NewWriter(zstdWriter)
+
+	names := make([]string, 0, len(entries))
+	for n := range entries {
+		names = append(names, n)
+	}
+
+	sort.Strings(names)
+
+	for _, name := range names {
+		content := entries[name]
+
+		mode := int64(0o644)
+		if filepath.Base(name) == "tarantool" {
+			mode = 0o755
+		}
+
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     name,
+			Mode:     mode,
+			Size:     int64(len(content)),
+			Format:   tar.FormatPAX,
+		}))
+
+		_, err := tarWriter.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, zstdWriter.Close())
+}
+
+// rockFiles returns the archive entries for a rock's own subtree under .rocks/:
+// a share module and its rock-manifest directory at the given version.
+func rockFiles(name, version string) map[string]string {
+	module := ".rocks/share/tarantool/" + name + "/init.lua"
+	rockManifest := ".rocks/share/tarantool/rocks/" + name + "/" + version + "/rock"
+
+	return map[string]string{
+		module:       "-- " + name + "\n",
+		rockManifest: name + " " + version + "\n",
+	}
+}
+
+// mergeFiles unions several archive-entry maps.
+func mergeFiles(fileMaps ...map[string]string) map[string]string {
+	out := map[string]string{}
+
+	for _, m := range fileMaps {
+		maps.Copy(out, m)
+	}
+
+	return out
+}
+
+// readFile returns a file's content or fails the test.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path) //nolint:gosec // Test reads from a temp path.
+	require.NoError(t, err)
+
+	return string(data)
+}

--- a/cli/manifest/install/install.go
+++ b/cli/manifest/install/install.go
@@ -1,0 +1,391 @@
+// Package install implements tt package install: it unpacks a .tt package
+// archive into a chosen scope and brings the tree to a runnable state. A
+// with-deps archive installed into the project scope is a plain offline
+// extraction; every other case extracts the package's own files and refetches
+// its dependency closure from the registry using the lock's pins.
+//
+// The one genuinely new problem it solves is joint resolution: several packages
+// installed side by side in one project share a single .rocks/ tree, so a
+// dependency two of them lock at different versions must be reconciled to one
+// version both can accept — or fail with an explanation rather than a silent
+// pick. See reconcile.go.
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/tarantool/go-luarocks/client"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// Source constants mirror the closed set the resolver writes into the lock.
+const sourceRegistry = "registry"
+const sourcePath = "path"
+
+// Options configures one install run over one or more archives.
+type Options struct {
+	// ProjectDir is the install-root for project scope (the caller's cwd). It
+	// must be absolute; user and system scopes derive their roots from the
+	// environment and ignore it.
+	ProjectDir string
+	// Scope selects where the packages are installed. The zero value ("") is
+	// project.
+	Scope Scope
+	// Archives are the .tt files to install, in order.
+	Archives []string
+	// Locked refuses an archive whose lock no longer matches its manifest.
+	Locked bool
+	// Upgrade installs over an already-installed package only when the archive's
+	// version is higher; a not-higher --upgrade is a no-op.
+	Upgrade bool
+	// Force reinstalls over an already-installed package (destructive).
+	Force bool
+	// Yes skips the confirmation prompt raised when reconciliation changes an
+	// installed dependency's version.
+	Yes bool
+	// Tarantool carries the facts the rocks adapter needs to refetch
+	// dependencies; required only when an install refetches from the registry
+	// (a --without-deps archive or a reconciled version the archive lacks).
+	Tarantool rocks.TarantoolInfo
+	// Servers overrides the rock-server list; nil uses the adapter default.
+	Servers []string
+	// Logger receives the adapter's structured logs; nil disables it.
+	Logger *slog.Logger
+	// Warn receives non-fatal diagnostics; nil drops them.
+	Warn func(string)
+	// Confirm is asked before a reconciliation changes an installed dependency's
+	// version; returning false aborts that archive. Nil proceeds (the CLI wires a
+	// real prompt; Yes bypasses it entirely).
+	Confirm func(prompt string) bool
+}
+
+func (o Options) warn(msg string) {
+	if o.Warn != nil {
+		o.Warn(msg)
+	}
+}
+
+// OneResult reports the outcome of installing a single archive.
+type OneResult struct {
+	// Archive is the archive path.
+	Archive string
+	// Package is the installed package's name.
+	Package string
+	// Version is its version.
+	Version string
+	// Scope is where it was installed.
+	Scope Scope
+	// Skipped is set when a --upgrade found nothing newer and did nothing.
+	Skipped bool
+}
+
+// Failure pairs an archive with the error installing it produced.
+type Failure struct {
+	Archive string
+	Err     error
+}
+
+// Result reports what an install run produced across all its archives.
+type Result struct {
+	// Installed holds one entry per archive that succeeded (Skipped ones
+	// included).
+	Installed []OneResult
+	// Failed holds one entry per archive that failed.
+	Failed []Failure
+}
+
+// Run installs every archive in opts.Archives into the selected scope and maps
+// the outcome to a process exit code through an *ExitError: a single archive
+// surfaces its own failure code; a multi-archive run where some succeeded and
+// some failed exits 3. A nil error means every archive installed (or was a
+// no-op upgrade).
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	scope, err := ParseScope(string(opts.Scope))
+	if err != nil {
+		return nil, stateErrorf("%w", err)
+	}
+
+	opts.Scope = scope
+
+	result := &Result{Installed: nil, Failed: nil}
+
+	for _, archivePath := range opts.Archives {
+		one, err := installOne(ctx, opts, archivePath)
+		if err != nil {
+			result.Failed = append(result.Failed, Failure{Archive: archivePath, Err: err})
+
+			continue
+		}
+
+		result.Installed = append(result.Installed, *one)
+	}
+
+	return result, aggregateError(result)
+}
+
+// aggregateError collapses per-archive outcomes into the run's error: none for
+// an all-clear run, a partial-failure (exit 3) when some archives passed and
+// some failed, and the single failure's own error otherwise (so a lone archive
+// keeps its exit code).
+func aggregateError(result *Result) error {
+	if len(result.Failed) == 0 {
+		return nil
+	}
+
+	if len(result.Installed) > 0 {
+		total := len(result.Installed) + len(result.Failed)
+
+		return &ExitError{
+			Code: exitPartialError,
+			Err:  fmt.Errorf("%w (%d of %d)", errPartialInstall, len(result.Failed), total),
+		}
+	}
+
+	return result.Failed[0].Err
+}
+
+// installOne installs a single archive, returning its outcome or a typed error
+// carrying the right exit code.
+func installOne(ctx context.Context, opts Options, archivePath string) (*OneResult, error) {
+	archive, err := OpenArchive(archivePath)
+	if err != nil {
+		return nil, stateErrorf("%w", err)
+	}
+
+	header, err := archive.ReadHeader()
+	if err != nil {
+		return nil, stateErrorf("%w", err)
+	}
+
+	// A with-deps archive into user/system is refused from the header alone,
+	// before anything touches disk.
+	if header.WithDeps && !opts.Scope.AcceptsWithDeps() {
+		return nil, stateErrorf("%w (scope %s)", errWithDepsScope, opts.Scope)
+	}
+
+	if opts.Locked {
+		if want := manifest.HashBytes(header.ManifestBytes); header.Lock.ManifestHash != want {
+			return nil, stateErrorf("%w: archive lock does not match its manifest", errLockStale)
+		}
+	}
+
+	lay, err := resolveLayout(opts.Scope, opts.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	installed, err := installedPackages(lay, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	skip, err := checkCollision(opts, header, installed)
+	if err != nil {
+		return nil, err
+	}
+
+	if skip {
+		return &OneResult{
+			Archive: archivePath, Package: header.Manifest.Package.Name,
+			Version: header.Version, Scope: opts.Scope, Skipped: true,
+		}, nil
+	}
+
+	err = checkRuntime(opts, header, installed)
+	if err != nil {
+		return nil, err
+	}
+
+	err = apply(ctx, opts, archive, header, lay, installed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OneResult{
+		Archive: archivePath, Package: header.Manifest.Package.Name,
+		Version: header.Version, Scope: opts.Scope, Skipped: false,
+	}, nil
+}
+
+// checkCollision enforces the name-collision policy and reports whether the
+// install is a no-op (a --upgrade with nothing newer). A collision without
+// --force or --upgrade is exit 1.
+func checkCollision(opts Options, header *Header, installed []installedPackage) (bool, error) {
+	name := header.Manifest.Package.Name
+
+	existing, ok := findInstalled(installed, name)
+	if !ok {
+		return false, nil
+	}
+
+	if existing.primary {
+		return false, stateErrorf(
+			"%w: %q is the project's primary package, not a guest", errNameCollision, name)
+	}
+
+	switch {
+	case opts.Force:
+		return false, nil
+	case opts.Upgrade:
+		if !versionHigher(header.Version, existing.version) {
+			opts.warn(fmt.Sprintf(
+				"%s %s is not newer than the installed %s; nothing to do",
+				name, header.Version, existing.version))
+
+			return true, nil
+		}
+
+		return false, nil
+	default:
+		return false, stateErrorf("%w: %q %s (use --upgrade or --force)",
+			errNameCollision, name, existing.version)
+	}
+}
+
+// apply resolves the dependency plan and realizes it: remove stale versions,
+// extract the archive, and refetch any registry-sourced dependency.
+func apply(
+	ctx context.Context, opts Options, archive *Archive,
+	header *Header, lay layout, installed []installedPackage,
+) error {
+	productName, err := selectProduct(header.Manifest)
+	if err != nil {
+		return err
+	}
+
+	plan, err := planDeps(header, productName, installed, lay, header.WithDeps)
+	if err != nil {
+		return err
+	}
+
+	err = confirmReconciliation(opts, plan)
+	if err != nil {
+		return err
+	}
+
+	err = removeStaleVersions(lay, plan)
+	if err != nil {
+		return err
+	}
+
+	extractRuntime := header.WithDeps && !runtimeExists(lay)
+
+	mapper := extractMapper(opts.Scope, plan.skipNames, extractRuntime)
+
+	err = archive.Extract(lay.root, mapper)
+	if err != nil {
+		return fmt.Errorf("extracting %s: %w", archive.Path(), err)
+	}
+
+	err = refetch(ctx, opts, lay, plan)
+	if err != nil {
+		return err
+	}
+
+	return writeMetadata(lay, header)
+}
+
+// confirmReconciliation asks for confirmation when the plan changes an
+// already-installed dependency's version. --yes and a nil Confirm proceed.
+func confirmReconciliation(opts Options, plan installPlan) error {
+	var changed []string
+
+	for _, d := range plan.decisions {
+		if d.removeVersion != "" {
+			changed = append(changed, fmt.Sprintf("%s -> %s", d.name, d.version))
+		}
+	}
+
+	if len(changed) == 0 || opts.Yes || opts.Confirm == nil {
+		return nil
+	}
+
+	prompt := fmt.Sprintf("reconciling shared dependencies changes: %v; proceed?", changed)
+	if !opts.Confirm(prompt) {
+		return stateErrorf("aborted at reconciliation")
+	}
+
+	return nil
+}
+
+// rockInstaller is the slice of go-luarocks' *client.Rocks the refetch loop
+// drives: install a pinned rock into the tree. *client.Rocks satisfies it;
+// tests fake it so the loop is exercised without a registry.
+type rockInstaller interface {
+	Install(ctx context.Context, name string, opts client.InstallOpts) error
+}
+
+// refetch installs every registry-sourced dependency of the plan into the tree
+// at its reconciled version. It builds the rocks adapter lazily, so an offline
+// with-deps install (no registry decisions) never needs Tarantool.
+func refetch(ctx context.Context, opts Options, lay layout, plan installPlan) error {
+	pending := registryDecisions(plan)
+	if len(pending) == 0 {
+		return nil
+	}
+
+	adapter := rocks.New(rocks.BuildConfig(opts.Tarantool, rocks.ConfigOptions{
+		Tree:       lay.tree,
+		WorkingDir: lay.root,
+		Servers:    opts.Servers,
+		Logger:     opts.Logger,
+	}))
+
+	rockClient, err := adapter.Client(client.BackendNative)
+	if err != nil {
+		return fmt.Errorf("rocks client: %w", err)
+	}
+
+	return installDeps(ctx, rockClient, pending, opts.Servers, opts.warn)
+}
+
+// registryDecisions selects the plan's decisions that must be refetched from the
+// registry.
+func registryDecisions(plan installPlan) []depDecision {
+	var pending []depDecision
+
+	for _, d := range plan.decisions {
+		if d.source == fromRegistry {
+			pending = append(pending, d)
+		}
+	}
+
+	return pending
+}
+
+// installDeps refetches each decision's pinned rock into the tree with
+// dependency resolution off: the closure is already complete and ordered, so no
+// rock re-resolves its own dependencies — the same discipline tt package fetch
+// uses, here against the archive's lock.
+func installDeps(
+	ctx context.Context, installer rockInstaller,
+	decisions []depDecision, servers []string, warn func(string),
+) error {
+	for _, decision := range decisions {
+		if warn != nil {
+			warn(fmt.Sprintf("fetching %s %s", decision.name, decision.version))
+		}
+
+		installErr := installer.Install(ctx, decision.name, client.InstallOpts{
+			Version: decision.version, Servers: servers, Deps: client.DepsNone,
+		})
+		if installErr != nil {
+			return fmt.Errorf("installing %s %s: %w",
+				decision.name, decision.version, installErr)
+		}
+	}
+
+	return nil
+}
+
+// runtimeExists reports whether the install-root already holds a _runtime/ tree.
+func runtimeExists(lay layout) bool {
+	info, err := os.Stat(runtimePath(lay))
+
+	return err == nil && info.IsDir()
+}

--- a/cli/manifest/install/install_internal_test.go
+++ b/cli/manifest/install/install_internal_test.go
@@ -1,0 +1,236 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// sharedDep is the single registry dependency the multi-package tests share.
+const sharedDep = "luasocket"
+
+// withRocks is a with-deps archive spec for a package that ships its own files
+// and the shared registry dependency, at the given locked version and declared
+// constraint.
+func withRocks(name, version, depVer, depConstraint string) archiveSpec {
+	return archiveSpec{
+		name: name, version: version, withRuntime: "3.0.5",
+		deps:     map[string]string{sharedDep: depConstraint},
+		lockDeps: []LockDep{{Name: sharedDep, Version: depVer, Source: "registry"}},
+		files:    mergeFiles(rockFiles(name, version), rockFiles(sharedDep, depVer)),
+	}
+}
+
+// installInto runs one install into a fresh project directory.
+func installInto(t *testing.T, dir string, opts Options, archives ...string) (*Result, error) {
+	t.Helper()
+
+	opts.ProjectDir = dir
+	opts.Archives = archives
+	opts.Yes = true
+
+	return Run(context.Background(), opts)
+}
+
+// TestInstallWithDepsOffline covers the headline case: a with-deps archive into
+// an empty project is a pure offline extraction — the tree lands and no network
+// is touched (no Tarantool facts are provided).
+func TestInstallWithDepsOffline(t *testing.T) {
+	t.Parallel()
+
+	archive := withRocks("my-app", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+
+	dir := t.TempDir()
+	result, err := installInto(t, dir, Options{Scope: ScopeProject}, archive)
+	require.NoError(t, err)
+	require.Len(t, result.Installed, 1)
+
+	assert.FileExists(t, filepath.Join(dir, ".rocks", "share", "tarantool", "my-app", "init.lua"))
+	assert.FileExists(t,
+		filepath.Join(dir, ".rocks", "share", "tarantool", "luasocket", "init.lua"))
+	assert.FileExists(t, filepath.Join(dir, "_runtime", "tarantool", "bin", "tarantool"))
+}
+
+// TestInstallWritesMetadata checks the per-package metadata install records for
+// list/uninstall and refcounting.
+func TestInstallWritesMetadata(t *testing.T) {
+	t.Parallel()
+
+	archive := withRocks("my-app", "1.2.3", "3.0.4", ">=3.0.0").build(t)
+
+	dir := t.TempDir()
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, archive)
+	require.NoError(t, err)
+
+	metaDir := filepath.Join(dir, ".rocks", "manifests", "my-app")
+	assert.FileExists(t, filepath.Join(metaDir, "manifest.toml"))
+	assert.FileExists(t, filepath.Join(metaDir, "lock.toml"))
+	assert.Equal(t, "1.2.3\n", readFile(t, filepath.Join(metaDir, "VERSION")))
+
+	lock, err := manifest.ParseLock([]byte(readFile(t, filepath.Join(metaDir, "lock.toml"))))
+	require.NoError(t, err)
+
+	pin, ok := lockedVersion(lock, "luasocket")
+	require.True(t, ok)
+	assert.Equal(t, "3.0.4", pin)
+}
+
+// TestInstallWithDepsIntoUserRejected pins the header check: a with-deps archive
+// aimed at user or system is exit 1, before anything is written.
+func TestInstallWithDepsIntoUserRejected(t *testing.T) {
+	t.Parallel()
+
+	archive := withRocks("my-app", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+
+	_, err := installInto(t, t.TempDir(), Options{Scope: ScopeUser}, archive)
+	require.ErrorIs(t, err, errWithDepsScope)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+// TestInstallCollision covers the name-collision policy: a second install of the
+// same package without --force/--upgrade is exit 1; --force reinstalls.
+func TestInstallCollision(t *testing.T) {
+	t.Parallel()
+
+	archive := withRocks("my-app", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+	dir := t.TempDir()
+
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, archive)
+	require.NoError(t, err)
+
+	_, err = installInto(t, dir, Options{Scope: ScopeProject}, archive)
+	require.ErrorIs(t, err, errNameCollision)
+	assert.Equal(t, exitStateError, ExitCode(err))
+
+	_, err = installInto(t, dir, Options{Scope: ScopeProject, Force: true}, archive)
+	require.NoError(t, err, "--force reinstalls over the collision")
+}
+
+// TestInstallUpgrade covers --upgrade: it installs only a strictly higher
+// version and no-ops otherwise.
+func TestInstallUpgrade(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	v1 := withRocks("my-app", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, v1)
+	require.NoError(t, err)
+
+	// Same version under --upgrade: nothing to do.
+	result, err := installInto(t, dir, Options{Scope: ScopeProject, Upgrade: true}, v1)
+	require.NoError(t, err)
+	require.Len(t, result.Installed, 1)
+	assert.True(t, result.Installed[0].Skipped)
+
+	// Higher version under --upgrade: installed.
+	v2 := withRocks("my-app", "2.0.0", "3.0.4", ">=3.0.0").build(t)
+
+	result, err = installInto(t, dir, Options{Scope: ScopeProject, Upgrade: true}, v2)
+	require.NoError(t, err)
+	assert.False(t, result.Installed[0].Skipped)
+	assert.Equal(t, "2.0.0\n",
+		readFile(t, filepath.Join(dir, ".rocks", "manifests", "my-app", "VERSION")))
+}
+
+// installedRockVersions lists the version directories present for a rock.
+func installedRockVersions(t *testing.T, dir, rock string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(
+		filepath.Join(dir, ".rocks", "share", "tarantool", "rocks", rock))
+	require.NoError(t, err)
+
+	var versions []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			versions = append(versions, entry.Name())
+		}
+	}
+
+	return versions
+}
+
+// TestInstallMultiSharedSameVersion covers two packages that lock the shared
+// dependency at the same version: it lands exactly once.
+func TestInstallMultiSharedSameVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	router := withRocks("router", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+	storage := withRocks("storage", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, router)
+	require.NoError(t, err)
+
+	_, err = installInto(t, dir, Options{Scope: ScopeProject}, storage)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"3.0.4"}, installedRockVersions(t, dir, "luasocket"))
+}
+
+// TestInstallMultiSharedReconciled covers two packages whose compatible
+// constraints lock the shared dependency at different versions: the higher
+// version is reconciled to and the older one is removed.
+func TestInstallMultiSharedReconciled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	router := withRocks("router", "1.0.0", "3.0.4", ">=3.0.0").build(t)
+	storage := withRocks("storage", "1.0.0", "3.1.0", ">=3.0.0,<4.0.0").build(t)
+
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, router)
+	require.NoError(t, err)
+
+	_, err = installInto(t, dir, Options{Scope: ScopeProject}, storage)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"3.1.0"}, installedRockVersions(t, dir, "luasocket"),
+		"reconciled to the higher version, old one removed")
+}
+
+// TestInstallMultiSharedIncompatible covers two packages whose constraints no
+// locked version can satisfy: exit 1 with a breakdown.
+func TestInstallMultiSharedIncompatible(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	router := withRocks("router", "1.0.0", "3.0.4", "<3.1.0").build(t)
+	storage := withRocks("storage", "1.0.0", "3.1.0", ">=3.1.0").build(t)
+
+	_, err := installInto(t, dir, Options{Scope: ScopeProject}, router)
+	require.NoError(t, err)
+
+	_, err = installInto(t, dir, Options{Scope: ScopeProject}, storage)
+	require.ErrorIs(t, err, errIncompatibleDeps)
+	assert.Equal(t, exitStateError, ExitCode(err))
+	assert.Contains(t, err.Error(), "router pinned 3.0.4")
+}
+
+// TestInstallPartialMultiExit3 covers one invocation over several archives where
+// some install and some fail: exit code 3.
+func TestInstallPartialMultiExit3(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	router := withRocks("router", "1.0.0", "3.0.4", "<3.1.0").build(t)
+	storage := withRocks("storage", "1.0.0", "3.1.0", ">=3.1.0").build(t)
+
+	result, err := installInto(t, dir, Options{Scope: ScopeProject}, router, storage)
+	require.Error(t, err)
+	assert.Equal(t, exitPartialError, ExitCode(err))
+	assert.Len(t, result.Installed, 1)
+	assert.Len(t, result.Failed, 1)
+	assert.Equal(t, "router", result.Installed[0].Package)
+}

--- a/cli/manifest/install/plan.go
+++ b/cli/manifest/install/plan.go
@@ -1,0 +1,315 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tarantool/go-luarocks/deps"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// depSource says where a dependency's files come from in the resolved plan.
+type depSource int
+
+const (
+	// fromArchive extracts the dependency's subtree straight from the .tt archive
+	// (a with-deps install of the version the archive already carries).
+	fromArchive depSource = iota
+	// fromRegistry refetches the pinned version from the registry (a
+	// --without-deps install, or a project whose reconciled version the archive
+	// does not carry).
+	fromRegistry
+	// skipDep leaves the dependency untouched: it is already installed at the
+	// reconciled version.
+	skipDep
+)
+
+// depDecision is the plan for one dependency of the package being installed.
+type depDecision struct {
+	name string
+	// version is the reconciled version to end up on disk.
+	version string
+	// source says how to realize that version.
+	source depSource
+	// removeVersion is a stale on-disk version directory to delete first, empty
+	// when nothing is being replaced.
+	removeVersion string
+}
+
+// installPlan is the resolved decision for every registry dependency of the
+// package being installed.
+type installPlan struct {
+	decisions []depDecision
+	// skipNames is the set of dependency names whose files must NOT be taken
+	// from the archive (their reconciled version stays whatever is on disk).
+	skipNames map[string]struct{}
+}
+
+// planDeps reconciles every registry dependency the package brings against what
+// is already installed and decides, per dependency, whether to extract it from
+// the archive, refetch it from the registry, or leave the installed copy in
+// place. withDeps selects the archive vs registry source for a dependency the
+// installed tree does not already satisfy.
+func planDeps(
+	header *Header, productName string, installed []installedPackage, lay layout, withDeps bool,
+) (installPlan, error) {
+	prod, ok := header.Lock.Products[productName]
+	if !ok {
+		var zero installPlan
+
+		return zero, stateErrorf("archive lock has no closure for product %q", productName)
+	}
+
+	plan := installPlan{decisions: nil, skipNames: map[string]struct{}{}}
+
+	for _, dep := range prod.Dependencies {
+		if dep.Source != sourceRegistry {
+			// Path dependencies are the package's own sub-projects; a with-deps
+			// archive carries them, and there is no registry to refetch them from.
+			if withDeps {
+				plan.decisions = append(plan.decisions, depDecision{
+					name: dep.Name, version: dep.Version, source: fromArchive, removeVersion: "",
+				})
+			}
+
+			continue
+		}
+
+		decision, err := planRegistryDep(dep, header, installed, lay, withDeps)
+		if err != nil {
+			var zero installPlan
+
+			return zero, err
+		}
+
+		plan.decisions = append(plan.decisions, decision)
+
+		if decision.source == skipDep {
+			plan.skipNames[dep.Name] = struct{}{}
+		}
+	}
+
+	return plan, nil
+}
+
+// planRegistryDep reconciles one registry dependency and decides its source.
+func planRegistryDep(
+	dep manifest.LockDependency, header *Header,
+	installed []installedPackage, lay layout, withDeps bool,
+) (depDecision, error) {
+	contributions := collectContributions(dep.Name, dep.Version, header.Manifest, installed)
+
+	winner, err := reconcile(dep.Name, contributions)
+	if err != nil {
+		var zero depDecision
+
+		return zero, err
+	}
+
+	onDisk, hasOnDisk := installedVersion(lay, dep.Name)
+
+	switch {
+	case winner == dep.Version:
+		// The archive carries the winning version. Replace a differing installed
+		// copy; a with-deps archive extracts it, a --without-deps one refetches it.
+		remove := ""
+		if hasOnDisk && !sameVersion(onDisk, winner) {
+			remove = onDisk
+		}
+
+		src := fromRegistry
+		if withDeps {
+			src = fromArchive
+		}
+
+		return depDecision{name: dep.Name, version: winner, source: src, removeVersion: remove}, nil
+	case hasOnDisk && sameVersion(onDisk, winner):
+		// The reconciled version is already installed; leave it in place.
+		return depDecision{
+			name: dep.Name, version: winner, source: skipDep, removeVersion: "",
+		}, nil
+	default:
+		// The winner is neither the archive's version nor what is on disk. Only
+		// the registry can supply it; a with-deps offline install cannot.
+		if withDeps {
+			var zero depDecision
+
+			return zero, stateErrorf(
+				"%w: reconciled %s to %s, which this offline archive does not carry",
+				errIncompatibleDeps, dep.Name, winner)
+		}
+
+		remove := ""
+		if hasOnDisk {
+			remove = onDisk
+		}
+
+		return depDecision{
+			name: dep.Name, version: winner, source: fromRegistry, removeVersion: remove,
+		}, nil
+	}
+}
+
+// collectContributions gathers the pin and declared constraint every relevant
+// package puts on a shared dependency: the package being installed, plus every
+// already-installed package whose lock also pins it.
+func collectContributions(
+	dep, newPin string, newManifest *manifest.Manifest, installed []installedPackage,
+) []contribution {
+	contributions := []contribution{{
+		pkg:        newManifest.Package.Name,
+		pin:        newPin,
+		constraint: declaredConstraint(newManifest, dep),
+	}}
+
+	for _, pkg := range installed {
+		if pkg.lock == nil {
+			continue
+		}
+
+		pin, ok := lockedVersion(pkg.lock, dep)
+		if !ok {
+			continue
+		}
+
+		contributions = append(contributions, contribution{
+			pkg:        pkg.name,
+			pin:        pin,
+			constraint: declaredConstraint(pkg.manifest, dep),
+		})
+	}
+
+	return contributions
+}
+
+// declaredConstraint returns the version constraint a manifest declares for a
+// dependency, across the global map and every component map. Multiple
+// declarations are AND-ed by comma-joining, matching the resolver. An unknown
+// or path dependency contributes no constraint.
+func declaredConstraint(man *manifest.Manifest, dep string) string {
+	if man == nil {
+		return ""
+	}
+
+	var parts []string
+
+	collect := func(deps map[string]manifest.Dependency) {
+		if decl, ok := deps[dep]; ok && decl.Source != sourcePath && decl.Version != "" {
+			parts = append(parts, decl.Version)
+		}
+	}
+
+	collect(man.Dependencies)
+
+	for _, comp := range man.Components {
+		collect(comp.Dependencies)
+	}
+
+	return joinConstraints(parts)
+}
+
+// joinConstraints comma-joins constraint expressions into one, dropping empties.
+func joinConstraints(parts []string) string {
+	out := ""
+
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		if out == "" {
+			out = part
+		} else {
+			out += "," + part
+		}
+	}
+
+	return out
+}
+
+// lockedVersion returns the version a lock pins for a dependency across all its
+// products.
+func lockedVersion(lock *manifest.Lock, dep string) (string, bool) {
+	for _, prod := range lock.Products {
+		for _, d := range prod.Dependencies {
+			if d.Name == dep {
+				return d.Version, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// installedVersion reads the version of a rock currently installed in the tree
+// from <tree>/share/tarantool/rocks/<dep>/<version>/. It returns the first
+// version directory found; a well-formed tree holds exactly one per rock.
+func installedVersion(lay layout, dep string) (string, bool) {
+	rocksDir := filepath.Join(lay.share, "rocks", dep)
+
+	entries, err := os.ReadDir(rocksDir)
+	if err != nil {
+		return "", false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return entry.Name(), true
+		}
+	}
+
+	return "", false
+}
+
+// sameVersion reports whether two version strings denote the same version,
+// tolerating formatting differences (a trailing "-1" revision, say).
+func sameVersion(left, right string) bool {
+	if left == right {
+		return true
+	}
+
+	parsedLeft, err := deps.ParseVersion(left)
+	if err != nil {
+		return false
+	}
+
+	parsedRight, err := deps.ParseVersion(right)
+	if err != nil {
+		return false
+	}
+
+	return deps.Compare(parsedLeft, parsedRight) == 0
+}
+
+// rockRemovePaths lists the on-disk paths that hold one version of a rock: its
+// module trees under share/ and lib/, and its rock-manifest directory.
+func rockRemovePaths(lay layout, dep, version string) []string {
+	return []string{
+		filepath.Join(lay.share, dep),
+		filepath.Join(lay.lib, dep),
+		filepath.Join(lay.share, "rocks", dep, version),
+	}
+}
+
+// removeStaleVersions deletes the on-disk files of any dependency version the
+// plan is replacing, so a reconciled upgrade does not leave two versions of a
+// rock side by side.
+func removeStaleVersions(lay layout, plan installPlan) error {
+	for _, decision := range plan.decisions {
+		if decision.removeVersion == "" {
+			continue
+		}
+
+		for _, stalePath := range rockRemovePaths(lay, decision.name, decision.removeVersion) {
+			err := os.RemoveAll(stalePath)
+			if err != nil {
+				return fmt.Errorf("removing stale %s %s: %w",
+					decision.name, decision.removeVersion, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cli/manifest/install/plan_internal_test.go
+++ b/cli/manifest/install/plan_internal_test.go
@@ -1,0 +1,67 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerFor parses an archiveSpec into a Header without writing an archive, for
+// plan-level tests.
+func headerFor(t *testing.T, spec archiveSpec) *Header {
+	t.Helper()
+
+	ar, err := OpenArchive(spec.build(t))
+	require.NoError(t, err)
+
+	header, err := ar.ReadHeader()
+	require.NoError(t, err)
+
+	return header
+}
+
+// TestPlanWithoutDepsRoutesToRegistry covers the --without-deps routing: a
+// dependency the archive does not carry and the tree does not have is fetched
+// from the registry.
+func TestPlanWithoutDepsRoutesToRegistry(t *testing.T) {
+	t.Parallel()
+
+	header := headerFor(t, archiveSpec{
+		name: "some-lib", version: "2.0.0",
+		deps:     map[string]string{"luasocket": ">=3.0.0"},
+		lockDeps: []LockDep{{Name: "luasocket", Version: "3.0.4", Source: "registry"}},
+	})
+
+	lay, err := resolveLayout(ScopeProject, t.TempDir())
+	require.NoError(t, err)
+
+	plan, err := planDeps(header, "default", nil, lay, false)
+	require.NoError(t, err)
+
+	require.Len(t, plan.decisions, 1)
+	assert.Equal(t, "luasocket", plan.decisions[0].name)
+	assert.Equal(t, "3.0.4", plan.decisions[0].version)
+	assert.Equal(t, fromRegistry, plan.decisions[0].source)
+}
+
+// TestPlanWithDepsRoutesToArchive covers the with-deps routing: the same
+// dependency is taken from the archive, not the registry.
+func TestPlanWithDepsRoutesToArchive(t *testing.T) {
+	t.Parallel()
+
+	header := headerFor(t, archiveSpec{
+		name: "my-app", version: "1.0.0", withRuntime: "3.0.5",
+		deps:     map[string]string{"luasocket": ">=3.0.0"},
+		lockDeps: []LockDep{{Name: "luasocket", Version: "3.0.4", Source: "registry"}},
+	})
+
+	lay, err := resolveLayout(ScopeProject, t.TempDir())
+	require.NoError(t, err)
+
+	plan, err := planDeps(header, "default", nil, lay, true)
+	require.NoError(t, err)
+
+	require.Len(t, plan.decisions, 1)
+	assert.Equal(t, fromArchive, plan.decisions[0].source)
+}

--- a/cli/manifest/install/reconcile.go
+++ b/cli/manifest/install/reconcile.go
@@ -1,0 +1,171 @@
+package install
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	luarocks "github.com/tarantool/go-luarocks"
+	"github.com/tarantool/go-luarocks/deps"
+)
+
+// contribution is one package's stake in a shared dependency: the version that
+// package's lock pinned, and the version constraint its manifest declared. The
+// constraint is empty for a purely transitive dependency — one a package pulls
+// in without declaring, so it pins a version but restricts nothing.
+type contribution struct {
+	// pkg is the package that brought this dependency.
+	pkg string
+	// pin is the exact version the package's lock recorded.
+	pin string
+	// constraint is the version expression the package's manifest declared,
+	// e.g. ">=3.0.0,<4.0.0". Empty when the dependency is transitive.
+	constraint string
+}
+
+// reconcile chooses the single locked version of a shared dependency that all
+// contributing packages can live with. The choice is made only among the
+// versions the packages already locked — no registry is consulted and nothing
+// is re-resolved:
+//
+//   - if every package pinned the same version, that version is used;
+//   - otherwise the pins that satisfy every package's declared constraint are
+//     the candidates, and the highest of them wins;
+//   - if no pin satisfies all constraints, it is a hard error carrying a
+//     breakdown of who pinned what and whose constraint excluded it.
+//
+// dep is the dependency name, used only for diagnostics. contributions must be
+// non-empty.
+func reconcile(dep string, contributions []contribution) (string, error) {
+	if len(contributions) == 0 {
+		return "", fmt.Errorf("%w %q: no contributors", errIncompatibleDeps, dep)
+	}
+
+	pins, err := parsePins(dep, contributions)
+	if err != nil {
+		return "", err
+	}
+
+	if allEqual(pins) {
+		return contributions[0].pin, nil
+	}
+
+	constraints, err := gatherConstraints(dep, contributions)
+	if err != nil {
+		return "", err
+	}
+
+	best, ok := highestMatching(pins, constraints)
+	if ok {
+		return best, nil
+	}
+
+	return "", incompatibleError(dep, contributions)
+}
+
+// parsePin pairs a contribution's raw pin string with its parsed version.
+type parsedPin struct {
+	raw     string
+	version luarocks.Version
+}
+
+// parsePins parses every contribution's pin into a comparable version.
+func parsePins(dep string, contributions []contribution) ([]parsedPin, error) {
+	pins := make([]parsedPin, 0, len(contributions))
+
+	for _, contrib := range contributions {
+		version, err := deps.ParseVersion(contrib.pin)
+		if err != nil {
+			return nil, fmt.Errorf("%w %q: package %q pinned unparseable version %q: %w",
+				errIncompatibleDeps, dep, contrib.pkg, contrib.pin, err)
+		}
+
+		pins = append(pins, parsedPin{raw: contrib.pin, version: version})
+	}
+
+	return pins, nil
+}
+
+// allEqual reports whether every pin is the same version.
+func allEqual(pins []parsedPin) bool {
+	for i := 1; i < len(pins); i++ {
+		if deps.Compare(pins[i].version, pins[0].version) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// gatherConstraints parses and unions every declared constraint. Transitive
+// contributions (empty constraint) add nothing. The union is an AND: a
+// candidate must satisfy all of them at once.
+func gatherConstraints(
+	dep string, contributions []contribution,
+) ([]luarocks.VersionConstraint, error) {
+	all := make([]luarocks.VersionConstraint, 0, len(contributions))
+
+	for _, contrib := range contributions {
+		if contrib.constraint == "" {
+			continue
+		}
+
+		parsed, err := deps.ParseConstraints(contrib.constraint)
+		if err != nil {
+			return nil, fmt.Errorf("%w %q: package %q declared unparseable constraint %q: %w",
+				errIncompatibleDeps, dep, contrib.pkg, contrib.constraint, err)
+		}
+
+		all = append(all, parsed...)
+	}
+
+	return all, nil
+}
+
+// highestMatching returns the highest pin that satisfies every constraint, and
+// whether any pin did. With no constraints every pin qualifies, so the highest
+// pin wins outright.
+func highestMatching(
+	pins []parsedPin, constraints []luarocks.VersionConstraint,
+) (string, bool) {
+	// Highest first, so the first match is the answer.
+	sorted := make([]parsedPin, len(pins))
+	copy(sorted, pins)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return deps.Compare(sorted[i].version, sorted[j].version) > 0
+	})
+
+	for _, pin := range sorted {
+		if len(constraints) == 0 || deps.Match(pin.version, constraints) {
+			return pin.raw, true
+		}
+	}
+
+	return "", false
+}
+
+// incompatibleError builds the diagnostic for a shared dependency no locked
+// version satisfies: every package's pin, and every declared constraint, so the
+// user can see which requirement excluded which version.
+func incompatibleError(dep string, contributions []contribution) error {
+	pins := make([]string, 0, len(contributions))
+	constraints := make([]string, 0, len(contributions))
+
+	for _, contrib := range contributions {
+		pins = append(pins, fmt.Sprintf("%s pinned %s", contrib.pkg, contrib.pin))
+
+		if contrib.constraint != "" {
+			constraints = append(constraints,
+				fmt.Sprintf("%s requires %s", contrib.pkg, contrib.constraint))
+		}
+	}
+
+	msg := fmt.Sprintf("%s: %s", dep, strings.Join(pins, ", "))
+	if len(constraints) > 0 {
+		msg += "; " + strings.Join(constraints, ", ")
+	}
+
+	msg += "; no locked version satisfies every requirement"
+
+	return &ExitError{Code: exitStateError, Err: fmt.Errorf("%w: %s", errIncompatibleDeps, msg)}
+}

--- a/cli/manifest/install/reconcile_internal_test.go
+++ b/cli/manifest/install/reconcile_internal_test.go
@@ -1,0 +1,93 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconcileIdenticalPins keeps the trivial case: when every package locked
+// the same version, that version is chosen and constraints never matter.
+func TestReconcileIdenticalPins(t *testing.T) {
+	t.Parallel()
+
+	got, err := reconcile("luasocket", []contribution{
+		{pkg: "router", pin: "3.0.4", constraint: ">=3.0.0"},
+		{pkg: "storage", pin: "3.0.4", constraint: ">=3.0.0,<4.0.0"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.4", got)
+}
+
+// TestReconcileHighestCompatible pins the core rule: among divergent pins, the
+// highest that satisfies every declared constraint wins.
+func TestReconcileHighestCompatible(t *testing.T) {
+	t.Parallel()
+
+	got, err := reconcile("luasocket", []contribution{
+		{pkg: "router", pin: "3.0.4", constraint: ">=3.0.0"},
+		{pkg: "storage", pin: "3.1.0", constraint: ">=3.0.0,<4.0.0"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "3.1.0", got)
+}
+
+// TestReconcileConstraintExcludesHighest covers a constraint that rules the
+// highest pin out, so the next-highest satisfying pin is chosen instead.
+func TestReconcileConstraintExcludesHighest(t *testing.T) {
+	t.Parallel()
+
+	got, err := reconcile("luasocket", []contribution{
+		{pkg: "router", pin: "3.0.4", constraint: ">=3.0.0"},
+		{pkg: "storage", pin: "3.1.0", constraint: "<3.1.0"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.4", got, "3.1.0 is excluded by storage's <3.1.0")
+}
+
+// TestReconcileIncompatible covers constraints that cannot be jointly satisfied
+// by any locked version: a hard error with a breakdown, carrying exit code 1.
+func TestReconcileIncompatible(t *testing.T) {
+	t.Parallel()
+
+	_, err := reconcile("luasocket", []contribution{
+		{pkg: "router", pin: "3.0.4", constraint: "<3.1.0"},
+		{pkg: "storage", pin: "3.1.0", constraint: ">=3.1.0"},
+	})
+	require.ErrorIs(t, err, errIncompatibleDeps)
+
+	var exit *ExitError
+	require.ErrorAs(t, err, &exit)
+	assert.Equal(t, exitStateError, exit.Code)
+
+	assert.Contains(t, err.Error(), "router pinned 3.0.4")
+	assert.Contains(t, err.Error(), "storage pinned 3.1.0")
+	assert.Contains(t, err.Error(), "requires")
+}
+
+// TestReconcileTransitiveNoConstraint covers a purely transitive shared
+// dependency: no package declares a constraint, so the highest pin wins.
+func TestReconcileTransitiveNoConstraint(t *testing.T) {
+	t.Parallel()
+
+	got, err := reconcile("inspect", []contribution{
+		{pkg: "router", pin: "3.1.2"},
+		{pkg: "storage", pin: "3.1.3"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "3.1.3", got)
+}
+
+// TestReconcileOneConstraintDrivesChoice covers divergent pins where only one
+// package constrains the range; the highest pin still inside that range wins.
+func TestReconcileOneConstraintDrivesChoice(t *testing.T) {
+	t.Parallel()
+
+	got, err := reconcile("inspect", []contribution{
+		{pkg: "router", pin: "3.1.3"},
+		{pkg: "storage", pin: "3.1.2", constraint: "==3.1.2"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "3.1.2", got, "router's 3.1.3 is excluded by storage's ==3.1.2")
+}

--- a/cli/manifest/install/refetch_internal_test.go
+++ b/cli/manifest/install/refetch_internal_test.go
@@ -1,0 +1,89 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tarantool/go-luarocks/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeInstaller records the Install calls the refetch loop makes, standing in
+// for a registry so the --without-deps download path is exercised offline.
+type fakeInstaller struct {
+	calls []client.InstallOpts
+	names []string
+	err   error
+}
+
+func (f *fakeInstaller) Install(_ context.Context, name string, opts client.InstallOpts) error {
+	f.names = append(f.names, name)
+	f.calls = append(f.calls, opts)
+
+	return f.err
+}
+
+// TestInstallDepsRefetchesPins covers the --without-deps download loop: each
+// registry decision is installed at its exact pin with dependency resolution
+// off, so nothing re-resolves its own closure.
+func TestInstallDepsRefetchesPins(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeInstaller{calls: nil, names: nil, err: nil}
+
+	decisions := []depDecision{
+		{name: "luasocket", version: "3.0.4", source: fromRegistry, removeVersion: ""},
+		{name: "inspect", version: "3.1.3", source: fromRegistry, removeVersion: ""},
+	}
+
+	err := installDeps(context.Background(), fake, decisions, []string{"srv"}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"luasocket", "inspect"}, fake.names)
+
+	for _, opts := range fake.calls {
+		assert.Equal(t, client.DepsNone, opts.Deps, "the closure is complete; no re-resolution")
+		assert.Equal(t, []string{"srv"}, opts.Servers)
+	}
+
+	assert.Equal(t, "3.0.4", fake.calls[0].Version)
+	assert.Equal(t, "3.1.3", fake.calls[1].Version)
+}
+
+// TestInstallDepsPropagatesError covers a registry failure surfacing with the
+// dependency named.
+func TestInstallDepsPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeInstaller{calls: nil, names: nil, err: errors.New("registry down")}
+
+	decisions := []depDecision{
+		{name: "luasocket", version: "3.0.4", source: fromRegistry, removeVersion: ""},
+	}
+
+	err := installDeps(context.Background(), fake, decisions, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "luasocket 3.0.4")
+}
+
+// TestRegistryDecisionsSelectsOnlyRegistry checks that only registry-sourced
+// decisions are refetched — archived and skipped ones never hit the network.
+func TestRegistryDecisionsSelectsOnlyRegistry(t *testing.T) {
+	t.Parallel()
+
+	plan := installPlan{
+		decisions: []depDecision{
+			{name: "a", version: "1", source: fromArchive, removeVersion: ""},
+			{name: "b", version: "2", source: fromRegistry, removeVersion: ""},
+			{name: "c", version: "3", source: skipDep, removeVersion: ""},
+		},
+		skipNames: nil,
+	}
+
+	got := registryDecisions(plan)
+	require.Len(t, got, 1)
+	assert.Equal(t, "b", got[0].name)
+}

--- a/cli/manifest/install/roundtrip_internal_test.go
+++ b/cli/manifest/install/roundtrip_internal_test.go
@@ -1,0 +1,101 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest/build"
+	"github.com/tarantool/tt/cli/manifest/pack"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// roundtripManifest is a dependency-free pure-Lua package: it packs and installs
+// with no compiler, no registry and no tarantool binary.
+const roundtripManifest = `manifest_version = '0.1'
+
+[package]
+name = 'round-app'
+include = ['README.md']
+
+[platform]
+tarantool = '>=3.0.0,<4.0.0'
+tt = '>=3.1.0'
+
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+include = ['*.lua']
+`
+
+// TestPackInstallRoundtrip drives the real pack writer into the real install
+// reader: a --without-deps archive of a dependency-free app is packed, then
+// installed offline into a fresh project, and its files and metadata land where
+// they belong. This is the headline offline path with no fabricated archive in
+// the middle.
+func TestPackInstallRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	writeSource(t, src, map[string]string{
+		"app.manifest.toml": roundtripManifest,
+		"VERSION":           "1.0.0\n",
+		"init.lua":          "return 1\n",
+		"README.md":         "round-app\n",
+	})
+
+	packed, err := pack.Run(context.Background(), pack.Options{
+		ProjectDir:  src,
+		WithoutDeps: true,
+		OutputDir:   filepath.Join(src, "_out"),
+		Build: build.Options{
+			TtVersion: "tt test",
+			Tarantool: rocks.TarantoolInfo{Prefix: "/nonexistent", Version: "3.0.0"},
+		},
+	})
+	require.NoError(t, err)
+
+	deploy := t.TempDir()
+	result, err := Run(context.Background(), Options{
+		ProjectDir: deploy,
+		Scope:      ScopeProject,
+		Archives:   []string{packed.Path},
+		Yes:        true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Installed, 1)
+	assert.Equal(t, "round-app", result.Installed[0].Package)
+
+	// The package's own files land in the shared tree.
+	assert.FileExists(t,
+		filepath.Join(deploy, ".rocks", "share", "tarantool", "round-app", "init.lua"))
+	assert.FileExists(t,
+		filepath.Join(deploy, ".rocks", "share", "tarantool", "round-app", "version.lua"))
+
+	// Metadata lands under manifests/ for list/uninstall.
+	metaDir := filepath.Join(deploy, ".rocks", "manifests", "round-app")
+	assert.FileExists(t, filepath.Join(metaDir, "manifest.toml"))
+	assert.FileExists(t, filepath.Join(metaDir, "lock.toml"))
+	assert.Equal(t, "1.0.0\n", readFile(t, filepath.Join(metaDir, "VERSION")))
+
+	// The project's own manifest is not overwritten by the guest's.
+	assert.NoFileExists(t, filepath.Join(deploy, "app.manifest.toml"))
+}
+
+// writeSource writes a set of files into dir, creating parents.
+func writeSource(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644)) //nolint:gosec
+	}
+}

--- a/cli/manifest/install/runtime.go
+++ b/cli/manifest/install/runtime.go
@@ -1,0 +1,135 @@
+package install
+
+import (
+	"path/filepath"
+
+	"github.com/tarantool/go-luarocks/deps"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// runtimePath is the install-root's _runtime/ directory.
+func runtimePath(lay layout) string {
+	return filepath.Join(lay.root, runtimeDirName)
+}
+
+// versionHigher reports whether candidate is a strictly higher version than
+// current. An unparseable or empty current counts as lower, so a first install
+// (no recorded version) always upgrades.
+func versionHigher(candidate, current string) bool {
+	cand, err := deps.ParseVersion(candidate)
+	if err != nil {
+		return false
+	}
+
+	cur, err := deps.ParseVersion(current)
+	if err != nil {
+		return true
+	}
+
+	return deps.Compare(cand, cur) > 0
+}
+
+// selectProduct picks the product whose closure the archive's lock carries: the
+// only product, or the one marked default. A build/pack always resolves against
+// one product, so the archive lock normally holds exactly one.
+func selectProduct(man *manifest.Manifest) (string, error) {
+	if len(man.Products) == 1 {
+		for name := range man.Products {
+			return name, nil
+		}
+	}
+
+	for name, prod := range man.Products {
+		if prod.Default {
+			return name, nil
+		}
+	}
+
+	if len(man.Products) == 0 {
+		return "", stateErrorf("archive manifest defines no products")
+	}
+
+	return "", stateErrorf("archive manifest has several products and none is default")
+}
+
+// checkRuntime validates the bundled runtime of a with-deps project install
+// against the runtime the project already fixed. The primary package's
+// [platform] constraints govern; when there is no primary package the first
+// install sets the versions and later ones must match what is on disk.
+//
+// The on-disk runtime carries no queryable version, so the check is only as
+// strong as the primary package's declared constraints: a bundled runtime that
+// violates them is refused (exit 1); with no primary package and no constraints,
+// the runtime is accepted and shared (the first install's tree is kept).
+func checkRuntime(opts Options, header *Header, installed []installedPackage) error {
+	if !header.WithDeps || opts.Scope != ScopeProject {
+		return nil
+	}
+
+	primary, ok := findPrimary(installed)
+	if !ok {
+		return nil
+	}
+
+	plat := primary.manifest.Platform
+
+	checks := []struct {
+		name       string
+		bundled    string
+		constraint manifest.Constraint
+	}{
+		{"tarantool", header.Lock.BundledTarantool, plat.Tarantool},
+		{"tt", header.Lock.BundledTt, plat.Tt},
+		{"tcm", header.Lock.BundledTcm, plat.Tcm},
+	}
+
+	for _, check := range checks {
+		if check.bundled == "" || check.constraint.Version == "" {
+			continue
+		}
+
+		ok, err := runtimeSatisfies(check.bundled, check.constraint.Version)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return stateErrorf(
+				"%w: bundled %s %s does not satisfy the project's requirement %q (from %s)",
+				errRuntimeMismatch, check.name, check.bundled, check.constraint.Version,
+				primary.name)
+		}
+	}
+
+	return nil
+}
+
+// findPrimary returns the project's primary package among the installed set.
+func findPrimary(installed []installedPackage) (installedPackage, bool) {
+	for _, pkg := range installed {
+		if pkg.primary && pkg.manifest != nil {
+			return pkg, true
+		}
+	}
+
+	var zero installedPackage
+
+	return zero, false
+}
+
+// runtimeSatisfies reports whether a concrete bundled version satisfies a
+// constraint expression.
+func runtimeSatisfies(version, constraint string) (bool, error) {
+	parsed, err := deps.ParseVersion(version)
+	if err != nil {
+		return false, stateErrorf("unparseable bundled version %q: %w", version, err)
+	}
+
+	constraints, err := deps.ParseConstraints(constraint)
+	if err != nil {
+		return false, stateErrorf("unparseable platform constraint %q: %w", constraint, err)
+	}
+
+	return deps.Match(parsed, constraints), nil
+}

--- a/cli/manifest/install/scope.go
+++ b/cli/manifest/install/scope.go
@@ -1,0 +1,127 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Scope is where tt package install lays a package down. The three scopes
+// differ in install-root and in the on-disk layout Tarantool's loaders expect;
+// they also differ in what archive they accept (only project takes a with-deps
+// archive).
+type Scope string
+
+const (
+	// ScopeProject installs into <cwd>/.rocks/, the self-contained deployment
+	// tree. It is the default and the only scope that accepts a with-deps
+	// archive (the bundled _runtime/ has no place in a user or system tree).
+	ScopeProject Scope = "project"
+	// ScopeUser installs into ~/.luarocks/, the personal LuaRocks tree. It
+	// accepts only a --without-deps archive.
+	ScopeUser Scope = "user"
+	// ScopeSystem installs into /usr/, the OS-package-style tree. It needs root
+	// and accepts only a --without-deps archive.
+	ScopeSystem Scope = "system"
+)
+
+// ParseScope validates a --scope value, defaulting an empty string to project.
+func ParseScope(raw string) (Scope, error) {
+	switch Scope(raw) {
+	case "", ScopeProject:
+		return ScopeProject, nil
+	case ScopeUser:
+		return ScopeUser, nil
+	case ScopeSystem:
+		return ScopeSystem, nil
+	default:
+		return "", fmt.Errorf("%w %q (want project, user or system)", errUnknownScope, raw)
+	}
+}
+
+// AcceptsWithDeps reports whether the scope may receive a with-deps archive.
+// Only project does: user and system are shared LuaRocks trees where bundling a
+// runtime is meaningless, so a with-deps archive is rejected before any write.
+func (scope Scope) AcceptsWithDeps() bool {
+	return scope == ScopeProject
+}
+
+// layout is the resolved set of directories one scope installs into.
+type layout struct {
+	// root is the install-root: <cwd> for project, the tree root otherwise.
+	root string
+	// tree is the rocks tree root the go-luarocks adapter reads and installs
+	// into (<cwd>/.rocks for project, the root itself for user/system).
+	tree string
+	// share and lib are the module directories a package's own files and its
+	// dependencies land under, relative subtrees of the tree.
+	share string
+	lib   string
+	// manifests is where tt records per-package install metadata
+	// (.rocks/manifests/<pkg>/) used by list/uninstall and dependency
+	// refcounting.
+	manifests string
+}
+
+// resolveLayout maps a scope to its concrete directories. projectDir is the
+// install-root for project scope (the caller's cwd); user and system derive
+// their roots from the environment. The returned paths are absolute.
+func resolveLayout(scope Scope, projectDir string) (layout, error) {
+	switch scope {
+	case ScopeProject:
+		tree := filepath.Join(projectDir, rocksDirName)
+
+		return layout{
+			root:      projectDir,
+			tree:      tree,
+			share:     filepath.Join(tree, shareTarantool),
+			lib:       filepath.Join(tree, libTarantool),
+			manifests: filepath.Join(tree, manifestsDirName),
+		}, nil
+	case ScopeUser:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			var zero layout
+
+			return zero, fmt.Errorf("locating home directory: %w", err)
+		}
+
+		root := filepath.Join(home, ".luarocks")
+
+		return layout{
+			root:      root,
+			tree:      root,
+			share:     filepath.Join(root, shareLua),
+			lib:       filepath.Join(root, libLua),
+			manifests: filepath.Join(root, manifestsDirName),
+		}, nil
+	case ScopeSystem:
+		root := systemRoot
+
+		return layout{
+			root:      root,
+			tree:      root,
+			share:     filepath.Join(root, shareTarantool),
+			lib:       filepath.Join(root, libTarantool),
+			manifests: filepath.Join(root, manifestsDirName),
+		}, nil
+	default:
+		var zero layout
+
+		return zero, fmt.Errorf("%w %q", errUnknownScope, scope)
+	}
+}
+
+// Rocks-tree layout roots. The project and system scopes follow the Tarantool
+// convention (share/tarantool, lib/tarantool); the user scope follows the
+// LuaRocks 5.1 convention.
+const (
+	rocksDirName     = ".rocks"
+	manifestsDirName = "manifests"
+	shareTarantool   = "share/tarantool"
+	libTarantool     = "lib/tarantool"
+	shareLua         = "share/lua/5.1"
+	libLua           = "lib/lua/5.1"
+	// systemRoot is the OS-package install-root.
+	systemRoot = "/usr"
+)

--- a/cli/manifest/install/scope_internal_test.go
+++ b/cli/manifest/install/scope_internal_test.go
@@ -1,0 +1,54 @@
+package install
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseScope covers the accepted values and the default.
+func TestParseScope(t *testing.T) {
+	t.Parallel()
+
+	for input, want := range map[string]Scope{
+		"":        ScopeProject,
+		"project": ScopeProject,
+		"user":    ScopeUser,
+		"system":  ScopeSystem,
+	} {
+		got, err := ParseScope(input)
+		require.NoError(t, err, input)
+		assert.Equal(t, want, got, input)
+	}
+
+	_, err := ParseScope("global")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errUnknownScope)
+}
+
+// TestAcceptsWithDeps pins the rule that only project takes a with-deps archive.
+func TestAcceptsWithDeps(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, ScopeProject.AcceptsWithDeps())
+	assert.False(t, ScopeUser.AcceptsWithDeps())
+	assert.False(t, ScopeSystem.AcceptsWithDeps())
+}
+
+// TestResolveLayoutProject fixes the project-scope directory layout.
+func TestResolveLayoutProject(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	lay, err := resolveLayout(ScopeProject, dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, dir, lay.root)
+	assert.Equal(t, filepath.Join(dir, ".rocks"), lay.tree)
+	assert.Equal(t, filepath.Join(dir, ".rocks", "share", "tarantool"), lay.share)
+	assert.Equal(t, filepath.Join(dir, ".rocks", "lib", "tarantool"), lay.lib)
+	assert.Equal(t, filepath.Join(dir, ".rocks", "manifests"), lay.manifests)
+}

--- a/cli/manifest/install/state.go
+++ b/cli/manifest/install/state.go
@@ -1,0 +1,216 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Per-package metadata file names inside .rocks/manifests/<pkg>/.
+const (
+	metaManifestFile = "manifest.toml"
+	metaLockFile     = "lock.toml"
+	metaVersionFile  = "VERSION"
+	// primaryManifestFile / primaryLockFile are the primary package's files in
+	// the install-root itself, not under manifests/.
+	primaryManifestFile = manifestFileName
+	primaryLockFile     = lockFileName
+	// metaFilePerm is the mode metadata files are written with: world-readable,
+	// matching the rocks tree they sit beside.
+	metaFilePerm = 0o644
+)
+
+// installedPackage is one package already present in a scope: the primary
+// package the project develops (project scope only) or a guest installed
+// earlier. Its manifest and lock drive collision checks and the joint
+// resolution of shared dependencies.
+type installedPackage struct {
+	// name is the package name.
+	name string
+	// manifest is its parsed manifest; nil if unreadable (a guest may predate a
+	// manifest-writing tt, and the primary package need not exist).
+	manifest *manifest.Manifest
+	// lock is its parsed lock; nil if unreadable.
+	lock *manifest.Lock
+	// version is the recorded version string, for --upgrade comparisons.
+	version string
+	// primary marks the project's own package, which uninstall refuses to touch.
+	primary bool
+}
+
+// installedPackages enumerates every package already present in the scope: the
+// primary package (project scope, when <root>/app.manifest.toml exists) plus
+// every guest under manifests/. A guest whose metadata is missing or unreadable
+// is skipped rather than failing the whole install — a half-written earlier
+// install must not wedge every later one.
+func installedPackages(lay layout, scope Scope) ([]installedPackage, error) {
+	var packages []installedPackage
+
+	if scope == ScopeProject {
+		if primary, ok := readPrimary(lay.root); ok {
+			packages = append(packages, primary)
+		}
+	}
+
+	entries, err := os.ReadDir(lay.manifests)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return packages, nil
+		}
+
+		return nil, fmt.Errorf("reading install state %s: %w", lay.manifests, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		guest, ok := readGuest(lay.manifests, entry.Name())
+		if ok {
+			packages = append(packages, guest)
+		}
+	}
+
+	return packages, nil
+}
+
+// findInstalled returns the installed package with the given name, if any.
+func findInstalled(packages []installedPackage, name string) (installedPackage, bool) {
+	for _, p := range packages {
+		if p.name == name {
+			return p, true
+		}
+	}
+
+	var zero installedPackage
+
+	return zero, false
+}
+
+// readPrimary reads the project's own package from the install-root. The
+// manifest is optional (a bare deploy directory has none); when present its lock
+// beside it is read too.
+func readPrimary(root string) (installedPackage, bool) {
+	var zero installedPackage
+
+	//nolint:gosec // Reads tt's own install-state files.
+	manBytes, err := os.ReadFile(filepath.Join(root, primaryManifestFile))
+	if err != nil {
+		return zero, false
+	}
+
+	man, _, err := manifest.ParseManifest(manBytes)
+	if err != nil {
+		return zero, false
+	}
+
+	pkg := installedPackage{
+		name:     man.Package.Name,
+		manifest: man,
+		lock:     readLockFile(filepath.Join(root, primaryLockFile)),
+		version:  "",
+		primary:  true,
+	}
+
+	return pkg, true
+}
+
+// readGuest reads one installed guest's metadata from manifests/<name>/.
+func readGuest(manifestsDir, name string) (installedPackage, bool) {
+	var zero installedPackage
+
+	dir := filepath.Join(manifestsDir, name)
+
+	//nolint:gosec // Reads tt's own install-state files.
+	manBytes, err := os.ReadFile(filepath.Join(dir, metaManifestFile))
+	if err != nil {
+		return zero, false
+	}
+
+	man, _, err := manifest.ParseManifest(manBytes)
+	if err != nil {
+		return zero, false
+	}
+
+	pkg := installedPackage{
+		name:     man.Package.Name,
+		manifest: man,
+		lock:     readLockFile(filepath.Join(dir, metaLockFile)),
+		version:  readVersionFile(filepath.Join(dir, metaVersionFile)),
+		primary:  false,
+	}
+
+	return pkg, true
+}
+
+// readLockFile parses a lock file, returning nil when it is absent or unreadable
+// — a guest may predate a lock-writing tt, and the primary package need not have
+// a lock at all.
+func readLockFile(path string) *manifest.Lock {
+	data, err := os.ReadFile(path) //nolint:gosec // Reads tt's own install-state files.
+	if err != nil {
+		return nil
+	}
+
+	lock, err := manifest.ParseLock(data)
+	if err != nil {
+		return nil
+	}
+
+	return lock
+}
+
+// readVersionFile reads a VERSION file, returning "" when it is absent.
+func readVersionFile(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec // Reads tt's own install-state files.
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(data))
+}
+
+// writeMetadata records a freshly installed guest's metadata under
+// manifests/<pkg>/: the manifest, the lock and the version. This is the
+// inventory list/uninstall read and the ledger dependency refcounting stands
+// on — a dependency is owned by every package whose lock lists it.
+func writeMetadata(lay layout, header *Header) error {
+	dir := filepath.Join(lay.manifests, header.Manifest.Package.Name)
+
+	err := os.MkdirAll(dir, dirPerm)
+	if err != nil {
+		return fmt.Errorf("creating metadata directory: %w", err)
+	}
+
+	lockBytes, err := header.Lock.Marshal()
+	if err != nil {
+		return fmt.Errorf("serializing lock metadata: %w", err)
+	}
+
+	files := []struct {
+		name string
+		data []byte
+	}{
+		{metaManifestFile, header.ManifestBytes},
+		{metaLockFile, lockBytes},
+		{metaVersionFile, []byte(header.Version + "\n")},
+	}
+
+	for _, file := range files {
+		// Install metadata is world-readable by design, matching the rocks tree.
+		path := filepath.Join(dir, file.name)
+
+		err := os.WriteFile(path, file.data, metaFilePerm)
+		if err != nil {
+			return fmt.Errorf("writing %s metadata: %w", file.name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Unpack a .tt package archive into a scope and bring the tree to a runnable state. A with-deps archive in the project scope is a plain offline extraction (tar xf, no network); a --without-deps archive additionally refetches its dependency closure from the registry by the lock's exact pins, reusing tt package fetch's install-with-DepsNone loop. user and system scopes accept only --without-deps archives — a with-deps archive there is refused from the archive header before anything touches disk.

Joint resolution handles several packages sharing one project .rocks/ tree: a dependency they lock at different versions is reconciled to the highest locked version that satisfies every package's declared constraint, or the install fails with a breakdown of who pinned what. The choice is made only among versions already locked — no registry is consulted — over go-luarocks' version and constraint primitives.

Per-package metadata (manifest, lock, VERSION) is recorded under .rocks/manifests/<pkg>/ for inventory and dependency refcounting. --locked refuses an archive whose lock diverges from its manifest, --upgrade installs only a strictly higher version, --force reinstalls over a collision, --yes skips the reconciliation prompt. A single archive surfaces its own failure code; a multi-archive run where some succeed and some fail exits 3.

The archive reader is new: pack shipped a write-only tar+zstd writer, so install carries its own reader, with a tar-slip guard on every entry.

Closes TNTP-8613