### PR TITLE
tests: fix vclock backup tests

### DIFF
--- a/cli/backup/chain/build_test.go
+++ b/cli/backup/chain/build_test.go
@@ -243,9 +243,13 @@ func TestBuildMarksVclockMismatchOnBothShards(t *testing.T) {
 
 func TestBuildSkipsVclockCheckForFullBackup(t *testing.T) {
 	// A full backup's vclock_begin is never compared with the previous manifest:
-	// a full is a chain root, not a delta.
+	// A full-backup fragment produced by `tt backup start` has vclock_begin == nil
+	// (box.backup.info() returns no prev_vclock for a full backup).
 	prev := manifestFixture("prev", "", "prev",
 		backup.BackupTypeFull, 10, 0, 10, nil)
+	for _, shard := range prev.Shards {
+		shard.Instance.VclockBegin = nil
+	}
 	// next is declared as a full with an arbitrary vclock_begin that would fail
 	// an incremental check against prev's vclock_end.
 	next := manifestFixture("next", "prev", "next",

--- a/cli/backup/start_test.go
+++ b/cli/backup/start_test.go
@@ -130,9 +130,13 @@ func readArchiveEntries(t *testing.T, path string) map[string][]byte {
 // vend is mapped to vclock (end). rps == nil omits the recovery_points key;
 // an empty non-nil slice yields recovery_points = [].
 func infoMap(files []string, vbegin, vend Vclock, rps *[]map[any]any) map[any]any {
+	backupType := BackupTypeFull
+	if len(vbegin) > 0 {
+		backupType = BackupTypeIncremental
+	}
 	m := map[any]any{
 		"files":  toAnySlice(files),
-		"type":   "full",
+		"type":   backupType,
 		"vclock": toVclockMap(vend),
 	}
 	if len(vbegin) > 0 {
@@ -216,7 +220,7 @@ func TestStartBackup_buildsArchiveAndLeavesBackupOpen(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500, 2: 230}, Vclock{1: 1502, 2: 230}, &[]map[any]any{
+	info := infoMap(walFiles, nil, Vclock{1: 1502, 2: 230}, &[]map[any]any{
 		{
 			"label":      "rp-1",
 			"replica_id": uint64(1),
@@ -258,7 +262,7 @@ func TestStartBackup_fragmentFields(t *testing.T) {
 	writeWAL(t, walDir, "00000000000000001500.snap", goldenSnap)
 	writeWAL(t, walDir, "00000000000000001500.xlog", goldenXlog)
 
-	info := infoMap(walFiles, Vclock{1: 1500, 2: 230}, Vclock{1: 1502, 2: 230}, &[]map[any]any{
+	info := infoMap(walFiles, nil, Vclock{1: 1502, 2: 230}, &[]map[any]any{
 		{
 			"label":      "rp-1",
 			"replica_id": uint64(1),
@@ -305,7 +309,7 @@ func TestStartBackup_fragmentFields(t *testing.T) {
 // fails.
 func TestStartBackup_failLoudOnAlreadyOpen(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	m := &mockEvaler{queue: [][]any{{info}}}
 
 	_, err := Start(m, BackupStartOpts{BackupID: "bid"})
@@ -322,11 +326,11 @@ func TestStartBackup_fromVclockPropagated(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, Vclock{1: 42, 2: 7}, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
-	_, err := Start(m, BackupStartOpts{
+	archivePath, err := Start(m, BackupStartOpts{
 		BackupID:   "bid",
 		FromVclock: Vclock{1: 42, 2: 7},
 	})
@@ -338,6 +342,14 @@ func TestStartBackup_fromVclockPropagated(t *testing.T) {
 	require.Len(t, startArgs, 1)
 	got := startArgs[0].(map[string]any)
 	require.Equal(t, map[uint32]uint64{1: 42, 2: 7}, got["from_vclock"])
+
+	fragmentData, err := os.ReadFile(fragmentPathFor(archivePath))
+	require.NoError(t, err)
+	var fragment Fragment
+	require.NoError(t, json.Unmarshal(fragmentData, &fragment))
+	require.Equal(t, BackupTypeIncremental, fragment.Type)
+	require.Equal(t, Vclock{1: 42, 2: 7}, fragment.VclockBegin)
+	require.Equal(t, Vclock{1: 1502}, fragment.VclockEnd)
 }
 
 // TestStartBackup_fullBackupOmitsFromVclock checks a full backup (FromVclock
@@ -347,7 +359,7 @@ func TestStartBackup_fullBackupOmitsFromVclock(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -367,7 +379,7 @@ func TestStartBackup_ttlPropagated(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -400,7 +412,7 @@ func TestStartBackup_recoveryPointsStates(t *testing.T) {
 			walDir := t.TempDir()
 			writeWalFiles(t, walDir)
 
-			info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, tc.rps)
+			info := infoMap(walFiles, nil, Vclock{1: 1502}, tc.rps)
 			inst := instanceMap("router-001", walDir, "")
 			m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -429,7 +441,7 @@ func TestStartBackup_fileNotFound(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
 	walDir := t.TempDir()
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -444,7 +456,7 @@ func TestStartBackup_instNameFallback(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("", walDir, "")
 	delete(inst, "instance_name")
 	m := &mockEvaler{queue: startQueue(info, inst)}
@@ -490,7 +502,7 @@ func TestStartBackup_cleansUpOnFragmentWriteFailure(t *testing.T) {
 	walDir := t.TempDir()
 	writeWalFiles(t, walDir)
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -534,7 +546,7 @@ func TestStartBackup_packError(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(walDir, "00000000000000001500.snap"), 0o755))
 	writeWAL(t, walDir, "00000000000000001500.xlog", []byte("xlog"))
 
-	info := infoMap(walFiles, Vclock{1: 1500}, Vclock{1: 1502}, nil)
+	info := infoMap(walFiles, nil, Vclock{1: 1502}, nil)
 	inst := instanceMap("router-001", walDir, "")
 	m := &mockEvaler{queue: startQueue(info, inst)}
 
@@ -564,7 +576,7 @@ func TestStartBackup_resolveFilesSplitDirs(t *testing.T) {
 	writeWAL(t, vinylDir, vinylFile, []byte("vinyl"))
 
 	files := append(slices.Clone(walFiles), vinylFile)
-	info := infoMap(files, Vclock{1: 1500, 2: 230}, Vclock{1: 1502, 2: 230}, nil)
+	info := infoMap(files, nil, Vclock{1: 1502, 2: 230}, nil)
 	inst := instanceMap("router-001", walDir, memtxDir)
 	inst["vinyl_dir"] = vinylDir
 	m := &mockEvaler{queue: startQueue(info, inst)}

--- a/cli/backup/testdata/cluster_manifest.json
+++ b/cli/backup/testdata/cluster_manifest.json
@@ -12,7 +12,7 @@
         "instance_uuid": "aaaaaaaa-0000-0000-0000-000000000001",
         "instance_name": "router-001",
         "hostname": "tarantool-node-01.prod.example.com",
-        "vclock_begin": {"1": 1500, "2": 230},
+        "vclock_begin": null,
         "vclock_end": {"1": 1502, "2": 230},
         "artifact": {
           "path": "20260312T120000Z-replicaset_A_uuid.tar.zst",
@@ -36,7 +36,7 @@
         "instance_uuid": "bbbbbbbb-0000-0000-0000-000000000001",
         "instance_name": "storage-001",
         "hostname": "tarantool-node-03.prod.example.com",
-        "vclock_begin": {"3": 800, "4": 110},
+        "vclock_begin": null,
         "vclock_end": {"3": 801, "4": 110},
         "artifact": {
           "path": "20260312T120000Z-replicaset_B_uuid.tar.zst",

--- a/cli/backup/testdata/fragment_a.json
+++ b/cli/backup/testdata/fragment_a.json
@@ -4,7 +4,7 @@
   "instance_name": "router-001",
   "hostname": "tarantool-node-01.prod.example.com",
   "type": "full",
-  "vclock_begin": {"1": 1500, "2": 230},
+  "vclock_begin": null,
   "vclock_end": {"1": 1502, "2": 230},
   "files": [
     "00000000000000001500.snap",

--- a/cli/backup/testdata/fragment_b.json
+++ b/cli/backup/testdata/fragment_b.json
@@ -4,7 +4,7 @@
   "instance_name": "storage-001",
   "hostname": "tarantool-node-03.prod.example.com",
   "type": "full",
-  "vclock_begin": {"3": 800, "4": 110},
+  "vclock_begin": null,
   "vclock_end": {"3": 801, "4": 110},
   "files": [
     "00000000000000000800.snap",

--- a/cli/backup/testdata/fragment_with_empty_recovery_points.json
+++ b/cli/backup/testdata/fragment_with_empty_recovery_points.json
@@ -4,7 +4,7 @@
   "instance_name": "router-001",
   "hostname": "tarantool-node-01.prod.example.com",
   "type": "full",
-  "vclock_begin": {"0": 12, "1": 1500},
+  "vclock_begin": null,
   "vclock_end": {"0": 12, "1": 1502},
   "files": [
     "00000000000000001500.snap",

--- a/cli/backup/testdata/fragment_without_recovery_points.json
+++ b/cli/backup/testdata/fragment_without_recovery_points.json
@@ -4,7 +4,7 @@
   "instance_name": "router-001",
   "hostname": "tarantool-node-01.prod.example.com",
   "type": "full",
-  "vclock_begin": {"0": 12, "1": 1500},
+  "vclock_begin": null,
   "vclock_end": {"0": 12, "1": 1502},
   "files": [
     "00000000000000001500.snap",

--- a/cli/backup/testdata/start/golden_instance_backup.json
+++ b/cli/backup/testdata/start/golden_instance_backup.json
@@ -4,7 +4,7 @@
   "instance_name": "router-001",
   "hostname": "",
   "type": "full",
-  "vclock_begin": {"1": 1500, "2": 230},
+  "vclock_begin": null,
   "vclock_end": {"1": 1502, "2": 230},
   "files": [
     "00000000000000001500.snap",

--- a/cli/backup/validation.go
+++ b/cli/backup/validation.go
@@ -19,8 +19,10 @@ func (fragment Fragment) Validate() error {
 	if !isValidBackupType(fragment.Type) {
 		return fmt.Errorf("invalid backup type %q", fragment.Type)
 	}
-	if len(fragment.VclockBegin) == 0 {
-		return fmt.Errorf("vclock_begin is empty")
+	// vclock_begin (box.backup.info().prev_vclock) is only present for an
+	// incremental backup.
+	if fragment.Type == BackupTypeIncremental && len(fragment.VclockBegin) == 0 {
+		return fmt.Errorf("vclock_begin is empty for an incremental backup")
 	}
 	if len(fragment.VclockEnd) == 0 {
 		return fmt.Errorf("vclock_end is empty")
@@ -125,8 +127,11 @@ func validateShardInstance(replicasetUUID string, instance ShardInstance) error 
 	if instance.Hostname == "" {
 		return fmt.Errorf("shard %q hostname is empty", replicasetUUID)
 	}
-	if len(instance.VclockBegin) == 0 {
-		return fmt.Errorf("shard %q vclock_begin is empty", replicasetUUID)
+	if instance.Artifact.Type == BackupTypeIncremental && len(instance.VclockBegin) == 0 {
+		return fmt.Errorf(
+			"shard %q vclock_begin is empty for an incremental backup",
+			replicasetUUID,
+		)
 	}
 	if len(instance.VclockEnd) == 0 {
 		return fmt.Errorf("shard %q vclock_end is empty", replicasetUUID)

--- a/cli/backup/validation_test.go
+++ b/cli/backup/validation_test.go
@@ -55,13 +55,22 @@ func TestFragmentValidate(t *testing.T) {
 			wantError: "invalid backup type",
 		},
 		{
-			name: "empty vclock begin",
+			name: "incremental with empty vclock begin",
+			fragment: func() Fragment {
+				fragment := valid
+				fragment.Type = BackupTypeIncremental
+				fragment.VclockBegin = nil
+				return fragment
+			}(),
+			wantError: "vclock_begin is empty for an incremental backup",
+		},
+		{
+			name: "full backup with nil vclock begin is valid",
 			fragment: func() Fragment {
 				fragment := valid
 				fragment.VclockBegin = nil
 				return fragment
 			}(),
-			wantError: "vclock_begin is empty",
 		},
 		{
 			name: "empty vclock end",
@@ -155,7 +164,19 @@ func TestClusterManifestValidate(t *testing.T) {
 			wantError: "is not present in topology",
 		},
 		{
-			name: "successful shard with empty vclock begin",
+			name: "incremental shard with empty vclock begin",
+			manifest: func() ClusterManifest {
+				manifest := valid()
+				shard := manifest.Shards[testRSA]
+				shard.Instance.Artifact.Type = BackupTypeIncremental
+				shard.Instance.VclockBegin = nil
+				manifest.Shards[testRSA] = shard
+				return manifest
+			}(),
+			wantError: "vclock_begin is empty for an incremental backup",
+		},
+		{
+			name: "full shard with nil vclock begin is valid",
 			manifest: func() ClusterManifest {
 				manifest := valid()
 				shard := manifest.Shards[testRSA]
@@ -163,7 +184,6 @@ func TestClusterManifestValidate(t *testing.T) {
 				manifest.Shards[testRSA] = shard
 				return manifest
 			}(),
-			wantError: "vclock_begin is empty",
 		},
 		{
 			name: "invalid artifact type",

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -446,14 +446,15 @@ func NewClusterCmd() *cobra.Command {
 		Long: "Discover and print the current cluster topology by connecting to " +
 			"cluster nodes via net.box.\n\n" +
 			"The cluster configuration can be loaded from a file, etcd, or " +
-			"Tarantool Config Storage. It is used to determine the list of " +
-			"instances and their listen URIs. Each instance is contacted " +
-			"via net.box, the live topology is collected and merged into " +
-			"a single view.\n\n" +
+			"Tarantool Config Storage.\n" +
+			"It is used to determine the list of instances and their listen URIs." +
+			"Each instance is contacted via net.box,\n" +
+			"the live topology is collected and merged into a single view.\n\n" +
 			"JSON output contains replicasets keyed by UUID and their instances " +
-			"(instance_uuid, instance_name, hostname, mode, status). If a replicaset " +
-			"is unreachable and its UUID is not configured, its name is used as " +
-			"the key. Unreachable instances have the status \"not reachable\".\n\n" +
+			"(instance_uuid, instance_name, hostname, mode, status).\n" +
+			"If a replicaset is unreachable and its UUID is not configured, its name is used as " +
+			"the key.\n" +
+			"Unreachable instances have the status \"not reachable\".\n\n" +
 			clusterUriHelp,
 		Run:  RunModuleFunc(internalClusterTopologyModule),
 		Args: cobra.NoArgs,

--- a/test/integration/backup/backup_helpers.py
+++ b/test/integration/backup/backup_helpers.py
@@ -134,49 +134,53 @@ def _unpack_archive(archive_path, destination):
     return sorted(extracted)
 
 
-def inspect_backup_artifact(
-    archive_path,
-    unpack_dir,
-    backup_id,
-    instance,
-    expected_type,
-):
+# Fields that cannot be made deterministic in a test environment:
+#   hostname         — the OS hostname of the machine running the test.
+#   timestamp        — the wall-clock time of a recovery point.
+#   checksum_sha256  — the archive checksum.
+# Everything else is deterministic: UUIDs are pinned in the test app config,
+# vclock/LSNs are fixed by the deterministic operation sequence.
+_VOLATILE_FRAGMENT_KEYS = {"hostname", "checksum_sha256"}
+
+
+def assert_fragment_matches_golden(fragment, golden_path):
+    with open(golden_path, "r") as src:
+        golden = json.load(src)
+
+    actual = {k: v for k, v in fragment.items() if k not in _VOLATILE_FRAGMENT_KEYS}
+    for rp in actual["recovery_points"]:
+        rp.pop("timestamp", None)
+
+    assert actual == golden
+
+
+def inspect_backup_artifact(archive_path, unpack_dir, backup_id):
     expected_dir = backup_dir(backup_id)
     assert os.path.dirname(archive_path) == expected_dir
-    expected_base = f"{backup_id}-{instance['replicaset_uuid']}"
-    assert os.path.basename(archive_path) == f"{expected_base}.tar.zst"
     assert os.path.isfile(archive_path), f"archive not found: {archive_path}"
 
-    fragment_path = os.path.join(expected_dir, f"{expected_base}.json")
+    fragment_path = archive_path.removesuffix(".tar.zst") + ".json"
     assert os.path.isfile(fragment_path), f"manifest fragment not found: {fragment_path}"
     with open(fragment_path, "r") as src:
         fragment = json.load(src)
 
-    assert fragment["replicaset_uuid"] == instance["replicaset_uuid"]
-    assert fragment["instance_uuid"] == instance["instance_uuid"]
-    assert fragment["instance_name"] == instance["instance_name"]
-    assert fragment["hostname"] == instance["hostname"]
-    assert fragment["type"] == expected_type
+    # The replicaset_uuid in the fragment must match the archive file name.
+    assert os.path.basename(archive_path) == (
+        f"{backup_id}-{fragment['replicaset_uuid']}.tar.zst"
+    ), fragment
 
-    vclock_end = fragment["vclock_end"]
-    assert isinstance(vclock_end, dict) and vclock_end, fragment
-    assert all(int(replica_id) >= 0 for replica_id in vclock_end)
-    assert all(isinstance(lsn, int) and lsn >= 0 for lsn in vclock_end.values())
-
-    assert "recovery_points" in fragment, fragment
-    assert isinstance(fragment["recovery_points"], list), fragment
-
+    # Checksum is the sha256 of the actual archive bytes.
     checksum = fragment["checksum_sha256"]
     assert len(checksum) == 64 and all(c in "0123456789abcdef" for c in checksum)
-    assert _sha256_file(archive_path) == checksum
+    assert _sha256_file(archive_path) == checksum, fragment
 
-    manifest_files = fragment["files"]
-    assert manifest_files, fragment
-    assert len(manifest_files) == len(set(manifest_files)), fragment
-    assert all(os.path.basename(name) == name for name in manifest_files), fragment
+    # The archive must contain exactly the files listed in the fragment.
+    assert fragment["files"], fragment
+    assert len(fragment["files"]) == len(set(fragment["files"])), fragment
+    assert all(os.path.basename(name) == name for name in fragment["files"]), fragment
 
     extracted_files = _unpack_archive(archive_path, unpack_dir)
-    assert extracted_files == sorted(manifest_files)
+    assert extracted_files == sorted(fragment["files"]), fragment
 
     return fragment
 

--- a/test/integration/backup/test_app/config.yaml
+++ b/test/integration/backup/test_app/config.yaml
@@ -12,4 +12,7 @@ groups:
     replicasets:
       storage-001:
         instances:
-          storage-001-a: {}
+          storage-001-a:
+            database:
+              instance_uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+              replicaset_uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'

--- a/test/integration/backup/test_backup_start.py
+++ b/test/integration/backup/test_backup_start.py
@@ -1,15 +1,16 @@
 import os
+from pathlib import Path
 
 import pytest
 from backup_helpers import (
     TT_BACKUP_APP,
     app_instance,
     archive_path_from_output,
+    assert_fragment_matches_golden,
     backup_dir,
     eval_yaml_app,
     finalize_backup,
     get_backup_info_app,
-    get_instance_info_app,
     inspect_backup_artifact,
     start_backup,
 )
@@ -17,6 +18,7 @@ from backup_helpers import (
 from utils import get_tarantool_version, is_tarantool_less
 
 STORAGE_1_A = "storage-001-a"
+TESTDATA_DIR = Path(__file__).parent / "testdata"
 
 tarantool_major, tarantool_minor = get_tarantool_version()
 BACKUP_SUPPORTED = not is_tarantool_less(3, 8)
@@ -30,16 +32,9 @@ skip_reason = (
 @pytest.mark.tt_app(**TT_BACKUP_APP)
 def test_start_full_artifact_and_open_backup_lifecycle(tt, tt_app, tmp_path):
     target = app_instance(tt_app, STORAGE_1_A)
-    instance = get_instance_info_app(tt, target)
 
     eval_yaml_app(tt, target, "return box.snapshot()")
-
-    recovery_point = eval_yaml_app(
-        tt,
-        target,
-        "return box.backup.recovery_point.create({label = 'rp-itest'})",
-    )
-    assert recovery_point is not None
+    eval_yaml_app(tt, target, "box.backup.recovery_point.create({label = 'rp-itest'})")
 
     backup_id = "itest-full"
     rc, out = start_backup(tt, target, backup_id)
@@ -47,27 +42,10 @@ def test_start_full_artifact_and_open_backup_lifecycle(tt, tt_app, tmp_path):
 
     try:
         archive_path = archive_path_from_output(out)
-        fragment = inspect_backup_artifact(
-            archive_path,
-            tmp_path / "full",
-            backup_id,
-            instance,
-            expected_type="full",
-        )
-        assert fragment["vclock_begin"] is None
-        assert any(name.endswith(".snap") for name in fragment["files"])
-        assert any(name.endswith(".run") for name in fragment["files"])
-        matching_points = [
-            point for point in fragment["recovery_points"] if point.get("label") == "rp-itest"
-        ]
-        assert len(matching_points) == 1, fragment
-        point = matching_points[0]
-        assert point["replica_id"] == recovery_point["replica_id"]
-        assert point["lsn"] == recovery_point["lsn"]
-        assert point["timestamp"] == pytest.approx(recovery_point["timestamp"])
+        fragment = inspect_backup_artifact(archive_path, tmp_path / "full", backup_id)
+        assert_fragment_matches_golden(fragment, TESTDATA_DIR / "fragment_full.golden.json")
 
-        # This is only a lifecycle ping. Artifact correctness is asserted above
-        # from the archive and its manifest fragment, not from box.backup.info().
+        # Lifecycle: the backup stays open after start.
         assert get_backup_info_app(tt, target) is not None
 
         with open(archive_path, "rb") as src:
@@ -90,7 +68,6 @@ def test_start_full_artifact_and_open_backup_lifecycle(tt, tt_app, tmp_path):
 @pytest.mark.tt_app(**TT_BACKUP_APP)
 def test_start_incremental_continues_full_artifact(tt, tt_app, tmp_path):
     target = app_instance(tt_app, STORAGE_1_A)
-    instance = get_instance_info_app(tt, target)
 
     full_id = "itest-inc-full"
     rc, out = start_backup(tt, target, full_id)
@@ -100,8 +77,6 @@ def test_start_incremental_continues_full_artifact(tt, tt_app, tmp_path):
             archive_path_from_output(out),
             tmp_path / "full",
             full_id,
-            instance,
-            expected_type="full",
         )
     finally:
         rc, finalize_out = finalize_backup(tt, target, full_id)
@@ -128,11 +103,15 @@ def test_start_incremental_continues_full_artifact(tt, tt_app, tmp_path):
             archive_path_from_output(out),
             tmp_path / "incremental",
             inc_id,
-            instance,
-            expected_type="incremental",
         )
+        assert_fragment_matches_golden(
+            inc_fragment,
+            TESTDATA_DIR / "fragment_incremental.golden.json",
+        )
+
+        # Cross-field consistency: the incremental must continue the full
+        # backup's end vclock (the value we passed via --from-vclock).
         assert inc_fragment["vclock_begin"] == full_fragment["vclock_end"]
-        assert any(name.endswith(".xlog") for name in inc_fragment["files"])
         assert any(
             inc_fragment["vclock_end"].get(replica_id, 0) > lsn
             for replica_id, lsn in full_fragment["vclock_end"].items()

--- a/test/integration/backup/test_last.py
+++ b/test/integration/backup/test_last.py
@@ -85,6 +85,15 @@ def test_last_json_single_manifest(tt, backup_storage):
     assert parsed["status"] == "OK"
     assert parsed["schema_version"] == 1
 
+    shard = parsed["shards"]["11111111-1111-1111-1111-111111111111"]["instance"]
+    assert shard["vclock_begin"] is None, shard
+    assert shard["vclock_end"] == {"1": 100}, shard
+    artifact = shard["artifact"]
+    assert artifact["type"] == "full"
+    assert artifact["compression"] == "zstd"
+    assert any(name.endswith(".snap") for name in artifact["files"]), artifact
+    assert artifact["recovery_points"][0]["label"] == "rp-1", artifact
+
 
 @pytest.mark.parametrize("backup_storage", STORAGE_BACKENDS, indirect=True)
 def test_last_returns_latest_manifest(tt, backup_storage):

--- a/test/integration/backup/testdata/fragment_full.golden.json
+++ b/test/integration/backup/testdata/fragment_full.golden.json
@@ -1,0 +1,24 @@
+{
+  "replicaset_uuid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "instance_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "instance_name": "storage-001-a",
+  "type": "full",
+  "vclock_begin": null,
+  "vclock_end": {
+    "1": 37
+  },
+  "files": [
+    "00000000000000000035.snap",
+    "00000000000000000000.vylog",
+    "00000000000000000004.index",
+    "00000000000000000004.run",
+    "00000000000000000035.xlog"
+  ],
+  "recovery_points": [
+    {
+      "label": "rp-itest",
+      "replica_id": 1,
+      "lsn": 36
+    }
+  ]
+}

--- a/test/integration/backup/testdata/fragment_incremental.golden.json
+++ b/test/integration/backup/testdata/fragment_incremental.golden.json
@@ -1,0 +1,16 @@
+{
+  "replicaset_uuid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "instance_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "instance_name": "storage-001-a",
+  "type": "incremental",
+  "vclock_begin": {
+    "1": 35
+  },
+  "vclock_end": {
+    "1": 41
+  },
+  "files": [
+    "00000000000000000035.xlog"
+  ],
+  "recovery_points": []
+}

--- a/test/integration/backup/testdata/manifest_full.json
+++ b/test/integration/backup/testdata/manifest_full.json
@@ -12,15 +12,23 @@
         "instance_uuid": "aaaaaaaa-0000-0000-0000-000000000001",
         "instance_name": "router-001",
         "hostname": "localhost",
-        "vclock_begin": {"1": 0},
+        "vclock_begin": null,
         "vclock_end": {"1": 100},
         "artifact": {
           "path": "data/2026-01-01-full-11111111-1111-1111-1111-111111111111.tar.zst",
           "size_bytes": 1024,
           "checksum_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           "compression": "zstd",
-          "files": ["00000000000000000000.snap"],
-          "recovery_points": [],
+          "files": [
+            "00000000000000000099.snap",
+            "00000000000000000000.vylog",
+            "00000000000000000001.index",
+            "00000000000000000001.run",
+            "00000000000000000099.xlog"
+          ],
+          "recovery_points": [
+            {"label": "rp-1", "replica_id": 1, "lsn": 99, "timestamp": 1735689600.0}
+          ],
           "type": "full"
         }
       }


### PR DESCRIPTION
The tests in cli/backup were based on the RFC, which differs from the final implementation in tarantool. Full backup does not return vclock_begin, so all golden files have been overwritten. In addition, the tt backup start integration tests have been changed. Now they are compared with golden files, which makes the comparison deterministic.

Part of TNTP-8608
