### PR TITLE
backup: add backup upload command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of flags empties a storage.
 - `tt backup plan`: add backup planning command that computes last
   valid manifest for `tt backup start`.
+- `tt backup upload`: add a command that builds a cluster manifest from
+  per-shard fragments and uploads archives and the manifest to file or S3
+  storage.
 
 ### Changed
 
@@ -36,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   instead of `0.1.25`. 0.1.42 is the first release shipping the `vshard-router`
   backend of the `roles.recovery-point-manager` role, which is what lets a
   backup take a cluster-wide recovery point.
+- `tt backup`: remove `creation_duration` from the cluster manifest — the
+  field was unused and is no longer serialized.
 
 ### Fixed
 

--- a/cli/backup/aggregation.go
+++ b/cli/backup/aggregation.go
@@ -37,7 +37,6 @@ type AggregateInput struct {
 	BaseFullBackupID BackupID
 	PreviousBackupID BackupID
 	CreationTime     time.Time
-	CreationDuration time.Duration
 	Topology         Topology
 	Shards           []*ShardInput
 }
@@ -77,7 +76,6 @@ func NewAggregateInput(
 	previousBackupID BackupID,
 	baseFullBackupID BackupID,
 	creationTime time.Time,
-	creationDuration time.Duration,
 	topology Topology,
 	shards []*ShardInput,
 ) AggregateInput {
@@ -86,7 +84,6 @@ func NewAggregateInput(
 		PreviousBackupID: previousBackupID,
 		BaseFullBackupID: baseFullBackupID,
 		CreationTime:     creationTime,
-		CreationDuration: creationDuration,
 		Topology:         topology,
 		Shards:           shards,
 	}
@@ -119,7 +116,6 @@ func newClusterManifest(in AggregateInput) *ClusterManifest {
 		BaseFullBackupID: in.BaseFullBackupID,
 		Status:           StatusFailed,
 		CreationTime:     in.CreationTime,
-		CreationDuration: in.CreationDuration,
 		Shards:           make(map[string]Shard, len(in.Shards)),
 		Topology:         in.Topology,
 		Warnings:         make([]Warning, 0),

--- a/cli/backup/aggregation_test.go
+++ b/cli/backup/aggregation_test.go
@@ -15,7 +15,6 @@ func TestAggregateSuccessfulManifest(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: 2300 * time.Millisecond,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards: []*ShardInput{
 			{
@@ -36,7 +35,6 @@ func TestAggregateSuccessfulManifest(t *testing.T) {
 	require.Equal(t, int64(42), shard.Instance.Artifact.SizeBytes)
 	require.Equal(t, "zstd", shard.Instance.Artifact.Compression)
 	require.Len(t, shard.Instance.Artifact.RecoveryPoints, 2)
-	require.Equal(t, 2300*time.Millisecond, manifest.CreationDuration)
 }
 
 func TestAggregateUnavailableShard(t *testing.T) {
@@ -44,7 +42,6 @@ func TestAggregateUnavailableShard(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards:           []*ShardInput{{ReplicasetUUID: testRSA}},
 	})
@@ -62,7 +59,6 @@ func TestAggregateNilRecoveryPointsAddsWarningAndEmptySlice(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards:           []*ShardInput{{ReplicasetUUID: testRSA, Fragment: &fragment}},
 	})
@@ -81,7 +77,6 @@ func TestAggregateEmptyRecoveryPointsDoesNotAddWarning(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards:           []*ShardInput{{ReplicasetUUID: testRSA, Fragment: &fragment}},
 	})
@@ -96,7 +91,6 @@ func TestAggregateShardErrorUsesErrorShard(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards: []*ShardInput{{
 			ReplicasetUUID: testRSA,
@@ -117,7 +111,6 @@ func TestAggregateRejectsInvalidFragment(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA),
 		Shards:           []*ShardInput{{ReplicasetUUID: testRSA, Fragment: &fragment}},
 	})
@@ -131,7 +124,6 @@ func TestAggregateRejectsReplicasetMismatch(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: time.Second,
 		Topology:         topologyFromClusterManifestFixture(t, testRSB),
 		Shards:           []*ShardInput{{ReplicasetUUID: testRSB, Fragment: &fragment}},
 	})
@@ -146,7 +138,6 @@ func TestAggregateBuildsClusterManifest(t *testing.T) {
 		BackupID:         testBackupID,
 		BaseFullBackupID: testBackupID,
 		CreationTime:     testCreationTime(),
-		CreationDuration: 2300 * time.Millisecond,
 		Topology:         topologyFromClusterManifestFixture(t, testRSA, testRSB, testRSC),
 		Shards: []*ShardInput{
 			{

--- a/cli/backup/chain/helpers_test.go
+++ b/cli/backup/chain/helpers_test.go
@@ -132,7 +132,6 @@ func manifestFixture(
 		BaseFullBackupID: backup.BackupID(base),
 		Status:           backup.StatusOK,
 		CreationTime:     time.Unix(createdAt, 0).UTC(),
-		CreationDuration: time.Second,
 		Shards:           make(map[string]backup.Shard, 2),
 		Topology: backup.Topology{Replicasets: map[string][]backup.TopologyInstance{
 			replicasetA: {{InstanceUUID: masterA}},

--- a/cli/backup/gc/helpers_test.go
+++ b/cli/backup/gc/helpers_test.go
@@ -199,7 +199,6 @@ func (f *fixture) addBackup(spec backupSpec) *backup.ClusterManifest {
 		BaseFullBackupID: backup.BackupID(spec.base),
 		Status:           backup.StatusOK,
 		CreationTime:     creationTime,
-		CreationDuration: time.Second,
 		Shards:           make(map[string]backup.Shard, len(spec.replicasets)),
 		Topology:         backup.Topology{Replicasets: map[string][]backup.TopologyInstance{}},
 		Warnings:         []backup.Warning{},

--- a/cli/backup/manifest.go
+++ b/cli/backup/manifest.go
@@ -13,7 +13,6 @@ type ClusterManifest struct {
 	BaseFullBackupID BackupID         `json:"base_full_backup_id"`
 	Status           Status           `json:"status"`
 	CreationTime     time.Time        `json:"creation_time"`
-	CreationDuration time.Duration    `json:"creation_duration"`
 	Shards           map[string]Shard `json:"shards"` // Key is replicaset.
 	Topology         Topology         `json:"topology"`
 	Warnings         []Warning        `json:"warnings"` // Empty is [].

--- a/cli/backup/plan.go
+++ b/cli/backup/plan.go
@@ -29,9 +29,10 @@ type ReplicasetPlan struct {
 
 // BackupPlan is the output of the plan command.
 type BackupPlan struct {
-	Mode             BackupType                `json:"mode"`
+	Type             BackupType                `json:"mode"`
 	Replicasets      map[string]ReplicasetPlan `json:"replicasets,omitempty"`
 	PreviousBackupID BackupID                  `json:"previous_backup_id,omitempty"`
+	BaseFullBackupID BackupID                  `json:"base_full_backup_id,omitempty"`
 }
 
 var (
@@ -90,7 +91,7 @@ func planFull(live *LiveTopology) (*BackupPlan, error) {
 		}
 	}
 
-	return &BackupPlan{Mode: BackupTypeFull, Replicasets: replicasets}, nil
+	return &BackupPlan{Type: BackupTypeFull, Replicasets: replicasets}, nil
 }
 
 // planIncremental validates the latest manifest against the live topology.
@@ -145,9 +146,10 @@ func planIncremental(latest *ClusterManifest, live *LiveTopology) (*BackupPlan, 
 	}
 
 	return &BackupPlan{
-		Mode:             BackupTypeIncremental,
+		Type:             BackupTypeIncremental,
 		Replicasets:      replicasets,
 		PreviousBackupID: latest.BackupID,
+		BaseFullBackupID: latest.BaseFullBackupID,
 	}, nil
 }
 

--- a/cli/backup/plan_test.go
+++ b/cli/backup/plan_test.go
@@ -59,7 +59,7 @@ func TestPlanFullSelectsFirstRW(t *testing.T) {
 
 	plan, err := Plan(BackupTypeFull, nil, live)
 	require.NoError(t, err)
-	assert.Equal(t, BackupTypeFull, plan.Mode)
+	assert.Equal(t, BackupTypeFull, plan.Type)
 	assert.Empty(t, plan.PreviousBackupID)
 	assert.Nil(t, plan.Replicasets[testRSa].FromVclock)
 	assert.Equal(t, testInstA, plan.Replicasets[testRSa].MasterInstanceUUID)
@@ -96,7 +96,7 @@ func TestPlanIncrementalValid(t *testing.T) {
 
 	plan, err := Plan(BackupTypeIncremental, latest, live)
 	require.NoError(t, err)
-	assert.Equal(t, BackupTypeIncremental, plan.Mode)
+	assert.Equal(t, BackupTypeIncremental, plan.Type)
 	assert.Equal(t, BackupID("bk-1"), plan.PreviousBackupID)
 	assert.Equal(t, Vclock{1: 100}, plan.Replicasets[testRSa].FromVclock)
 }
@@ -211,7 +211,7 @@ func TestPlanIncrementalMasterStillRW(t *testing.T) {
 
 func TestPlanFullJSONNoFromVclockNoPrevious(t *testing.T) {
 	plan := &BackupPlan{
-		Mode: BackupTypeFull,
+		Type: BackupTypeFull,
 		Replicasets: map[string]ReplicasetPlan{
 			testRSa: {MasterInstanceUUID: testInstA, MasterInstanceName: "a-001"},
 		},
@@ -232,7 +232,7 @@ func TestPlanFullJSONNoFromVclockNoPrevious(t *testing.T) {
 
 func TestPlanIncrementalJSONHasFromVclockAndPrevious(t *testing.T) {
 	plan := &BackupPlan{
-		Mode:             BackupTypeIncremental,
+		Type:             BackupTypeIncremental,
 		PreviousBackupID: "20260312T110000Z",
 		Replicasets: map[string]ReplicasetPlan{
 			testRSa: {

--- a/cli/backup/testdata/cluster_manifest.json
+++ b/cli/backup/testdata/cluster_manifest.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "20260312T120000Z",
   "status": "OK",
   "creation_time": "2026-03-12T12:00:02.456Z",
-  "creation_duration": 2300000000,
   "shards": {
     "11111111-1111-1111-1111-111111111111": {
       "instance": {

--- a/cli/backup/upload.go
+++ b/cli/backup/upload.go
@@ -1,0 +1,244 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/tarantool/tt/cli/backup/storage"
+)
+
+// ArchiveToUpload pairs a local archive file with its storage destination.
+type ArchiveToUpload struct {
+	LocalPath      string
+	StorageKey     string
+	Size           int64
+	ReplicasetUUID string
+}
+
+// Upload uploads archives and the manifest to storage.
+// If the upload fails, all previously uploaded
+// archives are deleted.
+func Upload(
+	ctx context.Context,
+	store storage.Storage,
+	keyPrefix string,
+	backupID BackupID,
+	manifestData []byte,
+	archives []ArchiveToUpload,
+) error {
+	uploadedKeys := make([]string, 0, len(archives))
+
+	for _, archive := range archives {
+		if err := putFile(ctx, store, archive.StorageKey,
+			archive.LocalPath, archive.Size); err != nil {
+			deleteObjects(ctx, store, uploadedKeys)
+			return fmt.Errorf("upload archive for replicaset %q: %w", archive.ReplicasetUUID, err)
+		}
+		uploadedKeys = append(uploadedKeys, archive.StorageKey)
+	}
+
+	manifestKey := keyPrefix + storage.ManifestKey(string(backupID))
+	if err := storage.PutBytes(ctx, store, manifestKey, manifestData); err != nil {
+		deleteObjects(ctx, store, uploadedKeys)
+		return fmt.Errorf("upload manifest: %w", err)
+	}
+
+	return nil
+}
+
+// PrepareArchives stats each local archive, extracts the replicaset UUID from
+// its filename, and computes the storage key. Returns a slice ready for Upload
+// and a map of replicaset_uuid → ArtifactLocation for manifest building.
+func PrepareArchives(
+	paths []string,
+	keyPrefix string,
+	backupID BackupID,
+) ([]ArchiveToUpload, map[string]*ArtifactLocation, error) {
+	archives := make([]ArchiveToUpload, 0, len(paths))
+	locations := make(map[string]*ArtifactLocation, len(paths))
+
+	for _, archivePath := range paths {
+		info, err := os.Stat(archivePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("stat archive %q: %w", archivePath, err)
+		}
+
+		replicasetUUID, err := uuidFromArchivePath(archivePath, string(backupID))
+		if err != nil {
+			return nil, nil, fmt.Errorf("archive %q: %w", archivePath, err)
+		}
+
+		if _, exists := locations[replicasetUUID]; exists {
+			return nil, nil, fmt.Errorf("duplicate archive for replicaset %q", replicasetUUID)
+		}
+
+		storageKey := keyPrefix + storage.ArchiveKey(string(backupID), replicasetUUID)
+
+		archives = append(archives, ArchiveToUpload{
+			LocalPath:      archivePath,
+			StorageKey:     storageKey,
+			Size:           info.Size(),
+			ReplicasetUUID: replicasetUUID,
+		})
+		locations[replicasetUUID] = &ArtifactLocation{
+			Path:      storageKey,
+			SizeBytes: info.Size(),
+		}
+	}
+
+	return archives, locations, nil
+}
+
+// StoragePrefix builds a storage key prefix from a cluster name and an
+// optional environment. Returns "" when clusterName is empty, so keys never
+// start with a leading or doubled slash.
+func StoragePrefix(clusterName, environment string) string {
+	if clusterName == "" {
+		return ""
+	}
+
+	return storage.PrefixWithSlash(path.Join(clusterName, environment))
+}
+
+// BuildTopologyFromFragments builds a Topology from the collected fragments.
+// Each fragment represents the master instance that produced the backup.
+func BuildTopologyFromFragments(fragments []*Fragment) Topology {
+	replicasets := make(map[string][]TopologyInstance, len(fragments))
+	for _, fragment := range fragments {
+		replicasets[fragment.ReplicasetUUID] = append(
+			replicasets[fragment.ReplicasetUUID],
+			TopologyInstance{
+				InstanceUUID: fragment.InstanceUUID,
+				InstanceName: fragment.InstanceName,
+				Hostname:     fragment.Hostname,
+			},
+		)
+	}
+	return Topology{Replicasets: replicasets}
+}
+
+// ReadPlan reads and decodes a tt backup plan JSON file.
+func ReadPlan(filePath string) (*BackupPlan, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read plan %q: %w", filePath, err)
+	}
+
+	var plan BackupPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return nil, fmt.Errorf("decode plan %q: %w", filePath, err)
+	}
+
+	return &plan, nil
+}
+
+// ValidateFragmentsAgainstPlan checks that every replicaset expected by the
+// plan has a matching fragment.
+func ValidateFragmentsAgainstPlan(fragments []*Fragment, plan *BackupPlan) error {
+	covered := make(map[string]bool, len(fragments))
+	for _, fragment := range fragments {
+		covered[fragment.ReplicasetUUID] = true
+	}
+
+	var missing []string
+	for replicasetUUID := range plan.Replicasets {
+		if !covered[replicasetUUID] {
+			missing = append(missing, replicasetUUID)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return fmt.Errorf("plan expects %d replicasets but fragments are missing for: %s",
+			len(plan.Replicasets), strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+// SplitPaths splits a comma-separated list of paths and trims whitespace.
+func SplitPaths(commaSeparated string) []string {
+	if commaSeparated == "" {
+		return nil
+	}
+
+	paths := strings.Split(commaSeparated, ",")
+	for i := range paths {
+		paths[i] = strings.TrimSpace(paths[i])
+	}
+
+	return paths
+}
+
+// ReadFragments reads and decodes per-shard instance_backup.json files.
+func ReadFragments(paths []string) ([]*Fragment, error) {
+	fragments := make([]*Fragment, 0, len(paths))
+	for _, filePath := range paths {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("read fragment %q: %w", filePath, err)
+		}
+
+		fragment, err := DecodeFragment(data)
+		if err != nil {
+			return nil, fmt.Errorf("read fragment %q: %w", filePath, err)
+		}
+
+		fragments = append(fragments, fragment)
+	}
+
+	return fragments, nil
+}
+
+// uuidFromArchivePath extracts the replicaset UUID from an archive filename.
+// The expected filename format is <backup-id>-<replicaset_uuid>.tar.zst.
+func uuidFromArchivePath(archivePath, backupID string) (string, error) {
+	baseName := filepath.Base(archivePath)
+
+	name := strings.TrimSuffix(baseName, ".tar.zst")
+	if name == baseName {
+		return "", fmt.Errorf("file does not have .tar.zst extension")
+	}
+
+	prefix := backupID + "-"
+	if !strings.HasPrefix(name, prefix) {
+		return "", fmt.Errorf(
+			"archive filename %q does not start with backup-id %q", baseName, backupID)
+	}
+
+	replicasetUUID := strings.TrimPrefix(name, prefix)
+	if replicasetUUID == "" {
+		return "", fmt.Errorf("empty replicaset UUID in filename %q", baseName)
+	}
+
+	return replicasetUUID, nil
+}
+
+// putFile uploads the local file at filePath to the storage under key.
+func putFile(ctx context.Context, store storage.Storage, key, filePath string, size int64) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", filePath, err)
+	}
+	defer file.Close()
+
+	if err := store.Put(ctx, key, file, size); err != nil {
+		return fmt.Errorf("put %q: %w", key, err)
+	}
+
+	return nil
+}
+
+// deleteObjects best-effort deletes the given keys from storage. Errors are
+// ignored: the primary failure has already been reported, and orphaned
+// archives without a manifest are harmless.
+func deleteObjects(ctx context.Context, store storage.Storage, keys []string) {
+	for _, key := range keys {
+		_ = store.Delete(ctx, key)
+	}
+}

--- a/cli/backup/upload_test.go
+++ b/cli/backup/upload_test.go
@@ -1,0 +1,598 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/tt/cli/backup/storage"
+)
+
+// mockStorage is an in-memory storage.Storage implementation for testing
+// Upload, PrepareArchives and rollback behaviour.
+type mockStorage struct {
+	objects   map[string][]byte
+	putErr    func(key string) error // if non-nil, called on Put to decide failure
+	deleted   []string               // tracks keys passed to Delete (for rollback assertions)
+	deleteErr func(key string) error
+}
+
+func newMockStorage() *mockStorage {
+	return &mockStorage{objects: make(map[string][]byte)}
+}
+
+func (s *mockStorage) List(context.Context, string) ([]storage.ObjectInfo, error) {
+	return nil, nil
+}
+
+func (s *mockStorage) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	data, ok := s.objects[key]
+	if !ok {
+		return nil, storage.ErrKeyNotFound
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *mockStorage) Put(_ context.Context, key string, r io.Reader, size int64) error {
+	if s.putErr != nil {
+		if err := s.putErr(key); err != nil {
+			return fmt.Errorf("put %q: %w", key, err)
+		}
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if int64(len(data)) != size {
+		return fmt.Errorf("size mismatch: got %d, want %d", len(data), size)
+	}
+	s.objects[key] = data
+	return nil
+}
+
+func (s *mockStorage) Delete(_ context.Context, key string) error {
+	s.deleted = append(s.deleted, key)
+	if s.deleteErr != nil {
+		return fmt.Errorf("delete %q: %w", key, s.deleteErr(key))
+	}
+	delete(s.objects, key)
+	return nil
+}
+
+func (s *mockStorage) has(key string) bool {
+	_, ok := s.objects[key]
+	return ok
+}
+
+// writeArchiveFile creates a .tar.zst archive with the given content and
+// returns its path. The filename follows the <backup-id>-<replicaset_uuid>.tar.zst
+// convention so that uuidFromArchivePath can extract the UUID.
+func writeArchiveFile(t *testing.T, dir, backupID, replicasetUUID string, content []byte) string {
+	t.Helper()
+	name := fmt.Sprintf("%s-%s.tar.zst", backupID, replicasetUUID)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	return path
+}
+
+// writeFragmentFile writes a valid fragment JSON to a temporary file.
+func writeFragmentFile(t *testing.T, dir, name string, fragment Fragment) string {
+	t.Helper()
+	data, err := json.Marshal(fragment)
+	require.NoError(t, err)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}
+
+// testFragment returns a minimal valid Fragment for the given replicaset.
+func testFragment(replicasetUUID string) Fragment {
+	return Fragment{
+		ReplicasetUUID: replicasetUUID,
+		InstanceUUID:   "inst-" + replicasetUUID,
+		InstanceName:   "master-001",
+		Hostname:       "host-" + replicasetUUID,
+		Type:           BackupTypeFull,
+		VclockEnd:      Vclock{1: 100},
+		Files:          []string{"00000000000000000100.xlog"},
+		ChecksumSHA256: "abc123",
+	}
+}
+
+func TestUpload(t *testing.T) {
+	ctx := context.Background()
+	backupID := BackupID("bid")
+	manifestData := []byte(`{"backup_id":"bid"}`)
+	manifestKey := storage.ManifestKey(string(backupID))
+
+	dir := t.TempDir()
+	archiveA := writeArchiveFile(t, dir, string(backupID), testRSA, []byte("archive-a"))
+	archiveB := writeArchiveFile(t, dir, string(backupID), testRSB, []byte("archive-b"))
+	keyA := "data/bid-" + testRSA + ".tar.zst"
+	keyB := "data/bid-" + testRSB + ".tar.zst"
+
+	twoArchives := []ArchiveToUpload{
+		{LocalPath: archiveA, StorageKey: keyA, Size: 9, ReplicasetUUID: testRSA},
+		{LocalPath: archiveB, StorageKey: keyB, Size: 9, ReplicasetUUID: testRSB},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		store := newMockStorage()
+		err := Upload(ctx, store, "", backupID, manifestData, twoArchives)
+		require.NoError(t, err)
+
+		assert.True(t, store.has(keyA))
+		assert.True(t, store.has(keyB))
+		assert.True(t, store.has(manifestKey))
+		assert.Equal(t, manifestData, store.objects[manifestKey])
+		assert.Empty(t, store.deleted)
+	})
+
+	t.Run("manifest only, no archives", func(t *testing.T) {
+		store := newMockStorage()
+		err := Upload(ctx, store, "", backupID, manifestData, nil)
+		require.NoError(t, err)
+
+		assert.True(t, store.has(manifestKey))
+		assert.Empty(t, store.deleted)
+	})
+
+	t.Run("rollback on manifest failure", func(t *testing.T) {
+		store := newMockStorage()
+		store.putErr = func(key string) error {
+			if key == manifestKey {
+				return fmt.Errorf("manifest storage error")
+			}
+			return nil
+		}
+
+		err := Upload(ctx, store, "", backupID, manifestData, twoArchives)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "upload manifest")
+
+		// Both archives were rolled back.
+		assert.Contains(t, store.deleted, keyA)
+		assert.Contains(t, store.deleted, keyB)
+		assert.False(t, store.has(keyA))
+		assert.False(t, store.has(keyB))
+		assert.False(t, store.has(manifestKey))
+	})
+
+	t.Run("rollback on second archive failure", func(t *testing.T) {
+		store := newMockStorage()
+		store.putErr = func(key string) error {
+			if key == keyB {
+				return fmt.Errorf("storage unavailable")
+			}
+			return nil
+		}
+
+		err := Upload(ctx, store, "", backupID, manifestData, twoArchives)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "upload archive for replicaset")
+		assert.Contains(t, err.Error(), testRSB)
+
+		// First archive was uploaded, then rolled back.
+		assert.Contains(t, store.deleted, keyA)
+		assert.False(t, store.has(keyA))
+		assert.False(t, store.has(keyB))
+		assert.False(t, store.has(manifestKey))
+	})
+
+	t.Run("first archive fails, nothing to rollback", func(t *testing.T) {
+		store := newMockStorage()
+		store.putErr = func(key string) error {
+			if key == keyA {
+				return fmt.Errorf("first archive fails")
+			}
+			return nil
+		}
+
+		err := Upload(ctx, store, "", backupID, manifestData, []ArchiveToUpload{
+			{LocalPath: archiveA, StorageKey: keyA, Size: 9, ReplicasetUUID: testRSA},
+		})
+		require.Error(t, err)
+
+		assert.Empty(t, store.deleted)
+		assert.False(t, store.has(keyA))
+	})
+}
+
+func TestPrepareArchives(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		dir := t.TempDir()
+		backupID := BackupID("20260326T120000Z")
+		keyPrefix := "cluster/prod/"
+
+		path1 := writeArchiveFile(t, dir, string(backupID), testRSA, []byte("content-a"))
+		path2 := writeArchiveFile(t, dir, string(backupID), testRSB, []byte("content-bb"))
+
+		archives, locations, err := PrepareArchives([]string{path1, path2}, keyPrefix, backupID)
+		require.NoError(t, err)
+
+		require.Len(t, archives, 2)
+		require.Len(t, locations, 2)
+
+		wantKeyA := "cluster/prod/data/20260326T120000Z-" + testRSA + ".tar.zst"
+		wantKeyB := "cluster/prod/data/20260326T120000Z-" + testRSB + ".tar.zst"
+
+		assert.Equal(t, path1, archives[0].LocalPath)
+		assert.Equal(t, testRSA, archives[0].ReplicasetUUID)
+		assert.Equal(t, int64(9), archives[0].Size)
+		assert.Equal(t, wantKeyA, archives[0].StorageKey)
+
+		assert.Equal(t, path2, archives[1].LocalPath)
+		assert.Equal(t, testRSB, archives[1].ReplicasetUUID)
+		assert.Equal(t, int64(10), archives[1].Size)
+		assert.Equal(t, wantKeyB, archives[1].StorageKey)
+
+		locA := locations[testRSA]
+		require.NotNil(t, locA)
+		assert.Equal(t, wantKeyA, locA.Path)
+		assert.Equal(t, int64(9), locA.SizeBytes)
+
+		locB := locations[testRSB]
+		require.NotNil(t, locB)
+		assert.Equal(t, wantKeyB, locB.Path)
+		assert.Equal(t, int64(10), locB.SizeBytes)
+	})
+
+	t.Run("empty paths", func(t *testing.T) {
+		archives, locations, err := PrepareArchives(nil, "prefix/", "bid")
+		require.NoError(t, err)
+		assert.Empty(t, archives)
+		assert.Empty(t, locations)
+	})
+
+	t.Run("duplicate replicaset", func(t *testing.T) {
+		dir1 := t.TempDir()
+		dir2 := t.TempDir()
+		backupID := BackupID("bid")
+		path1 := writeArchiveFile(t, dir1, string(backupID), testRSA, []byte("a"))
+		path2 := writeArchiveFile(t, dir2, string(backupID), testRSA, []byte("b"))
+
+		_, _, err := PrepareArchives([]string{path1, path2}, "", backupID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate archive for replicaset")
+	})
+
+	// Error cases that need a file on disk.
+	errorCases := []struct {
+		name     string
+		filename string
+		backupID string
+		wantErr  string
+	}{
+		{"wrong extension", "bid-uuid.zip", "bid", ".tar.zst extension"},
+		{"wrong backup-id prefix", "other-id-uuid.tar.zst", "bid", "does not start with backup-id"},
+		{"empty uuid", "bid-.tar.zst", "bid", "empty replicaset UUID"},
+	}
+
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.filename)
+			require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+
+			_, _, err := PrepareArchives([]string{path}, "", BackupID(tc.backupID))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	t.Run("non-existent file", func(t *testing.T) {
+		_, _, err := PrepareArchives([]string{"/nonexistent/path.tar.zst"}, "", "bid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stat archive")
+	})
+}
+
+func TestStoragePrefix(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		environment string
+		want        string
+	}{
+		{"both set", "cluster", "prod", "cluster/prod/"},
+		{"only cluster", "cluster", "", "cluster/"},
+		{"only env", "", "prod", ""},
+		{"both empty", "", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, StoragePrefix(tc.clusterName, tc.environment))
+		})
+	}
+}
+
+func TestBuildTopologyFromFragments(t *testing.T) {
+	cases := []struct {
+		name      string
+		fragments []*Fragment
+		want      map[string][]TopologyInstance
+	}{
+		{
+			"multiple replicasets",
+			[]*Fragment{
+				{
+					ReplicasetUUID: testRSA,
+					InstanceUUID:   "inst-a",
+					InstanceName:   "a-001",
+					Hostname:       "host-a",
+				},
+				{
+					ReplicasetUUID: testRSB,
+					InstanceUUID:   "inst-b",
+					InstanceName:   "b-001",
+					Hostname:       "host-b",
+				},
+			},
+			map[string][]TopologyInstance{
+				testRSA: {{InstanceUUID: "inst-a", InstanceName: "a-001", Hostname: "host-a"}},
+				testRSB: {{InstanceUUID: "inst-b", InstanceName: "b-001", Hostname: "host-b"}},
+			},
+		},
+		{
+			"empty",
+			nil,
+			map[string][]TopologyInstance{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			topology := BuildTopologyFromFragments(tc.fragments)
+			assert.Equal(t, tc.want, topology.Replicasets)
+		})
+	}
+}
+
+func TestReadPlan(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+		want    *BackupPlan
+	}{
+		{
+			"valid plan",
+			`{"mode":"full","replicasets":{"rs-a":{"master_instance_uuid":"inst-a"}}}`,
+			"",
+			&BackupPlan{
+				Type:        BackupTypeFull,
+				Replicasets: map[string]ReplicasetPlan{"rs-a": {MasterInstanceUUID: "inst-a"}},
+			},
+		},
+		{
+			"invalid JSON",
+			`{invalid`,
+			"decode plan",
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "plan.json")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o644))
+
+			plan, err := ReadPlan(path)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want.Type, plan.Type)
+			assert.Equal(t, tc.want.Replicasets, plan.Replicasets)
+		})
+	}
+
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := ReadPlan("/nonexistent/plan.json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read plan")
+	})
+}
+
+func TestValidateFragmentsAgainstPlan(t *testing.T) {
+	cases := []struct {
+		name      string
+		fragments []*Fragment
+		plan      *BackupPlan
+		wantErr   string
+	}{
+		{
+			"all covered",
+			[]*Fragment{{ReplicasetUUID: testRSA}, {ReplicasetUUID: testRSB}},
+			&BackupPlan{Replicasets: map[string]ReplicasetPlan{testRSA: {}, testRSB: {}}},
+			"",
+		},
+		{
+			"missing fragments",
+			[]*Fragment{{ReplicasetUUID: testRSA}},
+			&BackupPlan{Replicasets: map[string]ReplicasetPlan{
+				testRSA: {}, testRSB: {}, testRSC: {},
+			}},
+			"missing for",
+		},
+		{
+			"extra fragments are ok",
+			[]*Fragment{{ReplicasetUUID: testRSA}, {ReplicasetUUID: testRSB}},
+			&BackupPlan{Replicasets: map[string]ReplicasetPlan{testRSA: {}}},
+			"",
+		},
+		{
+			"empty plan",
+			[]*Fragment{{ReplicasetUUID: testRSA}},
+			&BackupPlan{Replicasets: map[string]ReplicasetPlan{}},
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFragmentsAgainstPlan(tc.fragments, tc.plan)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateFragmentsAgainstPlanMissingSorted(t *testing.T) {
+	// Missing UUIDs must appear sorted in the error message.
+	fragments := []*Fragment{{ReplicasetUUID: testRSA}}
+	plan := &BackupPlan{Replicasets: map[string]ReplicasetPlan{
+		testRSA: {}, testRSB: {}, testRSC: {},
+	}}
+
+	err := ValidateFragmentsAgainstPlan(fragments, plan)
+	require.Error(t, err)
+	assert.Less(t, strings.Index(err.Error(), testRSB), strings.Index(err.Error(), testRSC))
+}
+
+func TestSplitPaths(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"single", "/tmp/a.json", []string{"/tmp/a.json"}},
+		{"multiple", "/tmp/a.json,/tmp/b.json", []string{"/tmp/a.json", "/tmp/b.json"}},
+		{"with whitespace", " /tmp/a.json , /tmp/b.json ", []string{"/tmp/a.json", "/tmp/b.json"}},
+		{"single with spaces", "  /tmp/a.json  ", []string{"/tmp/a.json"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, SplitPaths(tc.input))
+		})
+	}
+}
+
+func TestReadFragments(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		dir := t.TempDir()
+		pathA := writeFragmentFile(t, dir, "a.json", testFragment(testRSA))
+		pathB := writeFragmentFile(t, dir, "b.json", testFragment(testRSB))
+
+		fragments, err := ReadFragments([]string{pathA, pathB})
+		require.NoError(t, err)
+		require.Len(t, fragments, 2)
+		assert.Equal(t, testRSA, fragments[0].ReplicasetUUID)
+		assert.Equal(t, testRSB, fragments[1].ReplicasetUUID)
+		assert.Equal(t, BackupTypeFull, fragments[0].Type)
+	})
+
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"invalid JSON", "{invalid", "read fragment"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bad.json")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o644))
+
+			_, err := ReadFragments([]string{path})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		fragments, err := ReadFragments(nil)
+		require.NoError(t, err)
+		assert.Empty(t, fragments)
+	})
+
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := ReadFragments([]string{"/nonexistent/fragment.json"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read fragment")
+	})
+}
+
+func TestUUIDFromArchivePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		backupID string
+		wantUUID string
+		wantErr  string
+	}{
+		{
+			"valid",
+			"/tmp/bid-11111111-1111-1111-1111-111111111111.tar.zst",
+			"bid",
+			"11111111-1111-1111-1111-111111111111",
+			"",
+		},
+		{
+			"with nested directory",
+			"/tmp/tt-backup/bid-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.tar.zst",
+			"bid",
+			"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			"",
+		},
+		{
+			"wrong extension",
+			"/tmp/bid-uuid.zip",
+			"bid",
+			"",
+			".tar.zst extension",
+		},
+		{
+			"wrong backup-id prefix",
+			"/tmp/other-id-uuid.tar.zst",
+			"bid",
+			"",
+			"does not start with backup-id",
+		},
+		{
+			"empty uuid after prefix",
+			"/tmp/bid-.tar.zst",
+			"bid",
+			"",
+			"empty replicaset UUID",
+		},
+		{
+			"backup-id only, no separator",
+			"/tmp/bid.tar.zst",
+			"bid",
+			"",
+			"does not start with backup-id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uuid, err := uuidFromArchivePath(tc.path, tc.backupID)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUUID, uuid)
+		})
+	}
+}

