### PR TITLE
vshard: bump to 0.1.42 and cover backup of a sharded cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `tt stop`: preliminary interrupts the processes to enable parallel termination.
+- `tt create vshard_cluster`: the generated rockspec now pins `vshard 0.1.42`
+  instead of `0.1.25`. 0.1.42 is the first release shipping the `vshard-router`
+  backend of the `roles.recovery-point-manager` role, which is what lets a
+  backup take a cluster-wide recovery point.
 
 ### Fixed
 

--- a/cli/create/builtin_templates/templates/vshard_cluster/{{.name}}-scm-1.rockspec.tt.template
+++ b/cli/create/builtin_templates/templates/vshard_cluster/{{.name}}-scm-1.rockspec.tt.template
@@ -4,7 +4,7 @@ source  = {
     url = '/dev/null',
 }
 dependencies = {
-    'vshard == 0.1.25'
+    'vshard == 0.1.42'
 }
 build = {
     type = 'none';

--- a/test/integration/backup/backup_helpers.py
+++ b/test/integration/backup/backup_helpers.py
@@ -15,10 +15,10 @@ BACKUP_TMP_ROOT = os.path.join(tempfile.gettempdir(), "tt-backup")
 def eval_yaml_app(tt, target, lua):
     proc = tt.run("connect", target, "-f-", input=lua, timeout=30)
     assert proc.returncode == 0, proc.stdout
-    return _parse_yaml(proc.stdout)
+    return parse_yaml(proc.stdout)
 
 
-def _parse_yaml(out):
+def parse_yaml(out):
     marker = out.find("\n---")
     if marker != -1:
         out = out[marker + 1 :]

--- a/test/integration/backup/conftest.py
+++ b/test/integration/backup/conftest.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from minio import Minio
+from sharded_helpers import start_sharded_app
 
 GARAGE_IMAGE = "dxflrs/garage:v2.3.0"
 GARAGE_BUCKET = "tt-backup-test"
@@ -122,3 +123,20 @@ def garage(tmp_path_factory):
             capture_output=True,
             text=True,
         )
+
+
+@pytest.fixture(scope="module")
+def sharded_app(tt_cmd, tmp_path_factory):
+    """A running two-shard vshard cluster with the recovery point manager role.
+
+    Module-scoped: building the app downloads and installs the pinned vshard
+    rock, which is too slow to repeat per test.
+    """
+    # Short name on purpose: it is a prefix of every instance's console socket
+    # path, which must fit into sun_path (see start_sharded_app).
+    env_dir = tmp_path_factory.mktemp("shard")
+    app = start_sharded_app(tt_cmd, env_dir)
+    try:
+        yield app
+    finally:
+        app.tt("stop", "-y", assert_rc=False)

--- a/test/integration/backup/sharded_app/config.yaml
+++ b/test/integration/backup/sharded_app/config.yaml
@@ -1,0 +1,80 @@
+credentials:
+  users:
+    guest:
+      roles: [super]
+    client:
+      password: 'secret'
+      roles: [super]
+    replicator:
+      password: 'secret'
+      roles: [replication]
+    storage:
+      password: 'secret'
+      roles: [sharding]
+
+iproto:
+  advertise:
+    peer:
+      login: replicator
+    sharding:
+      login: storage
+
+sharding:
+  bucket_count: 100
+
+groups:
+  storages:
+    app:
+      file: 'storage.lua'
+    sharding:
+      roles: [storage]
+    replication:
+      failover: manual
+    replicasets:
+      storage-001:
+        leader: storage-001-a
+        database:
+          replicaset_uuid: '11111111-1111-1111-1111-111111111111'
+        instances:
+          storage-001-a:
+            database:
+              instance_uuid: '1a1a1a1a-1a1a-1a1a-1a1a-1a1a1a1a1a1a'
+            iproto:
+              listen:
+                - uri: localhost:3341
+      storage-002:
+        leader: storage-002-a
+        database:
+          replicaset_uuid: '22222222-2222-2222-2222-222222222222'
+        instances:
+          storage-002-a:
+            database:
+              instance_uuid: '2a2a2a2a-2a2a-2a2a-2a2a-2a2a2a2a2a2a'
+            iproto:
+              listen:
+                - uri: localhost:3342
+  routers:
+    app:
+      file: 'router.lua'
+    sharding:
+      roles: [router]
+    # The recovery point manager runs on the router and uses the vshard-router
+    # backend shipped by vshard 0.1.42+
+    # (roles/recovery-point-manager/backends/vshard-router.lua). No 'create'
+    # schedule: the tests create cluster recovery points explicitly, so the
+    # number of points on each storage stays deterministic.
+    roles: [roles.recovery-point-manager]
+    roles_cfg:
+      roles.recovery-point-manager:
+        backend: vshard-router
+    replicasets:
+      router-001:
+        database:
+          replicaset_uuid: '33333333-3333-3333-3333-333333333333'
+        instances:
+          router-001-a:
+            database:
+              instance_uuid: '3a3a3a3a-3a3a-3a3a-3a3a-3a3a3a3a3a3a'
+            iproto:
+              listen:
+                - uri: localhost:3343

