### PR TITLE
backup: add verify command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Tarantool Config Storage with table and JSON output.
 - `tt backup last`: add support for displaying the latest backup manifest from
   file or S3 storage.
+- `tt backup verify`: add a read-only health check of a backup storage: missing
+  and corrupted archives, breaks in the backup chain, and dangling archives.
+  Exits with 2 when problems are found.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   file or S3 storage.
 - `tt backup verify`: add a read-only health check of a backup storage: missing
   and corrupted archives, breaks in the backup chain, and dangling archives.
-  Exits with 2 when problems are found.
+  Exits with 2 when problems are found. Archives of a backup newer than every
+  stored manifest are reported as an upload in progress and do not make the
+  storage unhealthy.
 
 ### Changed
 

--- a/cli/backup/chain/build.go
+++ b/cli/backup/chain/build.go
@@ -13,62 +13,175 @@ import (
 	"github.com/tarantool/tt/cli/backup/storage"
 )
 
-// Load reads every stored manifest and builds a fully marked chain.
+// Unreadable is a listed manifest that could not be turned into a chain entry.
+type Unreadable struct {
+	// Key is the storage key of the manifest.
+	Key string
+	// Err explains why the manifest could not be used.
+	Err error
+}
+
+// Load reads every stored manifest and builds a fully marked chain. A manifest
+// that cannot be read or decoded fails the whole load: a chain silently missing
+// a link would send its caller down a broken recovery path. Callers that
+// diagnose the storage rather than recover from it use LoadPartial.
 func Load(ctx context.Context, store storage.Storage) (*Chain, error) {
-	manifests, err := loadManifests(ctx, store)
+	chain, unreadable, err := LoadPartial(ctx, store)
 	if err != nil {
-		if errors.Is(err, errManifestVanished) {
-			manifests, err = loadManifests(ctx, store)
-			if errors.Is(err, errManifestVanished) {
-				return nil, fmt.Errorf("load manifests: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("load manifests: %w", err)
-		}
+		return nil, fmt.Errorf("load chain: %w", err)
 	}
 
-	chain, err := Build(manifests)
-	if err != nil {
-		return nil, fmt.Errorf("build chain: %w", err)
+	if len(unreadable) > 0 {
+		return nil, fmt.Errorf(
+			"load manifest %q: %w", unreadable[0].Key, unreadable[0].Err,
+		)
 	}
 
 	return chain, nil
 }
 
+// LoadPartial builds the chain from the manifests it could read and returns the
+// ones it could not, so that a diagnostic caller (tt backup verify) reports a
+// single broken object instead of going blind on the whole storage.
+func LoadPartial(
+	ctx context.Context,
+	store storage.Storage,
+) (*Chain, []Unreadable, error) {
+	loaded, unreadable, err := loadManifests(ctx, store)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load manifests: %w", err)
+	}
+
+	// A manifest that LIST reported but GET could not find is usually gc
+	// deleting it mid-run: redo the listing once before believing it.
+	if slices.ContainsFunc(unreadable, isVanished) {
+		loaded, unreadable, err = loadManifests(ctx, store)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load manifests: %w", err)
+		}
+	}
+
+	// A manifest with no backup_id, or two claiming the same one, would make
+	// Build reject the storage whole, leaving the diagnostic caller with nothing
+	// to report about the very defects it exists to name.
+	manifests, unusable := splitUnusable(loaded)
+	unreadable = append(unreadable, unusable...)
+
+	chain, err := Build(manifests)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build chain: %w", err)
+	}
+
+	return chain, unreadable, nil
+}
+
 // errManifestVanished marks a manifest that LIST reported but GET could not find.
 var errManifestVanished = errors.New("manifest vanished between list and get")
 
-// loadManifests lists and reads every manifest once, reporting errManifestVanished
-// when a listed key is missing on GET so Load can retry.
+// isVanished reports whether a manifest was listed but missing on GET.
+func isVanished(unreadable Unreadable) bool {
+	return errors.Is(unreadable.Err, errManifestVanished)
+}
+
+// loadedManifest pairs a decoded manifest with the key it came from. A defect
+// that only the key can name - two objects claiming one backup_id - is otherwise
+// impossible to report against the right object.
+type loadedManifest struct {
+	Key      string
+	Manifest *backup.ClusterManifest
+}
+
+// errDuplicateBackupID marks manifests sharing one backup_id.
+var errDuplicateBackupID = errors.New("duplicate backup_id")
+
+// errMissingBackupID marks a manifest with nothing to key it by.
+var errMissingBackupID = errors.New("manifest has no backup_id")
+
+// splitUnusable separates out manifests that cannot become chain entries: one
+// carrying no backup_id has nothing to key it by, and of two objects claiming
+// the same id neither can be told to be the authentic one. Both are reported
+// against their storage key - the only name they have left - while the rest of
+// the storage is still checked.
+func splitUnusable(loaded []loadedManifest) ([]*backup.ClusterManifest, []Unreadable) {
+	claims := make(map[backup.BackupID]int, len(loaded))
+	for _, item := range loaded {
+		claims[item.Manifest.BackupID]++
+	}
+
+	manifests := make([]*backup.ClusterManifest, 0, len(loaded))
+	unusable := make([]Unreadable, 0)
+
+	for _, item := range loaded {
+		switch id := item.Manifest.BackupID; {
+		case id == "":
+			unusable = append(unusable, Unreadable{Key: item.Key, Err: errMissingBackupID})
+		case claims[id] > 1:
+			unusable = append(unusable, Unreadable{
+				Key: item.Key,
+				Err: fmt.Errorf("%w %q: another object claims it too",
+					errDuplicateBackupID, id),
+			})
+		default:
+			manifests = append(manifests, item.Manifest)
+		}
+	}
+
+	slices.SortFunc(unusable, func(a, b Unreadable) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	return manifests, unusable
+}
+
+// loadManifests lists and reads every manifest once, collecting the ones that
+// could not be read or decoded instead of failing on the first of them. Only a
+// failure to list at all is returned as an error.
 func loadManifests(
 	ctx context.Context,
 	store storage.Storage,
-) ([]*backup.ClusterManifest, error) {
+) ([]loadedManifest, []Unreadable, error) {
 	objects, err := store.List(ctx, storage.ManifestsPrefix())
 	if err != nil {
-		return nil, fmt.Errorf("list manifests: %w", err)
+		return nil, nil, fmt.Errorf("list manifests: %w", err)
 	}
 
-	manifests := make([]*backup.ClusterManifest, 0, len(objects))
+	manifests := make([]loadedManifest, 0, len(objects))
+	unreadable := make([]Unreadable, 0)
+
 	for _, object := range objects {
-		data, err := storage.GetBytes(ctx, store, object.Key)
+		manifest, err := loadManifest(ctx, store, object.Key)
 		if err != nil {
-			if errors.Is(err, storage.ErrKeyNotFound) {
-				return nil, fmt.Errorf("%w: %q", errManifestVanished, object.Key)
-			}
-
-			return nil, fmt.Errorf("load manifest %q: %w", object.Key, err)
+			unreadable = append(unreadable, Unreadable{Key: object.Key, Err: err})
+			continue
 		}
 
-		var manifest backup.ClusterManifest
-		if err := json.Unmarshal(data, &manifest); err != nil {
-			return nil, fmt.Errorf("decode manifest %q: %w", object.Key, err)
-		}
-
-		manifests = append(manifests, &manifest)
+		manifests = append(manifests, loadedManifest{Key: object.Key, Manifest: manifest})
 	}
 
-	return manifests, nil
+	return manifests, unreadable, nil
+}
+
+// loadManifest reads and decodes one manifest.
+func loadManifest(
+	ctx context.Context,
+	store storage.Storage,
+	key string,
+) (*backup.ClusterManifest, error) {
+	data, err := storage.GetBytes(ctx, store, key)
+	if err != nil {
+		if errors.Is(err, storage.ErrKeyNotFound) {
+			return nil, fmt.Errorf("%w: %q", errManifestVanished, key)
+		}
+
+		return nil, fmt.Errorf("read manifest %q: %w", key, err)
+	}
+
+	var manifest backup.ClusterManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest %q: %w", key, err)
+	}
+
+	return &manifest, nil
 }
 
 // Build groups manifests, attaches own and inherited chain problems, and