--- a/cli/backup/validation_test.go
+++ b/cli/backup/validation_test.go
@@ -259,7 +259,6 @@ func TestClusterManifestIsValidAndSerializable(t *testing.T) {
 	for _, want := range []string{
 		`"schema_version":1`,
 		`"previous_backup_id":""`,
-		`"creation_duration":2300000000`,
 		`"status":"OK"`,
 		`"550e8400-e29b-41d4-a716-446655440000"`,
 		`"6ba7b810-9dad-11d1-80b4-00c04fd430c8"`,
@@ -276,7 +275,6 @@ func TestClusterManifestIsValidAndSerializable(t *testing.T) {
 		BaseFullBackupID BackupID         `json:"base_full_backup_id"`
 		Status           Status           `json:"status"`
 		CreationTime     time.Time        `json:"creation_time"`
-		CreationDuration time.Duration    `json:"creation_duration"`
 		Shards           map[string]Shard `json:"shards"`
 		Topology         Topology         `json:"topology"`
 		Warnings         []Warning        `json:"warnings"`
@@ -286,7 +284,6 @@ func TestClusterManifestIsValidAndSerializable(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &roundTrip))
 	decoded := ClusterManifest(roundTrip)
 	require.NoError(t, decoded.Validate())
-	require.Equal(t, 2300*time.Millisecond, decoded.CreationDuration)
 }
 
 func testClusterManifest(t *testing.T, status Status) ClusterManifest {

--- a/cli/backup/verify/helpers_test.go
+++ b/cli/backup/verify/helpers_test.go
@@ -155,7 +155,6 @@ func (f *fixture) addBackup(
 		BaseFullBackupID: backup.BackupID(base),
 		Status:           backup.StatusOK,
 		CreationTime:     time.Unix(0, 0).UTC(),
-		CreationDuration: time.Second,
 		Shards:           make(map[string]backup.Shard, 1),
 		Topology: backup.Topology{Replicasets: map[string][]backup.TopologyInstance{
 			replicasetA: {{

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -51,6 +51,15 @@ var (
 	backupPlanCfg     string
 	backupPlanFormat  string
 	backupPlanTimeout time.Duration
+
+	backupUploadArchives    string
+	backupUploadFragments   string
+	backupUploadPlan        string
+	backupUploadBackupID    string
+	backupUploadClusterName string
+	backupUploadEnvironment string
+	backupUploadKeepLocal   bool
+	backupUploadTimeout     time.Duration
 )
 
 const (
@@ -75,25 +84,36 @@ const (
 	defaultGcTimeout = 10 * time.Minute
 )
 
+const backupPlanTargetHelp = `backup mode (required):
+  incremental - build on top of the latest manifest (requires a valid chain)
+  full        - start a new chain, no chain checks
+
+For --target=incremental the command loads the latest manifest, builds the
+backup chain, and verifies that the latest manifest is the chain's latest
+entry with no problems. If any check fails, the command exits with a
+detailed error (no auto-promotion to full).`
+
 // backupStorageURIHelp documents the --backup-storage flag value for every
 // manager-side backup command.
 const backupStorageURIHelp = `The --backup-storage flag accepts a URI describing the
 storage backend:
 
-  file://<abs_path>?Prefix=<subdir>
-      Local filesystem storage. The path must be absolute.
-      Query parameters:
-        Prefix  - subdirectory within the path (optional).
+	Local filesystem storage. The path must be absolute.
+	  Query parameters:
+	    Prefix  - subdirectory within the path (optional).
+	  Examples:
+	    file://<abs_path>?Prefix=<subdir>
 
-  s3+https://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
-  s3+http://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
-      S3-compatible storage. Use s3+https for TLS, s3+http for plain TCP.
+    S3-compatible storage. Use s3+https for TLS, s3+http for plain TCP.
       The first path segment after the host is the bucket name, the rest is
       the optional key prefix.
       Query parameters:
         Region           - AWS region (optional).
         AccessKeyID      - access key ID (required).
-        SecretAccessKey  - secret access key (required).`
+        SecretAccessKey  - secret access key (required).
+      Examples:
+        s3+https://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...
+        s3+http://endpoint:port/bucket/prefix?Region=...&AccessKeyID=...&SecretAccessKey=...`
 
 // NewBackupCmd creates the parent `tt backup` command.
 func NewBackupCmd() *cobra.Command {
@@ -109,6 +129,7 @@ func NewBackupCmd() *cobra.Command {
 		newBackupVerifyCmd(),
 		newBackupGcCmd(),
 		newBackupPlanCmd(),
+		newBackupUploadCmd(),
 	)
 
 	return backupCmd
@@ -155,7 +176,7 @@ archive. Idempotent: if the backup is already closed, it does not fail.`,
 	cmd.Flags().StringVarP(&backupFinalizeCfg, "config", "c", "",
 		"path to the cluster configuration file (for <APP:INSTANCE>)")
 	cmd.Flags().StringVar(&backupFinalizeID, "backup-id", "",
-		"backup identifier; local artifacts of the target replicaset are removed")
+		"backup identifier (required); local artifacts of the target replicaset are removed")
 	cmd.MarkFlagRequired("backup-id")
 
 	return cmd
@@ -165,8 +186,7 @@ func newBackupLastCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "last --backup-storage=<uri> [--format <table|json>]",
 		Short: "Show the last backup manifest from the storage",
-		Long: `Find the latest manifest in the storage and print it to stdout.` +
-			backupStorageURIHelp,
+		Long:  `Find the latest manifest in the storage and print it to stdout.`,
 		Example: `$ tt backup last --backup-storage=file:///var/backups
   $ tt backup last --backup-storage=file:///var/backups?Prefix=mycluster
   $ tt backup last --backup-storage=s3+https://s3.example.com:9000/... \
@@ -177,9 +197,9 @@ func newBackupLastCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
-		"storage URI (file://<path> or s3+http(s)://host:port/bucket/prefix?...")
+		backupStorageURIHelp)
 	cmd.Flags().StringVar(&backupLastFormat, "format", formatTable,
-		"output format: table or json")
+		"output format: `table` or `json`")
 	cmd.Flags().DurationVar(&backupLastTimeout, "timeout", time.Minute,
 		"timeout for connecting to and reading from the storage")
 
@@ -193,20 +213,7 @@ func newBackupPlanCmd() *cobra.Command {
 		Use:   "plan --target=(incremental|full) --backup-storage=<uri> [flags]",
 		Short: "Plan the next backup: mode, master source, from_vclock",
 		Long: `Compute a backup plan from the current cluster topology and the latest
-manifest in the storage.
-
-` + backupStorageURIHelp + `
-
-The --target flag selects the requested backup mode:
-  incremental - build on top of the latest manifest (requires a valid chain)
-  full        - start a new chain, no chain checks
-
-For --target=incremental the command loads the latest manifest, builds the
-backup chain, and verifies that the latest manifest is the chain's latest
-entry with no problems. If any check fails, the command exits with a
-detailed error (no auto-promotion to full).
-
-` + clusterUriHelp,
+		manifest in the storage.`,
 		Example: `$ tt backup plan --target=incremental --backup-storage=file:///var/backups
   $ tt backup plan --target=full --backup-storage=file:///var/backups --format json
   $ tt backup plan --target=incremental --backup-storage=s3+https://... -c cluster.yaml`,
@@ -216,21 +223,189 @@ detailed error (no auto-promotion to full).
 
 	addTarantoolConnectFlags(cmd)
 	cmd.Flags().StringVar(&backupPlanMode, "target", "",
-		"backup mode: incremental | full (required)")
+		backupPlanTargetHelp)
 	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
-		"storage URI (file://<path> or s3+http(s)://host:port/bucket/prefix?...")
+		backupStorageURIHelp)
 	cmd.Flags().StringVarP(&backupPlanCfg, "config", "c", "",
-		"path or URI of the cluster configuration (same as 'tt cluster topology -c')")
+		clusterUriHelp)
 	cmd.Flags().StringVar(&backupPlanFormat, "format", formatJSON,
 		"output format: table or json")
 	cmd.Flags().DurationVar(&backupPlanTimeout, "timeout", time.Minute,
-		"timeout for storage operations")
+		"timeout for storage operations in minutes")
 
 	cmd.MarkFlagRequired("target")
 	cmd.MarkFlagRequired("backup-storage")
 	cmd.MarkFlagRequired("config")
 
 	return cmd
+}
+
+func newBackupUploadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upload [flags]",
+		Short: "Build cluster manifest from per-shard fragments and upload to storage",
+		Long: `Run on the manager host after the orchestrator collected .tar.zst archives
+and instance_backup.json fragments from all cluster nodes.`,
+		Example: `$ tt backup upload \
+    --archives /tmp/bkp/20260326T120000Z-A.tar.zst,/tmp/bkp/20260326T120000Z-B.tar.zst \
+    --fragments /tmp/bkp/A.json,/tmp/bkp/B.json \
+    --plan /tmp/bkp/plan.json \
+    --backup-storage file:///var/backups \
+    --backup-id 20260326T120000Z \
+    --cluster-name payments-cluster \
+    --environment production`,
+		Args: cobra.NoArgs,
+		RunE: runBackupUpload,
+	}
+
+	cmd.Flags().StringVar(&backupUploadArchives, "archives", "",
+		"comma-separated paths to .tar.zst archives (required)")
+	cmd.Flags().StringVar(&backupUploadFragments, "fragments", "",
+		"comma-separated paths to per-shard instance_backup.json fragments")
+	cmd.Flags().StringVar(&backupUploadPlan, "plan", "",
+		"path to tt backup plan JSON (required); provides type, "+
+			"previous_backup_id and expected replicasets")
+	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
+		backupStorageURIHelp)
+	cmd.Flags().StringVar(&backupUploadBackupID, "backup-id", "",
+		"backup identifier, e.g. 20260326T120000Z (required)")
+	cmd.Flags().StringVar(&backupUploadClusterName, "cluster-name", "",
+		"cluster name; used as a storage path component")
+	cmd.Flags().StringVar(&backupUploadEnvironment, "environment", "",
+		"environment tag (production, staging, ...); used as a storage path component")
+	cmd.Flags().BoolVar(&backupUploadKeepLocal, "keep-local", false,
+		"keep local .tar.zst copies on the manager host after successful upload")
+	cmd.Flags().DurationVar(&backupUploadTimeout, "timeout", 30*time.Minute,
+		"timeout for storage operations in minutes")
+
+	cmd.MarkFlagRequired("archives")
+	cmd.MarkFlagRequired("fragments")
+	cmd.MarkFlagRequired("plan")
+	cmd.MarkFlagRequired("backup-storage")
+	cmd.MarkFlagRequired("backup-id")
+
+	return cmd
+}
+
+func runBackupUpload(cmd *cobra.Command, args []string) error {
+	cmdCtx.CommandName = cmd.Name()
+
+	keyPrefix := backup.StoragePrefix(backupUploadClusterName, backupUploadEnvironment)
+	backupID := backup.BackupID(backupUploadBackupID)
+	fragmentPaths := backup.SplitPaths(backupUploadFragments)
+	archivePaths := backup.SplitPaths(backupUploadArchives)
+
+	if len(fragmentPaths) != len(archivePaths) {
+		return fmt.Errorf("fragment and archive paths must have the same length")
+	}
+
+	// Read the plan, fragments, and validate coverage.
+	plan, err := backup.ReadPlan(backupUploadPlan)
+	if err != nil {
+		return fmt.Errorf("failed to read plan: %w", err)
+	}
+
+	fragments, err := backup.ReadFragments(fragmentPaths)
+	if err != nil {
+		return fmt.Errorf("failed to read fragments: %w", err)
+	}
+
+	if err := backup.ValidateFragmentsAgainstPlan(fragments, plan); err != nil {
+		return fmt.Errorf("failed to validate fragments: %w", err)
+	}
+
+	// Prepare archives: stat, extract UUIDs, compute storage keys..
+	archives, locationsByReplicaset, err := backup.PrepareArchives(
+		archivePaths, keyPrefix, backupID)
+	if err != nil {
+		return fmt.Errorf("failed to prepare archives: %w", err)
+	}
+
+	manifestData, err := buildUploadManifest(backupID, plan, fragments, locationsByReplicaset)
+	if err != nil {
+		return fmt.Errorf("failed to build manifest: %w", err)
+	}
+
+	// Open storage.
+	storeCfg, err := backup.ParseStorageURI(backupStorageConfig)
+	if err != nil {
+		return fmt.Errorf("failed to parse storage URI: %w", err)
+	}
+
+	store, err := backup.OpenStorage(storeCfg)
+	if err != nil {
+		return fmt.Errorf("failed to open storage: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), backupUploadTimeout)
+	defer cancel()
+
+	// Upload archives, then the manifest. On manifest failure, uploaded
+	// archives are rolled back (deleted from storage).
+	if err := backup.Upload(ctx, store, keyPrefix, backupID, manifestData, archives); err != nil {
+		return fmt.Errorf("failed to upload: %w", err)
+	}
+
+	log.Infof("backup %q uploaded successfully (%d shards)", backupID, len(fragments))
+
+	// Remove local archives unless --keep-local was requested.
+	if !backupUploadKeepLocal {
+		removeLocalArchives(archivePaths)
+	}
+
+	return nil
+}
+
+// buildUploadManifest aggregates the cluster manifest from the plan and
+// fragments and returns its JSON encoding.
+func buildUploadManifest(
+	backupID backup.BackupID,
+	plan *backup.BackupPlan,
+	fragments []*backup.Fragment,
+	locationsByReplicaset map[string]*backup.ArtifactLocation,
+) ([]byte, error) {
+	baseFullBackupID := plan.BaseFullBackupID
+	if plan.Type == backup.BackupTypeFull {
+		baseFullBackupID = backupID
+	}
+
+	shards := make([]*backup.ShardInput, 0, len(fragments))
+	for _, fragment := range fragments {
+		shards = append(shards, &backup.ShardInput{
+			ReplicasetUUID: fragment.ReplicasetUUID,
+			Fragment:       fragment,
+			Location:       locationsByReplicaset[fragment.ReplicasetUUID],
+		})
+	}
+
+	manifest, err := backup.Aggregate(backup.AggregateInput{
+		BackupID:         backupID,
+		PreviousBackupID: plan.PreviousBackupID,
+		BaseFullBackupID: baseFullBackupID,
+		CreationTime:     time.Now(),
+		Topology:         backup.BuildTopologyFromFragments(fragments),
+		Shards:           shards,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate manifest: %w", err)
+	}
+
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	return manifestData, nil
+}
+
+// removeLocalArchives best-effort removes local archive files, logging a
+// warning for any failure other than the file already being gone.
+func removeLocalArchives(paths []string) {
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			log.Warnf("failed to remove local archive %q: %s", path, err)
+		}
+	}
 }
 
 func runBackupLast(cmd *cobra.Command, args []string) error {
@@ -289,7 +464,6 @@ func printManifestTable(manifest *backup.ClusterManifest) {
 		log.Infof("  Base full backup: %s", manifest.BaseFullBackupID)
 	}
 	log.Infof("  Created:          %s", manifest.CreationTime.Format(time.RFC3339))
-	log.Infof("  Duration:         %s", manifest.CreationDuration)
 	log.Infof("  Shards:           %d", len(manifest.Shards))
 	if len(manifest.Warnings) > 0 {
 		log.Infof("  Warnings:         %d", len(manifest.Warnings))
@@ -302,37 +476,29 @@ func newBackupVerifyCmd() *cobra.Command {
 		Short: "Check backup manifests and archives in the storage",
 		Long: `Health-check the backup storage and report what is wrong with it.
 
-Usage:
-  tt backup verify --backup-storage=<uri> [--format <table|json>]
+	The check reads the whole storage and reports:
+	  - manifests referring to archives that are not stored;
+	  - archives whose bytes do not match checksum_sha256 of the manifest;
+	  - breaks in the previous_backup_id chain (orphans and forks);
+	  - increments whose vclock_begin does not continue the previous backup;
+	  - archives no manifest refers to.
 
-The check reads the whole storage and reports:
+	An archive of a backup newer than every stored manifest is reported too, but
+	as an upload in progress rather than a problem: an upload writes its archives
+	before the manifest that references them, so this is what a backup being taken
+	right now looks like from the outside.
 
-  - manifests referring to archives that are not stored;
-  - archives whose bytes do not match checksum_sha256 of the manifest;
-  - breaks in the previous_backup_id chain (orphans and forks);
-  - increments whose vclock_begin does not continue the previous backup;
-  - archives no manifest refers to.
-
-An archive of a backup newer than every stored manifest is reported too, but
-as an upload in progress rather than a problem: an upload writes its archives
-before the manifest that references them, so this is what a backup being taken
-right now looks like from the outside.
-
-Nothing is ever deleted or repaired: removing backups is 'tt backup gc'.
-Exit codes: 0 - the storage is healthy, 2 - problems were found, 1 - the
-storage could not be checked.
-
-` + backupStorageURIHelp + `
-
-Examples:
-  tt backup verify --backup-storage=file:///var/backups
-  tt backup verify --backup-storage=file:///var/backups --format json`,
+	Nothing is ever deleted or repaired: removing backups is 'tt backup gc'.
+	Exit codes: 0 - the storage is healthy, 2 - problems were found, 1 - the
+	storage could not be checked.`,
+		Example: `$ tt backup verify --backup-storage=file:///var/backups
+  $ tt backup verify --backup-storage=file:///var/backups --format json`,
 		Args: cobra.NoArgs,
 		RunE: runBackupVerify,
 	}
 
 	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
-		"storage URI (file://<path> or s3+http(s)://host:port/bucket/prefix?...")
+		backupStorageURIHelp)
 	cmd.Flags().StringVar(&backupVerifyFormat, "format", formatTable,
 		"output format: table or json")
 	cmd.Flags().DurationVar(&backupVerifyTimeout, "timeout", defaultVerifyTimeout,
@@ -460,37 +626,27 @@ func newBackupGcCmd() *cobra.Command {
 		Use:   "gc",
 		Short: "Delete old backup chains and dangling archives from the storage",
 		Long: `Delete backups the retention rules no longer cover, and clean up archives
-no manifest refers to.
+	no manifest refers to.
 
-Usage:
-  tt backup gc --backup-storage=<uri> [--keep-full N] [--keep-days D] [--dry-run]
+	Retention rules combine: a backup is deleted only when no rule keeps it.
+	Deletion cascades: a full backup goes only together with every increment
+	based on it, and a chain is cut from its newest end, so a kept increment
+	always keeps the backups it is recovered from.
 
-Retention rules combine: a backup is deleted only when no rule keeps it.
-Without --keep-full or --keep-days nothing is deleted at all, since every
-backup would then match "not kept". Deletion cascades: a full backup goes only
-together with every increment based on it, and a chain is cut from its newest
-end, so a kept increment always keeps the backups it is recovered from.
+	Three things are never deleted, whatever the rules say: the chain holding
+	the newest manifest, because an upload may be appending to it; the newest
+	chain that can still be recovered from; and archives newer than the newest
+	stored manifest. This means gc cannot empty a storage; remove the storage
+	root with your storage tooling if that is what you want.
 
-Three things are never deleted, whatever the rules say: the chain holding the
-newest manifest, because an upload may be appending to it; the newest chain
-that can still be recovered from; and archives newer than the newest stored
-manifest. This means gc cannot empty a storage; remove the storage root with
-your storage tooling if that is what you want.
+	Chains with problems (a fork, a tail whose full backup is gone) are left
+	for 'tt backup verify' to report.
 
-Chains with problems (a fork, a tail whose full backup is gone) are left for
-'tt backup verify' to report, except a tail whose every manifest is older than
---orphan-age, which is collected like a dangling archive.
-
-A dangling archive is re-checked with a direct read of its manifest just before
-it is deleted, so a run may keep an archive its plan listed; --dry-run reports
-the plan, and a real run reports what it kept.
-
-` + backupStorageURIHelp + `
-
-Examples:
-  tt backup gc --backup-storage=file:///var/backups --keep-full 3 --dry-run
-  tt backup gc --backup-storage=file:///var/backups --keep-days 30
-  tt backup gc --backup-storage=file:///var/backups --keep-full 2 --keep-days 7`,
+	A dangling archive is re-checked with a direct read of its manifest just
+	before it is deleted, so a run may keep an archive its plan listed.`,
+		Example: `$ tt backup gc --backup-storage=file:///var/backups --keep-full 3 --dry-run
+  $ tt backup gc --backup-storage=file:///var/backups --keep-days 30
+  $ tt backup gc --backup-storage=file:///var/backups --keep-full 2 --keep-days 7`,
 		Args: cobra.NoArgs,
 		RunE: runBackupGc,
 		// A failed run has already printed what it managed to delete; burying that
@@ -499,15 +655,18 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&backupStorageConfig, "backup-storage", "",
-		"storage URI (file://<path> or s3+http(s)://host:port/bucket/prefix?...")
+		backupStorageURIHelp)
 	cmd.Flags().IntVar(&backupGcKeepFull, "keep-full", 0,
-		"keep the last N healthy backup chains")
+		"keep the last N healthy backup chains; "+
+			"without --keep-full or --keep-days nothing is deleted at all")
 	cmd.Flags().IntVar(&backupGcKeepDays, "keep-days", 0,
 		"keep backups created within the last D days")
 	cmd.Flags().DurationVar(&backupGcOrphanAge, "orphan-age", gc.DefaultOrphanAge,
-		"minimum age of a dangling archive before it is deleted; 0 means the default")
+		"minimum age before a dangling archive or a problem chain tail "+
+			"is deleted; 0 means the default")
 	cmd.Flags().BoolVar(&backupGcDryRun, "dry-run", false,
-		"report what would be deleted without deleting anything")
+		"report what would be deleted without deleting anything; "+
+			"a real run reports what it kept vs what the plan listed")
 	cmd.Flags().StringVar(&backupGcFormat, "format", formatTable,
 		"output format: table or json")
 	cmd.Flags().DurationVar(&backupGcTimeout, "timeout", defaultGcTimeout,
@@ -918,7 +1077,7 @@ func formatChainProblems(problems []*chain.Problem) string {
 // printPlanTable prints the backup plan as a human-readable table.
 func printPlanTable(plan *backup.BackupPlan) {
 	log.Info("Backup plan")
-	log.Infof("  Mode:              %s", plan.Mode)
+	log.Infof("  Mode:              %s", plan.Type)
 	if plan.PreviousBackupID != "" {
 		log.Infof("  Previous backup:   %s", plan.PreviousBackupID)
 	}

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -387,17 +387,17 @@ func addOrchestratorFlags(cmd *cobra.Command) {
 // addTarantoolConnectFlags adds flags to configure Tarantool connection.
 func addTarantoolConnectFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&replicasetUser, "username", "u", "",
-		`username for the URI case`)
+		`username for a cluster connection`)
 	cmd.Flags().StringVarP(&replicasetPassword, "password", "p", "",
-		`password for the URI case`)
+		`password for a cluster connection`)
 	cmd.Flags().StringVar(&replicasetSslKeyFile, "sslkeyfile", "",
-		`path to a private SSL key file for the URI case`)
+		`path to a private SSL key file for a cluster connection`)
 	cmd.Flags().StringVar(&replicasetSslCertFile, "sslcertfile", "",
-		`path to an SSL certificate file for the URI case`)
+		`path to an SSL certificate file for a cluster connection`)
 	cmd.Flags().StringVar(&replicasetSslCaFile, "sslcafile", "",
-		`path to a trusted certificate authorities (CA) file for the URI case`)
+		`path to a trusted certificate authorities (CA) file for a cluster connection`)
 	cmd.Flags().StringVar(&replicasetSslCiphers, "sslciphers", "",
-		`colon-separated (:) list of SSL cipher suites for the URI case`)
+		`colon-separated (:) list of SSL cipher suites for a cluster connection`)
 }
 
 // replicasetCtx describes a context for the replicaset command.