--- a/test/integration/backup/sharded_app/instances.yml
+++ b/test/integration/backup/sharded_app/instances.yml
@@ -1,0 +1,3 @@
+storage-001-a:
+storage-002-a:
+router-001-a:

--- a/test/integration/backup/sharded_app/router.lua
+++ b/test/integration/backup/sharded_app/router.lua
@@ -1,0 +1,9 @@
+local vshard = require('vshard')
+
+-- Spread rows over both storage replicasets so every shard has data to back up.
+function fill(count)
+    for i = 1, count do
+        local bucket_id = vshard.router.bucket_id_mpcrc32({i})
+        vshard.router.callrw(bucket_id, 'put', {i, bucket_id, 'row-' .. i})
+    end
+end

--- a/test/integration/backup/sharded_app/sharded_app-scm-1.rockspec
+++ b/test/integration/backup/sharded_app/sharded_app-scm-1.rockspec
@@ -1,0 +1,13 @@
+package = 'sharded_app'
+version = 'scm-1'
+source  = {
+    url = '/dev/null',
+}
+dependencies = {
+    -- 0.1.42 is the first release shipping the recovery point manager
+    -- vshard-router backend, which the backup tests rely on.
+    'vshard == 0.1.42'
+}
+build = {
+    type = 'none';
+}

--- a/test/integration/backup/sharded_app/storage.lua
+++ b/test/integration/backup/sharded_app/storage.lua
@@ -1,0 +1,28 @@
+box.once('backup_test_spaces', function()
+    local memtx = box.schema.space.create('backup_test', {
+        format = {
+            {name = 'id',        type = 'unsigned'},
+            {name = 'bucket_id', type = 'unsigned'},
+            {name = 'data',      type = 'string'},
+        }
+    })
+    memtx:create_index('pk', {parts = {'id'}})
+    memtx:create_index('bucket_id', {parts = {'bucket_id'}, unique = false})
+
+    local vinyl = box.schema.space.create('backup_test_vinyl', {
+        engine = 'vinyl',
+        format = {
+            {name = 'id',        type = 'unsigned'},
+            {name = 'bucket_id', type = 'unsigned'},
+            {name = 'data',      type = 'string'},
+        }
+    })
+    vinyl:create_index('pk', {parts = {'id'}})
+    vinyl:create_index('bucket_id', {parts = {'bucket_id'}, unique = false})
+end)
+
+-- Called by the router to place a row on the shard owning bucket_id.
+function put(id, bucket_id, data)
+    box.space.backup_test:replace({id, bucket_id, data})
+    box.space.backup_test_vinyl:replace({id, bucket_id, 'vinyl-' .. data})
+end