@@ -99,7 +212,7 @@ func Build(manifests []*backup.ClusterManifest) (*Chain, error) {
 	// Reverse previous_backup_id links after every backup_id is indexed.
 	children := make(map[backup.BackupID][]*Entry, len(entries))
 
-	for _, entry := range entries {
+	for _, entry := range sortedEntries(entries) {
 		if previousID := entry.Manifest.PreviousBackupID; previousID != "" {
 			children[previousID] = append(children[previousID], entry)
 		}
@@ -137,7 +250,7 @@ func markProblems(
 	children map[backup.BackupID][]*Entry,
 ) {
 	// A structurally invalid manifest poisons its whole tail.
-	for _, entry := range entries {
+	for _, entry := range sortedEntries(entries) {
 		if err := entry.Manifest.Validate(); err != nil {
 			propagateProblem(entry, &Problem{
 				Kind:     ProblemInvalidManifest,
@@ -148,7 +261,7 @@ func markProblems(
 	}
 
 	// Orphan and vclock mismatch belong to one entry and poison its whole tail.
-	for _, entry := range entries {
+	for _, entry := range sortedEntries(entries) {
 		previousID := entry.Manifest.PreviousBackupID
 		parent := entries[previousID]
 		if previousID != "" && parent == nil {
@@ -167,8 +280,23 @@ func markProblems(
 		}
 	}
 
+	// A manifest whose previous_backup_id leads back to itself has no full backup
+	// to replay from. Left unflagged it would also drop out of the ordered group
+	// (it is reachable neither from the base nor as a tail root), and a manifest
+	// no command can see is one gc would happily delete around.
+	for _, entry := range sortedEntries(entries) {
+		if cycle := cycleThrough(entry, entries); cycle != "" {
+			propagateProblem(entry, &Problem{
+				Kind:     ProblemInvalidManifest,
+				BackupID: string(entry.Manifest.BackupID),
+				Detail:   fmt.Sprintf("previous_backup_id forms a cycle through %q", cycle),
+			}, children)
+		}
+	}
+
 	// A fork poisons every branch, not the common parent before the fork.
-	for previousID, forks := range children {
+	for _, previousID := range slices.Sorted(maps.Keys(children)) {
+		forks := children[previousID]
 		if len(forks) < 2 {
 			continue
 		}
@@ -192,6 +320,45 @@ func markProblems(
 				Detail:   detail,
 			}, children)
 		}
+	}
+}
+
+// sortedEntries returns the entries ordered by backup id. Every loop that
+// attaches problems must be deterministic: map iteration order would otherwise
+// decide in which order an entry collects problems inherited from several
+// ancestors, and that order reaches the verify report, where a cron job diffing
+// --format json would see changes that are not there.
+func sortedEntries(entries map[backup.BackupID]*Entry) []*Entry {
+	ordered := make([]*Entry, 0, len(entries))
+	for _, id := range slices.Sorted(maps.Keys(entries)) {
+		ordered = append(ordered, entries[id])
+	}
+
+	return ordered
+}
+
+// cycleThrough walks previous_backup_id back from an entry and returns the
+// backup id where the walk meets itself, or an empty id when the walk ends.
+func cycleThrough(entry *Entry, entries map[backup.BackupID]*Entry) backup.BackupID {
+	visited := map[backup.BackupID]bool{entry.Manifest.BackupID: true}
+
+	for current := entry; ; {
+		previousID := current.Manifest.PreviousBackupID
+		if previousID == "" {
+			return ""
+		}
+
+		parent, ok := entries[previousID]
+		if !ok {
+			return ""
+		}
+
+		if visited[previousID] {
+			return previousID
+		}
+
+		visited[previousID] = true
+		current = parent
 	}
 }
 
@@ -377,6 +544,18 @@ func orderGroup(
 		}
 
 		appendTree(entry)
+	}
+
+	// Whatever is still unvisited is reachable neither from the full backup nor
+	// from a tail root, which means its links close a cycle. Such a manifest is
+	// marked as a problem, but it must not silently disappear from the chain:
+	// every consumer decides what to do with a manifest it can see, and none can
+	// account for one it cannot.
+	for _, entry := range group.Entries {
+		if !visited[entry.Manifest.BackupID] {
+			visited[entry.Manifest.BackupID] = true
+			ordered = append(ordered, entry)
+		}
 	}
 
 	group.Entries = ordered

--- a/cli/backup/chain/build_test.go
+++ b/cli/backup/chain/build_test.go
@@ -348,7 +348,9 @@ func TestBuildDetectsRealMismatchAcrossHole(t *testing.T) {
 func TestBuildHandlesCycleInPreviousBackupID(t *testing.T) {
 	// A cycle in previous_backup_id must not hang Build. Because both entries
 	// resolve their previous_backup_id to an existing entry, neither is marked
-	// as an orphan. The cycle itself is not currently detected as a Problem.
+	// as an orphan; the cycle is reported as an invalid manifest instead. Here
+	// "a" is its own group base, so both entries stay reachable - see
+	// TestLoadPartialKeepsManifestsInACycle for the case where they are not.
 	a := manifestFixture("a", "b", "a",
 		backup.BackupTypeFull, 10, 0, 10, nil)
 	b := manifestFixture("b", "a", "a",
@@ -356,6 +358,7 @@ func TestBuildHandlesCycleInPreviousBackupID(t *testing.T) {
 
 	chain := buildFixtureChain(t, a, b)
 	require.Len(t, chain.Manifests(), 2)
+	require.NotEmpty(t, chain.Problems())
 }
 
 type problemExpectation struct {

--- a/cli/backup/chain/load_test.go
+++ b/cli/backup/chain/load_test.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -107,6 +108,149 @@ func TestLoadMarksInvalidManifest(t *testing.T) {
 	chain, err := Load(t.Context(), store)
 	require.NoError(t, err)
 	require.Contains(t, problemKinds(chain.Problems()), ProblemInvalidManifest)
+}
+
+func TestLoadPartialReportsUndecodableManifest(t *testing.T) {
+	// A single broken object must not hide the manifests around it.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.objects[storage.ManifestKey("broken")] = []byte("{")
+
+	chain, unreadable, err := LoadPartial(t.Context(), store)
+	require.NoError(t, err)
+	require.Equal(t, []backup.BackupID{"full"}, entryIDs(chain.Groups()[0].Entries))
+	require.Len(t, unreadable, 1)
+	require.Equal(t, storage.ManifestKey("broken"), unreadable[0].Key)
+	require.ErrorContains(t, unreadable[0].Err, "decode manifest")
+}
+
+func TestLoadPartialReportsDuplicateBackupID(t *testing.T) {
+	// A manifest copied to a second key used to make Build reject the storage
+	// whole, so verify exited "could not check" and said nothing about the very
+	// defect it exists to name. Both copies are reported and distrusted; the
+	// backups around them are still checked.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	other := manifestFixture("other", "", "other", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.addManifest(t, other)
+	store.objects[storage.ManifestsPrefix()+"full-copy.json"] =
+		store.objects[storage.ManifestKey("full")]
+
+	chain, unreadable, err := LoadPartial(t.Context(), store)
+
+	require.NoError(t, err)
+	require.Len(t, unreadable, 2)
+	require.Equal(t, storage.ManifestsPrefix()+"full-copy.json", unreadable[0].Key)
+	require.Equal(t, storage.ManifestKey("full"), unreadable[1].Key)
+	require.ErrorContains(t, unreadable[0].Err, "duplicate backup_id")
+	require.Equal(t, []backup.BackupID{"other"}, entryIDs(chain.Groups()[0].Entries))
+}
+
+func TestLoadPartialOrdersProblemsDeterministically(t *testing.T) {
+	// The loops that attach problems used to run over maps, so an entry
+	// inheriting from several broken ancestors collected them in whatever order
+	// Go felt like that run. One run cannot catch it - the orderings differ only
+	// across runs - so the same storage is built repeatedly and compared.
+	build := func() []string {
+		store := newMemoryStorage()
+		// Two invalid ancestors poisoning the same tail. They must fail in
+		// different ways: identical details would make a reordering invisible.
+		first := manifestFixture("a-bad", "", "a-bad", backup.BackupTypeFull, 10, 0, 10, nil)
+		first.Status = ""
+		second := manifestFixture("b-bad", "a-bad", "a-bad",
+			backup.BackupTypeIncremental, 20, 10, 20, nil)
+		second.SchemaVersion = 99
+		tail := manifestFixture("c-tail", "b-bad", "a-bad",
+			backup.BackupTypeIncremental, 30, 20, 30, nil)
+		store.addManifest(t, first)
+		store.addManifest(t, second)
+		store.addManifest(t, tail)
+
+		chain, _, err := LoadPartial(t.Context(), store)
+		require.NoError(t, err)
+
+		details := make([]string, 0)
+		for _, problem := range chain.Problems() {
+			details = append(details, fmt.Sprintf("%v|%s|%s",
+				problem.Kind, problem.BackupID, problem.Detail))
+		}
+
+		return details
+	}
+
+	want := build()
+	require.NotEmpty(t, want, "the fixture must actually produce problems")
+
+	for range 50 {
+		require.Equal(t, want, build(), "problem order must not vary between runs")
+	}
+}
+
+func TestLoadPartialKeepsManifestsInACycle(t *testing.T) {
+	// Two increments pointing at each other are reachable neither from the full
+	// backup nor as tail roots. They used to fall out of the ordered group
+	// entirely: unchecked, uncounted, and with their archives reported dangling
+	// on top - verify blaming the healthy half of a broken pair.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	first := manifestFixture("a", "b", "full", backup.BackupTypeIncremental, 20, 10, 20, nil)
+	second := manifestFixture("b", "a", "full", backup.BackupTypeIncremental, 30, 20, 30, nil)
+	store.addManifest(t, full)
+	store.addManifest(t, first)
+	store.addManifest(t, second)
+
+	chain, unreadable, err := LoadPartial(t.Context(), store)
+
+	require.NoError(t, err)
+	require.Empty(t, unreadable)
+	require.ElementsMatch(t,
+		[]backup.BackupID{"full", "a", "b"},
+		entryIDs(chain.Groups()[0].Entries),
+		"a manifest no command can see is one gc would delete around",
+	)
+	require.NotEmpty(t, chain.Problems(), "the cycle must be reported, not hidden")
+}
+
+func TestLoadFailsOnDuplicateBackupID(t *testing.T) {
+	// Load stays fail-loud: a caller that recovers from the chain must not be
+	// handed one of two objects claiming the same backup.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.objects[storage.ManifestsPrefix()+"full-copy.json"] =
+		store.objects[storage.ManifestKey("full")]
+
+	_, err := Load(t.Context(), store)
+
+	require.ErrorContains(t, err, "duplicate backup_id")
+}
+
+func TestLoadPartialRetriesOnVanishedManifest(t *testing.T) {
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.getMisses[storage.ManifestKey("full")] = 1
+
+	chain, unreadable, err := LoadPartial(t.Context(), store)
+	require.NoError(t, err)
+	require.Empty(t, unreadable)
+	require.Equal(t, []backup.BackupID{"full"}, entryIDs(chain.Groups()[0].Entries))
+}
+
+func TestLoadPartialReportsPhantomManifest(t *testing.T) {
+	// Listed but never readable: the retry does not help, so it is reported.
+	store := newMemoryStorage()
+	full := manifestFixture("full", "", "full", backup.BackupTypeFull, 10, 0, 10, nil)
+	store.addManifest(t, full)
+	store.phantom[storage.ManifestKey("ghost")] = true
+
+	chain, unreadable, err := LoadPartial(t.Context(), store)
+	require.NoError(t, err)
+	require.Len(t, chain.Manifests(), 1)
+	require.Len(t, unreadable, 1)
+	require.ErrorContains(t, unreadable[0].Err, "vanished")
 }
 
 func TestLoadReturnsListError(t *testing.T) {

--- a/cli/backup/storage/fs/fs.go
+++ b/cli/backup/storage/fs/fs.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tarantool/tt/cli/backup/storage"
@@ -39,6 +40,9 @@ type Config struct {
 // Storage is a local filesystem backup storage backend.
 type Storage struct {
 	root string
+	// sweepOnce keeps the stale-temp-file sweep on the write path: a process that
+	// never puts anything must not delete anything either.
+	sweepOnce sync.Once
 }
 
 // New opens local filesystem backup storage.
@@ -66,10 +70,7 @@ func New(cfg Config) (*Storage, error) {
 		return nil, fmt.Errorf("failed to resolve storage root %q: %w", cfg.Path, err)
 	}
 
-	s := &Storage{root: root}
-	s.sweepStaleTempFiles()
-
-	return s, nil
+	return &Storage{root: root}, nil
 }
 
 // sweepStaleTempFiles best-effort removes temp files left behind by interrupted
@@ -77,6 +78,11 @@ func New(cfg Config) (*Storage, error) {
 // Such files are hidden from List and cannot be Deleted through the API, so they
 // would otherwise accumulate forever. Errors are ignored: this is an optimization,
 // not a guarantee, and the root may not exist yet.
+//
+// It runs on the first Put rather than in New. Only Put creates these files, and
+// read-only callers - tt backup verify above all, whose contract is that it
+// deletes nothing whatever it finds - must not remove anything just by opening
+// the storage.
 func (s *Storage) sweepStaleTempFiles() {
 	cutoff := time.Now().Add(-staleTempFileAge)
 	_ = filepath.WalkDir(s.root, func(path string, d os.DirEntry, err error) error {
@@ -225,6 +231,8 @@ func (s *Storage) Put(ctx context.Context, key string, r io.Reader, size int64) 
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("failed to put object %q: %w", key, err)
 	}
+
+	s.sweepOnce.Do(s.sweepStaleTempFiles)
 
 	path, err := s.objectPath(key)
 	if err != nil {

--- a/cli/backup/storage/fs/fs_test.go
+++ b/cli/backup/storage/fs/fs_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/backup/storage"
@@ -238,6 +239,37 @@ func TestConcurrentPut(t *testing.T) {
 	actual, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	require.Equal(t, []byte("data"), actual)
+}
+
+func TestStaleTempFileSurvivesReadOnlyUse(t *testing.T) {
+	// A leftover temp file is the residue of an interrupted upload - evidence an
+	// operator may want to look at, and something tt backup verify promises never
+	// to remove whatever it finds. Opening and reading the storage must therefore
+	// delete nothing; only a writer sweeps.
+	root := t.TempDir()
+	dir := filepath.Join(root, "cluster", "production", "data")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	stale := filepath.Join(dir, tempFilePrefix+"interrupted")
+	require.NoError(t, os.WriteFile(stale, []byte("half an upload"), 0o600))
+	aged := time.Now().Add(-2 * staleTempFileAge)
+	require.NoError(t, os.Chtimes(stale, aged, aged))
+
+	s := newTestStorage(t, root)
+	require.FileExists(t, stale, "opening the storage must not delete anything")
+
+	_, err := s.List(t.Context(), storage.DataPrefix())
+	require.NoError(t, err)
+	require.FileExists(t, stale, "listing must not delete anything")
+
+	data := []byte("archive")
+	require.NoError(t, s.Put(
+		t.Context(),
+		storage.ArchiveKey("sweep", "11111111-1111-1111-1111-111111111111"),
+		bytes.NewReader(data),
+		int64(len(data)),
+	))
+	require.NoFileExists(t, stale, "the first put still sweeps stale temp files")
 }
 
 func newTestStorage(t *testing.T, root string) *Storage {

--- a/cli/backup/storage/keys.go
+++ b/cli/backup/storage/keys.go
@@ -1,6 +1,9 @@
 package storage
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ManifestsPrefix returns the relative key prefix for backup manifests.
 func ManifestsPrefix() string {
@@ -20,4 +23,86 @@ func ManifestKey(backupID string) string {
 // ArchiveKey returns a relative key for a replicaset backup archive object.
 func ArchiveKey(backupID, replicasetUUID string) string {
 	return fmt.Sprintf("%s%s-%s.tar.zst", DataPrefix(), backupID, replicasetUUID)
+}
+
+// ManifestBackupID returns the backup id a manifest key belongs to. It is the
+// inverse of ManifestKey, used to name an object whose content could not be
+// read; false means the key is not a manifest key.
+func ManifestBackupID(key string) (string, bool) {
+	backupID, ok := strings.CutPrefix(key, ManifestsPrefix())
+	if !ok {
+		return "", false
+	}
+
+	backupID, ok = strings.CutSuffix(backupID, ".json")
+	if !ok || backupID == "" {
+		return "", false
+	}
+
+	return backupID, true
+}
+
+// uuidLength is the length of a canonical replicaset UUID (8-4-4-4-12).
+const uuidLength = 36
+
+// ArchiveBackupID splits an archive key into the backup id and the replicaset
+// UUID it was produced for. It is the inverse of ArchiveKey: a backup id may
+// itself contain dashes, so the key is parsed from the right, where the UUID has
+// a fixed shape. False means the key does not name an archive of this layout.
+func ArchiveBackupID(key string) (string, string, bool) {
+	name, ok := strings.CutPrefix(key, DataPrefix())
+	if !ok {
+		return "", "", false
+	}
+
+	name, ok = strings.CutSuffix(name, ".tar.zst")
+	if !ok {
+		return "", "", false
+	}
+
+	// The separator sits right before the trailing UUID; anything before it is
+	// the backup id, which must not be empty.
+	separator := len(name) - uuidLength - 1
+	if separator < 1 || name[separator] != '-' {
+		return "", "", false
+	}
+
+	replicasetUUID := name[separator+1:]
+	if !isUUID(replicasetUUID) {
+		return "", "", false
+	}
+
+	return name[:separator], replicasetUUID, true
+}
+
+// isUUID reports whether s is a canonical lowercase-or-uppercase hex UUID.
+func isUUID(s string) bool {
+	if len(s) != uuidLength {
+		return false
+	}
+
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !isHexDigit(r) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// isHexDigit reports whether r is a hexadecimal digit.
+func isHexDigit(r rune) bool {
+	switch {
+	case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		return true
+	default:
+		return false
+	}
 }

--- a/cli/backup/storage/storage_test.go
+++ b/cli/backup/storage/storage_test.go
@@ -44,6 +44,22 @@ func TestKeyHelpers(t *testing.T) {
 	)
 }
 
+func TestManifestBackupID(t *testing.T) {
+	backupID, ok := ManifestBackupID(ManifestKey("20260102T030405Z"))
+	require.True(t, ok)
+	require.Equal(t, "20260102T030405Z", backupID)
+
+	for _, key := range []string{
+		"data/20260102T030405Z-rs.tar.zst",
+		"manifests/20260102T030405Z.tar.zst",
+		"manifests/.json",
+		"20260102T030405Z.json",
+	} {
+		_, ok := ManifestBackupID(key)
+		require.Falsef(t, ok, "key %q must not parse as a manifest key", key)
+	}
+}
+
 func TestErrKeyNotFoundComparable(t *testing.T) {
 	require.True(t, errors.Is(ErrKeyNotFound, ErrKeyNotFound))
 }

--- a/cli/backup/validation.go
+++ b/cli/backup/validation.go
@@ -62,6 +62,12 @@ func (manifest ClusterManifest) validateHeader() error {
 	if manifest.Shards == nil {
 		return fmt.Errorf("shards is nil")
 	}
+	// A backup of no shards is not a backup. Left valid, such a manifest reads as
+	// healthy while referring to nothing, so verify blames its archives as
+	// dangling and gc collects them once they age past --orphan-age.
+	if len(manifest.Shards) == 0 {
+		return fmt.Errorf("shards is empty")
+	}
 	if manifest.Topology.Replicasets == nil {
 		return fmt.Errorf("topology.replicasets is nil")
 	}

--- a/cli/backup/validation_test.go
+++ b/cli/backup/validation_test.go
@@ -135,6 +135,15 @@ func TestClusterManifestValidate(t *testing.T) {
 			wantError: "invalid status",
 		},
 		{
+			name: "empty shards",
+			manifest: func() ClusterManifest {
+				manifest := valid()
+				manifest.Shards = map[string]Shard{}
+				return manifest
+			}(),
+			wantError: "shards is empty",
+		},
+		{
 			name: "shard has both instance and error",
 			manifest: func() ClusterManifest {
 				manifest := valid()

--- a/cli/backup/verify/helpers_test.go
+++ b/cli/backup/verify/helpers_test.go
@@ -1,0 +1,280 @@
+package verify
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/backup"
+	"github.com/tarantool/tt/cli/backup/storage"
+)
+
+const (
+	replicasetA = "11111111-1111-1111-1111-111111111111"
+	replicasetB = "22222222-2222-2222-2222-222222222222"
+	masterA     = "aaaaaaaa-0000-0000-0000-000000000001"
+	masterB     = "bbbbbbbb-0000-0000-0000-000000000001"
+)
+
+// memoryStorage is an in-memory Storage that also records every mutation, so
+// that tests can assert verify is read-only.
+type memoryStorage struct {
+	objects  map[string][]byte
+	modified map[string]time.Time
+	// readErrs[key] makes Get succeed but the returned reader fail mid-stream.
+	readErrs map[string]error
+	listErr  error
+	// puts and deletes record mutations; verify must leave both empty.
+	puts    []string
+	deletes []string
+}
+
+func newMemoryStorage() *memoryStorage {
+	return &memoryStorage{
+		objects:  make(map[string][]byte),
+		modified: make(map[string]time.Time),
+		readErrs: make(map[string]error),
+	}
+}
+
+func (s *memoryStorage) List(_ context.Context, prefix string) ([]storage.ObjectInfo, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+
+	objects := make([]storage.ObjectInfo, 0)
+	for key, data := range s.objects {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		objects = append(objects, storage.ObjectInfo{
+			Key:          key,
+			Size:         int64(len(data)),
+			LastModified: s.modified[key],
+		})
+	}
+
+	slices.SortFunc(objects, func(a, b storage.ObjectInfo) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
+
+	return objects, nil
+}
+
+func (s *memoryStorage) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ErrKeyNotFound
+	}
+
+	if err := s.readErrs[key]; err != nil {
+		return io.NopCloser(io.MultiReader(
+			bytes.NewReader(data),
+			&failingReader{err: err},
+		)), nil
+	}
+
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *memoryStorage) Put(_ context.Context, key string, r io.Reader, _ int64) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read data: %w", err)
+	}
+
+	s.puts = append(s.puts, key)
+	s.objects[key] = data
+	s.modified[key] = time.Unix(0, 0).UTC()
+
+	return nil
+}
+
+func (s *memoryStorage) Delete(_ context.Context, key string) error {
+	s.deletes = append(s.deletes, key)
+	delete(s.objects, key)
+
+	return nil
+}
+
+// snapshot copies the stored keys and their contents for a mutation check.
+func (s *memoryStorage) snapshot() map[string]string {
+	objects := make(map[string]string, len(s.objects))
+	for key, data := range s.objects {
+		objects[key] = string(data)
+	}
+
+	return objects
+}
+
+// failingReader always fails, simulating an archive truncated in transit.
+type failingReader struct {
+	err error
+}
+
+func (r *failingReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+// fixture builds a synthetic backup storage: manifests under manifests/ and
+// their archives under data/, with real checksums.
+type fixture struct {
+	t     *testing.T
+	store *memoryStorage
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	return &fixture{t: t, store: newMemoryStorage()}
+}
+
+// addBackup stores a healthy one-shard backup and returns its manifest.
+func (f *fixture) addBackup(
+	id, previous, base string,
+	backupType backup.BackupType,
+	vclockBegin, vclockEnd uint64,
+) *backup.ClusterManifest {
+	f.t.Helper()
+
+	manifest := &backup.ClusterManifest{
+		SchemaVersion:    backup.SchemaVersion,
+		BackupID:         backup.BackupID(id),
+		PreviousBackupID: backup.BackupID(previous),
+		BaseFullBackupID: backup.BackupID(base),
+		Status:           backup.StatusOK,
+		CreationTime:     time.Unix(0, 0).UTC(),
+		CreationDuration: time.Second,
+		Shards:           make(map[string]backup.Shard, 1),
+		Topology: backup.Topology{Replicasets: map[string][]backup.TopologyInstance{
+			replicasetA: {{
+				InstanceUUID: masterA,
+				InstanceName: masterA,
+				Hostname:     "localhost",
+			}},
+		}},
+		Warnings: []backup.Warning{},
+	}
+
+	content := []byte("archive of " + id)
+	key := storage.ArchiveKey(id, replicasetA)
+	manifest.Shards[replicasetA] = backup.Shard{Instance: &backup.ShardInstance{
+		InstanceUUID: masterA,
+		InstanceName: masterA,
+		Hostname:     "localhost",
+		VclockBegin:  vclockBeginOf(backupType, vclockBegin),
+		VclockEnd:    backup.Vclock{1: vclockEnd},
+		Artifact: backup.Artifact{
+			Path:           key,
+			SizeBytes:      int64(len(content)),
+			ChecksumSHA256: checksumOf(content),
+			Compression:    "zstd",
+			Files:          []string{"00000000000000000000.xlog"},
+			RecoveryPoints: []backup.RecoveryPoint{},
+			Type:           backupType,
+		},
+	}}
+
+	f.putObject(key, content)
+	f.putManifest(manifest)
+
+	return manifest
+}
+
+// vclockBeginOf returns the vclock a backup of this type starts from. Only an
+// incremental has one: a full backup starts from nothing.
+func vclockBeginOf(backupType backup.BackupType, vclockBegin uint64) backup.Vclock {
+	if backupType != backup.BackupTypeIncremental {
+		return nil
+	}
+
+	return backup.Vclock{1: vclockBegin}
+}
+
+// mustJSON serializes a manifest for tests that store it under a key of their
+// own choosing rather than the one its backup id implies.
+func mustJSON(t *testing.T, manifest *backup.ClusterManifest) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	return data
+}
+
+// putManifest (re)writes a manifest, picking up any test mutation of it.
+func (f *fixture) putManifest(manifest *backup.ClusterManifest) {
+	f.t.Helper()
+
+	data, err := json.Marshal(manifest)
+	require.NoError(f.t, err)
+
+	f.putObject(storage.ManifestKey(string(manifest.BackupID)), data)
+}
+
+// putObject writes an object directly, bypassing the mutation log.
+func (f *fixture) putObject(key string, data []byte) {
+	f.t.Helper()
+
+	f.store.objects[key] = data
+	f.store.modified[key] = time.Unix(0, 0).UTC()
+}
+
+// verify runs the health check and asserts the storage was left untouched.
+func (f *fixture) verify() *Report {
+	f.t.Helper()
+
+	before := f.store.snapshot()
+
+	report, err := Verify(f.t.Context(), f.store)
+	require.NoError(f.t, err)
+
+	require.Empty(f.t, f.store.deletes, "verify must not delete anything")
+	require.Empty(f.t, f.store.puts, "verify must not write anything")
+	require.Equal(f.t, before, f.store.snapshot(), "verify must not change the storage")
+
+	return report
+}
+
+func checksumOf(data []byte) string {
+	digest := sha256.Sum256(data)
+
+	return hex.EncodeToString(digest[:])
+}
+
+// issueKinds returns the kinds of the reported issues in report order.
+func issueKinds(report *Report) []IssueKind {
+	kinds := make([]IssueKind, 0, len(report.Issues))
+	for _, issue := range report.Issues {
+		kinds = append(kinds, issue.Kind)
+	}
+
+	return kinds
+}
+
+// findIssue returns the only issue of the given kind.
+func findIssue(t *testing.T, report *Report, kind IssueKind) Issue {
+	t.Helper()
+
+	found := make([]Issue, 0, 1)
+	for _, issue := range report.Issues {
+		if issue.Kind == kind {
+			found = append(found, issue)
+		}
+	}
+
+	require.Len(t, found, 1, "expected exactly one %q issue in %v", kind, report.Issues)
+
+	return found[0]
+}

--- a/cli/backup/verify/verify.go
+++ b/cli/backup/verify/verify.go
@@ -31,6 +31,10 @@ const (
 	IssueChecksumMissing IssueKind = "checksum_missing"
 	// IssueDanglingArchive marks a stored archive no manifest refers to.
 	IssueDanglingArchive IssueKind = "dangling_archive"
+	// IssueUploadInProgress marks an unreferenced archive of a backup newer than
+	// every stored manifest: an upload writes its archives before the manifest
+	// that references them, so this is what a backup being uploaded looks like.
+	IssueUploadInProgress IssueKind = "upload_in_progress"
 	// IssueChainOrphan marks a manifest whose previous backup is absent.
 	IssueChainOrphan IssueKind = "chain_orphan"
 	// IssueChainFork marks a manifest sharing its previous backup with another one.
@@ -61,6 +65,10 @@ type Issue struct {
 	Archive string `json:"archive,omitempty"`
 	// Inherited reports a chain problem that originated in an ancestor manifest.
 	Inherited bool `json:"inherited,omitempty"`
+	// Informational marks a finding that a healthy storage can legitimately
+	// contain. It is reported, because an operator reading the output wants to
+	// see everything that is there, but it does not make the storage unhealthy.
+	Informational bool `json:"informational,omitempty"`
 	// Detail explains the problem in one line.
 	Detail string `json:"detail"`
 }
@@ -76,9 +84,29 @@ type Report struct {
 	Issues []Issue `json:"issues"`
 }
 
-// OK reports whether the storage is healthy.
+// OK reports whether the storage is healthy. Informational findings do not
+// count: a backup being uploaded right now is not a defect, and a check that
+// fails during every nightly backup teaches its operator to ignore it.
 func (r *Report) OK() bool {
-	return len(r.Issues) == 0
+	for _, issue := range r.Issues {
+		if !issue.Informational {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Problems counts the findings that make the storage unhealthy.
+func (r *Report) Problems() int {
+	problems := 0
+	for _, issue := range r.Issues {
+		if !issue.Informational {
+			problems++
+		}
+	}
+
+	return problems
 }
 
 // Verify reads every manifest, recomputes the checksum of every archive it
@@ -132,7 +160,14 @@ func Verify(ctx context.Context, store storage.Storage) (*Report, error) {
 		}
 	}
 
-	dangling, err := danglingIssues(ctx, store, referenced, undetermined)
+	// A storage with no manifest object at all may be a cluster whose very first
+	// backup is uploading now. One whose only manifest is unreadable is not: it
+	// has a manifest, it just cannot be believed, and that is reported already.
+	stored := len(backupChain.Manifests()) + len(unreadable)
+
+	dangling, err := danglingIssues(
+		ctx, store, newestBackupID(backupChain), stored > 0, referenced, undetermined,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check for dangling archives: %w", err)
 	}
@@ -339,6 +374,8 @@ func undeterminedBackups(unreadable []chain.Unreadable) map[string]struct{} {
 func danglingIssues(
 	ctx context.Context,
 	store storage.Storage,
+	newest backup.BackupID,
+	anyManifests bool,
 	referenced map[string]struct{},
 	undetermined map[string]struct{},
 ) ([]Issue, error) {
@@ -353,22 +390,66 @@ func danglingIssues(
 			continue
 		}
 
-		if backupID, _, ok := storage.ArchiveBackupID(object.Key); ok {
+		backupID, _, parsed := storage.ArchiveBackupID(object.Key)
+		if parsed {
 			if _, undecided := undetermined[backupID]; undecided {
 				continue
 			}
 		}
 
-		issues = append(issues, Issue{
-			Kind:    IssueDanglingArchive,
-			Archive: object.Key,
-			Detail: fmt.Sprintf(
-				"archive is not referenced by any manifest (%d bytes, modified %s)",
-				object.Size,
-				object.LastModified.UTC().Format("2006-01-02T15:04:05Z"),
-			),
-		})
+		issues = append(issues, danglingIssue(object, backupID, parsed, newest, anyManifests))
 	}
 
 	return issues, nil
+}
+
+// danglingIssue describes one unreferenced archive: a backup being uploaded
+// right now, or an archive nothing points at any more.
+func danglingIssue(
+	object storage.ObjectInfo,
+	backupID string,
+	parsed bool,
+	newest backup.BackupID,
+	anyManifests bool,
+) Issue {
+	where := fmt.Sprintf(
+		"%d bytes, modified %s",
+		object.Size,
+		object.LastModified.UTC().Format("2006-01-02T15:04:05Z"),
+	)
+
+	// An upload writes every archive before the manifest that references them,
+	// so an archive of a backup newer than every stored manifest - or any archive
+	// at all when no manifest is stored yet - is what an upload in progress looks
+	// like from the outside. Age cannot tell the two apart: a long upload makes
+	// its first archives old while it is still running.
+	if parsed && (!anyManifests || (newest != "" && backup.BackupID(backupID) > newest)) {
+		return Issue{
+			Kind:          IssueUploadInProgress,
+			BackupID:      backupID,
+			Archive:       object.Key,
+			Informational: true,
+			Detail: fmt.Sprintf(
+				"archive of a backup newer than every stored manifest, "+
+					"an upload may still be in progress (%s)", where,
+			),
+		}
+	}
+
+	return Issue{
+		Kind:    IssueDanglingArchive,
+		Archive: object.Key,
+		Detail:  fmt.Sprintf("archive is not referenced by any manifest (%s)", where),
+	}
+}
+
+// newestBackupID returns the greatest stored backup id, or an empty id when the
+// storage holds no manifest at all.
+func newestBackupID(backupChain *chain.Chain) backup.BackupID {
+	latest := backupChain.Latest()
+	if latest == nil {
+		return ""
+	}
+
+	return latest.Manifest.BackupID
 }

--- a/cli/backup/verify/verify.go
+++ b/cli/backup/verify/verify.go
@@ -1,0 +1,374 @@
+// Package verify health-checks a backup storage: manifest chain integrity,
+// archive presence and checksums, dangling archives. It never deletes anything.
+package verify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/tarantool/tt/cli/backup"
+	"github.com/tarantool/tt/cli/backup/chain"
+	"github.com/tarantool/tt/cli/backup/storage"
+)
+
+// IssueKind classifies one problem found in the storage.
+type IssueKind string
+
+const (
+	// IssueMissingArchive marks a manifest referencing an archive that is not stored.
+	IssueMissingArchive IssueKind = "missing_archive"
+	// IssueUnreadableArchive marks an archive that exists but cannot be read to the end.
+	IssueUnreadableArchive IssueKind = "unreadable_archive"
+	// IssueChecksumMismatch marks an archive whose bytes do not match the manifest.
+	IssueChecksumMismatch IssueKind = "checksum_mismatch"
+	// IssueChecksumMissing marks a manifest that carries no checksum to compare against.
+	IssueChecksumMissing IssueKind = "checksum_missing"
+	// IssueDanglingArchive marks a stored archive no manifest refers to.
+	IssueDanglingArchive IssueKind = "dangling_archive"
+	// IssueChainOrphan marks a manifest whose previous backup is absent.
+	IssueChainOrphan IssueKind = "chain_orphan"
+	// IssueChainFork marks a manifest sharing its previous backup with another one.
+	IssueChainFork IssueKind = "chain_fork"
+	// IssueVclockMismatch marks an increment that does not continue its ancestor.
+	IssueVclockMismatch IssueKind = "vclock_mismatch"
+	// IssueInvalidManifest marks a structurally invalid manifest.
+	IssueInvalidManifest IssueKind = "invalid_manifest"
+	// IssueUnreadableManifest marks a stored manifest that could not be read or decoded.
+	IssueUnreadableManifest IssueKind = "unreadable_manifest"
+	// IssueChainProblem marks a chain problem this package does not classify further.
+	IssueChainProblem IssueKind = "chain_problem"
+)
+
+// Issue is one problem found in the storage.
+type Issue struct {
+	// Kind classifies the problem.
+	Kind IssueKind `json:"kind"`
+	// BackupID identifies the affected manifest, empty for a dangling archive.
+	BackupID string `json:"backup_id,omitempty"`
+	// Manifest is the storage key of the affected manifest. It is the only name
+	// left when the content is unusable: a manifest carrying no backup_id, or one
+	// of two objects claiming the same one, cannot be pointed at any other way.
+	Manifest string `json:"manifest,omitempty"`
+	// ReplicasetUUID identifies the affected shard, when the problem is shard-local.
+	ReplicasetUUID string `json:"replicaset_uuid,omitempty"`
+	// Archive is the storage key of the affected archive, when there is one.
+	Archive string `json:"archive,omitempty"`
+	// Inherited reports a chain problem that originated in an ancestor manifest.
+	Inherited bool `json:"inherited,omitempty"`
+	// Detail explains the problem in one line.
+	Detail string `json:"detail"`
+}
+
+// Report is the outcome of a storage health check.
+type Report struct {
+	// Manifests is the number of manifests read from the storage.
+	Manifests int `json:"manifests_checked"`
+	// Archives is the number of archives referenced by those manifests.
+	Archives int `json:"archives_checked"`
+	// Issues lists every problem found, manifest by manifest in chain order,
+	// dangling archives last.
+	Issues []Issue `json:"issues"`
+}
+
+// OK reports whether the storage is healthy.
+func (r *Report) OK() bool {
+	return len(r.Issues) == 0
+}
+
+// Verify reads every manifest, recomputes the checksum of every archive it
+// references, and lists archives no manifest refers to. It only reads: no
+// object is written or deleted, whatever it finds.
+func Verify(ctx context.Context, store storage.Storage) (*Report, error) {
+	// A manifest that cannot be read is a finding, not a reason to stop: the
+	// rest of the storage still has to be checked.
+	backupChain, unreadable, err := chain.LoadPartial(ctx, store)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load backup chain: %w", err)
+	}
+
+	// A manifest that was not read because the run was cut short says nothing
+	// about the storage. Calling it unreadable would let an expired deadline
+	// masquerade as corruption.
+	for _, manifest := range unreadable {
+		if isRunCutShort(manifest.Err) {
+			return nil, fmt.Errorf("failed to read manifest %q: %w", manifest.Key, manifest.Err)
+		}
+	}
+
+	// An unreadable manifest still counts as seen, and it is reported first: the
+	// problems below may well be its missing links.
+	report := &Report{
+		Manifests: len(unreadable),
+		Issues:    unreadableIssues(unreadable),
+	}
+	// referenced collects archive keys claimed by a manifest, so that whatever
+	// is left in data/ afterwards is dangling.
+	referenced := make(map[string]struct{})
+	// An unreadable manifest still owns its archives; it just cannot be parsed
+	// to say which. Calling them dangling would tell the operator - and gc, which
+	// consumes exactly this issue - to delete live backup data, so the backups
+	// behind those manifests are excluded from the dangling scan instead.
+	undetermined := undeterminedBackups(unreadable)
+
+	for _, group := range backupChain.Groups() {
+		for _, entry := range group.Entries {
+			report.Manifests++
+			report.Issues = append(report.Issues, chainIssues(entry)...)
+
+			archives, issues, err := verifyArchives(ctx, store, entry.Manifest, referenced)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check backup %q: %w",
+					entry.Manifest.BackupID, err)
+			}
+
+			report.Archives += archives
+			report.Issues = append(report.Issues, issues...)
+		}
+	}
+
+	dangling, err := danglingIssues(ctx, store, referenced, undetermined)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for dangling archives: %w", err)
+	}
+
+	report.Issues = append(report.Issues, dangling...)
+
+	return report, nil
+}
+
+// unreadableIssues converts the manifests the chain could not read into issues.
+func unreadableIssues(unreadable []chain.Unreadable) []Issue {
+	issues := make([]Issue, 0, len(unreadable))
+
+	for _, manifest := range unreadable {
+		// The content is unusable, so the key is all that names the backup. It is
+		// carried explicitly rather than left to the error text: an operator has
+		// to be able to find the object, and a key derived from the id is exactly
+		// what is unavailable here.
+		backupID, _ := storage.ManifestBackupID(manifest.Key)
+		issues = append(issues, Issue{
+			Kind:     IssueUnreadableManifest,
+			BackupID: backupID,
+			Manifest: manifest.Key,
+			Detail:   fmt.Sprintf("manifest is unusable: %v", manifest.Err),
+		})
+	}
+
+	return issues
+}
+
+// chainIssues converts the chain problems of one manifest into issues.
+func chainIssues(entry *chain.Entry) []Issue {
+	issues := make([]Issue, 0, len(entry.Problems))
+
+	for _, problem := range entry.Problems {
+		issues = append(issues, Issue{
+			Kind:      chainIssueKind(problem.Kind),
+			BackupID:  problem.BackupID,
+			Inherited: problem.Inherited,
+			Detail:    problem.Detail,
+		})
+	}
+
+	return issues
+}
+
+// chainIssueKind maps a chain problem kind to an issue kind.
+func chainIssueKind(kind chain.ProblemKind) IssueKind {
+	switch kind {
+	case chain.ProblemOrphan:
+		return IssueChainOrphan
+	case chain.ProblemFork:
+		return IssueChainFork
+	case chain.ProblemVclockMismatch:
+		return IssueVclockMismatch
+	case chain.ProblemInvalidManifest:
+		return IssueInvalidManifest
+	default:
+		return IssueChainProblem
+	}
+}
+
+// verifyArchives checks every archive one manifest refers to, adding their keys
+// to referenced, and returns the number of archives checked.
+func verifyArchives(
+	ctx context.Context,
+	store storage.Storage,
+	manifest *backup.ClusterManifest,
+	referenced map[string]struct{},
+) (int, []Issue, error) {
+	// Sort the shards so that the report of one manifest is stable across runs.
+	replicasetUUIDs := make([]string, 0, len(manifest.Shards))
+	for replicasetUUID := range manifest.Shards {
+		replicasetUUIDs = append(replicasetUUIDs, replicasetUUID)
+	}
+
+	slices.Sort(replicasetUUIDs)
+
+	archives := 0
+	issues := make([]Issue, 0)
+
+	for _, replicasetUUID := range replicasetUUIDs {
+		// A shard that failed to back up carries an error instead of an artifact;
+		// the manifest already records it, there is nothing to check in storage.
+		instance := manifest.Shards[replicasetUUID].Instance
+		if instance == nil {
+			continue
+		}
+
+		archives++
+
+		archiveIssues, err := verifyArchive(
+			ctx, store, manifest, replicasetUUID, instance, referenced,
+		)
+		if err != nil {
+			return archives, issues, fmt.Errorf("failed to check shard %q: %w",
+				replicasetUUID, err)
+		}
+
+		issues = append(issues, archiveIssues...)
+	}
+
+	return archives, issues, nil
+}
+
+// verifyArchive checks presence and checksum of one shard archive.
+func verifyArchive(
+	ctx context.Context,
+	store storage.Storage,
+	manifest *backup.ClusterManifest,
+	replicasetUUID string,
+	instance *backup.ShardInstance,
+	referenced map[string]struct{},
+) ([]Issue, error) {
+	issue := func(kind IssueKind, key, format string, args ...any) []Issue {
+		return []Issue{{
+			Kind:           kind,
+			BackupID:       string(manifest.BackupID),
+			ReplicasetUUID: replicasetUUID,
+			Archive:        key,
+			Detail:         fmt.Sprintf(format, args...),
+		}}
+	}
+
+	key, err := storage.CleanKey(instance.Artifact.Path)
+	if err != nil {
+		return issue(IssueMissingArchive, instance.Artifact.Path,
+			"manifest artifact path %q is not a storage key: %v",
+			instance.Artifact.Path, err), nil
+	}
+
+	referenced[key] = struct{}{}
+
+	checksum, err := archiveChecksum(ctx, store, key)
+	switch {
+	case errors.Is(err, storage.ErrKeyNotFound):
+		return issue(IssueMissingArchive, key, "archive is not present in the storage"), nil
+	case isRunCutShort(err):
+		// The archive was never read, so nothing is known about it. Reporting it
+		// as unreadable would turn "I ran out of time" into "your backups are
+		// corrupt" - and, with the archives after it unchecked too, into a pile
+		// of dangling reports as well.
+		return nil, fmt.Errorf("failed to read archive %q: %w", key, err)
+	case err != nil:
+		return issue(IssueUnreadableArchive, key, "failed to read archive: %v", err), nil
+	}
+
+	expected := instance.Artifact.ChecksumSHA256
+	switch {
+	case expected == "":
+		return issue(IssueChecksumMissing, key,
+			"manifest has no checksum_sha256, actual checksum is %s", checksum), nil
+	case !strings.EqualFold(expected, checksum):
+		return issue(IssueChecksumMismatch, key,
+			"checksum_sha256 is %s, actual checksum is %s", expected, checksum), nil
+	}
+
+	return nil, nil
+}
+
+// isRunCutShort reports whether an error means the run was stopped rather than
+// the storage being at fault: a cancelled context or an expired --timeout. Such
+// a run must exit "could not check", never "problems found".
+func isRunCutShort(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// archiveChecksum streams the archive out of the storage into a hash: archives
+// are hundreds of megabytes, and verify has no reason to keep or spool them.
+func archiveChecksum(ctx context.Context, store storage.Storage, key string) (string, error) {
+	reader, err := store.Get(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("failed to get archive %q: %w", key, err)
+	}
+	defer reader.Close()
+
+	digest := sha256.New()
+	if _, err := io.Copy(digest, reader); err != nil {
+		return "", fmt.Errorf("failed to read archive %q: %w", key, err)
+	}
+
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+// undeterminedBackups returns the ids of backups whose manifest could not be
+// read. Their archives cannot be classified: only the manifest knows whether it
+// still refers to them. A key that does not name a manifest at all claims no
+// archives, so it is skipped.
+func undeterminedBackups(unreadable []chain.Unreadable) map[string]struct{} {
+	backups := make(map[string]struct{}, len(unreadable))
+
+	for _, manifest := range unreadable {
+		if backupID, ok := storage.ManifestBackupID(manifest.Key); ok {
+			backups[backupID] = struct{}{}
+		}
+	}
+
+	return backups
+}
+
+// danglingIssues lists stored archives that no manifest refers to. Archives of a
+// backup in undetermined are left out: their manifest is unreadable, so whether
+// they are still referenced is unknown, and unknown must not read as garbage.
+func danglingIssues(
+	ctx context.Context,
+	store storage.Storage,
+	referenced map[string]struct{},
+	undetermined map[string]struct{},
+) ([]Issue, error) {
+	objects, err := store.List(ctx, storage.DataPrefix())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list archives: %w", err)
+	}
+
+	issues := make([]Issue, 0)
+	for _, object := range objects {
+		if _, ok := referenced[object.Key]; ok {
+			continue
+		}
+
+		if backupID, _, ok := storage.ArchiveBackupID(object.Key); ok {
+			if _, undecided := undetermined[backupID]; undecided {
+				continue
+			}
+		}
+
+		issues = append(issues, Issue{
+			Kind:    IssueDanglingArchive,
+			Archive: object.Key,
+			Detail: fmt.Sprintf(
+				"archive is not referenced by any manifest (%d bytes, modified %s)",
+				object.Size,
+				object.LastModified.UTC().Format("2006-01-02T15:04:05Z"),
+			),
+		})
+	}
+
+	return issues, nil
+}

--- a/cli/backup/verify/verify_test.go
+++ b/cli/backup/verify/verify_test.go
@@ -1,0 +1,377 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/backup"
+	"github.com/tarantool/tt/cli/backup/storage"
+)
+
+func TestVerifyEmptyStorage(t *testing.T) {
+	report := newFixture(t).verify()
+
+	require.True(t, report.OK())
+	require.Empty(t, report.Issues)
+	require.Zero(t, report.Manifests)
+	require.Zero(t, report.Archives)
+}
+
+func TestVerifyHealthyStorageIsSilent(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	f.addBackup("incremental", "full", "full", backup.BackupTypeIncremental, 10, 20)
+
+	report := f.verify()
+
+	require.True(t, report.OK())
+	require.Empty(t, report.Issues)
+	require.Equal(t, 2, report.Manifests)
+	require.Equal(t, 2, report.Archives)
+}
+
+func TestVerifyChecksEveryChain(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full-1", "", "full-1", backup.BackupTypeFull, 0, 10)
+	f.addBackup("full-2", "", "full-2", backup.BackupTypeFull, 0, 10)
+	// Only the archive of the second, unrelated chain is corrupted.
+	f.putObject(storage.ArchiveKey("full-2", replicasetA), []byte("corrupted"))
+
+	report := f.verify()
+
+	require.Equal(t, []IssueKind{IssueChecksumMismatch}, issueKinds(report))
+	require.Equal(t, "full-2", report.Issues[0].BackupID)
+	require.Equal(t, 2, report.Manifests)
+}
+
+func TestVerifyMissingArchive(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	key := storage.ArchiveKey("full", replicasetA)
+	delete(f.store.objects, key)
+
+	report := f.verify()
+
+	require.False(t, report.OK())
+	require.Equal(t, []IssueKind{IssueMissingArchive}, issueKinds(report))
+
+	issue := findIssue(t, report, IssueMissingArchive)
+	require.Equal(t, "full", issue.BackupID)
+	require.Equal(t, replicasetA, issue.ReplicasetUUID)
+	require.Equal(t, key, issue.Archive)
+	// The archive is still counted: verify checked it and found it missing.
+	require.Equal(t, 1, report.Archives)
+}
+
+func TestVerifyEmptyArtifactPath(t *testing.T) {
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	manifest.Shards[replicasetA].Instance.Artifact.Path = ""
+	f.putManifest(manifest)
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueMissingArchive)
+	require.Contains(t, issue.Detail, "not a storage key")
+	// The unreferenced archive is reported as dangling on top of the broken link.
+	require.Equal(t,
+		[]IssueKind{IssueMissingArchive, IssueDanglingArchive},
+		issueKinds(report),
+	)
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	key := storage.ArchiveKey("full", replicasetA)
+	corrupted := []byte("corrupted archive")
+	f.putObject(key, corrupted)
+
+	report := f.verify()
+
+	require.Equal(t, []IssueKind{IssueChecksumMismatch}, issueKinds(report))
+
+	issue := findIssue(t, report, IssueChecksumMismatch)
+	require.Equal(t, key, issue.Archive)
+	require.Contains(t, issue.Detail, checksumOf(corrupted))
+}
+
+func TestVerifyChecksumMissing(t *testing.T) {
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	manifest.Shards[replicasetA].Instance.Artifact.ChecksumSHA256 = ""
+	f.putManifest(manifest)
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueChecksumMissing)
+	require.Equal(t, storage.ArchiveKey("full", replicasetA), issue.Archive)
+}
+
+func TestVerifyChecksumComparisonIsCaseInsensitive(t *testing.T) {
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	artifact := &manifest.Shards[replicasetA].Instance.Artifact
+	artifact.ChecksumSHA256 = strings.ToUpper(artifact.ChecksumSHA256)
+	f.putManifest(manifest)
+
+	require.True(t, f.verify().OK())
+}
+
+func TestVerifyUnreadableArchive(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	key := storage.ArchiveKey("full", replicasetA)
+	f.store.readErrs[key] = errors.New("connection reset by peer")
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueUnreadableArchive)
+	require.Equal(t, key, issue.Archive)
+	require.Contains(t, issue.Detail, "connection reset by peer")
+}
+
+func TestVerifyBrokenChain(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	// The parent of the increment is not in the storage: an orphan tail.
+	f.addBackup("orphan", "vanished", "full", backup.BackupTypeIncremental, 10, 20)
+
+	report := f.verify()
+
+	require.Equal(t, []IssueKind{IssueChainOrphan}, issueKinds(report))
+
+	issue := findIssue(t, report, IssueChainOrphan)
+	require.Equal(t, "orphan", issue.BackupID)
+	require.Contains(t, issue.Detail, "vanished")
+	require.False(t, issue.Inherited)
+}
+
+func TestVerifyVclockMismatch(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	// vclock_begin of the increment does not continue vclock_end of the full.
+	f.addBackup("incremental", "full", "full", backup.BackupTypeIncremental, 15, 20)
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueVclockMismatch)
+	require.Equal(t, "incremental", issue.BackupID)
+	require.Contains(t, issue.Detail, replicasetA)
+}
+
+func TestVerifyChainFork(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	f.addBackup("inc-a", "full", "full", backup.BackupTypeIncremental, 10, 20)
+	f.addBackup("inc-b", "full", "full", backup.BackupTypeIncremental, 10, 20)
+
+	report := f.verify()
+
+	forks := make([]Issue, 0, 2)
+	for _, issue := range report.Issues {
+		if issue.Kind == IssueChainFork {
+			forks = append(forks, issue)
+		}
+	}
+
+	require.Len(t, forks, 2)
+	require.Equal(t, "inc-a", forks[0].BackupID)
+	require.Equal(t, "inc-b", forks[1].BackupID)
+}
+
+func TestVerifyReportsInheritedChainProblems(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	f.addBackup("orphan", "vanished", "full", backup.BackupTypeIncremental, 10, 20)
+	f.addBackup("tail", "orphan", "full", backup.BackupTypeIncremental, 20, 30)
+
+	report := f.verify()
+
+	inherited := make([]Issue, 0, 1)
+	for _, issue := range report.Issues {
+		if issue.Inherited {
+			inherited = append(inherited, issue)
+		}
+	}
+
+	require.Len(t, inherited, 1)
+	require.Equal(t, IssueChainOrphan, inherited[0].Kind)
+	require.Equal(t, "tail", inherited[0].BackupID)
+}
+
+func TestVerifyInvalidManifest(t *testing.T) {
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	// A shard outside the declared topology fails manifest validation.
+	manifest.Shards[replicasetB] = manifest.Shards[replicasetA]
+	f.putManifest(manifest)
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueInvalidManifest)
+	require.Equal(t, "full", issue.BackupID)
+	require.Contains(t, issue.Detail, replicasetB)
+}
+
+func TestVerifyDanglingArchive(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	dangling := storage.ArchiveKey("2026-01-01-vanished", replicasetA)
+	f.putObject(dangling, []byte("nobody refers to me"))
+
+	report := f.verify()
+
+	issue := findIssue(t, report, IssueDanglingArchive)
+	require.Equal(t, dangling, issue.Archive)
+	require.Empty(t, issue.BackupID)
+	require.Contains(t, issue.Detail, "not referenced")
+}
+
+func TestVerifySkipsShardsWithoutArtifact(t *testing.T) {
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	// A replicaset that failed to back up carries an error, not an artifact.
+	manifest.Topology.Replicasets[replicasetB] = []backup.TopologyInstance{{
+		InstanceUUID: masterB,
+		InstanceName: masterB,
+		Hostname:     "localhost",
+	}}
+	manifest.Shards[replicasetB] = backup.Shard{Error: "instance unreachable"}
+	manifest.Status = backup.StatusDegraded
+	f.putManifest(manifest)
+
+	report := f.verify()
+
+	require.True(t, report.OK())
+	require.Equal(t, 1, report.Archives)
+}
+
+func TestVerifyReportsEveryProblemClassAtOnce(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	// Checksum mismatch on the full backup.
+	f.putObject(storage.ArchiveKey("full", replicasetA), []byte("corrupted"))
+	// Missing archive and a vclock gap on the increment.
+	f.addBackup("incremental", "full", "full", backup.BackupTypeIncremental, 15, 20)
+	delete(f.store.objects, storage.ArchiveKey("incremental", replicasetA))
+	// A chain break and a dangling archive on top.
+	f.addBackup("orphan", "vanished", "full", backup.BackupTypeIncremental, 20, 30)
+	f.putObject(storage.ArchiveKey("2026-01-01-vanished", replicasetA), []byte("dangling"))
+
+	report := f.verify()
+
+	require.Equal(t, []IssueKind{
+		IssueChecksumMismatch,
+		IssueVclockMismatch,
+		IssueMissingArchive,
+		IssueChainOrphan,
+		IssueDanglingArchive,
+	}, issueKinds(report))
+	require.Equal(t, 3, report.Manifests)
+	require.Equal(t, 3, report.Archives)
+}
+
+func TestVerifyFailsOnStorageError(t *testing.T) {
+	f := newFixture(t)
+	f.store.listErr = errors.New("storage is unreachable")
+
+	_, err := Verify(t.Context(), f.store)
+
+	require.ErrorContains(t, err, "storage is unreachable")
+}
+
+func TestVerifyReportsUndecodableManifest(t *testing.T) {
+	// One broken object must not blind the check: the rest is still verified.
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	f.putObject(storage.ManifestKey("broken"), []byte("{"))
+	f.putObject(storage.ArchiveKey("full", replicasetA), []byte("corrupted"))
+
+	report := f.verify()
+
+	require.Equal(t,
+		[]IssueKind{IssueUnreadableManifest, IssueChecksumMismatch},
+		issueKinds(report),
+	)
+	require.Equal(t, "broken", report.Issues[0].BackupID)
+	require.Contains(t, report.Issues[0].Detail, "decode manifest")
+	require.Equal(t, 2, report.Manifests)
+	require.Equal(t, 1, report.Archives)
+}
+
+func TestVerifyNamesObjectsItCannotIdentify(t *testing.T) {
+	// Every issue has to point at something an operator can go and look at. A
+	// manifest with no backup_id and a stray object under manifests/ both used to
+	// produce a row with no backup id, no archive and no key: "something here is
+	// broken", with no way to find out what.
+	f := newFixture(t)
+	unnamed := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	unnamed.BackupID = ""
+	f.putObject(storage.ManifestKey("unnamed"), mustJSON(t, unnamed))
+	f.putObject(storage.ManifestsPrefix()+"README.txt", []byte("not a manifest"))
+
+	report := f.verify()
+
+	require.Len(t, report.Issues, 2)
+	for _, issue := range report.Issues {
+		require.Equal(t, IssueUnreadableManifest, issue.Kind)
+		require.NotEmpty(t, issue.Manifest, "issue must name the object: %+v", issue)
+	}
+	require.Equal(t, storage.ManifestsPrefix()+"README.txt", report.Issues[0].Manifest)
+	require.Equal(t, storage.ManifestKey("unnamed"), report.Issues[1].Manifest)
+}
+
+func TestVerifyStopsWhenRunIsCutShort(t *testing.T) {
+	// An expired --timeout means the run could not finish, not that the storage
+	// is corrupt. Left as an unreadable_archive issue it would exit 2 "problems
+	// found", and every archive after it would go unread and be reported dangling
+	// on top - a healthy storage condemned because the clock ran out.
+	f := newFixture(t)
+	f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	f.store.readErrs[storage.ArchiveKey("full", replicasetA)] = context.DeadlineExceeded
+
+	_, err := Verify(t.Context(), f.store)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestVerifyReportsManifestWithoutShards(t *testing.T) {
+	// A manifest carrying no shards refers to nothing, so before it was rejected
+	// by validation it read as perfectly healthy while its archive looked like
+	// garbage - the storage was reported as needing a deletion instead of a fix.
+	f := newFixture(t)
+	manifest := f.addBackup("full", "", "full", backup.BackupTypeFull, 0, 10)
+	manifest.Shards = map[string]backup.Shard{}
+	f.putManifest(manifest)
+
+	report := f.verify()
+
+	require.Contains(t, issueKinds(report), IssueInvalidManifest)
+	require.Contains(t, report.Issues[0].Detail, "shards is empty")
+}
+
+func TestVerifyKeepsArchivesOfUndecodableManifest(t *testing.T) {
+	// The manifest is unreadable, so nothing can say whether it still refers to
+	// its archive. Reporting that archive as dangling would hand gc - which acts
+	// on exactly this issue - a live backup to delete. An archive belonging to no
+	// manifest at all is still reported, so the check is not simply switched off.
+	f := newFixture(t)
+	f.putObject(storage.ManifestKey("broken"), []byte("{"))
+	f.putObject(storage.ArchiveKey("broken", replicasetA), []byte("payload"))
+	f.putObject(storage.ArchiveKey("nobody", replicasetB), []byte("garbage"))
+
+	report := f.verify()
+
+	require.Equal(t,
+		[]IssueKind{IssueUnreadableManifest, IssueDanglingArchive},
+		issueKinds(report),
+	)
+	require.Equal(t,
+		storage.ArchiveKey("nobody", replicasetB),
+		report.Issues[1].Archive,
+	)
+}

--- a/cli/backup/verify/verify_test.go
+++ b/cli/backup/verify/verify_test.go
@@ -229,6 +229,73 @@ func TestVerifyDanglingArchive(t *testing.T) {
 	require.Equal(t, dangling, issue.Archive)
 	require.Empty(t, issue.BackupID)
 	require.Contains(t, issue.Detail, "not referenced")
+	require.False(t, issue.Informational)
+	require.False(t, report.OK())
+}
+
+func TestVerifyReportsAnUploadInProgressWithoutFailing(t *testing.T) {
+	// An upload writes its archives before the manifest that references them, so
+	// a verify running during the nightly backup sees unreferenced archives of a
+	// backup that is perfectly fine. Failing here would fire an alert on every
+	// backup, and an alert that always fires is one nobody reads.
+	f := newFixture(t)
+	f.addBackup("2026-01-01", "", "2026-01-01", backup.BackupTypeFull, 0, 10)
+	uploading := storage.ArchiveKey("2026-01-02", replicasetA)
+	f.putObject(uploading, []byte("still uploading"))
+
+	report := f.verify()
+
+	require.True(t, report.OK())
+	require.Zero(t, report.Problems())
+
+	issue := findIssue(t, report, IssueUploadInProgress)
+	require.Equal(t, uploading, issue.Archive)
+	require.Equal(t, "2026-01-02", issue.BackupID)
+	require.True(t, issue.Informational)
+	require.Contains(t, issue.Detail, "upload may still be in progress")
+}
+
+func TestVerifyReportsTheFirstUploadOfAnEmptyStorageAsInProgress(t *testing.T) {
+	// Nothing to compare against: a storage holding archives and no manifest at
+	// all is a cluster whose first backup has not finished uploading.
+	f := newFixture(t)
+	uploading := storage.ArchiveKey("2026-01-01", replicasetA)
+	f.putObject(uploading, []byte("still uploading"))
+
+	report := f.verify()
+
+	require.True(t, report.OK())
+	require.Equal(t, []IssueKind{IssueUploadInProgress}, issueKinds(report))
+}
+
+func TestVerifyStillFailsOnAnArchiveOlderThanTheNewestManifest(t *testing.T) {
+	// The pipeline has moved past this backup id, so nothing is uploading it any
+	// more: the archive is abandoned and the storage is not healthy.
+	f := newFixture(t)
+	f.addBackup("2026-01-02", "", "2026-01-02", backup.BackupTypeFull, 0, 10)
+	abandoned := storage.ArchiveKey("2026-01-01", replicasetA)
+	f.putObject(abandoned, []byte("abandoned"))
+
+	report := f.verify()
+
+	require.False(t, report.OK())
+	require.Equal(t, 1, report.Problems())
+	require.Equal(t, []IssueKind{IssueDanglingArchive}, issueKinds(report))
+}
+
+func TestVerifyCountsOnlyRealProblems(t *testing.T) {
+	f := newFixture(t)
+	f.addBackup("2026-01-01", "", "2026-01-01", backup.BackupTypeFull, 0, 10)
+	// One real defect and one upload in progress: the verdict follows the defect,
+	// and the count reports only it.
+	f.putObject(storage.ArchiveKey("2026-01-01", replicasetA), []byte("corrupted"))
+	f.putObject(storage.ArchiveKey("2026-01-02", replicasetA), []byte("uploading"))
+
+	report := f.verify()
+
+	require.False(t, report.OK())
+	require.Equal(t, 1, report.Problems())
+	require.Len(t, report.Issues, 2)
 }
 
 func TestVerifySkipsShardsWithoutArtifact(t *testing.T) {

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/backup"
+	"github.com/tarantool/tt/cli/backup/verify"
 	"github.com/tarantool/tt/cli/configure"
 	"github.com/tarantool/tt/cli/connect"
 	"github.com/tarantool/tt/cli/connector"
@@ -19,8 +20,8 @@ import (
 	"github.com/tarantool/tt/cli/util"
 )
 
-// tt backup start / finalize / last flags. They are package-level because cobra
-// flag bindings need stable addresses; only one backup subcommand runs per process.
+// tt backup start / finalize / last / verify flags. They are package-level because
+// cobra flag bindings need stable addresses; only one backup subcommand runs per process.
 var (
 	backupStartCfg        string
 	backupStartID         string
@@ -33,12 +34,48 @@ var (
 	backupStorageConfig string
 	backupLastFormat    string
 	backupLastTimeout   time.Duration
+
+	backupVerifyFormat  string
+	backupVerifyTimeout time.Duration
 )
 
 const (
 	formatTable = "table"
 	formatJSON  = "json"
 )
+
+const (
+	// backupVerifyProblemsExitCode is returned by `tt backup verify` when the
+	// storage is reachable but unhealthy, so that a cron job tells problems found
+	// from a run that could not check anything at all (exit code 1). It matches
+	// the fail-loud code of `tt backup start`.
+	backupVerifyProblemsExitCode = 2
+
+	// defaultVerifyTimeout covers a full pass over the storage: verify reads every
+	// archive end to end to recompute its checksum, so it needs far more time than
+	// the metadata-only commands.
+	defaultVerifyTimeout = 30 * time.Minute
+)
+
+// backupStorageURIHelp documents the --backup-storage flag value for every
+// manager-side backup command.
+const backupStorageURIHelp = `The --backup-storage flag accepts a URI describing the
+storage backend:
+
+  file://<abs_path>?Prefix=<subdir>
+      Local filesystem storage. The path must be absolute.
+      Query parameters:
+        Prefix  - subdirectory within the path (optional).
+
+  s3+https://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
+  s3+http://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
+      S3-compatible storage. Use s3+https for TLS, s3+http for plain TCP.
+      The first path segment after the host is the bucket name, the rest is
+      the optional key prefix.
+      Query parameters:
+        Region           - AWS region (optional).
+        AccessKeyID      - access key ID (required).
+        SecretAccessKey  - secret access key (required).`
 
 // NewBackupCmd creates the parent `tt backup` command.
 func NewBackupCmd() *cobra.Command {
@@ -51,6 +88,7 @@ func NewBackupCmd() *cobra.Command {
 		newBackupStartCmd(),
 		newBackupFinalizeCmd(),
 		newBackupLastCmd(),
+		newBackupVerifyCmd(),
 	)
 
 	return backupCmd
@@ -112,22 +150,7 @@ func newBackupLastCmd() *cobra.Command {
 Usage:
   tt backup last --backup-storage=<uri> [--format <table|json>]
 
-The --backup-storage flag accepts a URI describing the storage backend:
-
-  file://<abs_path>?Prefix=<subdir>
-      Local filesystem storage. The path must be absolute.
-      Query parameters:
-        Prefix  - subdirectory within the path (optional).
-
-  s3+https://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
-  s3+http://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
-      S3-compatible storage. Use s3+https for TLS, s3+http for plain TCP.
-      The first path segment after the host is the bucket name, the rest is
-      the optional key prefix.
-      Query parameters:
-        Region           - AWS region (optional).
-        AccessKeyID      - access key ID (required).
-        SecretAccessKey  - secret access key (required).
+` + backupStorageURIHelp + `
 
 Examples:
   tt backup last --backup-storage=file:///var/backups
@@ -212,6 +235,152 @@ func printManifestTable(manifest *backup.ClusterManifest) {
 	if len(manifest.Warnings) > 0 {
 		log.Infof("  Warnings:         %d", len(manifest.Warnings))
 	}
+}
+
+func newBackupVerifyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Check backup manifests and archives in the storage",
+		Long: `Health-check the backup storage and report what is wrong with it.
+
+Usage:
+  tt backup verify --backup-storage=<uri> [--format <table|json>]
+
+The check reads the whole storage and reports:
+
+  - manifests referring to archives that are not stored;
+  - archives whose bytes do not match checksum_sha256 of the manifest;
+  - breaks in the previous_backup_id chain (orphans and forks);
+  - increments whose vclock_begin does not continue the previous backup;
+  - archives no manifest refers to.
+
+Nothing is ever deleted or repaired: removing backups is 'tt backup gc'.
+Exit codes: 0 - the storage is healthy, 2 - problems were found, 1 - the
+storage could not be checked.
+
+` + backupStorageURIHelp + `
+
+Examples:
+  tt backup verify --backup-storage=file:///var/backups
+  tt backup verify --backup-storage=file:///var/backups --format json`,
+		Args: cobra.NoArgs,
+		RunE: runBackupVerify,
+	}
+
+	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
+		"storage URI (file://<path> or s3+http(s)://host:port/bucket/prefix?...")
+	cmd.Flags().StringVar(&backupVerifyFormat, "format", formatTable,
+		"output format: table or json")
+	cmd.Flags().DurationVar(&backupVerifyTimeout, "timeout", defaultVerifyTimeout,
+		"timeout for connecting to and reading from the storage; 0 means no limit")
+
+	cmd.MarkFlagRequired("backup-storage")
+
+	return cmd
+}
+
+func runBackupVerify(cmd *cobra.Command, args []string) error {
+	cmdCtx.CommandName = cmd.Name()
+
+	healthy, err := runBackupVerifyInner()
+	if err != nil {
+		return fmt.Errorf("backup verify: %w", err)
+	}
+
+	if !healthy {
+		// The report has already been printed; a second error line would only
+		// repeat it. The exit code carries the verdict for a cron job.
+		os.Exit(backupVerifyProblemsExitCode)
+	}
+
+	return nil
+}
+
+// runBackupVerifyInner checks the storage, prints the report and reports whether
+// the storage turned out to be healthy.
+func runBackupVerifyInner() (bool, error) {
+	if backupVerifyFormat != formatTable && backupVerifyFormat != formatJSON {
+		return false, fmt.Errorf("unsupported format %q: expected %q or %q",
+			backupVerifyFormat, formatTable, formatJSON)
+	}
+
+	cfg, err := backup.ParseStorageURI(backupStorageConfig)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse storage URI: %w", err)
+	}
+
+	store, err := backup.OpenStorage(cfg)
+	if err != nil {
+		return false, fmt.Errorf("failed to open storage: %w", err)
+	}
+
+	// A zero timeout means no limit, not "already expired": a storage large
+	// enough to outlast any sensible deadline still has to be checkable.
+	ctx := context.Background()
+	if backupVerifyTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, backupVerifyTimeout)
+		defer cancel()
+	}
+
+	report, err := verify.Verify(ctx, store)
+	if err != nil {
+		return false, fmt.Errorf("failed to verify backup storage: %w", err)
+	}
+
+	switch backupVerifyFormat {
+	case formatJSON:
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal verification report: %w", err)
+		}
+
+		fmt.Println(string(data))
+	case formatTable:
+		printVerifyReportTable(report)
+	}
+
+	return report.OK(), nil
+}
+
+func printVerifyReportTable(report *verify.Report) {
+	log.Info("Backup storage verification")
+	log.Infof("  Manifests checked: %d", report.Manifests)
+	log.Infof("  Archives checked:  %d", report.Archives)
+
+	if report.OK() {
+		log.Info("  Problems:          none")
+		return
+	}
+
+	log.Infof("  Problems:          %d", len(report.Issues))
+
+	for _, issue := range report.Issues {
+		inherited := ""
+		if issue.Inherited {
+			inherited = " (inherited)"
+		}
+
+		log.Warnf("  [%s]%s %s: %s",
+			issue.Kind, inherited, verifyIssueTarget(issue), issue.Detail)
+	}
+}
+
+// verifyIssueTarget names what an issue is about: a manifest, one of its shards,
+// or a stored archive.
+func verifyIssueTarget(issue verify.Issue) string {
+	parts := make([]string, 0, 3)
+	if issue.BackupID != "" {
+		parts = append(parts, "backup "+issue.BackupID)
+	}
+	if issue.ReplicasetUUID != "" {
+		parts = append(parts, "replicaset "+issue.ReplicasetUUID)
+	}
+	if issue.Archive != "" {
+		parts = append(parts, issue.Archive)
+	}
+
+	return strings.Join(parts, " ")
 }
 
 // applyBackupConfig reloads cliOpts/cmdCtx.Cli.ConfigPath from a per-command

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -254,6 +254,11 @@ The check reads the whole storage and reports:
   - increments whose vclock_begin does not continue the previous backup;
   - archives no manifest refers to.
 
+An archive of a backup newer than every stored manifest is reported too, but
+as an upload in progress rather than a problem: an upload writes its archives
+before the manifest that references them, so this is what a backup being taken
+right now looks like from the outside.
+
 Nothing is ever deleted or repaired: removing backups is 'tt backup gc'.
 Exit codes: 0 - the storage is healthy, 2 - problems were found, 1 - the
 storage could not be checked.
@@ -348,12 +353,11 @@ func printVerifyReportTable(report *verify.Report) {
 	log.Infof("  Manifests checked: %d", report.Manifests)
 	log.Infof("  Archives checked:  %d", report.Archives)
 
-	if report.OK() {
+	if problems := report.Problems(); problems > 0 {
+		log.Infof("  Problems:          %d", problems)
+	} else {
 		log.Info("  Problems:          none")
-		return
 	}
-
-	log.Infof("  Problems:          %d", len(report.Issues))
 
 	for _, issue := range report.Issues {
 		inherited := ""
@@ -361,8 +365,17 @@ func printVerifyReportTable(report *verify.Report) {
 			inherited = " (inherited)"
 		}
 
-		log.Warnf("  [%s]%s %s: %s",
+		line := fmt.Sprintf("  [%s]%s %s: %s",
 			issue.Kind, inherited, verifyIssueTarget(issue), issue.Detail)
+
+		// An informational finding is worth showing but is not what makes the
+		// storage unhealthy, so it must not look like the rest.
+		if issue.Informational {
+			log.Info(line)
+			continue
+		}
+
+		log.Warn(line)
 	}
 }
 

--- a/test/integration/backup/backup_helpers.py
+++ b/test/integration/backup/backup_helpers.py
@@ -2,11 +2,14 @@ import hashlib
 import json
 import os
 import subprocess
+import tempfile
 
 import tt_helper
 import yaml
 
-BACKUP_TMP_ROOT = os.path.join(os.path.realpath("/tmp"), "tt-backup")
+# Must resolve to the same directory as Go's os.TempDir() in cli/backup: both
+# honour TMPDIR, which on macOS points into /var/folders/... rather than /tmp.
+BACKUP_TMP_ROOT = os.path.join(tempfile.gettempdir(), "tt-backup")
 
 
 def eval_yaml_app(tt, target, lua):

--- a/test/integration/backup/backup_helpers.py
+++ b/test/integration/backup/backup_helpers.py
@@ -74,6 +74,15 @@ def backup_last(tt, storage_uri, fmt=None):
     return tt.exec(*args)
 
 
+def backup_verify(tt, storage_uri, fmt=None, timeout=None):
+    args = ["backup", "verify", "--backup-storage", storage_uri]
+    if fmt:
+        args.extend(["--format", fmt])
+    if timeout:
+        args.extend(["--timeout", timeout])
+    return tt.exec(*args)
+
+
 def archive_path_from_output(output):
     paths = [line.strip() for line in output.splitlines() if line.strip().endswith(".tar.zst")]
     assert len(paths) == 1, f"expected one archive path in output, got {paths}:\n{output}"

--- a/test/integration/backup/test_verify.py
+++ b/test/integration/backup/test_verify.py
@@ -395,7 +395,9 @@ def test_verify_vclock_mismatch(tt, storage):
 @pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
 def test_verify_dangling_archive(tt, storage):
     write_chain(storage)
-    dangling = archive_key("2026-01-03-never-uploaded")
+    # Older than the newest manifest: the pipeline has moved past this backup id,
+    # so nothing can still be uploading it.
+    dangling = archive_key("2026-01-01-abandoned")
     storage.put(dangling, b"no manifest refers to me")
 
     rc, report = verify_json(tt, storage)
@@ -406,11 +408,53 @@ def test_verify_dangling_archive(tt, storage):
 
 
 @pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_reports_an_upload_in_progress_without_failing(tt, storage):
+    # An upload writes its archives before the manifest referencing them, so a
+    # verify overlapping the nightly backup sees unreferenced archives of a
+    # healthy backup. Alerting on that would fire on every backup.
+    write_chain(storage)
+    uploading = archive_key("2026-01-03-uploading")
+    storage.put(uploading, b"still uploading")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK, report
+    assert issue_kinds(report) == ["upload_in_progress"]
+    assert report["issues"][0]["archive"] == uploading
+    assert report["issues"][0]["informational"] is True
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_reports_the_first_upload_of_an_empty_storage(tt, storage):
+    # No manifest to compare against: this is a cluster whose first backup has
+    # not finished uploading, not a storage full of garbage.
+    uploading = archive_key("2026-01-01-first")
+    storage.put(uploading, b"still uploading")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK, report
+    assert issue_kinds(report) == ["upload_in_progress"]
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_upload_in_progress_does_not_mask_a_real_problem(tt, storage):
+    write_chain(storage)
+    storage.put(archive_key("2026-01-03-uploading"), b"still uploading")
+    storage.put(archive_key("2026-01-01-full"), b"corrupted archive")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert sorted(issue_kinds(report)) == ["checksum_mismatch", "upload_in_progress"]
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
 def test_verify_reports_every_problem_class(tt, storage):
     write_chain(storage)
     storage.put(archive_key("2026-01-01-full"), b"corrupted archive")
     storage.delete(archive_key("2026-01-02-inc"))
-    storage.put(archive_key("2026-01-03-never-uploaded"), b"dangling")
+    storage.put(archive_key("2026-01-01-abandoned"), b"dangling")
     write_backup(
         storage,
         "2026-01-04-orphan",

--- a/test/integration/backup/test_verify.py
+++ b/test/integration/backup/test_verify.py
@@ -1,0 +1,685 @@
+import hashlib
+import io
+import json
+import os
+import time
+
+import pytest
+from backup_helpers import backup_verify
+
+REPLICASET = "11111111-1111-1111-1111-111111111111"
+REPLICASET_B = "22222222-2222-2222-2222-222222222222"
+INSTANCE = "aaaaaaaa-0000-0000-0000-000000000001"
+INSTANCE_B = "bbbbbbbb-0000-0000-0000-000000000001"
+
+VERIFY_OK = 0
+VERIFY_PROBLEMS_FOUND = 2
+
+STORAGE_BACKENDS = [
+    pytest.param(("file", ""), id="file"),
+    pytest.param(("s3", ""), marks=pytest.mark.docker, id="s3"),
+]
+PREFIXED_STORAGE_BACKENDS = [
+    pytest.param(("file", "mycluster"), id="file"),
+    pytest.param(("s3", "mycluster"), marks=pytest.mark.docker, id="s3"),
+]
+
+
+class FileStorage:
+    """Backup storage on the local filesystem."""
+
+    def __init__(self, root, prefix=""):
+        self.root = os.path.join(root, prefix) if prefix else root
+        self.uri = f"file://{root}" + (f"?Prefix={prefix}" if prefix else "")
+
+    def put(self, key, data):
+        path = os.path.join(self.root, key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as dst:
+            dst.write(data)
+
+    def delete(self, key):
+        os.remove(os.path.join(self.root, key))
+
+    def keys(self):
+        found = []
+        for directory, _, files in os.walk(self.root):
+            for name in files:
+                path = os.path.join(directory, name)
+                found.append(os.path.relpath(path, self.root))
+        return sorted(found)
+
+
+class S3Storage:
+    """Backup storage in an S3 bucket."""
+
+    def __init__(self, garage, prefix=""):
+        self.garage = garage
+        self.prefix = f"{prefix}/" if prefix else ""
+        self.uri = (
+            f"s3+http://{garage.endpoint}/{garage.bucket}"
+            f"{'/' + prefix if prefix else ''}"
+            f"?Region={garage.region}&AccessKeyID={garage.access_key}"
+            f"&SecretAccessKey={garage.secret_key}"
+        )
+
+    def put(self, key, data):
+        self.garage.client.put_object(
+            self.garage.bucket,
+            self.prefix + key,
+            io.BytesIO(data),
+            len(data),
+        )
+
+    def delete(self, key):
+        self.garage.client.remove_object(self.garage.bucket, self.prefix + key)
+
+    def keys(self):
+        return sorted(
+            obj.object_name.removeprefix(self.prefix)
+            for obj in self.garage.client.list_objects(self.garage.bucket, recursive=True)
+        )
+
+
+@pytest.fixture
+def storage(request, tmp_path):
+    backend, prefix = request.param
+    if backend == "file":
+        root = tmp_path / "backups"
+        root.mkdir()
+        yield FileStorage(str(root), prefix)
+        return
+
+    garage = request.getfixturevalue("garage")
+    s3 = S3Storage(garage, prefix)
+    try:
+        yield s3
+    finally:
+        for key in s3.keys():
+            s3.delete(key)
+
+
+def archive_key(backup_id, replicaset=REPLICASET):
+    return f"data/{backup_id}-{replicaset}.tar.zst"
+
+
+def manifest_key(backup_id):
+    return f"manifests/{backup_id}.json"
+
+
+def topology_instance(instance_uuid, instance_name):
+    return {
+        "instance_uuid": instance_uuid,
+        "instance_name": instance_name,
+        "hostname": "localhost",
+    }
+
+
+def shard_instance(
+    backup_id,
+    replicaset,
+    instance_uuid,
+    instance_name,
+    backup_type,
+    vclock_begin,
+    vclock_end,
+    content,
+):
+    return {
+        "instance_uuid": instance_uuid,
+        "instance_name": instance_name,
+        "hostname": "localhost",
+        # Only an incremental starts from a vclock: a full backup starts from
+        # nothing, and box.backup.info() reports no prev_vclock for it.
+        "vclock_begin": {"1": vclock_begin} if backup_type == "incremental" else None,
+        "vclock_end": {"1": vclock_end},
+        "artifact": {
+            "path": archive_key(backup_id, replicaset),
+            "size_bytes": len(content),
+            "checksum_sha256": hashlib.sha256(content).hexdigest(),
+            "compression": "zstd",
+            "files": ["00000000000000000000.snap"],
+            "recovery_points": [],
+            "type": backup_type,
+        },
+    }
+
+
+def build_manifest(backup_id, previous, base, backup_type, vclock_begin, vclock_end, content):
+    return {
+        "schema_version": 1,
+        "backup_id": backup_id,
+        "previous_backup_id": previous,
+        "base_full_backup_id": base,
+        "status": "OK",
+        "creation_time": "2026-01-01T00:00:00Z",
+        "creation_duration": 1000000000,
+        "shards": {
+            REPLICASET: {
+                "instance": shard_instance(
+                    backup_id,
+                    REPLICASET,
+                    INSTANCE,
+                    "storage-001-a",
+                    backup_type,
+                    vclock_begin,
+                    vclock_end,
+                    content,
+                ),
+            },
+        },
+        "topology": {
+            "replicasets": {
+                REPLICASET: [topology_instance(INSTANCE, "storage-001-a")],
+            },
+        },
+        "warnings": [],
+    }
+
+
+def write_backup(
+    storage,
+    backup_id,
+    previous="",
+    base=None,
+    backup_type="full",
+    vclock_begin=0,
+    vclock_end=100,
+):
+    """Store a healthy backup: an archive plus the manifest referring to it."""
+    content = f"archive of {backup_id}".encode()
+    manifest = build_manifest(
+        backup_id,
+        previous,
+        base if base is not None else backup_id,
+        backup_type,
+        vclock_begin,
+        vclock_end,
+        content,
+    )
+    storage.put(archive_key(backup_id), content)
+    write_manifest(storage, manifest)
+    return manifest
+
+
+def add_shard(storage, manifest, backup_type="full", vclock_begin=0, vclock_end=100):
+    """Add a second successfully backed up replicaset to a stored backup."""
+    backup_id = manifest["backup_id"]
+    content = f"archive of {backup_id} {REPLICASET_B}".encode()
+
+    storage.put(archive_key(backup_id, REPLICASET_B), content)
+    manifest["topology"]["replicasets"][REPLICASET_B] = [
+        topology_instance(INSTANCE_B, "storage-002-a"),
+    ]
+    manifest["shards"][REPLICASET_B] = {
+        "instance": shard_instance(
+            backup_id,
+            REPLICASET_B,
+            INSTANCE_B,
+            "storage-002-a",
+            backup_type,
+            vclock_begin,
+            vclock_end,
+            content,
+        ),
+    }
+    write_manifest(storage, manifest)
+
+    return manifest
+
+
+def add_failed_shard(storage, manifest, error="instance unreachable"):
+    """Add a replicaset that failed to back up: an error instead of an artifact."""
+    manifest["topology"]["replicasets"][REPLICASET_B] = [
+        topology_instance(INSTANCE_B, "storage-002-a"),
+    ]
+    manifest["shards"][REPLICASET_B] = {"error": error}
+    manifest["status"] = "degraded"
+    write_manifest(storage, manifest)
+
+    return manifest
+
+
+def write_manifest(storage, manifest):
+    storage.put(manifest_key(manifest["backup_id"]), json.dumps(manifest).encode())
+
+
+def write_chain(storage):
+    """Store a healthy full backup followed by an increment."""
+    full = write_backup(storage, "2026-01-01-full", vclock_begin=0, vclock_end=100)
+    incremental = write_backup(
+        storage,
+        "2026-01-02-inc",
+        previous="2026-01-01-full",
+        base="2026-01-01-full",
+        backup_type="incremental",
+        vclock_begin=100,
+        vclock_end=200,
+    )
+    return full, incremental
+
+
+def verify_json(tt, storage):
+    """Run verify, asserting the storage was not modified, and return its report."""
+    before = storage.keys()
+
+    rc, out = backup_verify(tt, storage.uri, fmt="json")
+    assert rc in (VERIFY_OK, VERIFY_PROBLEMS_FOUND), f"tt backup verify failed:\n{out}"
+
+    assert storage.keys() == before, "tt backup verify must not modify the storage"
+
+    return rc, json.loads(out)
+
+
+def issue_kinds(report):
+    return [issue["kind"] for issue in report["issues"]]
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_healthy_storage(tt, storage):
+    write_chain(storage)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK
+    assert report["issues"] == []
+    assert report["manifests_checked"] == 2
+    assert report["archives_checked"] == 2
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_reports_duplicate_backup_id(tt, storage):
+    """A manifest copied to a second key used to abort the whole run with "could
+    not check" and a usage dump, saying nothing at all about the storage - even
+    though a duplicated backup_id is exactly the defect verify exists to name."""
+    full, _ = write_chain(storage)
+    storage.put(manifest_key(full["backup_id"]) + ".copy", json.dumps(full).encode())
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    kinds = issue_kinds(report)
+    assert kinds.count("unreadable_manifest") == 2, report
+    details = " ".join(issue["detail"] for issue in report["issues"])
+    assert "duplicate backup_id" in details, report
+    # The untouched increment is still checked rather than lost with them.
+    assert report["archives_checked"] == 1, report
+
+
+@pytest.mark.parametrize("storage", [pytest.param(("file", ""), id="file")], indirect=True)
+def test_verify_keeps_stale_temp_files(tt, storage):
+    """Opening a file storage used to sweep leftover .tt-backup-* files, which
+    contradicts verify's promise to delete nothing whatever it finds. Such a file
+    is the residue of an interrupted upload - evidence, not garbage."""
+    write_chain(storage)
+
+    stale = os.path.join(storage.root, "data", ".tt-backup-interrupted")
+    os.makedirs(os.path.dirname(stale), exist_ok=True)
+    with open(stale, "wb") as dst:
+        dst.write(b"half an upload")
+    aged = time.time() - 48 * 60 * 60
+    os.utime(stale, (aged, aged))
+
+    # verify_json asserts the key set is unchanged, and keys() walks dotfiles too.
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK
+    assert report["issues"] == []
+    assert os.path.exists(stale)
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_empty_storage(tt, storage):
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK
+    assert report["manifests_checked"] == 0
+    assert report["issues"] == []
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_missing_archive(tt, storage):
+    write_chain(storage)
+    storage.delete(archive_key("2026-01-02-inc"))
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["missing_archive"]
+
+    issue = report["issues"][0]
+    assert issue["backup_id"] == "2026-01-02-inc"
+    assert issue["replicaset_uuid"] == REPLICASET
+    assert issue["archive"] == archive_key("2026-01-02-inc")
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_checksum_mismatch(tt, storage):
+    write_chain(storage)
+    storage.put(archive_key("2026-01-01-full"), b"corrupted archive")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["checksum_mismatch"]
+    assert report["issues"][0]["backup_id"] == "2026-01-01-full"
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_broken_chain(tt, storage):
+    _, incremental = write_chain(storage)
+    incremental["previous_backup_id"] = "2025-12-31-vanished"
+    write_manifest(storage, incremental)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["chain_orphan"]
+    assert "2025-12-31-vanished" in report["issues"][0]["detail"]
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_vclock_mismatch(tt, storage):
+    _, incremental = write_chain(storage)
+    # The increment starts past the end of the full backup: a hole in the WAL.
+    incremental["shards"][REPLICASET]["instance"]["vclock_begin"] = {"1": 150}
+    write_manifest(storage, incremental)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["vclock_mismatch"]
+    assert report["issues"][0]["backup_id"] == "2026-01-02-inc"
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_dangling_archive(tt, storage):
+    write_chain(storage)
+    dangling = archive_key("2026-01-03-never-uploaded")
+    storage.put(dangling, b"no manifest refers to me")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["dangling_archive"]
+    assert report["issues"][0]["archive"] == dangling
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_reports_every_problem_class(tt, storage):
+    write_chain(storage)
+    storage.put(archive_key("2026-01-01-full"), b"corrupted archive")
+    storage.delete(archive_key("2026-01-02-inc"))
+    storage.put(archive_key("2026-01-03-never-uploaded"), b"dangling")
+    write_backup(
+        storage,
+        "2026-01-04-orphan",
+        previous="2025-12-31-vanished",
+        base="2026-01-01-full",
+        backup_type="incremental",
+        vclock_begin=200,
+        vclock_end=300,
+    )
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert sorted(issue_kinds(report)) == sorted(
+        [
+            "checksum_mismatch",
+            "missing_archive",
+            "chain_orphan",
+            "dangling_archive",
+        ],
+    )
+
+
+@pytest.mark.parametrize("storage", PREFIXED_STORAGE_BACKENDS, indirect=True)
+def test_verify_with_prefix(tt, storage):
+    # Manifest paths and listed keys are both relative to the configured prefix,
+    # so a healthy prefixed storage must not look like one full of orphans.
+    write_chain(storage)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK, report
+    assert report["manifests_checked"] == 2
+    assert report["archives_checked"] == 2
+
+
+@pytest.mark.parametrize("storage", PREFIXED_STORAGE_BACKENDS, indirect=True)
+def test_verify_with_prefix_finds_problems(tt, storage):
+    write_chain(storage)
+    storage.delete(archive_key("2026-01-02-inc"))
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["missing_archive"]
+    assert report["issues"][0]["archive"] == archive_key("2026-01-02-inc")
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_unreadable_manifest_does_not_hide_the_rest(tt, storage):
+    write_chain(storage)
+    storage.put(manifest_key("2026-01-03-broken"), b"{")
+    storage.put(archive_key("2026-01-01-full"), b"corrupted archive")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["unreadable_manifest", "checksum_mismatch"]
+    assert report["issues"][0]["backup_id"] == "2026-01-03-broken"
+    assert report["manifests_checked"] == 3
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_checks_every_shard_of_a_manifest(tt, storage):
+    full = write_backup(storage, "2026-01-01-full")
+    add_shard(storage, full)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK, report
+    assert report["archives_checked"] == 2
+
+    # Corrupting one shard must point at that shard, and only at it.
+    storage.put(archive_key("2026-01-01-full", REPLICASET_B), b"corrupted archive")
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["checksum_mismatch"]
+    assert report["issues"][0]["replicaset_uuid"] == REPLICASET_B
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_skips_shard_that_failed_to_back_up(tt, storage):
+    # A replicaset that was unreachable carries an error, not an artifact:
+    # the manifest already records it, there is nothing to check in storage.
+    full = write_backup(storage, "2026-01-01-full")
+    add_failed_shard(storage, full)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_OK, report
+    assert report["archives_checked"] == 1
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_checksum_missing(tt, storage):
+    full = write_backup(storage, "2026-01-01-full")
+    full["shards"][REPLICASET]["instance"]["artifact"]["checksum_sha256"] = ""
+    write_manifest(storage, full)
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["checksum_missing"]
+    assert report["issues"][0]["archive"] == archive_key("2026-01-01-full")
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_inherited_chain_problem(tt, storage):
+    write_backup(storage, "2026-01-01-full")
+    # The parent of this increment is gone, and the next one inherits the break.
+    write_backup(
+        storage,
+        "2026-01-02-orphan",
+        previous="2025-12-31-vanished",
+        base="2026-01-01-full",
+        backup_type="incremental",
+        vclock_begin=100,
+        vclock_end=200,
+    )
+    write_backup(
+        storage,
+        "2026-01-03-tail",
+        previous="2026-01-02-orphan",
+        base="2026-01-01-full",
+        backup_type="incremental",
+        vclock_begin=200,
+        vclock_end=300,
+    )
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["chain_orphan", "chain_orphan"]
+
+    inherited = [issue for issue in report["issues"] if issue.get("inherited")]
+    assert len(inherited) == 1
+    assert inherited[0]["backup_id"] == "2026-01-03-tail"
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_verify_chain_fork(tt, storage):
+    write_chain(storage)
+    # A second increment on the same parent: the chain forks.
+    write_backup(
+        storage,
+        "2026-01-03-inc",
+        previous="2026-01-01-full",
+        base="2026-01-01-full",
+        backup_type="incremental",
+        vclock_begin=100,
+        vclock_end=300,
+    )
+
+    rc, report = verify_json(tt, storage)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["chain_fork", "chain_fork"]
+    assert {issue["backup_id"] for issue in report["issues"]} == {
+        "2026-01-02-inc",
+        "2026-01-03-inc",
+    }
+
+
+def test_verify_table_format(tt, tmp_path):
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_chain(storage)
+    storage.delete(archive_key("2026-01-02-inc"))
+
+    rc, out = backup_verify(tt, storage.uri)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert not out.lstrip().startswith("{")
+    assert "missing_archive" in out
+    assert "2026-01-02-inc" in out
+
+
+def test_verify_default_format_is_table(tt, tmp_path):
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_chain(storage)
+
+    rc, out = backup_verify(tt, storage.uri)
+
+    assert rc == VERIFY_OK
+    assert "Manifests checked" in out
+    assert not out.lstrip().startswith("{")
+
+
+def test_verify_invalid_format(tt, tmp_path):
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_chain(storage)
+
+    rc, out = backup_verify(tt, storage.uri, fmt="xml")
+
+    assert rc != VERIFY_OK
+    assert "unsupported format" in out.lower()
+
+
+def test_verify_missing_backup_storage_flag(tt):
+    rc, out = tt.exec("backup", "verify")
+
+    assert rc != VERIFY_OK
+    assert "required" in out.lower()
+
+
+@pytest.mark.docker
+def test_verify_s3_auth_error_does_not_expose_secret(tt, garage):
+    secret = "garage-invalid-secret"
+    uri = (
+        f"s3+http://{garage.endpoint}/{garage.bucket}"
+        f"?Region={garage.region}&AccessKeyID={garage.access_key}"
+        f"&SecretAccessKey={secret}"
+    )
+
+    rc, out = backup_verify(tt, uri, fmt="json")
+
+    assert rc == 1
+    assert secret not in out
+
+
+@pytest.mark.skipif(
+    os.getuid() == 0,
+    reason="Skipping the test, it shouldn't run as root",
+)
+def test_verify_unreadable_storage(tt, tmp_path):
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_chain(storage)
+    os.chmod(os.path.join(storage.root, "manifests"), 0o000)
+
+    try:
+        rc, out = backup_verify(tt, storage.uri, fmt="json")
+    finally:
+        os.chmod(os.path.join(storage.root, "manifests"), 0o755)
+
+    # An unreadable storage is an operational failure, not a health verdict.
+    assert rc == 1
+    assert "verify" in out.lower()
+
+
+@pytest.mark.skipif(
+    os.getuid() == 0,
+    reason="Skipping the test, it shouldn't run as root",
+)
+def test_verify_unreadable_archive(tt, tmp_path):
+    # The archive is listed and referenced, but its bytes cannot be read: that
+    # is not the same finding as a missing archive.
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_backup(storage, "2026-01-01-full")
+    archive = os.path.join(storage.root, archive_key("2026-01-01-full"))
+    os.chmod(archive, 0o000)
+
+    try:
+        rc, report = verify_json(tt, storage)
+    finally:
+        os.chmod(archive, 0o644)
+
+    assert rc == VERIFY_PROBLEMS_FOUND
+    assert issue_kinds(report) == ["unreadable_archive"]
+    assert report["issues"][0]["archive"] == archive_key("2026-01-01-full")
+
+
+def test_verify_timeout_expires(tt, tmp_path):
+    storage = FileStorage(str(tmp_path / "backups"))
+    write_chain(storage)
+
+    rc, out = backup_verify(tt, storage.uri, fmt="json", timeout="1ns")
+
+    # A storage that could not be read within the timeout is exit code 1, not a
+    # clean bill of health.
+    assert rc == 1
+    assert "context deadline exceeded" in out.lower()


### PR DESCRIPTION
Add `tt backup verify`, a read-only health check of a backup storage. It loads the manifest chain, recomputes sha256 of every referenced archive straight from the GET stream (archives are never spooled to disk), and lists archives no manifest refers to.

Reported problem classes: unreadable and structurally invalid manifests, missing and unreadable archives, checksum mismatches, breaks in the `previous_backup_id` chain (orphans and forks), increments whose `vclock_begin` does not continue their ancestor, and dangling archives. Chain problems come from `cli/backup/chain`, inherited ones included.

`chain.Load` is split into `Load` and `LoadPartial`: a diagnostic caller must report a single unreadable manifest and keep checking the rest of the storage, the way `tt cluster topology` degrades per instance, while a caller that recovers from the chain still fails loud on a missing link.

Nothing is ever written or deleted: removing backups stays with `tt backup gc`. The command exits with 2 when problems are found, so a cron job tells an unhealthy storage from a run that could not check anything at all (exit code 1); 2 matches the fail-loud code of `tt backup start`.


Two prerequisite fixes come first in the branch, each independently reviewable and each a defect in code already on master rather than anything verify introduces. `storage/fs` swept stale `.tt-backup-*` files when the storage was *opened*, which made verify's own promise ("Nothing is ever deleted or repaired") untrue before it had read a byte; the sweep moved to the first `Put`, so writers still clean up after writers and readers delete nothing. And a manifest with an empty `shards` map validated as healthy while referring to no archive at all, so verify called it fine and its archive unreferenced - which reads as "delete this".

Closes TNTP-8670