--- a/test/integration/backup/backup_helpers.py
+++ b/test/integration/backup/backup_helpers.py
@@ -109,6 +109,38 @@ def backup_gc(
     return tt.exec(*args)
 
 
+def backup_upload(
+    tt,
+    storage_uri,
+    archives,
+    fragments=None,
+    plan=None,
+    backup_id=None,
+    cluster_name=None,
+    environment=None,
+    keep_local=False,
+    timeout=None,
+):
+    args = ["backup", "upload", "--backup-storage", storage_uri]
+    if archives:
+        args.extend(["--archives", archives])
+    if fragments:
+        args.extend(["--fragments", fragments])
+    if plan:
+        args.extend(["--plan", plan])
+    if backup_id:
+        args.extend(["--backup-id", backup_id])
+    if cluster_name:
+        args.extend(["--cluster-name", cluster_name])
+    if environment:
+        args.extend(["--environment", environment])
+    if keep_local:
+        args.append("--keep-local")
+    if timeout:
+        args.extend(["--timeout", timeout])
+    return tt.exec(*args)
+
+
 def backup_plan(tt, target, storage_uri, config=None, fmt=None):
     args = ["backup", "plan", "--target", target, "--backup-storage", storage_uri]
     if config:

--- a/test/integration/backup/storage_helpers.py
+++ b/test/integration/backup/storage_helpers.py
@@ -65,6 +65,10 @@ class FileStorage:
                 found.append(os.path.relpath(path, self.root))
         return sorted(found)
 
+    def read(self, key):
+        with open(os.path.join(self.root, key), "rb") as src:
+            return src.read()
+
 
 class S3Storage:
     """Backup storage in an S3 bucket."""
@@ -95,6 +99,10 @@ class S3Storage:
             obj.object_name.removeprefix(self.prefix)
             for obj in self.garage.client.list_objects(self.garage.bucket, recursive=True)
         )