--- a/test/integration/backup/sharded_helpers.py
+++ b/test/integration/backup/sharded_helpers.py
@@ -1,0 +1,150 @@
+import json
+import shutil
+import time
+from pathlib import Path
+
+from backup_helpers import parse_yaml
+
+from utils import create_tt_config, run_command_and_get_output
+
+SHARDED_APP_NAME = "sharded_app"
+SHARDED_APP_SRC = Path(__file__).parent / SHARDED_APP_NAME
+
+# Ports must match sharded_app/config.yaml. vshard needs a real advertise URI,
+# so the sharded app listens on TCP instead of tt's default unix socket; that
+# also means the backup commands address the storages by <URI>, not by
+# <APP:INSTANCE>.
+STORAGE_URIS = {
+    "storage-001-a": "client:secret@localhost:3341",
+    "storage-002-a": "client:secret@localhost:3342",
+}
+ROUTER_INSTANCE = f"{SHARDED_APP_NAME}:router-001-a"
+
+# Replicaset UUIDs pinned in sharded_app/config.yaml, keyed by storage leader.
+STORAGE_REPLICASET_UUIDS = {
+    "storage-001-a": "11111111-1111-1111-1111-111111111111",
+    "storage-002-a": "22222222-2222-2222-2222-222222222222",
+}
+
+
+class ShardedApp:
+    """A built, started and vshard-bootstrapped sharded_app environment."""
+
+    def __init__(self, tt_cmd, env_dir: Path) -> None:
+        self.tt_cmd = tt_cmd
+        self.env_dir = env_dir
+        self.app_name = SHARDED_APP_NAME
+
+    def exec(self, *args, **kwargs):
+        """Same contract as tt_helper.Tt.exec, so that the backup_helpers
+        wrappers (start_backup, finalize_backup, ...) accept a ShardedApp."""
+        return run_command_and_get_output([self.tt_cmd, *args], cwd=self.env_dir, **kwargs)
+
+    def tt(self, *args, input=None, assert_rc=True):
+        rc, out = self.exec(*args, input=input)
+        if assert_rc:
+            assert rc == 0, f"tt {' '.join(args)} failed:\n{out}"
+        return rc, out
+
+    def eval(self, target, lua):
+        _, out = self.tt("connect", target, "-f-", input=lua)
+        return parse_yaml(out)
+
+    def eval_router(self, lua):
+        return self.eval(ROUTER_INSTANCE, lua)
+
+    def create_cluster_recovery_point(self, label):
+        """Create a recovery point on every storage master, going through the
+        vshard-router backend of the recovery point manager role."""
+        return self.eval_router(
+            "return box.backup.recovery_point.managers.default:create_point("
+            f"{{label = '{label}'}})",
+        )
+
+    def recovery_point_manager_info(self):
+        return self.eval_router("return box.backup.recovery_point.managers.default:info()")
+
+    def recovery_point_labels(self, instance):
+        """Labels stored in _recovery_point on a storage master, oldest first."""
+        return self.eval(
+            f"{self.app_name}:{instance}",
+            "local labels = {} "
+            "for _, t in box.space._recovery_point:pairs() do "
+            "    table.insert(labels, t[4].label) "
+            "end "
+            "return labels",
+        )
+
+
+def _wait(timeout, predicate, message):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        ok, last = predicate()
+        if ok:
+            return last
+        time.sleep(0.5)
+    raise AssertionError(f"{message}; last seen:\n{last}")
+
+
+def _wait_ready(app, timeout=60):
+    """Wait until tt can talk to every instance, not merely until the processes
+    exist. A RUNNING status only means the watchdog wrote a pid file; `box` is
+    filled in only once tt has connected over var/run/<instance>/tarantool.control,
+    and that socket is what `tt replicaset vshard bootstrap` needs."""
+    instances = [f"{app.app_name}:{name}" for name in STORAGE_URIS] + [ROUTER_INSTANCE]
+
+    def check():
+        _, out = app.tt("status", app.app_name, "--format", "json", assert_rc=False)
+        try:
+            status = json.loads(out)
+        except json.JSONDecodeError:
+            return False, out
+        ok = all(
+            status.get(inst, {}).get("status") == "RUNNING"
+            and status.get(inst, {}).get("box") == "running"
+            for inst in instances
+        )
+        return ok, out
+
+    _wait(timeout, check, "sharded_app instances did not become ready")
+
+
+def _wait_buckets_discovered(app, timeout=60):
+    def check():
+        info = app.eval_router(
+            "local i = require('vshard').router.info() "
+            "return {unknown = i.bucket.unknown, available_rw = i.bucket.available_rw}",
+        )
+        if not isinstance(info, dict):
+            return False, info
+        return info.get("unknown") == 0 and info.get("available_rw", 0) > 0, info
+
+    _wait(timeout, check, "vshard router did not discover all buckets")
+
+
+def start_sharded_app(tt_cmd, env_dir: Path) -> ShardedApp:
+    """Create a tt environment with sharded_app, build it (this installs the
+    pinned vshard rock), start it and bootstrap vshard."""
+    app = ShardedApp(tt_cmd, env_dir)
+    # A minimal tt.yaml instead of `tt init`, and the app straight in the
+    # environment root instead of under instances.enabled/, the way the other
+    # backup tests lay it out. Those 18 characters matter: `tt replicaset`
+    # reaches instances over var/run/<instance>/tarantool.control, and the full
+    # path has to stay under the 108-byte sun_path limit once pytest's own
+    # temporary directory is prepended.
+    create_tt_config(env_dir, "")
+    shutil.copytree(SHARDED_APP_SRC, env_dir / SHARDED_APP_NAME)
+
+    app.tt("build", SHARDED_APP_NAME)
+    app.tt("start", SHARDED_APP_NAME)
+    _wait_ready(app)
+    app.tt("replicaset", "vshard", "bootstrap", SHARDED_APP_NAME)
+    _wait_buckets_discovered(app)
+    return app
+
+
+def fragment_of(archive_path):
+    """Read the manifest fragment written next to an archive."""
+    with open(archive_path.removesuffix(".tar.zst") + ".json", "r") as src:
+        return json.load(src)

--- a/test/integration/backup/test_sharded.py
+++ b/test/integration/backup/test_sharded.py
@@ -1,0 +1,93 @@
+"""Backup of a sharded (vshard) cluster.
+
+These tests cover the part of the backup flow that only exists once vshard is
+in play: a *cluster* recovery point, created on the router through the
+recovery point manager role, has to reach every storage master and show up in
+the manifest fragment each shard produces.
+
+The vshard-router backend of the role ships with vshard 0.1.42+
+(roles/recovery-point-manager/backends/vshard-router.lua), which is the version
+pinned in sharded_app/sharded_app-scm-1.rockspec.
+
+Unlike test_backup_start.py these tests do not compare against golden
+fragments: vclocks on a sharded cluster move on their own (bucket bookkeeping,
+discovery, rebalancer), so the assertions are structural.
+"""
+
+import os
+
+import pytest
+from backup_helpers import archive_path_from_output, finalize_backup, start_backup
+from sharded_helpers import STORAGE_REPLICASET_UUIDS, STORAGE_URIS, fragment_of
+
+from utils import get_tarantool_version, is_tarantool_less
+
+tarantool_major, tarantool_minor = get_tarantool_version()
+BACKUP_SUPPORTED = not is_tarantool_less(3, 8)
+
+skip_reason = (
+    f"sharded backup requires Tarantool 3.8.0+ (running {tarantool_major}.{tarantool_minor})"
+)
+
+
+@pytest.mark.skipif(not BACKUP_SUPPORTED, reason=skip_reason)
+def test_recovery_point_manager_uses_vshard_router_backend(sharded_app):
+    info = sharded_app.recovery_point_manager_info()
+
+    assert info is not None, "the recovery point manager role did not start"
+    assert info["backend"]["backend_type"] == "vshard-router"
+
+
+@pytest.mark.skipif(not BACKUP_SUPPORTED, reason=skip_reason)
+def test_cluster_recovery_point_reaches_every_storage(sharded_app):
+    label = "rp-cluster-fanout"
+    points = sharded_app.create_cluster_recovery_point(label)
+
+    # The backend returns the created points keyed by replicaset name.
+    assert sorted(points) == ["storage-001", "storage-002"], points
+    for replicaset, created in points.items():
+        assert len(created) == 1, (replicaset, created)
+        assert created[0]["label"] == label, (replicaset, created)
+
+    for instance in STORAGE_URIS:
+        assert label in sharded_app.recovery_point_labels(instance), instance
+
+
+@pytest.mark.skipif(not BACKUP_SUPPORTED, reason=skip_reason)
+def test_start_carries_cluster_recovery_point_into_every_fragment(sharded_app):
+    label = "rp-cluster-backup"
+    backup_id = "itest-sharded"
+
+    sharded_app.eval_router("fill(50)")
+    sharded_app.create_cluster_recovery_point(label)
+
+    archives = {}
+    try:
+        for instance, uri in STORAGE_URIS.items():
+            rc, out = start_backup(sharded_app, uri, backup_id)
+            assert rc == 0, f"backup start on {instance} failed:\n{out}"
+            archives[instance] = archive_path_from_output(out)
+
+        # One archive per shard, all in the same per-backup directory, named
+        # after the replicaset the shard belongs to.
+        assert len({os.path.dirname(path) for path in archives.values()}) == 1, archives
+        for instance, path in archives.items():
+            uuid = STORAGE_REPLICASET_UUIDS[instance]
+            assert os.path.basename(path) == f"{backup_id}-{uuid}.tar.zst"
+
+        fragments = {inst: fragment_of(path) for inst, path in archives.items()}
+        for instance, fragment in fragments.items():
+            assert fragment["replicaset_uuid"] == STORAGE_REPLICASET_UUIDS[instance]
+            assert fragment["instance_name"] == instance
+            assert fragment["type"] == "full"
+            labels = [point["label"] for point in fragment["recovery_points"]]
+            assert label in labels, (instance, fragment["recovery_points"])
+
+        # The shards are independent: same label, but each shard records the
+        # point at its own LSN, and the replicaset UUIDs must not collide.
+        uuids = {fragment["replicaset_uuid"] for fragment in fragments.values()}
+        assert len(uuids) == len(fragments)
+    finally:
+        for instance, uri in STORAGE_URIS.items():
+            rc, out = finalize_backup(sharded_app, uri, backup_id)
+            assert rc == 0, f"backup finalize on {instance} failed:\n{out}"