+
+    def read(self, key):
+        response = self.garage.client.get_object(self.garage.bucket, self.prefix + key)
+        return response.read()
 
 
 def archive_key(backup_id, replicaset=REPLICASET):
@@ -160,7 +168,6 @@ def build_manifest(
         "base_full_backup_id": base,
         "status": "OK",
         "creation_time": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "creation_duration": 1000000000,
         "shards": {
             REPLICASET: {
                 "instance": shard_instance(

--- a/test/integration/backup/test_last.py
+++ b/test/integration/backup/test_last.py
@@ -195,18 +195,3 @@ def test_last_s3_auth_error_does_not_expose_secret(tt, garage):
     rc, out = backup_last(tt, uri, fmt="json")
     assert rc != 0
     assert secret not in out
-
-
-def test_last_parse_error_does_not_expose_password(tt):
-    password = "secret"
-    uri = f"s3+https://host/bucket?AccessKeyID=key&SecretAccessKey={password}%zz"
-
-    rc, out = backup_last(tt, uri, fmt="json")
-    assert rc != 0
-    assert password not in out
-
-
-def test_last_missing_backup_storage_flag(tt):
-    rc, out = tt.exec("backup", "last")
-    assert rc != 0
-    assert "required" in out.lower()

--- a/test/integration/backup/test_upload.py
+++ b/test/integration/backup/test_upload.py
@@ -1,0 +1,626 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from backup_helpers import backup_upload
+from storage_helpers import STORAGE_BACKENDS, FileStorage, S3Storage
+
+TESTDATA_DIR = Path(__file__).parent / "testdata"
+
+REPLICASET = "11111111-1111-1111-1111-111111111111"
+REPLICASET_B = "22222222-2222-2222-2222-222222222222"
+INSTANCE_UUID = "aaaaaaaa-0000-0000-0000-000000000001"
+INSTANCE_UUID_B = "bbbbbbbb-0000-0000-0000-000000000001"
+BACKUP_ID = "20260326T120000Z"
+ARCHIVE_CONTENT = b"archive payload abc"
+ARCHIVE_CONTENT_B = b"archive payload def"
+
+
+def _make_fragment(
+    replicaset=REPLICASET,
+    instance_uuid=INSTANCE_UUID,
+    instance_name="router-001",
+    backup_type="full",
+    vclock_end=100,
+    vclock_begin=None,
+):
+    return {
+        "replicaset_uuid": replicaset,
+        "instance_uuid": instance_uuid,
+        "instance_name": instance_name,
+        "hostname": "localhost",
+        "type": backup_type,
+        "vclock_begin": vclock_begin
+        if vclock_begin is not None
+        else ({"1": 50} if backup_type == "incremental" else None),
+        "vclock_end": {"1": vclock_end},
+        "files": ["00000000000000000100.xlog"],
+        "checksum_sha256": "abc123",
+        "recovery_points": [],
+    }
+
+
+def _make_plan(replicasets=None, mode="full", previous_backup_id=None, base_full_backup_id=None):
+    if replicasets is None:
+        replicasets = {
+            REPLICASET: {
+                "master_instance_uuid": INSTANCE_UUID,
+                "master_instance_name": "router-001",
+            },
+        }
+    plan = {"mode": mode, "replicasets": replicasets}
+    if previous_backup_id:
+        plan["previous_backup_id"] = previous_backup_id
+    if base_full_backup_id:
+        plan["base_full_backup_id"] = base_full_backup_id
+    return plan
+
+
+def _write_json(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def _write_archive(dir_path, backup_id, replicaset, content=ARCHIVE_CONTENT):
+    name = f"{backup_id}-{replicaset}.tar.zst"
+    path = os.path.join(dir_path, name)
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
+
+
+def _prepare_inputs(tmp_path, plan=None, fragment=None, backup_id=BACKUP_ID):
+    """Create archive, fragment and plan files under tmp_path and return their paths."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    plan = plan or _make_plan()
+    fragment = fragment or _make_fragment()
+
+    plan_path = work / "plan.json"
+    _write_json(plan_path, plan)
+
+    fragment_path = work / "fragment.json"
+    _write_json(fragment_path, fragment)
+
+    archive_path = _write_archive(str(work), backup_id, REPLICASET)
+
+    return str(archive_path), str(fragment_path), str(plan_path)
+
+
+def _load_golden(name):
+    return json.loads((TESTDATA_DIR / name).read_text())
+
+
+@pytest.fixture
+def storage(request, tmp_path):
+    backend, prefix = request.param
+    if backend == "file":
+        root = tmp_path / "backups"
+        root.mkdir()
+        yield FileStorage(str(root), prefix)
+        return
+
+    garage = request.getfixturevalue("garage")
+    s3 = S3Storage(garage, prefix)
+    try:
+        yield s3
+    finally:
+        for key in s3.keys():
+            s3.delete(key)
+
+
+UPLOAD_CASES = [
+    pytest.param(
+        {"cluster_name": None, "environment": None},
+        "",
+        id="no-cluster-no-env",
+    ),
+    pytest.param(
+        {"cluster_name": "payments", "environment": None},
+        "payments/",
+        id="cluster-only",
+    ),
+    pytest.param(
+        {"cluster_name": "payments", "environment": "production"},
+        "payments/production/",
+        id="cluster-and-env",
+    ),
+]
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+@pytest.mark.parametrize("flags,expected_prefix", UPLOAD_CASES)
+def test_upload_happy_path(tt, tmp_path, storage, flags, expected_prefix):
+    """Upload a single-shard full backup and verify storage contents."""
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+        cluster_name=flags["cluster_name"],
+        environment=flags["environment"],
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+    assert "uploaded successfully" in out.lower()
+
+    # The archive is in storage under the expected key.
+    expected_archive_key = expected_prefix + f"data/{BACKUP_ID}-{REPLICASET}.tar.zst"
+    assert expected_archive_key in storage.keys()
+    assert storage.read(expected_archive_key) == ARCHIVE_CONTENT
+
+    # The manifest is in storage under the expected key.
+    expected_manifest_key = expected_prefix + f"manifests/{BACKUP_ID}.json"
+    assert expected_manifest_key in storage.keys()
+
+    # The manifest matches the golden file (creation_time is non-deterministic).
+    uploaded_manifest = json.loads(storage.read(expected_manifest_key))
+    golden = _load_golden("upload_manifest_full.golden.json")
+
+    # The artifact path in the manifest must include the prefix.
+    expected_artifact_path = expected_prefix + f"data/{BACKUP_ID}-{REPLICASET}.tar.zst"
+    uploaded_manifest["shards"][REPLICASET]["instance"]["artifact"]["path"] = expected_artifact_path
+    golden["shards"][REPLICASET]["instance"]["artifact"]["path"] = expected_artifact_path
+
+    # creation_time is set to time.Now() by upload — strip it before comparing.
+    uploaded_manifest.pop("creation_time", None)
+    golden.pop("creation_time", None)
+
+    assert uploaded_manifest == golden, (
+        f"manifest mismatch:\n"
+        f"uploaded: {json.dumps(uploaded_manifest, indent=2)}\n"
+        f"golden:   {json.dumps(golden, indent=2)}"
+    )
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_upload_multi_shard(tt, tmp_path, storage):
+    """Upload two shards and verify both archives and the manifest are stored."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    frag_a = _make_fragment(replicaset=REPLICASET)
+    frag_b = _make_fragment(
+        replicaset=REPLICASET_B,
+        instance_uuid=INSTANCE_UUID_B,
+        instance_name="router-002",
+        vclock_end=200,
+    )
+
+    plan = _make_plan(
+        replicasets={
+            REPLICASET: {
+                "master_instance_uuid": INSTANCE_UUID,
+                "master_instance_name": "router-001",
+            },
+            REPLICASET_B: {
+                "master_instance_uuid": INSTANCE_UUID_B,
+                "master_instance_name": "router-002",
+            },
+        },
+    )
+
+    plan_path = work / "plan.json"
+    _write_json(plan_path, plan)
+
+    frag_a_path = work / "fragment_a.json"
+    frag_b_path = work / "fragment_b.json"
+    _write_json(frag_a_path, frag_a)
+    _write_json(frag_b_path, frag_b)
+
+    archive_a = _write_archive(str(work), BACKUP_ID, REPLICASET, ARCHIVE_CONTENT)
+    archive_b = _write_archive(str(work), BACKUP_ID, REPLICASET_B, ARCHIVE_CONTENT_B)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=f"{archive_a},{archive_b}",
+        fragments=f"{frag_a_path},{frag_b_path}",
+        plan=str(plan_path),
+        backup_id=BACKUP_ID,
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+    assert "2 shards" in out
+
+    keys = storage.keys()
+    assert f"data/{BACKUP_ID}-{REPLICASET}.tar.zst" in keys
+    assert f"data/{BACKUP_ID}-{REPLICASET_B}.tar.zst" in keys
+    assert f"manifests/{BACKUP_ID}.json" in keys
+
+    # Verify archive contents were uploaded correctly.
+    assert storage.read(f"data/{BACKUP_ID}-{REPLICASET}.tar.zst") == ARCHIVE_CONTENT
+    assert storage.read(f"data/{BACKUP_ID}-{REPLICASET_B}.tar.zst") == ARCHIVE_CONTENT_B
+
+    # Verify the manifest references both shards.
+    manifest = json.loads(storage.read(f"manifests/{BACKUP_ID}.json"))
+    assert REPLICASET in manifest["shards"]
+    assert REPLICASET_B in manifest["shards"]
+    assert manifest["shards"][REPLICASET]["instance"]["artifact"]["size_bytes"] == len(
+        ARCHIVE_CONTENT,
+    )
+    assert manifest["shards"][REPLICASET_B]["instance"]["artifact"]["size_bytes"] == len(
+        ARCHIVE_CONTENT_B,
+    )
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_upload_incremental(tt, tmp_path, storage):
+    """Upload an incremental backup with previous_backup_id and base_full_backup_id."""
+    previous_id = "20260325T120000Z"
+    base_id = "20260325T120000Z"
+
+    plan = _make_plan(
+        mode="incremental",
+        previous_backup_id=previous_id,
+        base_full_backup_id=base_id,
+    )
+    fragment = _make_fragment(backup_type="incremental", vclock_end=200, vclock_begin={"1": 100})
+
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path, plan=plan, fragment=fragment)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+
+    manifest = json.loads(storage.read(f"manifests/{BACKUP_ID}.json"))
+    assert manifest["previous_backup_id"] == previous_id
+    assert manifest["base_full_backup_id"] == base_id
+    assert manifest["shards"][REPLICASET]["instance"]["artifact"]["type"] == "incremental"
+    assert manifest["shards"][REPLICASET]["instance"]["vclock_begin"] == {"1": 100}
+    assert manifest["shards"][REPLICASET]["instance"]["vclock_end"] == {"1": 200}
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_upload_keep_local(tt, tmp_path, storage):
+    """--keep-local preserves the local archive after upload."""
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+        keep_local=True,
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+
+    assert os.path.isfile(archive_path), "local archive was removed despite --keep-local"
+    assert f"data/{BACKUP_ID}-{REPLICASET}.tar.zst" in storage.keys()
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_upload_removes_local_by_default(tt, tmp_path, storage):
+    """Without --keep-local, local archives are removed after successful upload."""
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+
+    assert not os.path.exists(archive_path), "local archive was not removed"
+    assert f"data/{BACKUP_ID}-{REPLICASET}.tar.zst" in storage.keys()
+
+
+@pytest.mark.parametrize("storage", STORAGE_BACKENDS, indirect=True)
+def test_upload_with_cluster_name_prefixes_keys(tt, tmp_path, storage):
+    """--cluster-name prefixes archive and manifest keys in storage."""
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = backup_upload(
+        tt,
+        storage.uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+        cluster_name="my-cluster",
+    )
+    assert rc == 0, f"tt backup upload failed:\n{out}"
+
+    keys = storage.keys()
+    assert any(k.startswith("my-cluster/data/") for k in keys)
+    assert any(k.startswith("my-cluster/manifests/") for k in keys)
+
+
+def test_upload_missing_backup_id(tt, tmp_path):
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = tt.exec(
+        "backup",
+        "upload",
+        "--archives",
+        archive_path,
+        "--fragments",
+        fragment_path,
+        "--plan",
+        plan_path,
+        "--backup-storage",
+        storage_uri,
+    )
+    assert rc != 0
+    assert "required" in out.lower()
+
+
+def test_upload_missing_archives(tt, tmp_path):
+    _, fragment_path, plan_path = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = tt.exec(
+        "backup",
+        "upload",
+        "--fragments",
+        fragment_path,
+        "--plan",
+        plan_path,
+        "--backup-storage",
+        storage_uri,
+        "--backup-id",
+        BACKUP_ID,
+    )
+    assert rc != 0
+    assert "required" in out.lower()
+
+
+def test_upload_missing_plan(tt, tmp_path):
+    archive_path, fragment_path, _ = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = tt.exec(
+        "backup",
+        "upload",
+        "--archives",
+        archive_path,
+        "--fragments",
+        fragment_path,
+        "--backup-storage",
+        storage_uri,
+        "--backup-id",
+        BACKUP_ID,
+    )
+    assert rc != 0
+    assert "required" in out.lower()
+
+
+def test_upload_missing_backup_storage(tt, tmp_path):
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = tt.exec(
+        "backup",
+        "upload",
+        "--archives",
+        archive_path,
+        "--fragments",
+        fragment_path,
+        "--plan",
+        plan_path,
+        "--backup-id",
+        BACKUP_ID,
+    )
+    assert rc != 0
+    assert "required" in out.lower()
+
+
+def test_upload_nonexistent_archive(tt, tmp_path):
+    _, fragment_path, plan_path = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives="/nonexistent/archive.tar.zst",
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "stat archive" in out.lower()
+
+
+def test_upload_nonexistent_plan(tt, tmp_path):
+    archive_path, fragment_path, _ = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan="/nonexistent/plan.json",
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "read plan" in out.lower()
+
+
+def test_upload_nonexistent_fragment(tt, tmp_path):
+    archive_path, _, plan_path = _prepare_inputs(tmp_path)
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=archive_path,
+        fragments="/nonexistent/fragment.json",
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "read fragment" in out.lower()
+
+
+def test_upload_invalid_plan_json(tt, tmp_path):
+    archive_path, fragment_path, _ = _prepare_inputs(tmp_path)
+    work = tmp_path / "work"
+    bad_plan = work / "bad_plan.json"
+    bad_plan.write_text("{invalid json")
+
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=str(bad_plan),
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "decode plan" in out.lower()
+
+
+def test_upload_invalid_fragment_json(tt, tmp_path):
+    archive_path, _, plan_path = _prepare_inputs(tmp_path)
+    work = tmp_path / "work"
+    bad_fragment = work / "bad_fragment.json"
+    bad_fragment.write_text("{invalid json")
+
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=archive_path,
+        fragments=str(bad_fragment),
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "read fragment" in out.lower()
+
+
+def test_upload_archive_wrong_backup_id_prefix(tt, tmp_path):
+    """Archive filename that doesn't start with the backup-id is rejected."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    # Write an archive with a different backup-id in the filename.
+    wrong_path = _write_archive(str(work), "wrong-id", REPLICASET)
+
+    plan = _make_plan()
+    plan_path = work / "plan.json"
+    _write_json(plan_path, plan)
+
+    fragment = _make_fragment()
+    fragment_path = work / "fragment.json"
+    _write_json(fragment_path, fragment)
+
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=wrong_path,
+        fragments=str(fragment_path),
+        plan=str(plan_path),
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "does not start with backup-id" in out.lower()
+
+
+def test_upload_archive_wrong_extension(tt, tmp_path):
+    """Archive without .tar.zst extension is rejected."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    bad_archive = os.path.join(str(work), f"{BACKUP_ID}-{REPLICASET}.zip")
+    with open(bad_archive, "wb") as f:
+        f.write(ARCHIVE_CONTENT)
+
+    plan = _make_plan()
+    plan_path = work / "plan.json"
+    _write_json(plan_path, plan)
+
+    fragment = _make_fragment()
+    fragment_path = work / "fragment.json"
+    _write_json(fragment_path, fragment)
+
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=bad_archive,
+        fragments=str(fragment_path),
+        plan=str(plan_path),
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert ".tar.zst" in out.lower()
+
+
+def test_upload_fragment_missing_replicaset(tt, tmp_path):
+    """Plan expects a replicaset that has no fragment."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    # Plan expects two replicasets, but only one fragment is provided.
+    plan = _make_plan(
+        replicasets={
+            REPLICASET: {
+                "master_instance_uuid": INSTANCE_UUID,
+                "master_instance_name": "router-001",
+            },
+            REPLICASET_B: {
+                "master_instance_uuid": INSTANCE_UUID_B,
+                "master_instance_name": "router-002",
+            },
+        },
+    )
+    plan_path = work / "plan.json"
+    _write_json(plan_path, plan)
+
+    fragment = _make_fragment(replicaset=REPLICASET)
+    fragment_path = work / "fragment.json"
+    _write_json(fragment_path, fragment)
+
+    archive_path = _write_archive(str(work), BACKUP_ID, REPLICASET)
+
+    storage_uri = f"file://{tmp_path / 'backups'}"
+
+    rc, out = backup_upload(
+        tt,
+        storage_uri,
+        archives=archive_path,
+        fragments=str(fragment_path),
+        plan=str(plan_path),
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "missing" in out.lower()
+    assert REPLICASET_B in out
+
+
+def test_upload_invalid_storage_uri(tt, tmp_path):
+    archive_path, fragment_path, plan_path = _prepare_inputs(tmp_path)
+
+    rc, out = backup_upload(
+        tt,
+        "not-a-uri",
+        archives=archive_path,
+        fragments=fragment_path,
+        plan=plan_path,
+        backup_id=BACKUP_ID,
+    )
+    assert rc != 0
+    assert "storage" in out.lower()

--- a/test/integration/backup/testdata/manifest_incremental.json
+++ b/test/integration/backup/testdata/manifest_incremental.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-02T00:00:00Z",
-  "creation_duration": 500000000,
   "shards": {
     "11111111-1111-1111-1111-111111111111": {
       "instance": {

--- a/test/integration/backup/testdata/plan_manifest_full.json
+++ b/test/integration/backup/testdata/plan_manifest_full.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-01T00:00:00Z",
-  "creation_duration": 1000000000,
   "shards": {
     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": {
       "instance": {

--- a/test/integration/backup/testdata/plan_manifest_incremental.json
+++ b/test/integration/backup/testdata/plan_manifest_incremental.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-02T00:00:00Z",
-  "creation_duration": 500000000,
   "shards": {
     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": {
       "instance": {

--- a/test/integration/backup/testdata/plan_manifest_orphan.json
+++ b/test/integration/backup/testdata/plan_manifest_orphan.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-03T00:00:00Z",
-  "creation_duration": 500000000,
   "shards": {
     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": {
       "instance": {

--- a/test/integration/backup/testdata/plan_manifest_wrong_master.json
+++ b/test/integration/backup/testdata/plan_manifest_wrong_master.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-01T00:00:00Z",
-  "creation_duration": 1000000000,
   "shards": {
     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": {
       "instance": {

--- a/test/integration/backup/testdata/plan_manifest_wrong_topology.json
+++ b/test/integration/backup/testdata/plan_manifest_wrong_topology.json
@@ -5,7 +5,6 @@
   "base_full_backup_id": "2026-01-01-full",
   "status": "OK",
   "creation_time": "2026-01-01T00:00:00Z",
-  "creation_duration": 1000000000,
   "shards": {
     "cccccccc-cccc-cccc-cccc-cccccccccccc": {
       "instance": {

--- a/test/integration/backup/testdata/upload_manifest_full.golden.json
+++ b/test/integration/backup/testdata/upload_manifest_full.golden.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "backup_id": "2026-01-01-full",
+  "backup_id": "20260326T120000Z",
   "previous_backup_id": "",
-  "base_full_backup_id": "2026-01-01-full",
+  "base_full_backup_id": "20260326T120000Z",
   "status": "OK",
-  "creation_time": "2026-01-01T00:00:00Z",
+  "creation_time": "0001-01-01T00:00:00Z",
   "shards": {
     "11111111-1111-1111-1111-111111111111": {
       "instance": {
@@ -12,22 +12,18 @@
         "instance_name": "router-001",
         "hostname": "localhost",
         "vclock_begin": null,
-        "vclock_end": {"1": 100},
+        "vclock_end": {
+          "1": 100
+        },
         "artifact": {
-          "path": "data/2026-01-01-full-11111111-1111-1111-1111-111111111111.tar.zst",
-          "size_bytes": 1024,
-          "checksum_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "path": "data/20260326T120000Z-11111111-1111-1111-1111-111111111111.tar.zst",
+          "size_bytes": 19,
+          "checksum_sha256": "abc123",
           "compression": "zstd",
           "files": [
-            "00000000000000000099.snap",
-            "00000000000000000000.vylog",
-            "00000000000000000001.index",
-            "00000000000000000001.run",
-            "00000000000000000099.xlog"
+            "00000000000000000100.xlog"
           ],
-          "recovery_points": [
-            {"label": "rp-1", "replica_id": 1, "lsn": 99, "timestamp": 1735689600.0}
-          ],
+          "recovery_points": [],
           "type": "full"
         }
       }


### PR DESCRIPTION
Add `tt backup upload` - a manager-host command that assembles a cluster manifest from per-shard instance_backup.json fragments and .tar.zst archives collected by the orchestrator, then uploads them to file or S3 storage.

Flags: --archives, --fragments, --plan, --backup-storage, --backup-id (required); --cluster-name, --environment (storage key prefix); --keep-local (retain local archives); --timeout.

Also:
- rename BackupPlan.Mode to Type (JSON tag "mode" unchanged) and add BaseFullBackupID to the plan;
- drop the unused CreationDuration field from ClusterManifest and AggregateInput.

Closes TNTP-8668