--- a/test/integration/pack/test_bundles/vshard_app/test_app/test_app-scm-1.rockspec
+++ b/test/integration/pack/test_bundles/vshard_app/test_app/test_app-scm-1.rockspec
@@ -4,7 +4,7 @@ source  = {
     url = '/dev/null',
 }
 dependencies = {
-    'vshard == 0.1.25'
+    'vshard == 0.1.42'
 }
 build = {
     type = 'none';

--- a/test/integration/pack/test_bundles/vshard_app_with_tcm_config/test_app/test_app-scm-1.rockspec
+++ b/test/integration/pack/test_bundles/vshard_app_with_tcm_config/test_app/test_app-scm-1.rockspec
@@ -4,7 +4,7 @@ source  = {
     url = '/dev/null',
 }
 dependencies = {
-    'vshard == 0.1.25'
+    'vshard == 0.1.42'
 }
 build = {
     type = 'none';

--- a/test/integration/replicaset/test_vshard_app_timeout/vshard_app-scm-1.rockspec
+++ b/test/integration/replicaset/test_vshard_app_timeout/vshard_app-scm-1.rockspec
@@ -4,7 +4,7 @@ source  = {
     url = '/dev/null',
 }
 dependencies = {
-    'vshard == 0.1.25'
+    'vshard == 0.1.42'
 }
 build = {
     type = 'none';


### PR DESCRIPTION
Every vshard pin in the tree still pointed at `0.1.25`: the built-in `vshard_cluster` template and the three test rockspecs. They move to `0.1.42`, which is the first release shipping `roles/recovery-point-manager/backends/vshard-router.lua` - the backend that lets the core `roles.recovery-point-manager` role take a cluster-wide recovery point through the router.

Part of TNTP-8032
