### PR TITLE
cli/cmd: tt package add, remove, update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,46 @@ jobs:
       - name: Static code check
         uses: ./.github/actions/static-code-check
 
+  # The strict `default: all` ruleset (.golangci.yml), over the packages its
+  # path-except rule names as adopted. Unlike static-code-check this job carries
+  # no label condition: it runs on every push and pull request, which is the
+  # point. The same ruleset was already wired as a pre-commit hook, but only
+  # inside the label-gated job above, so in practice it never ran - `pack` and
+  # `inventory` were added to its scope and accumulated 254 findings between
+  # them without anything going red.
+  strict-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # golangci-lint type-checks the whole module, and cli/aeon/protos is a
+          # submodule.
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+
+      - name: Setup Mage
+        run: |
+          git clone https://github.com/magefile/mage
+          cd mage
+          go run bootstrap.go
+        shell: bash
+
+      # Pinned, and pinned to the same version the golangci-lint-strict
+      # pre-commit hook installs: linter releases add checks, so an unpinned
+      # install turns an unrelated push red. Measured on 2026-08-31 - 2.12.2
+      # reports six findings on this tree that 2.11.4 does not.
+      - name: Setup golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+        shell: bash
+
+      - name: Strict lint
+        run: mage lint:strict
+        shell: bash
+
   tests-ce:
     if: |
       (github.event_name == 'push') ||

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,22 @@
 version: "2"
 
 # NOTE: this config is intentionally scoped to the freshly written code only.
-# The `cli/manifest` exclusion below limits all linters to that package so the
-# strict ruleset can be adopted incrementally instead of flooding the whole tt
-# tree with findings. Drop the `path-except` rule to lint everything.
+# The `path-except` exclusion below names the packages that are actually clean
+# under it, so the strict ruleset can be adopted incrementally instead of
+# flooding the whole tt tree with findings. Widening the scope means adding a
+# package to that rule - and cleaning it first, because the rule is a gate:
+# `mage lint:strict` runs this config in CI on every push, with no diff filter.
+#
+# The list is deliberately per-package rather than the whole `cli/manifest/`
+# subtree. The subtree form claimed packages that had never been cleaned:
+# measured on 2026-08-31, `pack` carried 171 findings, `inventory` 83, `build`
+# 55 and `build/backend` 50, and nothing complained because the only job that
+# ran this config was gated behind a `full-commit-check` PR label. Those four
+# are the outstanding work; every other package under cli/manifest is at zero.
 #
 # The project-wide lint still runs from `golangci-lint.yml` (see magefile.go);
-# this `.golangci.yml` is what a bare `golangci-lint run` picks up.
+# that one is a v1-format config and needs a v1 linter, which is why
+# `mage lint:golang` and `mage lint:strict` are separate targets.
 
 run:
   timeout: 3m
@@ -41,9 +51,12 @@ linters:
   exclusions:
     generated: lax
     rules:
-      # Scope linting to the freshly written code only. An issue is excluded
-      # when its path is NOT under cli/manifest/.
-      - path-except: (^|/)cli/manifest/
+      # Scope linting to the packages adopted into the strict ruleset. An issue
+      # is excluded when its path is NOT one of them: either a file directly in
+      # cli/manifest/, or anything under one of the named sub-packages. Add a
+      # sub-package here once it lints clean; build, build/backend, inventory
+      # and pack are the ones still outstanding.
+      - path-except: (^|/)cli/manifest/((deps|install|resolve|rocks|state|version)/|[^/]+\.go$)
         text: ".*"
       - path: _test.go
         linters:
@@ -153,7 +166,6 @@ linters:
             # such entries cost 14 spurious findings across inventory, install,
             # state and version tests before this was understood.
             - "github.com/tarantool/tt/cli/manifest"
-            - "github.com/tarantool/tt/cli/manifest/resolve"
             - "github.com/tarantool/go-luarocks"
             # cli/manifest/pack tests decompress the archive they just wrote.
             - "github.com/klauspost/compress/zstd"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,9 @@ linters:
             # imports that used to pass. Add sub-packages only where the broader
             # entry is already shadowed, as it is in this list.
             - "github.com/tarantool/tt/cli/manifest/state"
+            # cli/manifest/build and cli/manifest/deps drive the dependency
+            # resolver; deps also names resolve.Pins in its own signatures.
+            - "github.com/tarantool/tt/cli/manifest/resolve"
             # cli/manifest/inventory renders tt package list as YAML, the
             # machine-readable default for non-TTY output.
             - "gopkg.in/yaml.v3"
@@ -142,6 +145,7 @@ linters:
             - "github.com/hashicorp/go-version"
             - "github.com/stretchr/testify"
             - "github.com/tarantool/tt/cli/manifest"
+            - "github.com/tarantool/tt/cli/manifest/resolve"
             - "github.com/tarantool/go-luarocks"
             # cli/manifest/pack tests decompress the archive they just wrote.
             - "github.com/klauspost/compress/zstd"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,6 +144,14 @@ linters:
             - "github.com/pelletier/go-toml/v2"
             - "github.com/hashicorp/go-version"
             - "github.com/stretchr/testify"
+            # Covers every cli/manifest sub-package a test may import, including
+            # the rocks adapter the resolve engine fakes and the resolve package
+            # deps names in its own signatures. Do NOT list those sub-packages
+            # individually here: per the NOTE on the main list, depguard matches
+            # the longest prefix, so a sub-package entry shadows this one for its
+            # siblings and starts flagging imports that used to pass. Adding two
+            # such entries cost 14 spurious findings across inventory, install,
+            # state and version tests before this was understood.
             - "github.com/tarantool/tt/cli/manifest"
             - "github.com/tarantool/tt/cli/manifest/resolve"
             - "github.com/tarantool/go-luarocks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   another package still holds stays in place and is reported as kept. The
   project's own package is not a guest and uninstall refuses to remove it.
   `--scope` selects the tree and `--yes` skips the confirmation prompt.
+- `tt package add <name> [<constraint>]`, `tt package remove <name>` and
+  `tt package update [<name>]`: edit `[dependencies]` in `app.manifest.toml`
+  and re-resolve the lock. `add` takes `*` when no constraint is given, writes
+  to `[dev_dependencies]` under `--dev`, and rewrites the constraint of a
+  dependency that is already declared, reporting the previous one. The manifest
+  is edited in place: comments, key order and the formatting of every untouched
+  part of the file survive, and a declaration form that cannot be rewritten
+  safely is refused by name rather than guessed at. `add` and `remove` hold
+  every version the lock already pinned, so they never drag an unrelated
+  dependency forward; `tt package update` is the only command that pulls fresh
+  versions from the registry, and with a name it moves that one dependency and
+  holds the rest.
 - `tt status`: add `--format` option to support JSON and YAML output formats
 for machine-readable output.
 

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tarantool/tt/cli/manifest/build"
+	"github.com/tarantool/tt/cli/manifest/deps"
 	"github.com/tarantool/tt/cli/manifest/install"
 	"github.com/tarantool/tt/cli/manifest/inventory"
 	"github.com/tarantool/tt/cli/manifest/pack"
@@ -49,27 +50,242 @@ var (
 	packageTree   bool
 )
 
+// Flags specific to `tt package add`.
+var packageDev bool
+
 // NewPackageCmd creates the `tt package` command group: the manifest build
-// pipeline (build, fetch and pack), installation, and the inventory over what
-// is installed (list and uninstall).
+// pipeline (build, fetch and pack), the dependency-changing commands (add,
+// remove and update), installation, and the inventory over what is installed
+// (list and uninstall).
 func NewPackageCmd() *cobra.Command {
 	packageCmd := &cobra.Command{
 		Use:   "package",
 		Short: "Manage tt manifest packages",
 		Long: "Build, fetch, pack and install Tarantool packages described by " +
-			"app.manifest.toml, and manage what is installed.",
+			"app.manifest.toml, manage their dependencies, and manage what is " +
+			"installed.",
 	}
 
 	packageCmd.AddCommand(
 		newPackageBuildCmd(),
 		newPackageFetchCmd(),
 		newPackagePackCmd(),
+		newPackageAddCmd(),
+		newPackageRemoveCmd(),
+		newPackageUpdateCmd(),
 		newPackageInstallCmd(),
 		newPackageListCmd(),
 		newPackageUninstallCmd(),
 	)
 
 	return packageCmd
+}
+
+// newPackageAddCmd wires `tt package add NAME [CONSTRAINT]`.
+func newPackageAddCmd() *cobra.Command {
+	addCmd := &cobra.Command{
+		Use:   "add NAME [CONSTRAINT]",
+		Short: "Declare a dependency and re-resolve the lock",
+		Long: "Add NAME to [dependencies] — or, with --dev, to " +
+			"[dev_dependencies] — at the given version constraint, then " +
+			"re-resolve app.manifest.lock around it. Without a constraint the " +
+			"dependency is declared as '*': whatever the registry serves. A name " +
+			"the table already declares has its constraint rewritten in place; " +
+			"the rest of the declaration, and every comment and blank line in the " +
+			"file, is left exactly as it was. Every version the lock already " +
+			"holds is kept: only the new dependency and whatever it requires can " +
+			"move, because an edit to one dependency is not a request to upgrade " +
+			"the others — that is what tt package update is for. Nothing is " +
+			"fetched into .rocks/; the next tt package build picks the new lock " +
+			"up.",
+		Args: cobra.RangeArgs(1, 2),
+		Run: func(cmd *cobra.Command, args []string) {
+			constraint := ""
+			if len(args) == 2 {
+				constraint = args[1]
+			}
+
+			if err := runPackageAdd(args[0], constraint); err != nil {
+				log.Error(err.Error())
+				os.Exit(deps.ExitCode(err))
+			}
+		},
+	}
+
+	addCmd.Flags().BoolVar(&packageDev, "dev", false,
+		"declare the dependency in [dev_dependencies] instead of [dependencies]")
+
+	return addCmd
+}
+
+// runPackageAdd declares one dependency and reports what moved.
+func runPackageAdd(name, constraint string) error {
+	opts, err := dependencyOptions()
+	if err != nil {
+		return err
+	}
+
+	result, err := deps.Add(context.Background(), opts, name, constraint, packageDev)
+	if err != nil {
+		return err
+	}
+
+	table := "dependencies"
+	if packageDev {
+		table = "dev_dependencies"
+	}
+
+	declared := result.Manifest.Dependencies[name].Version
+	if packageDev {
+		declared = result.Manifest.DevDependencies[name].Version
+	}
+
+	if result.Change.Existed {
+		fmt.Printf("changed %s in [%s]: %s -> %s\n",
+			name, table, result.Change.Previous, declared)
+	} else {
+		fmt.Printf("added %s %s to [%s]\n", name, declared, table)
+	}
+
+	printMoves(result.Moves)
+
+	return nil
+}
+
+// newPackageRemoveCmd wires `tt package remove NAME`.
+func newPackageRemoveCmd() *cobra.Command {
+	removeCmd := &cobra.Command{
+		Use:   "remove NAME",
+		Short: "Drop a declared dependency and re-resolve the lock",
+		Long: "Remove NAME from [dependencies] and [dev_dependencies], then " +
+			"re-resolve app.manifest.lock without it. The rocks that were only " +
+			"there to satisfy it drop out of the closure with it; every other " +
+			"version is held. A name the manifest does not declare is an error " +
+			"rather than a silent success — it is almost always a typo — and so " +
+			"is a name only a component declares, since which component owns a " +
+			"dependency is not this command's decision to unmake. Nothing is " +
+			"deleted from .rocks/; tt package uninstall is what removes files.",
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPackageRemove(args[0]); err != nil {
+				log.Error(err.Error())
+				os.Exit(deps.ExitCode(err))
+			}
+		},
+	}
+
+	return removeCmd
+}
+
+// runPackageRemove drops one dependency and reports what left the closure.
+func runPackageRemove(name string) error {
+	opts, err := dependencyOptions()
+	if err != nil {
+		return err
+	}
+
+	result, err := deps.Remove(context.Background(), opts, name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("removed %s %s\n", name, result.Change.Previous)
+	printMoves(result.Moves)
+
+	return nil
+}
+
+// newPackageUpdateCmd wires `tt package update [NAME]`.
+func newPackageUpdateCmd() *cobra.Command {
+	updateCmd := &cobra.Command{
+		Use:   "update [NAME]",
+		Short: "Re-resolve the lock against newer registry versions",
+		Long: "Re-resolve app.manifest.lock, taking the newest version every " +
+			"constraint allows. This is the only command that pulls newer " +
+			"registry versions: a release upstream never makes a lock stale by " +
+			"itself, so a build keeps the versions it has until an update is " +
+			"asked for. With NAME only that dependency is freed and every other " +
+			"version is held, so the diff stays confined to it and whatever its " +
+			"new version requires. No declaration is changed — app.manifest.toml " +
+			"is not touched at all — and nothing is fetched into .rocks/.",
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := ""
+			if len(args) == 1 {
+				name = args[0]
+			}
+
+			if err := runPackageUpdate(name); err != nil {
+				log.Error(err.Error())
+				os.Exit(deps.ExitCode(err))
+			}
+		},
+	}
+
+	return updateCmd
+}
+
+// runPackageUpdate re-resolves the lock and reports what moved.
+func runPackageUpdate(name string) error {
+	opts, err := dependencyOptions()
+	if err != nil {
+		return err
+	}
+
+	result, err := deps.Update(context.Background(), opts, name)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Moves) == 0 {
+		fmt.Println("everything is already up to date")
+
+		return nil
+	}
+
+	printMoves(result.Moves)
+
+	return nil
+}
+
+// dependencyOptions assembles the options the three dependency commands share.
+//
+// All three re-resolve, and resolution evaluates rockspecs — which are Lua and
+// may branch on the Tarantool version — so a missing tarantool is a real error
+// here rather than something to work around.
+func dependencyOptions() (deps.Options, error) {
+	projectDir, err := absoluteWorkingDir()
+	if err != nil {
+		return deps.Options{}, err
+	}
+
+	tntInfo, err := tarantoolInfo()
+	if err != nil {
+		return deps.Options{}, err
+	}
+
+	return deps.Options{
+		ProjectDir: projectDir,
+		TtVersion:  "tt " + ttversion.GetVersion(true, false),
+		Tarantool:  tntInfo,
+		Warn:       func(msg string) { log.Warn(msg) },
+	}, nil
+}
+
+// printMoves reports the closure changes one per line: a rock that arrived
+// shows only its new version, one that dropped out is marked as such, and one
+// that moved shows both ends.
+func printMoves(moves []deps.Move) {
+	for _, move := range moves {
+		switch {
+		case move.From == "":
+			fmt.Printf("  %s %s\n", move.Name, move.To)
+		case move.To == "":
+			fmt.Printf("  %s %s -> (dropped)\n", move.Name, move.From)
+		default:
+			fmt.Printf("  %s %s -> %s\n", move.Name, move.From, move.To)
+		}
+	}
 }
 
 // newPackageListCmd wires `tt package list`.

--- a/cli/manifest/deps/commands.go
+++ b/cli/manifest/deps/commands.go
@@ -1,0 +1,213 @@
+package deps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// Add declares name in [dependencies] — or, with dev, in [dev_dependencies] —
+// at the given constraint, and re-resolves the lock around it.
+//
+// An empty constraint means defaultConstraint ("*"): "whatever the registry
+// serves". A name the table already declares has its constraint rewritten and
+// the previous one reported in Result.Change; nothing else about the
+// declaration moves, so a long-form entry keeps its source, registry and
+// comments.
+//
+// Every rock the lock already holds is pinned, so only the added rock and
+// whatever it drags in behind it can move. The added rock is not in the lock,
+// so it resolves fresh.
+func Add(
+	ctx context.Context, opts Options, name, constraint string, dev bool,
+) (*Result, error) {
+	return addWith(ctx, opts, engineFor(opts), name, constraint, dev)
+}
+
+// addWith is Add against an injected resolver.
+func addWith(
+	ctx context.Context, opts Options, res resolver, name, constraint string, dev bool,
+) (*Result, error) {
+	proj, err := load(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if constraint == "" {
+		constraint = defaultConstraint
+	}
+
+	table := manifest.TableDependencies
+	if dev {
+		table = manifest.TableDevDependencies
+	}
+
+	editor, err := manifest.NewEditor(proj.source)
+	if err != nil {
+		return nil, stateErrorf("reading %s for editing: %w", manifestFileName, err)
+	}
+
+	warnOtherTable(opts, editor, table, name)
+
+	change, err := editor.SetDependency(table, name, constraint)
+	if err != nil {
+		return nil, stateErrorf("%w", err)
+	}
+
+	// Hold every version the lock already chose: an edit to one dependency is
+	// not a request to move the others.
+	return apply(ctx, opts, res, proj, editor.Bytes(), resolve.PinsFromLock(proj.lock), change)
+}
+
+// warnOtherTable reports a name that is also declared in the table the add is
+// not targeting. Declaring a rock as both a runtime and a dev dependency is
+// legal TOML and parses, but it is almost always a mistake, and the add would
+// otherwise leave the stale declaration behind silently.
+func warnOtherTable(opts Options, editor *manifest.Editor, target manifest.DepTable, name string) {
+	if opts.Warn == nil {
+		return
+	}
+
+	for _, table := range editor.Locate(name) {
+		if table != target {
+			opts.Warn(fmt.Sprintf(
+				"%q is also declared in [%s]; that declaration is left as it is", name, table))
+		}
+	}
+}
+
+// Remove drops name's declaration from [dependencies] and [dev_dependencies]
+// and re-resolves the lock without it.
+//
+// A name the manifest does not declare is an error, not a no-op: the argument
+// is almost always a typo, and reporting success over one hides it. A name
+// declared only by a component is refused for the same reason it cannot be
+// added: which component owns a dependency is the user's decision, not this
+// command's, so the declaration is left for them to edit by hand.
+//
+// Every remaining rock is pinned, so the result differs from the old lock only
+// by what the removed rock was holding up.
+func Remove(ctx context.Context, opts Options, name string) (*Result, error) {
+	return removeWith(ctx, opts, engineFor(opts), name)
+}
+
+// removeWith is Remove against an injected resolver.
+func removeWith(
+	ctx context.Context, opts Options, res resolver, name string,
+) (*Result, error) {
+	proj, err := load(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	editor, err := manifest.NewEditor(proj.source)
+	if err != nil {
+		return nil, stateErrorf("reading %s for editing: %w", manifestFileName, err)
+	}
+
+	tables := editor.Locate(name)
+	if len(tables) == 0 {
+		return nil, notDeclared(proj.manifest, name)
+	}
+
+	var change manifest.Change
+
+	// A name in both tables is removed from both: after the command the manifest
+	// must not declare it at all, which is what the user asked for.
+	for _, table := range tables {
+		one, removeErr := editor.RemoveDependency(table, name)
+		if removeErr != nil {
+			return nil, stateErrorf("%w", removeErr)
+		}
+
+		if !change.Existed {
+			change = one
+		}
+	}
+
+	warnComponentDeclarations(opts, proj.manifest, name)
+
+	return apply(ctx, opts, res, proj, editor.Bytes(), resolve.PinsFromLock(proj.lock), change)
+}
+
+// warnComponentDeclarations reports a removed name that a component still
+// declares, so the user is not surprised to find it back in the closure.
+func warnComponentDeclarations(opts Options, man *manifest.Manifest, name string) {
+	if opts.Warn == nil {
+		return
+	}
+
+	var components []string
+
+	for _, place := range declaredIn(man, name) {
+		if strings.HasPrefix(place, "[components.") {
+			components = append(components, place)
+		}
+	}
+
+	if len(components) == 0 {
+		return
+	}
+
+	opts.Warn(fmt.Sprintf("%q is still declared in %s and stays in the closure",
+		name, strings.Join(components, ", ")))
+}
+
+// Update re-resolves the lock without changing a single declaration.
+//
+// With an empty name nothing is pinned: every rock takes the newest version its
+// constraints allow. This is the only command that pulls newer registry
+// versions — a new release upstream never makes a lock stale by itself — so it
+// is also the only one whose result can differ from a plain rebuild.
+//
+// With a name, that one rock is freed and every other pin is held, so the diff
+// is confined to it and whatever its new version requires. The name must be one
+// the manifest declares, in any of its tables including a component's: an
+// update names a dependency, and a dependency a component declares is one.
+func Update(ctx context.Context, opts Options, name string) (*Result, error) {
+	return updateWith(ctx, opts, engineFor(opts), name)
+}
+
+// updateWith is Update against an injected resolver.
+func updateWith(
+	ctx context.Context, opts Options, res resolver, name string,
+) (*Result, error) {
+	proj, err := load(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var pins resolve.Pins
+
+	if name != "" {
+		if len(declaredIn(proj.manifest, name)) == 0 {
+			return nil, notDeclared(proj.manifest, name)
+		}
+
+		pins = resolve.PinsFromLock(proj.lock, name)
+	}
+
+	// A nil edit: update changes no declaration, so the manifest on disk is
+	// already the one to resolve and its hash is already the right one.
+	return apply(ctx, opts, res, proj, nil, pins,
+		manifest.Change{Existed: false, Previous: ""})
+}
+
+// notDeclared builds the error for a name the manifest does not declare, naming
+// the component tables that do declare it when any do — the difference between
+// "you mistyped it" and "it is there, but somewhere this command may not touch"
+// is the whole of what the user needs to know.
+func notDeclared(man *manifest.Manifest, name string) error {
+	places := declaredIn(man, name)
+	if len(places) == 0 {
+		return stateErrorf("%q: %w", name, ErrNotDeclared)
+	}
+
+	return stateErrorf(
+		"%q is declared only in %s, which this command does not edit;"+
+			" change it there by hand: %w",
+		name, strings.Join(places, ", "), ErrNotDeclared)
+}

--- a/cli/manifest/deps/commands_internal_test.go
+++ b/cli/manifest/deps/commands_internal_test.go
@@ -1,0 +1,337 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// TestAdd_pinsEveryLockedVersion is the behavioural core of add: the rock being
+// added resolves fresh, every other rock is held at the version the lock
+// already chose. Without the pins an edit to one dependency would drag every
+// unrelated one forward.
+func TestAdd_pinsEveryLockedVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+	}))
+	res := &fakeResolver{}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "metrics", ">=1.0.0", false)
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Equal(t, resolve.Pins{"checks": "3.1.0-1", "luasocket": "3.0.0-1"}, res.pins[0])
+}
+
+// TestAdd_noLockPinsNothing covers a project that has never resolved: there is
+// nothing to hold, and that is a normal state rather than an error.
+func TestAdd_noLockPinsNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "metrics", "", false)
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Empty(t, res.pins[0])
+	assert.Contains(t, manifestOnDisk(t, dir), "metrics = \"*\"")
+}
+
+// TestAdd_lockRecordsTheEditedManifestHash pins the invariant the whole
+// read-edit-write-reparse-resolve order exists for. manifest_hash is taken over
+// the raw source bytes a Manifest was parsed from, so resolving the pre-edit
+// model stamps the lock with the pre-edit hash and IsStale then reports the
+// freshly written lock as stale on the very next command.
+func TestAdd_lockRecordsTheEditedManifestHash(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.1.0-1"}))
+	res := &fakeResolver{}
+
+	result, err := addWith(context.Background(), optsFor(dir), res, "metrics", ">=1.0.0", false)
+	require.NoError(t, err)
+
+	edited, warnings, err := manifest.ParseManifest([]byte(manifestOnDisk(t, dir)))
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	assert.Equal(t, edited.Hash(), result.Lock.ManifestHash)
+	assert.Equal(t, edited.Hash(), lockOnDisk(t, dir).ManifestHash)
+
+	// The engine only needs its project directory to answer this; the manifest
+	// declares no path dependency, so no adapter call can happen.
+	stale, reason, err := resolve.NewEngine(nil, dir, "tt test").
+		IsStale(edited, lockOnDisk(t, dir))
+	require.NoError(t, err)
+	assert.False(t, stale, reason)
+}
+
+// TestAdd_rewritesAnExistingConstraint covers a name the table already declares:
+// the constraint is replaced, the previous one is reported, and the comment
+// above the table is untouched.
+func TestAdd_rewritesAnExistingConstraint(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	result, err := addWith(context.Background(), optsFor(dir), res, "checks", ">=3.2.0", false)
+	require.NoError(t, err)
+
+	assert.True(t, result.Change.Existed)
+	assert.Equal(t, ">=3.0.0", result.Change.Previous)
+
+	source := manifestOnDisk(t, dir)
+	assert.Contains(t, source, `checks = ">=3.2.0"`)
+	assert.NotContains(t, source, "checks = '>=3.0.0'")
+	assert.Contains(t, source, "# checks validates the config; do not drop it.")
+}
+
+// TestAdd_devWritesTheDevTable covers --dev: the entry lands in
+// [dev_dependencies], and [dependencies] is left alone.
+func TestAdd_devWritesTheDevTable(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "luatest", ">=1.0.0", true)
+	require.NoError(t, err)
+
+	edited, _, err := manifest.ParseManifest([]byte(manifestOnDisk(t, dir)))
+	require.NoError(t, err)
+
+	assert.Contains(t, edited.DevDependencies, "luatest")
+	assert.NotContains(t, edited.Dependencies, "luatest")
+	assert.Contains(t, edited.Dependencies, "checks")
+}
+
+// TestAdd_resolveFailureLeavesTheManifestEdited covers the documented order: the
+// requested edit reaches disk first, so a failed resolution leaves the two files
+// disagreeing — and the error has to say so, because every later command will
+// fail the same way until the manifest is fixed.
+func TestAdd_resolveFailureLeavesTheManifestEdited(t *testing.T) {
+	t.Parallel()
+
+	before := lockOf(map[string]string{"checks": "3.1.0-1"})
+	dir := writeProject(t, baseManifest, before)
+	boom := errors.New("no server has it")
+	res := &fakeResolver{err: boom}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "metrics", ">=1.0.0", false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+	require.ErrorIs(t, err, ErrManifestEdited)
+	assert.Equal(t, 1, ExitCode(err))
+
+	assert.Contains(t, manifestOnDisk(t, dir), "metrics")
+	// The lock is exactly the one that was there: nothing rewrote it.
+	assert.Equal(t, "sha256:stale", lockOnDisk(t, dir).ManifestHash)
+}
+
+// TestAdd_reportsMoves checks the closure diff the CLI prints: a rock that
+// changed version, one that arrived, and one that dropped out. A rock that did
+// not move is not reported.
+func TestAdd_reportsMoves(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+		"gone":      "0.1.0-1",
+	}))
+	res := &fakeResolver{lock: lockOf(map[string]string{
+		"checks":    "3.2.0-1",
+		"luasocket": "3.0.0-1",
+		"metrics":   "1.0.0-1",
+	})}
+
+	result, err := addWith(context.Background(), optsFor(dir), res, "metrics", ">=1.0.0", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Move{
+		{Name: "checks", From: "3.1.0-1", To: "3.2.0-1"},
+		{Name: "gone", From: "0.1.0-1", To: ""},
+		{Name: "metrics", From: "", To: "1.0.0-1"},
+	}, result.Moves)
+}
+
+// TestRemove_dropsTheEntryAndPinsTheRest covers remove's own pin set — every
+// remaining rock is held — and that the declaration is gone from the file while
+// the comment above the table stays.
+func TestRemove_dropsTheEntryAndPinsTheRest(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+	}))
+	res := &fakeResolver{}
+
+	result, err := removeWith(context.Background(), optsFor(dir), res, "checks")
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Equal(t, resolve.Pins{"checks": "3.1.0-1", "luasocket": "3.0.0-1"}, res.pins[0])
+
+	assert.True(t, result.Change.Existed)
+	assert.Equal(t, ">=3.0.0", result.Change.Previous)
+
+	source := manifestOnDisk(t, dir)
+	assert.NotContains(t, source, "checks = ")
+	assert.Contains(t, source, "# checks validates the config; do not drop it.")
+}
+
+// TestRemove_unknownNameIsAnError pins the decided behaviour: a name the
+// manifest does not declare is exit 1, not a silent success. Nothing is written
+// and the resolver is never reached.
+func TestRemove_unknownNameIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := removeWith(context.Background(), optsFor(dir), res, "nosuchrock")
+	require.ErrorIs(t, err, ErrNotDeclared)
+	assert.Equal(t, 1, ExitCode(err))
+	assert.Empty(t, res.pins)
+	assert.Equal(t, baseManifest, manifestOnDisk(t, dir))
+}
+
+// TestUpdate_allPinsNothing is the one command that pulls newer registry
+// versions: no pins at all. Everything else in this package exists to make sure
+// no other command does that.
+func TestUpdate_allPinsNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.1.0-1"}))
+	res := &fakeResolver{}
+
+	_, err := updateWith(context.Background(), optsFor(dir), res, "")
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Nil(t, res.pins[0])
+	// No declaration changed, so the manifest is byte-for-byte what it was.
+	assert.Equal(t, baseManifest, manifestOnDisk(t, dir))
+}
+
+// TestUpdate_oneNameFreesOnlyThatRock covers the targeted form: the named rock
+// is left out of the pin set and every other one is held.
+func TestUpdate_oneNameFreesOnlyThatRock(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+	}))
+	res := &fakeResolver{}
+
+	_, err := updateWith(context.Background(), optsFor(dir), res, "checks")
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Equal(t, resolve.Pins{"luasocket": "3.0.0-1"}, res.pins[0])
+}
+
+// TestUpdate_unknownNameIsAnError mirrors remove: a name the manifest does not
+// declare is refused rather than quietly re-resolving everything.
+func TestUpdate_unknownNameIsAnError(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.1.0-1"}))
+	res := &fakeResolver{}
+
+	_, err := updateWith(context.Background(), optsFor(dir), res, "nosuchrock")
+	require.ErrorIs(t, err, ErrNotDeclared)
+	assert.Equal(t, 1, ExitCode(err))
+	assert.Empty(t, res.pins)
+}
+
+// componentManifest declares its only dependency inside a component, which is a
+// table neither add nor remove may edit.
+const componentManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+
+[components.lua.dependencies]
+checks = '>=3.0.0'
+`
+
+// TestRemove_componentOnlyDeclarationIsRefused: which component owns a
+// dependency is the user's decision, so remove refuses rather than guessing —
+// and says where the declaration actually is.
+func TestRemove_componentOnlyDeclarationIsRefused(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, componentManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := removeWith(context.Background(), optsFor(dir), res, "checks")
+	require.ErrorIs(t, err, ErrNotDeclared)
+	assert.Contains(t, err.Error(), "[components.lua.dependencies]")
+	assert.Empty(t, res.pins)
+}
+
+// TestUpdate_acceptsAComponentDeclaration: update edits nothing, so a
+// component's dependency is as updatable as a document-level one.
+func TestUpdate_acceptsAComponentDeclaration(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, componentManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+	}))
+	res := &fakeResolver{}
+
+	_, err := updateWith(context.Background(), optsFor(dir), res, "checks")
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Equal(t, resolve.Pins{"luasocket": "3.0.0-1"}, res.pins[0])
+}
+
+// TestAdd_warnsAboutTheOtherTable: a rock declared as both a runtime and a dev
+// dependency is legal TOML and almost always a mistake, so the add says so
+// instead of leaving the stale declaration behind silently.
+func TestAdd_warnsAboutTheOtherTable(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	var warnings []string
+
+	opts := optsFor(dir)
+
+	opts.Warn = func(msg string) { warnings = append(warnings, msg) }
+
+	_, err := addWith(context.Background(), opts, res, "checks", ">=3.0.0", true)
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "[dependencies]")
+}

--- a/cli/manifest/deps/deps.go
+++ b/cli/manifest/deps/deps.go
@@ -1,0 +1,460 @@
+// Package deps implements the three commands that change what a package
+// depends on: tt package add, tt package remove and tt package update. Each is
+// the same two-step transaction — edit the declaration, then re-resolve the
+// lock — and the whole package exists to make those two steps agree.
+//
+// The manifest half is done by the position-preserving editor in
+// cli/manifest (NewEditor): app.manifest.toml is hand-authored, so an edit
+// splices the one entry it touches and leaves every other byte, comment and
+// blank line exactly as it was. The lock half is cli/manifest/resolve. Nothing
+// here talks to a registry itself, materializes .rocks/ or runs a build: a
+// changed lock is picked up by the next tt package build.
+//
+// # What separates the three commands is the pin set
+//
+// Editing the manifest changes manifest_hash, which makes the lock stale, which
+// forces a re-resolution — and an unpinned re-resolution takes the newest
+// version every constraint allows, dragging every unrelated rock forward on an
+// edit that had nothing to do with it. resolve.Pins is what prevents that, and
+// choosing the pin set is the whole of what distinguishes the commands:
+//
+//   - Add and Remove pin everything the lock already holds. The rock being
+//     added is not in the lock, so it resolves fresh; every other rock keeps
+//     the version it had.
+//   - Update with no argument pins nothing. It is the only command that pulls
+//     newer registry versions, which is exactly the rule resolve.IsStale
+//     states.
+//   - Update with a name pins everything except that name, so one rock moves
+//     and the rest hold.
+//
+// A missing lock — a project that has never been built — is not an error: there
+// is nothing to hold, so the resolution runs unpinned and writes the first
+// lock.
+//
+// # The manifest is written before the lock is resolved
+//
+// The edit the user asked for reaches disk first, the way cargo does it, and
+// only then is the closure resolved. The alternative — hold both in memory and
+// write them together — would make a failed resolution leave no trace, which
+// reads as "the command did nothing" when what actually happened is "your
+// dependency is unsatisfiable". Writing first keeps the request visible and
+// editable: the user fixes the constraint in place and runs the command again.
+//
+// The cost is that a failed resolution leaves the two files disagreeing, and
+// every later command will re-resolve and fail identically until the manifest
+// is fixed. So that failure says so in as many words — see ErrManifestEdited;
+// a user who does not know the manifest changed cannot make sense of the next
+// command's error.
+package deps
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// rocksDirName is the project-scope tree root the rocks adapter is bound to.
+// Nothing here materializes into it; the adapter needs a tree to be configured
+// against, and it must be the one a following build uses.
+const rocksDirName = ".rocks"
+
+// defaultConstraint is what tt package add declares when the user names no
+// version: any version the registry serves.
+const defaultConstraint = "*"
+
+// defaultFilePerm is the mode a manifest is created with when its current mode
+// cannot be read. An existing manifest keeps the mode it has.
+const defaultFilePerm os.FileMode = 0o644
+
+// Options configures one dependency-changing run.
+type Options struct {
+	// ProjectDir is the directory holding app.manifest.toml and, next to it,
+	// app.manifest.lock. Required and must be absolute.
+	ProjectDir string
+	// TtVersion is the "tt x.y.z" string stamped into the rewritten lock's
+	// generated_by field.
+	TtVersion string
+	// Tarantool carries the Tarantool facts the rocks adapter needs. Resolution
+	// evaluates rockspecs, which are Lua and can branch on the Tarantool
+	// version, so this is required even though nothing is built here.
+	Tarantool rocks.TarantoolInfo
+	// Servers overrides the rock-server list; nil uses the adapter default.
+	Servers []string
+	// Logger receives the adapter's structured operation logs; nil disables it.
+	Logger *slog.Logger
+	// Warn receives non-fatal diagnostics: parse and validation warnings, and
+	// the resolver's report of a pin it had to drop. The library never logs
+	// directly; the CLI routes these through tt's logger. Nil drops them.
+	Warn func(string)
+}
+
+// emit surfaces non-fatal diagnostics through the Warn sink, if any.
+func (o Options) emit(warnings []string) {
+	if o.Warn == nil {
+		return
+	}
+
+	for _, w := range warnings {
+		o.Warn(w)
+	}
+}
+
+// Move is one rock whose place in the locked closure changed.
+//
+// An empty From is a rock the closure did not hold before — the added rock
+// itself, or one that arrived behind it. An empty To is a rock that dropped out
+// of the closure, which is what a remove mostly produces. A rock whose version
+// did not move is not reported at all.
+type Move struct {
+	// Name is the rock name.
+	Name string
+	// From is the version the previous lock held, empty when it held none.
+	From string
+	// To is the version the new lock holds, empty when it holds none.
+	To string
+}
+
+// Result reports what a run changed.
+type Result struct {
+	// Manifest is the manifest as it now stands on disk: re-parsed from the
+	// edited bytes, so its Hash matches what the lock records.
+	Manifest *manifest.Manifest
+	// Lock is the freshly written lock.
+	Lock *manifest.Lock
+	// Moves are the closure changes, in name order.
+	Moves []Move
+	// Change reports what happened to the declaration itself: whether one was
+	// already there and, if so, the constraint it carried. It is what lets the
+	// CLI say "checks >=3.0.0 -> >=3.1.0" rather than just "checks added", a
+	// distinction the moves cannot carry — they are versions, not constraints.
+	// A zero Change means the run declared nothing (tt package update).
+	Change manifest.Change
+}
+
+// resolver is the slice of resolve.Engine these commands drive: re-resolve a
+// manifest into a fresh lock, preferring a pin set. *resolve.Engine satisfies
+// it; tests substitute a fake so the pin selection can be asserted without a
+// registry.
+type resolver interface {
+	ResolvePinned(
+		ctx context.Context, man *manifest.Manifest, pins resolve.Pins,
+	) (*manifest.Lock, []string, error)
+}
+
+// ReResolve re-resolves man into a fresh lock, preferring pins.
+//
+// It is exported because it is the whole of tt package resolve: that command is
+// this step with no manifest edit in front of it, and duplicating the adapter
+// and engine wiring is how the two would drift apart. It does not write
+// anything — the caller decides whether the lock reaches disk.
+func ReResolve(
+	ctx context.Context, opts Options, man *manifest.Manifest, pins resolve.Pins,
+) (*manifest.Lock, []string, error) {
+	lock, warnings, err := engineFor(opts).ResolvePinned(ctx, man, pins)
+	if err != nil {
+		return nil, nil, stateErrorf("resolving dependencies: %w", err)
+	}
+
+	return lock, warnings, nil
+}
+
+// engineFor builds the resolution engine the commands drive: the rocks adapter
+// bound to the project's own tree, wrapped in a resolve.Engine anchored at the
+// project directory so path dependencies resolve relative to the manifest.
+func engineFor(opts Options) *resolve.Engine {
+	adapter := rocks.New(rocks.BuildConfig(opts.Tarantool, rocks.ConfigOptions{
+		Tree:       filepath.Join(opts.ProjectDir, rocksDirName),
+		WorkingDir: opts.ProjectDir,
+		Servers:    opts.Servers,
+		Logger:     opts.Logger,
+	}))
+
+	return resolve.NewEngine(adapter, opts.ProjectDir, opts.TtVersion)
+}
+
+// project is the on-disk state a run starts from.
+type project struct {
+	// manifest is the parsed and validated app.manifest.toml.
+	manifest *manifest.Manifest
+	// source is the exact bytes it was parsed from, which is what the editor
+	// splices and what manifest_hash is taken over.
+	source []byte
+	// perm is the manifest file's current mode, carried so rewriting it does not
+	// silently re-permission a file the user chmod'ed.
+	perm os.FileMode
+	// lock is the lock next to it, or nil when there is none. A project that has
+	// never been built has no lock, which is a normal state.
+	lock *manifest.Lock
+}
+
+// load reads the manifest and the lock from the project directory.
+//
+// A missing manifest is fatal: there is nothing to add to. A missing lock is
+// not — it means the project has never resolved, so the run has nothing to pin
+// and writes the first lock. A lock that exists but does not parse *is* fatal:
+// treating it as absent would silently discard every pin it holds and move
+// versions the user never asked to move.
+func load(opts Options) (*project, error) {
+	path := filepath.Join(opts.ProjectDir, manifestFileName)
+
+	data, err := os.ReadFile(path) //nolint:gosec // Reads the caller's own manifest.
+	if err != nil {
+		return nil, stateErrorf("reading %s: %w", manifestFileName, err)
+	}
+
+	man, warnings, err := manifest.ParseManifest(data)
+	if err != nil {
+		return nil, stateErrorf("parsing %s: %w", manifestFileName, err)
+	}
+
+	opts.emit(warnings)
+
+	validationWarnings, err := man.Validate()
+	if err != nil {
+		return nil, stateErrorf("invalid manifest: %w", err)
+	}
+
+	opts.emit(validationWarnings)
+
+	lock, err := loadLock(opts.ProjectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &project{
+		manifest: man,
+		source:   data,
+		perm:     manifestPerm(path),
+		lock:     lock,
+	}, nil
+}
+
+// loadLock parses the lock next to the manifest, reporting (nil, nil) when
+// there is none.
+func loadLock(projectDir string) (*manifest.Lock, error) {
+	path := filepath.Join(projectDir, lockFileName)
+
+	data, err := os.ReadFile(path) //nolint:gosec // Reads the caller's own lock.
+	if os.IsNotExist(err) {
+		return nil, nil //nolint:nilnil // A missing lock is a state, not a failure.
+	}
+
+	if err != nil {
+		return nil, stateErrorf("reading %s: %w", lockFileName, err)
+	}
+
+	lock, err := manifest.ParseLock(data)
+	if err != nil {
+		return nil, stateErrorf("parsing %s: %w", lockFileName, err)
+	}
+
+	return lock, nil
+}
+
+// manifestPerm reports the manifest's current mode, falling back to
+// defaultFilePerm when it cannot be read.
+func manifestPerm(path string) os.FileMode {
+	info, err := os.Stat(path)
+	if err != nil {
+		return defaultFilePerm
+	}
+
+	return info.Mode().Perm()
+}
+
+// apply is the second half of every command: persist the edited manifest when
+// there is one, re-resolve under pins, write the lock and report the moves.
+//
+// edited is nil for a run that changes no declaration (tt package update); then
+// the manifest on disk is already the one to resolve.
+//
+// The re-parse in the middle is load-bearing and is the one thing in this
+// package that is easy to get wrong. manifest_hash is SHA-256 over the raw
+// source bytes a Manifest was parsed from, held in an unexported field, and it
+// is what the lock records. Resolving the pre-edit *Manifest would therefore
+// stamp the lock with the pre-edit hash, and resolve.IsStale would report the
+// freshly written lock as stale on the very next command. Re-parsing the edited
+// bytes is the only way to get a Manifest whose Hash is the one now on disk.
+func apply(
+	ctx context.Context, opts Options, res resolver,
+	proj *project, edited []byte, pins resolve.Pins, change manifest.Change,
+) (*Result, error) {
+	man := proj.manifest
+
+	if edited != nil {
+		var err error
+
+		man, err = writeAndReparse(opts, proj, edited)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	lock, warnings, err := res.ResolvePinned(ctx, man, pins)
+	if err != nil {
+		if edited != nil {
+			return nil, stateErrorf("resolving dependencies: %w; %w", err, ErrManifestEdited)
+		}
+
+		return nil, stateErrorf("resolving dependencies: %w", err)
+	}
+
+	opts.emit(warnings)
+
+	err = writeLock(opts.ProjectDir, lock)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Manifest: man,
+		Lock:     lock,
+		Moves:    movesBetween(proj.lock, lock),
+		Change:   change,
+	}, nil
+}
+
+// writeAndReparse persists the edited manifest source and parses the bytes back
+// into the Manifest the resolution runs against. See apply for why the re-parse
+// cannot be skipped.
+//
+// Validation runs against the result, so an edit that produces a manifest the
+// validator refuses is reported as such — with ErrManifestEdited, because by
+// then the file on disk is the invalid one.
+func writeAndReparse(opts Options, proj *project, edited []byte) (*manifest.Manifest, error) {
+	path := filepath.Join(opts.ProjectDir, manifestFileName)
+
+	//nolint:gosec // Rewrites the caller's own manifest, at the path it was read from.
+	err := os.WriteFile(path, edited, proj.perm)
+	if err != nil {
+		return nil, stateErrorf("writing %s: %w", manifestFileName, err)
+	}
+
+	man, warnings, err := manifest.ParseManifest(edited)
+	if err != nil {
+		return nil, stateErrorf("parsing the edited %s: %w; %w",
+			manifestFileName, err, ErrManifestEdited)
+	}
+
+	opts.emit(warnings)
+
+	validationWarnings, err := man.Validate()
+	if err != nil {
+		return nil, stateErrorf("the edited manifest is invalid: %w; %w", err, ErrManifestEdited)
+	}
+
+	opts.emit(validationWarnings)
+
+	return man, nil
+}
+
+// writeLock marshals lock and writes it next to the manifest.
+func writeLock(projectDir string, lock *manifest.Lock) error {
+	data, err := lock.Marshal()
+	if err != nil {
+		return stateErrorf("marshaling %s: %w", lockFileName, err)
+	}
+
+	err = os.WriteFile(filepath.Join(projectDir, lockFileName), data, defaultFilePerm)
+	if err != nil {
+		return stateErrorf("writing %s: %w", lockFileName, err)
+	}
+
+	return nil
+}
+
+// movesBetween diffs two locked closures into the moves the CLI reports.
+func movesBetween(before, after *manifest.Lock) []Move {
+	old := closureOf(before)
+	current := closureOf(after)
+
+	names := map[string]bool{}
+	for name := range old {
+		names[name] = true
+	}
+
+	for name := range current {
+		names[name] = true
+	}
+
+	moves := make([]Move, 0, len(names))
+
+	for _, name := range sortedKeys(names) {
+		from, to := old[name], current[name]
+		if from == to {
+			continue
+		}
+
+		moves = append(moves, Move{Name: name, From: from, To: to})
+	}
+
+	return moves
+}
+
+// closureOf flattens a lock into rock name -> version across every product.
+//
+// Products hold independent closures, so two of them may legitimately pin
+// different versions of one rock. The moves are a human report of what changed,
+// not an input to anything, so a disagreement is settled by taking the first
+// product in name order rather than by inventing a winner — the same rock
+// reported once, deterministically.
+func closureOf(lock *manifest.Lock) map[string]string {
+	out := map[string]string{}
+	if lock == nil {
+		return out
+	}
+
+	for _, product := range sortedKeys(lock.Products) {
+		for _, dependency := range lock.Products[product].Dependencies {
+			if _, seen := out[dependency.Name]; !seen {
+				out[dependency.Name] = dependency.Version
+			}
+		}
+	}
+
+	return out
+}
+
+// sortedKeys returns a map's keys in sorted order, so every report this package
+// produces is deterministic.
+func sortedKeys[V any](m map[string]V) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// declaredIn reports every place the manifest declares name: the two
+// document-level tables and each component that names it. It backs the
+// "is this rock declared at all" check the remove and targeted-update commands
+// make, and its result is what their error message quotes.
+func declaredIn(man *manifest.Manifest, name string) []string {
+	var places []string
+
+	if _, ok := man.Dependencies[name]; ok {
+		places = append(places, "[dependencies]")
+	}
+
+	if _, ok := man.DevDependencies[name]; ok {
+		places = append(places, "[dev_dependencies]")
+	}
+
+	for _, component := range sortedKeys(man.Components) {
+		if _, ok := man.Components[component].Dependencies[name]; ok {
+			places = append(places, fmt.Sprintf("[components.%s.dependencies]", component))
+		}
+	}
+
+	return places
+}

--- a/cli/manifest/deps/errors.go
+++ b/cli/manifest/deps/errors.go
@@ -1,0 +1,54 @@
+package deps
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tarantool/tt/cli/manifest/build"
+)
+
+// File names the dependency commands read and write in the project root.
+const (
+	manifestFileName = "app.manifest.toml"
+	lockFileName     = "app.manifest.lock"
+)
+
+// exitStateError is the process exit code for a usage or state failure: a
+// dependency the manifest does not declare, a declaration written in a form the
+// editor refuses to rewrite, an unreadable or invalid manifest, a failed
+// resolution. It matches what build, pack, install and inventory use, so every
+// package command agrees.
+const exitStateError = 1
+
+var (
+	// ErrNotDeclared reports a remove or a targeted update aimed at a name the
+	// manifest's [dependencies]/[dev_dependencies] do not declare. It is
+	// deliberately an error rather than a no-op: a user who mistypes a rock name
+	// wants to hear about it, and "nothing to do" reads as success.
+	ErrNotDeclared = errors.New("dependency is not declared in the manifest")
+	// ErrManifestEdited reports a run whose manifest edit reached disk but whose
+	// resolution then failed, so the lock was left as it was. It is wrapped
+	// around the resolution failure rather than replacing it: the user needs
+	// both why the resolve failed and the fact that the two files no longer
+	// agree, because every following command will re-resolve and fail the same
+	// way until the manifest is fixed or the edit undone.
+	ErrManifestEdited = errors.New(
+		"the manifest was edited but the lock was not updated")
+)
+
+// ExitError re-exports build.ExitError so the dependency commands return the
+// same typed error the build, pack, install and inventory commands do.
+type ExitError = build.ExitError
+
+// ExitCode returns the process exit code for err, reusing the build package's
+// mapping so every package command agrees. A nil error is 0.
+func ExitCode(err error) int {
+	return build.ExitCode(err)
+}
+
+// stateErrorf wraps a formatted error as a state error (exit 1).
+//
+//nolint:err113 // Formatting helper, mirrors fmt.Errorf; callers pass %w wraps.
+func stateErrorf(format string, args ...any) error {
+	return &ExitError{Code: exitStateError, Err: fmt.Errorf(format, args...)}
+}

--- a/cli/manifest/deps/helpers_internal_test.go
+++ b/cli/manifest/deps/helpers_internal_test.go
@@ -1,0 +1,148 @@
+package deps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// baseManifest is a minimal valid manifest with one declared dependency and a
+// comment above it. The comment is load-bearing in more than one test: the
+// whole point of the position-preserving editor is that it survives.
+const baseManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+description = 'a test package'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+
+# checks validates the config; do not drop it.
+[dependencies]
+checks = '>=3.0.0'
+
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+`
+
+// fakeResolver stands in for resolve.Engine so the pin selection can be
+// asserted without a registry.
+//
+// It reproduces the one thing about the engine these tests depend on: the lock
+// it returns is stamped with the hash of the manifest it was handed. That is
+// what makes the re-parse invariant observable — hand it the pre-edit manifest
+// and the lock carries the pre-edit hash, exactly as the real engine would.
+type fakeResolver struct {
+	// pins records the pin set of every call, in order.
+	pins []resolve.Pins
+	// seen records the manifest each call was given.
+	seen []*manifest.Manifest
+	// lock is the closure every call returns; nil means an empty one.
+	lock *manifest.Lock
+	// warnings is returned alongside it.
+	warnings []string
+	// err, when set, fails every call.
+	err error
+}
+
+func (f *fakeResolver) ResolvePinned(
+	_ context.Context, man *manifest.Manifest, pins resolve.Pins,
+) (*manifest.Lock, []string, error) {
+	f.pins = append(f.pins, pins)
+	f.seen = append(f.seen, man)
+
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+
+	out := manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: "0.1",
+		GeneratedBy:     "tt test",
+		ManifestHash:    man.Hash(),
+	}
+
+	if f.lock != nil {
+		out.Products = f.lock.Products
+	}
+
+	return &out, f.warnings, nil
+}
+
+// lockOf builds a lock whose default product pins the given rocks.
+func lockOf(pins map[string]string) *manifest.Lock {
+	deps := make([]manifest.LockDependency, 0, len(pins))
+
+	for _, name := range sortedKeys(pins) {
+		deps = append(deps, manifest.LockDependency{
+			Name:    name,
+			Version: pins[name],
+			Source:  "registry",
+		})
+	}
+
+	return &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: "0.1",
+		GeneratedBy:     "tt test",
+		ManifestHash:    "sha256:stale",
+		Products:        map[string]manifest.LockProduct{"default": {Dependencies: deps}},
+	}
+}
+
+// writeProject lays a manifest and, optionally, a lock into a fresh directory.
+func writeProject(t *testing.T, source string, lock *manifest.Lock) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, manifestFileName), []byte(source), 0o600))
+
+	if lock != nil {
+		data, err := lock.Marshal()
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, lockFileName), data, 0o600))
+	}
+
+	return dir
+}
+
+// optsFor builds Options against a project directory.
+func optsFor(dir string) Options {
+	return Options{ProjectDir: dir, TtVersion: "tt test"}
+}
+
+// manifestOnDisk reads back the manifest source.
+func manifestOnDisk(t *testing.T, dir string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, manifestFileName)) //nolint:gosec // temp path
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// lockOnDisk reads back and parses the lock.
+func lockOnDisk(t *testing.T, dir string) *manifest.Lock {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, lockFileName)) //nolint:gosec // temp path
+	require.NoError(t, err)
+
+	lock, err := manifest.ParseLock(data)
+	require.NoError(t, err)
+
+	return lock
+}

--- a/cli/manifest/edit.go
+++ b/cli/manifest/edit.go
@@ -1,0 +1,231 @@
+package manifest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// This file is the writing half of the manifest data layer: it edits the
+// [dependencies]/[dev_dependencies] tables of an app.manifest.toml *in its own
+// source text* instead of re-marshaling the parsed model.
+//
+// Re-marshaling is not an option. go-toml keeps no comments, no key order and
+// no formatting in its AST, so Manifest.Marshal() returns a canonical document
+// that shares only the data with what the user wrote. app.manifest.toml is a
+// hand-authored file - people comment their pins and group their sections -
+// and manifest_hash is taken over the raw bytes, so a reformat is both rude
+// and semantically loud.
+//
+// So the approach is the one `go mod edit -require` uses: parse the source to
+// find the exact byte range of the entry being touched, splice the text, and
+// leave every other byte alone. The locating is done with
+// go-toml/v2/unstable's streaming expression parser, which reports the
+// top-level expressions of a document in source order along with the input
+// ranges of their key and value tokens.
+
+// DepTable names a dependency table an edit targets.
+//
+// Only the two document-level tables are addressable. A component's own
+// [components.<name>.dependencies] is deliberately out of reach: which
+// component a dependency belongs to is a decision `tt package add` does not
+// get to make for the user.
+type DepTable string
+
+const (
+	// TableDependencies is [dependencies]: what the package needs to run.
+	TableDependencies DepTable = "dependencies"
+	// TableDevDependencies is [dev_dependencies]: what only the package's own
+	// tests and tooling need.
+	TableDevDependencies DepTable = "dev_dependencies"
+)
+
+// ErrNoSuchDependency is returned by RemoveDependency when the target table
+// does not declare the name at all. SetDependency never returns it - a missing
+// name is what it is there to add. Callers match it with errors.Is.
+var ErrNoSuchDependency = errors.New("dependency is not declared")
+
+// ErrUnsupportedForm is returned when a declaration is written in a shape this
+// editor refuses to rewrite: a value that is neither a constraint string nor a
+// table, a table nested below the dependency, the same name declared twice, or
+// a request to set a version on a declaration that has no version key.
+//
+// The refusal is deliberate and is the whole safety model of this file. A
+// wrong splice destroys a file the user hand-wrote; a refusal costs them one
+// hand edit. Every error wrapping this sentinel names the construct that
+// caused it.
+var ErrUnsupportedForm = errors.New("dependency declaration cannot be edited automatically")
+
+// Change reports what an edit did to an existing declaration. A zero Change
+// means the edit created a declaration that was not there before.
+type Change struct {
+	Existed  bool   // A declaration was already there.
+	Previous string // Its previous version constraint, when Existed.
+}
+
+// Editor rewrites the dependency tables of a manifest's TOML source in place,
+// leaving every untouched byte of the file exactly as it was.
+//
+// It is not safe for concurrent use: every method re-indexes the current
+// source, so an edit must complete before the next one starts.
+type Editor struct {
+	src []byte
+}
+
+// NewEditor parses src for editing. The source has to be syntactically valid
+// TOML; it does not have to be a valid manifest, because a caller may well be
+// repairing one. Callers keep ownership of src: the Editor copies it.
+func NewEditor(src []byte) (*Editor, error) {
+	_, err := indexSource(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Editor{src: bytes.Clone(src)}, nil
+}
+
+// Bytes returns the edited source. The returned slice is a copy, so a caller
+// can hold on to an intermediate state across further edits.
+func (e *Editor) Bytes() []byte {
+	return bytes.Clone(e.src)
+}
+
+// Locate reports which dependency tables declare name, in a stable order
+// ([dependencies] before [dev_dependencies]).
+//
+// It reports presence, not editability: a name declared in a form
+// SetDependency would refuse is still located, because `tt package add` has to
+// tell "already there, in a shape I cannot touch" apart from "not there".
+func (e *Editor) Locate(name string) []DepTable {
+	doc, err := indexSource(e.src)
+	if err != nil {
+		// The source was valid when the Editor was built and every edit path
+		// re-checks its own output, so this is unreachable; an empty result is
+		// the honest answer rather than a panic.
+		return nil
+	}
+
+	var found []DepTable
+
+	for _, table := range []DepTable{TableDependencies, TableDevDependencies} {
+		if doc.declares(table, name) {
+			found = append(found, table)
+		}
+	}
+
+	return found
+}
+
+// SetDependency declares name in table with the given version constraint, or
+// rewrites the constraint of an existing declaration.
+//
+// What it rewrites depends on the form found:
+//
+//   - short form (name = ">=1.0.0"): the string value is replaced;
+//   - inline table (name = { source = "registry", version = ">=1.0.0" }) and
+//     sub-table ([dependencies.name] with its own lines): the value of the
+//     version key is replaced, and nothing else in the declaration moves;
+//   - a declaration with no version key - a path dependency, say - is refused
+//     with ErrUnsupportedForm. Pinning a version on a path dependency is
+//     contradictory, so guessing where the key should go would be wrong.
+//
+// When name is not declared yet it is appended as a short-form entry after the
+// last entry of the target table, or, when the table does not exist at all, in
+// a new section at the end of the file. Insertion is positional on purpose: a
+// section that happens to be sorted is not evidence that the user wants it
+// kept sorted, and reordering is the kind of diff noise this editor exists to
+// avoid.
+func (e *Editor) SetDependency(table DepTable, name, constraint string) (Change, error) {
+	var change Change
+
+	err := checkEditTarget(table, name)
+	if err != nil {
+		return change, err
+	}
+
+	if constraint == "" {
+		return change, invalid(string(table)+"."+name, "version constraint is empty")
+	}
+
+	doc, err := indexSource(e.src)
+	if err != nil {
+		return change, err
+	}
+
+	decl, err := doc.find(table, name)
+
+	switch {
+	case errors.Is(err, ErrNoSuchDependency):
+		e.src = doc.insert(table, name, constraint)
+
+		return change, nil
+	case err != nil:
+		return change, err
+	}
+
+	if !decl.hasVersion {
+		return change, fmt.Errorf("%s.%s: %w: the declaration carries no version key,"+
+			" edit it by hand", table, name, ErrUnsupportedForm)
+	}
+
+	change.Existed = true
+	change.Previous = decl.versionData
+	e.src = doc.replace(decl.version, quoteTOMLString(constraint))
+
+	return change, nil
+}
+
+// RemoveDependency drops name's declaration from table.
+//
+// The whole declaration goes: for a sub-table that is the [dependencies.name]
+// header and every line of its body, up to and including its last key - a
+// following table header, and any comment lines between that last key and it,
+// stay.
+//
+// Comment lines above the removed declaration are also left in place. Whether
+// a comment documents the entry below it or the section it sits in is
+// guesswork, and deleting a line the user wrote on a guess is worse than
+// leaving a stale one they can see and remove.
+//
+// Removing the last entry of a table leaves the now-empty table header behind,
+// which parses to an empty map and validates.
+func (e *Editor) RemoveDependency(table DepTable, name string) (Change, error) {
+	var change Change
+
+	err := checkEditTarget(table, name)
+	if err != nil {
+		return change, err
+	}
+
+	doc, err := indexSource(e.src)
+	if err != nil {
+		return change, err
+	}
+
+	decl, err := doc.find(table, name)
+	if err != nil {
+		return change, err
+	}
+
+	change.Existed = true
+	change.Previous = decl.versionData
+	e.src = doc.cut(doc.removalSpans(decl))
+
+	return change, nil
+}
+
+// checkEditTarget rejects arguments no edit can act on before any parsing is
+// done, so a typo in a table name cannot be mistaken for a missing dependency.
+func checkEditTarget(table DepTable, name string) error {
+	switch table {
+	case TableDependencies, TableDevDependencies:
+	default:
+		return invalid(string(table), "not a dependency table")
+	}
+
+	if name == "" {
+		return invalid(string(table), "dependency name is empty")
+	}
+
+	return nil
+}

--- a/cli/manifest/edit_test.go
+++ b/cli/manifest/edit_test.go
@@ -1,0 +1,761 @@
+package manifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// editPrelude and editTables are the minimum a manifest needs to parse and
+// validate, split so a fixture can put root-level dotted keys between them.
+//
+// The split matters: a dotted key is only a *root* key while no table header
+// has been seen yet, so `dependencies.foo = "1"` written after [platform] is
+// platform.dependencies.foo and not a dependency at all.
+const (
+	editPrelude = `manifest_version = "0.1"
+`
+	editTables = `
+[package]
+name = "demo"
+
+[platform]
+tarantool = ">=3.0.0"
+tt = ">=3.0.0"
+`
+	editHeader = editPrelude + editTables
+)
+
+// reparse runs edited bytes back through the real reader. Every mutation is
+// checked with it: an editor that emits TOML the manifest reader rejects has
+// destroyed a file the user hand-wrote, which is the worst failure this
+// package has.
+func reparse(t *testing.T, src []byte) *manifest.Manifest {
+	t.Helper()
+
+	mfst, warnings, err := manifest.ParseManifest(src)
+	require.NoError(t, err, "edited manifest must still parse:\n%s", src)
+	require.Empty(t, warnings)
+
+	_, err = mfst.Validate()
+	require.NoError(t, err, "edited manifest must still validate:\n%s", src)
+
+	return mfst
+}
+
+// edit builds an Editor over the fixture and fails the test if the fixture
+// itself is unusable.
+func edit(t *testing.T, src string) *manifest.Editor {
+	t.Helper()
+
+	editor, err := manifest.NewEditor([]byte(src))
+	require.NoError(t, err)
+
+	return editor
+}
+
+// TestEditorAddToExistingTable checks that a new dependency lands after the
+// last entry of the section rather than at the end of the file or in
+// alphabetical order.
+func TestEditorAddToExistingTable(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies]
+zzz = ">=1.0.0"
+aaa = ">=2.0.0"
+
+[dev_dependencies]
+luatest = ">=1.0.0"
+`
+	editor := edit(t, src)
+
+	change, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=3.1.0")
+	require.NoError(t, err)
+	assert.False(t, change.Existed)
+	assert.Empty(t, change.Previous)
+
+	assert.Equal(t, editHeader+`
+[dependencies]
+zzz = ">=1.0.0"
+aaa = ">=2.0.0"
+checks = ">=3.1.0"
+
+[dev_dependencies]
+luatest = ">=1.0.0"
+`, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=3.1.0", mfst.Dependencies["checks"].Version)
+	assert.Equal(t, "registry", mfst.Dependencies["checks"].Source)
+	assert.Len(t, mfst.Dependencies, 3)
+}
+
+// TestEditorAddSkipsSubTables checks the insertion point steps over a
+// dependency sub-table: a key appended after [dependencies.helper] would
+// silently become a field of helper.
+func TestEditorAddSkipsSubTables(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies]
+zzz = ">=1.0.0"
+
+[dependencies.helper]
+source = "path"
+path = "../helper"
+`
+	editor := edit(t, src)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=3.1.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, editHeader+`
+[dependencies]
+zzz = ">=1.0.0"
+checks = ">=3.1.0"
+
+[dependencies.helper]
+source = "path"
+path = "../helper"
+`, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=3.1.0", mfst.Dependencies["checks"].Version)
+	assert.Equal(t, "../helper", mfst.Dependencies["helper"].Path)
+}
+
+// TestEditorAddToEmptySection checks a section that only has a header.
+func TestEditorAddToEmptySection(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies]
+
+[dev_dependencies]
+luatest = ">=1.0.0"
+`
+	editor := edit(t, src)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=3.1.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, editHeader+`
+[dependencies]
+checks = ">=3.1.0"
+
+[dev_dependencies]
+luatest = ">=1.0.0"
+`, string(editor.Bytes()))
+
+	reparse(t, editor.Bytes())
+}
+
+// TestEditorAddCreatesTable covers the absent-table case for both tables: a
+// new section is appended at the end, one blank line down.
+func TestEditorAddCreatesTable(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name  string
+		table manifest.DepTable
+		want  string
+	}{
+		{
+			name:  "dependencies",
+			table: manifest.TableDependencies,
+			want:  editHeader + "\n[dependencies]\nchecks = \">=3.1.0\"\n",
+		},
+		{
+			name:  "dev_dependencies",
+			table: manifest.TableDevDependencies,
+			want:  editHeader + "\n[dev_dependencies]\nchecks = \">=3.1.0\"\n",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, editHeader)
+
+			change, err := editor.SetDependency(testCase.table, "checks", ">=3.1.0")
+			require.NoError(t, err)
+			assert.False(t, change.Existed)
+
+			assert.Equal(t, testCase.want, string(editor.Bytes()))
+
+			mfst := reparse(t, editor.Bytes())
+			if testCase.table == manifest.TableDependencies {
+				assert.Equal(t, ">=3.1.0", mfst.Dependencies["checks"].Version)
+			} else {
+				assert.Equal(t, ">=3.1.0", mfst.DevDependencies["checks"].Version)
+			}
+		})
+	}
+}
+
+// TestEditorAddAfterRootDottedKeys checks the case TOML makes special: a table
+// defined by dotted keys at the root cannot be reopened with a [header], so a
+// new entry has to be written as one more dotted key.
+func TestEditorAddAfterRootDottedKeys(t *testing.T) {
+	t.Parallel()
+
+	src := editPrelude + `dependencies.luasocket = ">=3.0.0"
+` + editTables
+	editor := edit(t, src)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=3.1.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, editPrelude+`dependencies.luasocket = ">=3.0.0"
+dependencies.checks = ">=3.1.0"
+`+editTables, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=3.1.0", mfst.Dependencies["checks"].Version)
+	assert.Equal(t, ">=3.0.0", mfst.Dependencies["luasocket"].Version)
+}
+
+// preserveFixture exercises every construct the editor has to walk past
+// untouched: a header comment, comments between and inside sections, a
+// trailing same-line comment on a neighbouring entry, an inline table, a
+// sub-table and aligned-with-spaces keys.
+const preserveFixture = `# app.manifest.toml for demo
+# second header line
+
+manifest_version = "0.1"
+
+[package]
+name        = "demo"
+description = "a demo package"   # keep me
+
+# --- what demo needs to run ---
+[dependencies]
+luasocket   = ">=3.0.0,<4.0.0"   # the socket library
+checks      = ">=3.1.0"
+inline      = { source = "registry", version = ">=1.0.0", kind = "library" }
+
+# helper lives in the sibling directory
+[dependencies.local-helper]
+source = "path"
+path   = "../helper"
+
+# --- and to test itself ---
+[dev_dependencies]
+luatest = ">=1.0.0"
+
+[platform]
+tarantool = ">=3.0.0"
+tt        = ">=3.0.0"
+`
+
+// TestEditorPreservesEverythingElse is the headline case: after rewriting one
+// constraint the file must differ from the original in exactly that one token.
+func TestEditorPreservesEverythingElse(t *testing.T) {
+	t.Parallel()
+
+	editor := edit(t, preserveFixture)
+
+	change, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=4.0.0")
+	require.NoError(t, err)
+	assert.True(t, change.Existed)
+	assert.Equal(t, ">=3.1.0", change.Previous)
+
+	want := strings.Replace(preserveFixture,
+		`checks      = ">=3.1.0"`, `checks      = ">=4.0.0"`, 1)
+	require.NotEqual(t, preserveFixture, want, "the fixture must contain the edited line")
+	assert.Equal(t, want, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=4.0.0", mfst.Dependencies["checks"].Version)
+	assert.Equal(t, ">=3.0.0,<4.0.0", mfst.Dependencies["luasocket"].Version)
+	assert.Equal(t, "a demo package", mfst.Package.Description)
+}
+
+// TestEditorSetRewritesEveryForm covers the three editable declaration forms
+// and the constraint each one reports as the previous value.
+func TestEditorSetRewritesEveryForm(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name     string
+		dep      string
+		previous string
+		want     string
+	}{
+		{
+			name:     "short",
+			dep:      "checks",
+			previous: ">=3.1.0",
+			want:     `checks      = ">=9.9.9"`,
+		},
+		{
+			name:     "inline table",
+			dep:      "inline",
+			previous: ">=1.0.0",
+			want: `inline      = ` +
+				`{ source = "registry", version = ">=9.9.9", kind = "library" }`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, preserveFixture)
+
+			change, err := editor.SetDependency(manifest.TableDependencies, testCase.dep, ">=9.9.9")
+			require.NoError(t, err)
+			assert.True(t, change.Existed)
+			assert.Equal(t, testCase.previous, change.Previous)
+
+			assert.Contains(t, string(editor.Bytes()), testCase.want)
+
+			mfst := reparse(t, editor.Bytes())
+			assert.Equal(t, ">=9.9.9", mfst.Dependencies[testCase.dep].Version)
+		})
+	}
+}
+
+// TestEditorSetSubTableVersion rewrites the version key of a long-form
+// declaration written as its own table, and leaves the rest of the body alone.
+func TestEditorSetSubTableVersion(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies.metrics]
+source   = "registry"
+version  = ">=0.15.0"     # pinned by the ops team
+registry = "https://rocks.example"
+`
+	editor := edit(t, src)
+
+	change, err := editor.SetDependency(manifest.TableDependencies, "metrics", ">=1.0.0")
+	require.NoError(t, err)
+	assert.True(t, change.Existed)
+	assert.Equal(t, ">=0.15.0", change.Previous)
+
+	assert.Equal(t, editHeader+`
+[dependencies.metrics]
+source   = "registry"
+version  = ">=1.0.0"     # pinned by the ops team
+registry = "https://rocks.example"
+`, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=1.0.0", mfst.Dependencies["metrics"].Version)
+	assert.Equal(t, "https://rocks.example", mfst.Dependencies["metrics"].Registry)
+}
+
+// TestEditorSetDottedKeyVersion rewrites a version declared as a root-level
+// dotted key.
+func TestEditorSetDottedKeyVersion(t *testing.T) {
+	t.Parallel()
+
+	src := editPrelude + `dependencies.metrics.source = "registry"
+dependencies.metrics.version = ">=0.15.0"
+` + editTables
+	editor := edit(t, src)
+
+	change, err := editor.SetDependency(manifest.TableDependencies, "metrics", ">=1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, ">=0.15.0", change.Previous)
+
+	assert.Equal(t, editPrelude+`dependencies.metrics.source = "registry"
+dependencies.metrics.version = ">=1.0.0"
+`+editTables, string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=1.0.0", mfst.Dependencies["metrics"].Version)
+}
+
+// TestEditorRefusesVersionlessForms checks the refusals: setting a constraint
+// on a declaration that has no version key is contradictory (a path dependency
+// has no version to pin), so the editor names the dependency and stops instead
+// of inventing a place for the key.
+func TestEditorRefusesVersionlessForms(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "path sub-table",
+			src: editHeader + "\n[dependencies.helper]\nsource = \"path\"\n" +
+				"path   = \"../helper\"\n",
+		},
+		{
+			name: "path inline table",
+			src: editHeader + "\n[dependencies]\n" +
+				"helper = { source = \"path\", path = \"../helper\" }\n",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, testCase.src)
+
+			change, err := editor.SetDependency(manifest.TableDependencies, "helper", ">=1.0.0")
+			require.ErrorIs(t, err, manifest.ErrUnsupportedForm)
+			assert.Contains(t, err.Error(), "dependencies.helper")
+			assert.False(t, change.Existed)
+
+			assert.Equal(t, testCase.src, string(editor.Bytes()),
+				"a refusal must not touch the file")
+		})
+	}
+}
+
+// TestEditorRefusesUneditableShapes covers the constructs the editor will not
+// splice: a value that is neither a constraint nor a table, and a table nested
+// below the dependency, which a removal would strand.
+func TestEditorRefusesUneditableShapes(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		src  string
+		dep  string
+	}{
+		{
+			name: "array value",
+			src:  editHeader + "\n[dependencies]\nweird = [\">=1.0.0\"]\n",
+			dep:  "weird",
+		},
+		{
+			name: "nested table",
+			src: editHeader + "\n[dependencies.weird]\nsource = \"registry\"\n" +
+				"version = \">=1.0.0\"\n\n[dependencies.weird.extra]\nkey = 1\n",
+			dep: "weird",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, testCase.src)
+
+			_, err := editor.SetDependency(manifest.TableDependencies, testCase.dep, ">=2.0.0")
+			require.ErrorIs(t, err, manifest.ErrUnsupportedForm)
+
+			_, err = editor.RemoveDependency(manifest.TableDependencies, testCase.dep)
+			require.ErrorIs(t, err, manifest.ErrUnsupportedForm)
+
+			assert.Equal(t, testCase.src, string(editor.Bytes()),
+				"a refusal must not touch the file")
+		})
+	}
+}
+
+// TestEditorRemoveEveryForm removes each of the four declaration forms and
+// checks the exact remaining bytes. The sub-table case is the interesting one:
+// the whole body goes and the next header stays, together with the comment
+// written above it.
+func TestEditorRemoveEveryForm(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "short",
+			src: editHeader + "\n[dependencies]\nchecks = \">=3.1.0\"\n" +
+				"luasocket = \">=3.0.0\"\n",
+			want: editHeader + "\n[dependencies]\nluasocket = \">=3.0.0\"\n",
+		},
+		{
+			name: "inline table",
+			src: editHeader + "\n[dependencies]\n" +
+				"checks = { source = \"registry\", version = \">=3.1.0\" }\n" +
+				"luasocket = \">=3.0.0\"\n",
+			want: editHeader + "\n[dependencies]\nluasocket = \">=3.0.0\"\n",
+		},
+		{
+			name: "sub-table stops at the next header",
+			src: editHeader + "\n[dependencies.checks]\nsource = \"registry\"\n" +
+				"version = \">=3.1.0\"\n\n# luasocket is separate\n" +
+				"[dependencies.luasocket]\nsource = \"registry\"\nversion = \">=3.0.0\"\n",
+			want: editHeader + "\n\n# luasocket is separate\n" +
+				"[dependencies.luasocket]\nsource = \"registry\"\nversion = \">=3.0.0\"\n",
+		},
+		{
+			// A blank line inside a table body is legal and common. It is not
+			// the end of the declaration, so a removal that stopped there
+			// would strand the keys below it under the previous table.
+			name: "sub-table with a blank line in its body",
+			src: editHeader + "\n[dependencies.checks]\nsource = \"registry\"\n\n" +
+				"version = \">=3.1.0\"\n\n# luasocket is separate\n" +
+				"[dependencies.luasocket]\nsource = \"registry\"\nversion = \">=3.0.0\"\n",
+			want: editHeader + "\n\n# luasocket is separate\n" +
+				"[dependencies.luasocket]\nsource = \"registry\"\nversion = \">=3.0.0\"\n",
+		},
+		{
+			name: "root dotted key",
+			src: editPrelude + "dependencies.checks = \">=3.1.0\"\n" +
+				"dependencies.luasocket = \">=3.0.0\"\n" + editTables,
+			want: editPrelude + "dependencies.luasocket = \">=3.0.0\"\n" + editTables,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, testCase.src)
+
+			change, err := editor.RemoveDependency(manifest.TableDependencies, "checks")
+			require.NoError(t, err)
+			assert.True(t, change.Existed)
+
+			assert.Equal(t, testCase.want, string(editor.Bytes()))
+
+			mfst := reparse(t, editor.Bytes())
+			assert.NotContains(t, mfst.Dependencies, "checks")
+			assert.Contains(t, mfst.Dependencies, "luasocket")
+		})
+	}
+}
+
+// TestEditorRemoveKeepsLeadingComment pins the deliberate choice not to guess
+// what a comment above an entry documents.
+func TestEditorRemoveKeepsLeadingComment(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies]
+# checks validates our config
+checks = ">=3.1.0"
+luasocket = ">=3.0.0"
+`
+	editor := edit(t, src)
+
+	_, err := editor.RemoveDependency(manifest.TableDependencies, "checks")
+	require.NoError(t, err)
+
+	assert.Equal(t, editHeader+`
+[dependencies]
+# checks validates our config
+luasocket = ">=3.0.0"
+`, string(editor.Bytes()))
+
+	reparse(t, editor.Bytes())
+}
+
+// TestEditorRemoveLastEntryKeepsHeader documents that an emptied section is
+// left in place: an empty table parses to an empty map and validates.
+func TestEditorRemoveLastEntryKeepsHeader(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + "\n[dependencies]\nchecks = \">=3.1.0\"\n"
+	editor := edit(t, src)
+
+	_, err := editor.RemoveDependency(manifest.TableDependencies, "checks")
+	require.NoError(t, err)
+	assert.Equal(t, editHeader+"\n[dependencies]\n", string(editor.Bytes()))
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Empty(t, mfst.Dependencies)
+}
+
+// TestEditorUnknownName checks the sentinel both mutations return for a name
+// that is not there - Set adds instead, Remove refuses.
+func TestEditorUnknownName(t *testing.T) {
+	t.Parallel()
+
+	editor := edit(t, preserveFixture)
+
+	change, err := editor.RemoveDependency(manifest.TableDependencies, "absent")
+	require.ErrorIs(t, err, manifest.ErrNoSuchDependency)
+	assert.False(t, change.Existed)
+	assert.Equal(t, preserveFixture, string(editor.Bytes()))
+
+	// A dependency declared in the other table is still absent from this one.
+	_, err = editor.RemoveDependency(manifest.TableDependencies, "luatest")
+	require.ErrorIs(t, err, manifest.ErrNoSuchDependency)
+
+	change, err = editor.SetDependency(manifest.TableDependencies, "absent", ">=1.0.0")
+	require.NoError(t, err)
+	assert.False(t, change.Existed)
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=1.0.0", mfst.Dependencies["absent"].Version)
+}
+
+// TestEditorLocate checks the report of which tables declare a name, including
+// a name declared in both.
+func TestEditorLocate(t *testing.T) {
+	t.Parallel()
+
+	src := editHeader + `
+[dependencies]
+luasocket = ">=3.0.0"
+helper    = { source = "path", path = "../helper" }
+
+[dev_dependencies]
+luatest   = ">=1.0.0"
+luasocket = ">=3.0.0"
+`
+	editor := edit(t, src)
+
+	assert.Equal(t,
+		[]manifest.DepTable{manifest.TableDependencies, manifest.TableDevDependencies},
+		editor.Locate("luasocket"))
+	assert.Equal(t, []manifest.DepTable{manifest.TableDependencies}, editor.Locate("helper"))
+	assert.Equal(t, []manifest.DepTable{manifest.TableDevDependencies}, editor.Locate("luatest"))
+	assert.Empty(t, editor.Locate("absent"))
+}
+
+// TestEditorLocateSubTableAndDotted checks Locate sees the long forms too, and
+// that it reports a declaration even when it is one SetDependency would
+// refuse - "already there, in a shape I cannot touch" is a different answer
+// from "not there".
+func TestEditorLocateSubTableAndDotted(t *testing.T) {
+	t.Parallel()
+
+	src := editPrelude + `dependencies.dotted = ">=1.0.0"
+` + editTables + `
+[dev_dependencies.helper]
+source = "path"
+path   = "../helper"
+`
+	editor := edit(t, src)
+
+	assert.Equal(t, []manifest.DepTable{manifest.TableDependencies}, editor.Locate("dotted"))
+	assert.Equal(t, []manifest.DepTable{manifest.TableDevDependencies}, editor.Locate("helper"))
+
+	_, err := editor.SetDependency(manifest.TableDevDependencies, "helper", ">=1.0.0")
+	require.ErrorIs(t, err, manifest.ErrUnsupportedForm)
+}
+
+// TestEditorPreservesLineEndings checks a CRLF file keeps its convention: an
+// inserted line must not mix "\n" into a document written with "\r\n".
+func TestEditorPreservesLineEndings(t *testing.T) {
+	t.Parallel()
+
+	src := strings.ReplaceAll(editHeader+"\n[dependencies]\nchecks = \">=3.1.0\"\n",
+		"\n", "\r\n")
+	editor := edit(t, src)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "luasocket", ">=3.0.0")
+	require.NoError(t, err)
+
+	out := string(editor.Bytes())
+	assert.Contains(t, out, "checks = \">=3.1.0\"\r\nluasocket = \">=3.0.0\"\r\n")
+	assert.Equal(t, strings.Count(out, "\n"), strings.Count(out, "\r\n"),
+		"every line break must stay a CRLF")
+
+	reparse(t, editor.Bytes())
+}
+
+// TestEditorPreservesMissingTrailingNewline checks a file that ended without a
+// line break does not silently gain one. Appending necessarily writes a break
+// before the new content; what is preserved is how the file *ends*.
+func TestEditorPreservesMissingTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "into an existing section",
+			src:  editHeader + "\n[dependencies]\nchecks = \">=3.1.0\"",
+			want: editHeader + "\n[dependencies]\nchecks = \">=3.1.0\"\nluasocket = \">=3.0.0\"",
+		},
+		{
+			name: "as a new section",
+			src:  strings.TrimSuffix(editHeader, "\n"),
+			want: strings.TrimSuffix(editHeader, "\n") +
+				"\n\n[dependencies]\nluasocket = \">=3.0.0\"",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			editor := edit(t, testCase.src)
+
+			_, err := editor.SetDependency(manifest.TableDependencies, "luasocket", ">=3.0.0")
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, string(editor.Bytes()))
+
+			mfst := reparse(t, editor.Bytes())
+			assert.Equal(t, ">=3.0.0", mfst.Dependencies["luasocket"].Version)
+		})
+	}
+}
+
+// TestEditorRejectsBadArguments covers the arguments no parse can rescue.
+func TestEditorRejectsBadArguments(t *testing.T) {
+	t.Parallel()
+
+	editor := edit(t, preserveFixture)
+
+	_, err := editor.SetDependency("components", "checks", ">=1.0.0")
+	require.Error(t, err)
+
+	_, err = editor.SetDependency(manifest.TableDependencies, "", ">=1.0.0")
+	require.Error(t, err)
+
+	_, err = editor.SetDependency(manifest.TableDependencies, "checks", "")
+	require.Error(t, err)
+
+	_, err = editor.RemoveDependency("components", "checks")
+	require.Error(t, err)
+
+	assert.Equal(t, preserveFixture, string(editor.Bytes()))
+}
+
+// TestNewEditorRejectsBrokenTOML checks the editor refuses to work on a source
+// it cannot locate anything in.
+func TestNewEditorRejectsBrokenTOML(t *testing.T) {
+	t.Parallel()
+
+	_, err := manifest.NewEditor([]byte("[dependencies\nchecks = \">=1.0.0\"\n"))
+	require.Error(t, err)
+}
+
+// TestEditorSequentialEdits checks the source stays consistent across several
+// edits, since each one re-indexes what the previous one produced.
+func TestEditorSequentialEdits(t *testing.T) {
+	t.Parallel()
+
+	editor := edit(t, preserveFixture)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "checks", ">=4.0.0")
+	require.NoError(t, err)
+
+	_, err = editor.RemoveDependency(manifest.TableDependencies, "local-helper")
+	require.NoError(t, err)
+
+	_, err = editor.SetDependency(manifest.TableDevDependencies, "luacov", ">=0.15.0")
+	require.NoError(t, err)
+
+	_, err = editor.SetDependency(manifest.TableDependencies, "checks", ">=5.0.0")
+	require.NoError(t, err)
+
+	mfst := reparse(t, editor.Bytes())
+	assert.Equal(t, ">=5.0.0", mfst.Dependencies["checks"].Version)
+	assert.NotContains(t, mfst.Dependencies, "local-helper")
+	assert.Equal(t, ">=0.15.0", mfst.DevDependencies["luacov"].Version)
+	assert.Equal(t, ">=1.0.0", mfst.DevDependencies["luatest"].Version)
+	assert.Contains(t, string(editor.Bytes()), "# app.manifest.toml for demo")
+}
+
+// TestEditorQuotesWhatItWrites checks a constraint is escaped rather than
+// pasted, so a value with a quote in it cannot break the document open.
+func TestEditorQuotesWhatItWrites(t *testing.T) {
+	t.Parallel()
+
+	editor := edit(t, editHeader)
+
+	_, err := editor.SetDependency(manifest.TableDependencies, "odd", `>=1.0.0"\ `)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(editor.Bytes()), `odd = ">=1.0.0\"\\ "`)
+
+	mfst, _, err := manifest.ParseManifest(editor.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, `>=1.0.0"\ `, mfst.Dependencies["odd"].Version)
+}

--- a/cli/manifest/editdecl.go
+++ b/cli/manifest/editdecl.go
@@ -1,0 +1,272 @@
+package manifest
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// This file classifies a dependency declaration into one of the forms the
+// editor knows how to rewrite, and turns it into the byte ranges edit.go
+// splices. Anything that does not classify cleanly is refused with
+// ErrUnsupportedForm rather than guessed at.
+
+// declForm is the shape a dependency is written in.
+type declForm int
+
+const (
+	// formShort is `name = ">=1.0.0"` - a bare constraint string.
+	formShort declForm = iota
+	// formInline is `name = { source = "registry", version = ">=1.0.0" }`.
+	formInline
+	// formTable covers every spelling of the long form that puts the fields on
+	// their own lines: a [dependencies.name] header with its body, and the
+	// dotted keys (`dependencies.name.version = "..."`) that mean the same
+	// thing. They are one form because they index identically - both produce
+	// key/value expressions with the path dependencies.name.<field>.
+	formTable
+)
+
+// declaration is one dependency located in a document.
+type declaration struct {
+	form declForm
+	// matches indexes every expression that belongs to the declaration, in
+	// source order.
+	matches []int
+	// header indexes the [dependencies.name] table header, or -1 when the
+	// declaration has none.
+	header int
+	// hasVersion reports whether a string-valued version constraint was found;
+	// version is its token range and versionData its decoded text.
+	hasVersion  bool
+	version     span
+	versionData string
+}
+
+// find locates name in table, classifying the declaration form.
+//
+// It returns ErrNoSuchDependency when nothing declares the name, and an error
+// wrapping ErrUnsupportedForm when something does but in a shape that cannot
+// be rewritten safely.
+func (d *document) find(table DepTable, name string) (*declaration, error) {
+	matches, header, err := d.collect(table, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%s.%s: %w", table, name, ErrNoSuchDependency)
+	}
+
+	entries, fields := d.split(matches)
+
+	switch {
+	case len(entries) > 1:
+		return nil, refuse(table, name, "it is declared more than once")
+	case len(entries) == 1 && (header >= 0 || len(fields) > 0):
+		return nil, refuse(table, name,
+			"it is declared both as a single key and as a table")
+	case len(entries) == 1:
+		return d.describeEntry(table, name, matches, entries[0])
+	}
+
+	return d.describeTable(table, name, matches, header, fields)
+}
+
+// collect gathers the expressions belonging to a dependency and rejects the
+// table shapes the editor cannot follow: an array of tables, a table nested
+// below the dependency (which a removal would strand), and the same
+// dependency opened by two headers.
+func (d *document) collect(table DepTable, name string) ([]int, int, error) {
+	var matches []int
+
+	header := -1
+
+	for idx := range d.exprs {
+		item := &d.exprs[idx]
+		if !hasDepPrefix(item.path, table, name) {
+			continue
+		}
+
+		switch item.kind {
+		case unstable.Table:
+			if len(item.path) != depthEntry {
+				return nil, 0, refuse(table, name,
+					"it has a nested table [%s]", joinKeys(item.path))
+			}
+
+			if header >= 0 {
+				return nil, 0, refuse(table, name, "its table header appears twice")
+			}
+
+			header = idx
+		case unstable.ArrayTable:
+			return nil, 0, refuse(table, name, "it is declared as an array of tables")
+		case unstable.KeyValue:
+		default:
+			return nil, 0, refuse(table, name, "it contains a %s expression", item.kind)
+		}
+
+		matches = append(matches, idx)
+	}
+
+	err := d.checkContiguous(table, name, matches, header)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return matches, header, nil
+}
+
+// checkContiguous refuses a declaration whose header is separated from its own
+// keys by another table header. Removal deletes one contiguous region from the
+// header to the last key, so a foreign header inside that region would be
+// deleted with it.
+func (d *document) checkContiguous(table DepTable, name string, matches []int, header int) error {
+	if header < 0 || len(matches) == 0 {
+		return nil
+	}
+
+	last := matches[len(matches)-1]
+	for i := header + 1; i < last; i++ {
+		if d.exprs[i].kind == unstable.Table || d.exprs[i].kind == unstable.ArrayTable {
+			return refuse(table, name, "another table is declared inside its body")
+		}
+	}
+
+	return nil
+}
+
+// split partitions the key/value expressions of a declaration into the ones
+// that are the declaration itself and the ones that are its long-form fields.
+func (d *document) split(matches []int) ([]int, []int) {
+	var entries, fields []int
+
+	for _, idx := range matches {
+		item := &d.exprs[idx]
+		if item.kind != unstable.KeyValue {
+			continue
+		}
+
+		if len(item.path) == depthEntry {
+			entries = append(entries, idx)
+		} else {
+			fields = append(fields, idx)
+		}
+	}
+
+	return entries, fields
+}
+
+// describeEntry classifies a dependency written as one key: a bare constraint
+// string or an inline table.
+func (d *document) describeEntry(
+	table DepTable, name string, matches []int, entry int,
+) (*declaration, error) {
+	item := &d.exprs[entry]
+
+	decl := &declaration{
+		form:        formShort,
+		matches:     matches,
+		header:      -1,
+		hasVersion:  false,
+		version:     span{start: 0, end: 0},
+		versionData: "",
+	}
+
+	switch item.valueKind {
+	case unstable.String:
+		decl.hasVersion = true
+		decl.version = item.value
+		decl.versionData = item.valueData
+	case unstable.InlineTable:
+		decl.form = formInline
+		decl.hasVersion = item.hasVersion
+		decl.version = item.version
+		decl.versionData = item.versionData
+	default:
+		return nil, refuse(table, name, "its value is a %s, not a constraint or a table",
+			item.valueKind)
+	}
+
+	return decl, nil
+}
+
+// describeTable classifies a dependency written as a [dependencies.name] table
+// or as dotted keys, and finds its version field.
+func (d *document) describeTable(
+	table DepTable, name string, matches []int, header int, fields []int,
+) (*declaration, error) {
+	decl := &declaration{
+		form:        formTable,
+		matches:     matches,
+		header:      header,
+		hasVersion:  false,
+		version:     span{start: 0, end: 0},
+		versionData: "",
+	}
+
+	for _, idx := range fields {
+		item := &d.exprs[idx]
+		if len(item.path) != depthField {
+			return nil, refuse(table, name, "it has a nested key %s", joinKeys(item.path))
+		}
+
+		if item.path[depthField-1] != versionKey || item.valueKind != unstable.String {
+			continue
+		}
+
+		decl.hasVersion = true
+		decl.version = item.value
+		decl.versionData = item.valueData
+	}
+
+	return decl, nil
+}
+
+// removalSpans returns the byte ranges RemoveDependency deletes, in ascending
+// order and never overlapping.
+//
+// A declaration with a table header is deleted as one region running from the
+// header's line to the line of its last key, so comments and blank lines
+// written inside the block go with it. Without a header - dotted keys, or a
+// single-key declaration - each line goes on its own, and whatever sits
+// between them stays.
+func (d *document) removalSpans(decl *declaration) []span {
+	if decl.header >= 0 {
+		last := decl.matches[len(decl.matches)-1]
+
+		return []span{{
+			start: d.lineStart(d.exprs[decl.header].start),
+			end:   d.lineEnd(d.exprs[last].end),
+		}}
+	}
+
+	spans := make([]span, 0, len(decl.matches))
+	for _, idx := range decl.matches {
+		spans = append(spans, span{
+			start: d.lineStart(d.exprs[idx].start),
+			end:   d.lineEnd(d.exprs[idx].end),
+		})
+	}
+
+	return spans
+}
+
+// refuse builds an ErrUnsupportedForm error naming the dependency and the
+// construct that stopped the edit, so the user knows what to fix by hand.
+func refuse(table DepTable, name, reason string, args ...any) error {
+	return fmt.Errorf("%s.%s: %w: %s", table, name, ErrUnsupportedForm,
+		fmt.Sprintf(reason, args...))
+}
+
+// joinKeys renders a key path the way it appears in the file.
+func joinKeys(path []string) string {
+	quoted := make([]string, 0, len(path))
+	for _, key := range path {
+		quoted = append(quoted, quoteTOMLKey(key))
+	}
+
+	return strings.Join(quoted, ".")
+}

--- a/cli/manifest/editsource.go
+++ b/cli/manifest/editsource.go
@@ -1,0 +1,374 @@
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// This file is the locating half of the manifest editor: it turns TOML source
+// text into byte ranges the splicing in edit.go can act on. Nothing here
+// mutates anything.
+
+// depthEntry is the length of the key path of a dependency declared directly
+// as a key of its table ("dependencies", "luasocket"); depthField is the
+// length of the path of one of its long-form fields ("dependencies",
+// "luasocket", "version").
+const (
+	depthEntry = 2
+	depthField = 3
+)
+
+// versionKey is the long-form field a version constraint lives in, and the
+// only field this editor ever rewrites.
+const versionKey = "version"
+
+// span is a half-open byte range [start, end) of a document's source.
+type span struct {
+	start int
+	end   int
+}
+
+// tomlExpr is one top-level TOML expression located in the source.
+//
+// The unstable parser reuses its node storage between expressions, so nothing
+// here may hold *unstable.Node: every field is a plain copy taken while the
+// expression was the current one.
+type tomlExpr struct {
+	kind unstable.Kind // Comment, Table, ArrayTable or KeyValue.
+	// path is the fully qualified key path: the enclosing table's path
+	// followed by the expression's own key. Nil for a comment.
+	path []string
+	// table is the path of the table header this expression sits under, nil at
+	// the document root. For a header it is the header's own path.
+	table []string
+	// start is the offset of the expression's first byte - the '[' of a table
+	// header, the first key character of a key/value, the '#' of a comment.
+	start int
+	// end is the offset just past its last non-blank byte, and so covers a
+	// trailing same-line comment, which the parser chains onto the expression
+	// rather than reporting separately.
+	end int
+
+	valueKind unstable.Kind // Kind of a key/value's value node.
+	value     span          // Raw token range of that value; quotes included.
+	valueData string        // Its decoded text, for a scalar.
+
+	// hasVersion and the two fields after it describe the version key of an
+	// inline-table value. Only a string-valued version counts: rewriting
+	// anything else would change the value's type.
+	hasVersion  bool
+	version     span
+	versionData string
+}
+
+// document is an indexed snapshot of one TOML source: its expressions in
+// source order plus the two whitespace conventions any inserted line has to
+// match.
+type document struct {
+	src             []byte
+	exprs           []tomlExpr
+	newline         string // "\n" or "\r\n", taken from the first line break.
+	trailingNewline bool   // Whether the source ends with a line break.
+}
+
+// indexSource parses src and records where every top-level expression starts
+// and ends.
+//
+// Comments are parsed as expressions (KeepComments) purely for their offsets:
+// they are what bounds the expression before them, so a comment line written
+// above an entry is not swallowed by the entry above it.
+func indexSource(src []byte) (*document, error) {
+	var parser unstable.Parser
+
+	parser.KeepComments = true
+	parser.Reset(src)
+
+	var (
+		exprs []tomlExpr
+		table []string
+	)
+
+	for parser.NextExpression() {
+		item, err := describeExpr(parser.Expression(), src, table)
+		if err != nil {
+			return nil, err
+		}
+
+		if item.kind == unstable.Table || item.kind == unstable.ArrayTable {
+			table = item.path
+		}
+
+		exprs = append(exprs, item)
+	}
+
+	err := parser.Error()
+	if err != nil {
+		return nil, fmt.Errorf("parsing manifest for editing: %w", err)
+	}
+
+	// An expression's end is only knowable once the next one is known: the
+	// parser reports where tokens are, not where an expression stops. The gap
+	// between two consecutive expressions is whitespace, so the end is the
+	// right-trimmed run up to the next start (or to EOF for the last one).
+	for idx := range exprs {
+		limit := len(src)
+		if idx+1 < len(exprs) {
+			limit = exprs[idx+1].start
+		}
+
+		exprs[idx].end = trimBlankSuffix(src, exprs[idx].start, limit)
+	}
+
+	doc := &document{
+		src:             src,
+		exprs:           exprs,
+		newline:         detectNewline(src),
+		trailingNewline: len(src) > 0 && src[len(src)-1] == '\n',
+	}
+
+	return doc, nil
+}
+
+// describeExpr copies out of one expression node everything the editor needs,
+// while that node is still the parser's current one.
+func describeExpr(node *unstable.Node, src []byte, table []string) (tomlExpr, error) {
+	var item tomlExpr
+
+	item.kind = node.Kind
+
+	switch node.Kind {
+	case unstable.Comment:
+		item.start = int(node.Raw.Offset)
+	case unstable.Table, unstable.ArrayTable:
+		// A Table node carries no Raw of its own - only its key children do -
+		// so the header's start is found by walking back from the first key
+		// over the whitespace and brackets that must precede it.
+		path, first := keyPath(node)
+
+		item.path = path
+		item.table = path
+		item.start = scanBackToBracket(src, first)
+	case unstable.KeyValue:
+		path, first := keyPath(node)
+
+		item.start = first
+		item.table = table
+		item.path = append(append([]string(nil), table...), path...)
+
+		describeValue(&item, node.Value())
+	default:
+		return item, fmt.Errorf("%w: unexpected %s expression at byte %d",
+			ErrUnsupportedForm, node.Kind, node.Raw.Offset)
+	}
+
+	return item, nil
+}
+
+// keyPath returns the decoded key path of a table header or key/value and the
+// offset of its first key token. Quoted keys are decoded, so a name is matched
+// as it is meant rather than as it is spelled.
+func keyPath(node *unstable.Node) ([]string, int) {
+	var path []string
+
+	first := 0
+	iter := node.Key()
+
+	for iter.Next() {
+		key := iter.Node()
+		if path == nil {
+			first = int(key.Raw.Offset)
+		}
+
+		path = append(path, string(key.Data))
+	}
+
+	return path, first
+}
+
+// describeValue records a key/value's value token and, for an inline table,
+// the token of its version field.
+func describeValue(item *tomlExpr, value *unstable.Node) {
+	item.valueKind = value.Kind
+	item.value = spanOf(value)
+	item.valueData = string(value.Data)
+
+	if value.Kind != unstable.InlineTable {
+		return
+	}
+
+	// An inline table's own Raw covers just the opening brace, so its extent
+	// is never used; what is needed is inside it.
+	iter := value.Children()
+	for iter.Next() {
+		entry := iter.Node()
+
+		path, _ := keyPath(entry)
+		if len(path) != 1 || path[0] != versionKey {
+			continue
+		}
+
+		field := entry.Value()
+		if field.Kind != unstable.String {
+			continue
+		}
+
+		item.hasVersion = true
+		item.version = spanOf(field)
+		item.versionData = string(field.Data)
+	}
+}
+
+// spanOf converts a node's raw token range into a span.
+func spanOf(node *unstable.Node) span {
+	return span{
+		start: int(node.Raw.Offset),
+		end:   int(node.Raw.Offset) + int(node.Raw.Length),
+	}
+}
+
+// scanBackToBracket walks back from a table header's first key token over the
+// whitespace and the one or two '[' that TOML allows there, and returns the
+// offset of the first bracket.
+func scanBackToBracket(src []byte, keyStart int) int {
+	pos := keyStart
+	for pos > 0 && (src[pos-1] == ' ' || src[pos-1] == '\t') {
+		pos--
+	}
+
+	for pos > 0 && src[pos-1] == '[' {
+		pos--
+	}
+
+	return pos
+}
+
+// trimBlankSuffix returns the offset just past the last non-blank byte of
+// src[start:limit].
+func trimBlankSuffix(src []byte, start, limit int) int {
+	end := limit
+	for end > start && isBlankByte(src[end-1]) {
+		end--
+	}
+
+	return end
+}
+
+// isBlankByte reports whether b is whitespace or a line break.
+func isBlankByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+}
+
+// detectNewline reports the line ending the source already uses, so an
+// inserted line does not mix conventions into a CRLF file.
+func detectNewline(src []byte) string {
+	idx := bytes.IndexByte(src, '\n')
+	if idx > 0 && src[idx-1] == '\r' {
+		return "\r\n"
+	}
+
+	return "\n"
+}
+
+// lineStart returns the offset of the first byte of the line containing pos.
+func (d *document) lineStart(pos int) int {
+	return bytes.LastIndexByte(d.src[:pos], '\n') + 1
+}
+
+// lineEnd returns the offset just past the line break that ends the line
+// containing pos, or the end of the source when that line is unterminated.
+func (d *document) lineEnd(pos int) int {
+	idx := bytes.IndexByte(d.src[pos:], '\n')
+	if idx < 0 {
+		return len(d.src)
+	}
+
+	return pos + idx + 1
+}
+
+// declares reports whether the table declares name in any form, editable or
+// not.
+func (d *document) declares(table DepTable, name string) bool {
+	for i := range d.exprs {
+		if hasDepPrefix(d.exprs[i].path, table, name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasDepPrefix reports whether a key path belongs to the given dependency:
+// either it is the declaration itself ("dependencies", "luasocket") or one of
+// its fields below that.
+func hasDepPrefix(path []string, table DepTable, name string) bool {
+	return len(path) >= depthEntry && path[0] == string(table) && path[1] == name
+}
+
+// quoteTOMLString renders s as a TOML basic string, escaping what the format
+// requires. Everything a constraint can contain is representable this way, so
+// there is no value SetDependency has to refuse for being unwritable.
+func quoteTOMLString(str string) string {
+	var out strings.Builder
+
+	out.WriteByte('"')
+
+	for _, char := range str {
+		switch char {
+		case '"':
+			out.WriteString(`\"`)
+		case '\\':
+			out.WriteString(`\\`)
+		case '\b':
+			out.WriteString(`\b`)
+		case '\t':
+			out.WriteString(`\t`)
+		case '\n':
+			out.WriteString(`\n`)
+		case '\f':
+			out.WriteString(`\f`)
+		case '\r':
+			out.WriteString(`\r`)
+		default:
+			if char < ' ' || char == 0x7f {
+				fmt.Fprintf(&out, `\u%04X`, char)
+			} else {
+				out.WriteRune(char)
+			}
+		}
+	}
+
+	out.WriteByte('"')
+
+	return out.String()
+}
+
+// quoteTOMLKey renders name as a TOML key, quoting it only when it is not a
+// bare key. Package names are [a-z][a-z0-9-]* and so never need quoting, but
+// the editor is not the place to assume the manifest already validates.
+func quoteTOMLKey(name string) string {
+	for i := range len(name) {
+		char := name[i]
+
+		bare := char >= 'A' && char <= 'Z' ||
+			char >= 'a' && char <= 'z' ||
+			char >= '0' && char <= '9' ||
+			char == '-' || char == '_'
+		if !bare {
+			return quoteTOMLString(name)
+		}
+	}
+
+	if name == "" {
+		return quoteTOMLString(name)
+	}
+
+	return name
+}
+
+// formatEntry renders a short-form dependency line.
+func formatEntry(name, constraint string) string {
+	return quoteTOMLKey(name) + " = " + quoteTOMLString(constraint)
+}

--- a/cli/manifest/editsplice.go
+++ b/cli/manifest/editsplice.go
@@ -1,0 +1,183 @@
+package manifest
+
+import (
+	"bytes"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// This file does the actual text surgery: it turns a located span into new
+// source bytes. Every function here returns a fresh slice and leaves the
+// document's own source untouched, so a failed edit cannot half-apply.
+
+// replace swaps the bytes of one token for new text.
+func (d *document) replace(at span, text string) []byte {
+	out := make([]byte, 0, len(d.src)-(at.end-at.start)+len(text))
+
+	out = append(out, d.src[:at.start]...)
+	out = append(out, text...)
+	out = append(out, d.src[at.end:]...)
+
+	return out
+}
+
+// cut deletes the given spans, which must be ascending and non-overlapping.
+func (d *document) cut(spans []span) []byte {
+	out := make([]byte, 0, len(d.src))
+	prev := 0
+
+	for _, at := range spans {
+		out = append(out, d.src[prev:at.start]...)
+		prev = at.end
+	}
+
+	return append(out, d.src[prev:]...)
+}
+
+// insert adds a short-form declaration for a dependency the document does not
+// have yet, and returns the new source.
+//
+// Where it lands depends on what the file already has, in this order:
+//
+//  1. an explicit [dependencies] header - after the last key that header owns,
+//     or straight after the header when it owns none. Sub-tables of the
+//     section ([dependencies.helper]) are stepped over rather than appended
+//     to, since a key after their header would land inside them;
+//  2. no header but root-level dotted keys (dependencies.foo = "...") - as one
+//     more dotted key after the last of them. TOML forbids opening a
+//     [dependencies] table that dotted keys already defined, so a new section
+//     would not parse;
+//  3. neither - a fresh section at the end of the file.
+func (d *document) insert(table DepTable, name, constraint string) []byte {
+	entry := formatEntry(name, constraint)
+
+	header := d.sectionHeader(table)
+	if header >= 0 {
+		anchor := d.lastSectionKey(table, header)
+
+		return d.spliceLine(d.lineEnd(d.exprs[anchor].end), d.indentOf(anchor)+entry)
+	}
+
+	dotted := d.lastRootDottedKey(table)
+	if dotted >= 0 {
+		line := d.indentOf(dotted) + quoteTOMLKey(string(table)) + "." + entry
+
+		return d.spliceLine(d.lineEnd(d.exprs[dotted].end), line)
+	}
+
+	return d.appendSection(table, entry)
+}
+
+// sectionHeader returns the index of the [dependencies]/[dev_dependencies]
+// header, or -1 when the document has none.
+func (d *document) sectionHeader(table DepTable) int {
+	for i := range d.exprs {
+		item := &d.exprs[i]
+		if item.kind == unstable.Table && len(item.path) == 1 && item.path[0] == string(table) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// lastSectionKey returns the index of the last key/value written directly
+// under the section header, falling back to the header itself for an empty
+// section.
+func (d *document) lastSectionKey(table DepTable, header int) int {
+	anchor := header
+
+	for idx := header + 1; idx < len(d.exprs); idx++ {
+		item := &d.exprs[idx]
+		if item.kind != unstable.KeyValue {
+			continue
+		}
+
+		if len(item.table) == 1 && item.table[0] == string(table) {
+			anchor = idx
+		}
+	}
+
+	return anchor
+}
+
+// lastRootDottedKey returns the index of the last root-level dotted key that
+// declares something in the table, or -1 when there is none.
+func (d *document) lastRootDottedKey(table DepTable) int {
+	found := -1
+
+	for idx := range d.exprs {
+		item := &d.exprs[idx]
+		if item.kind != unstable.KeyValue || item.table != nil {
+			continue
+		}
+
+		if len(item.path) >= depthEntry && item.path[0] == string(table) {
+			found = idx
+		}
+	}
+
+	return found
+}
+
+// indentOf returns the leading whitespace of the line an expression starts on,
+// so an inserted line lines up with the ones around it.
+func (d *document) indentOf(idx int) string {
+	start := d.exprs[idx].start
+
+	return string(d.src[d.lineStart(start):start])
+}
+
+// spliceLine inserts one line at a line boundary.
+//
+// The one interesting case is a file whose last line has no line break: there
+// the break has to be written before the new line rather than after it, so the
+// file keeps ending the way it did.
+func (d *document) spliceLine(offset int, line string) []byte {
+	out := make([]byte, 0, len(d.src)+len(line)+len(d.newline))
+
+	out = append(out, d.src[:offset]...)
+
+	if offset == len(d.src) && !d.trailingNewline {
+		out = append(out, d.newline...)
+
+		return append(out, line...)
+	}
+
+	out = append(out, line...)
+	out = append(out, d.newline...)
+
+	return append(out, d.src[offset:]...)
+}
+
+// appendSection adds a new dependency section at the end of the file,
+// separated from what is already there by one blank line.
+//
+// The file's trailing-newline habit is preserved either way: a file that ended
+// without a line break still ends without one afterwards.
+func (d *document) appendSection(table DepTable, entry string) []byte {
+	out := bytes.Clone(d.src)
+
+	if len(out) > 0 {
+		if !d.trailingNewline {
+			out = append(out, d.newline...)
+		}
+
+		// One blank line, unless the file already ends with one.
+		if !bytes.HasSuffix(out, []byte(d.newline+d.newline)) {
+			out = append(out, d.newline...)
+		}
+	}
+
+	out = append(out, '[')
+	out = append(out, table...)
+	out = append(out, ']')
+	out = append(out, d.newline...)
+	out = append(out, entry...)
+
+	if d.trailingNewline || len(d.src) == 0 {
+		out = append(out, d.newline...)
+	}
+
+	return out
+}

--- a/cli/manifest/resolve/cache.go
+++ b/cli/manifest/resolve/cache.go
@@ -13,7 +13,10 @@ import (
 // hash it once rather than once per product. It is scoped to one resolution
 // pass; a rock version's rockspec is immutable, and a requirement is keyed by
 // its exact (name, constraint, registry), so every cached value is sound to
-// reuse within the run. Not safe for concurrent use - resolution is sequential.
+// reuse within the run. A preferred version rides in the constraint expression
+// (see walker.resolveRegistry) rather than beside it, which is what keeps a
+// pinned and an unpinned query for the same rock in distinct cache slots. Not
+// safe for concurrent use - resolution is sequential.
 type resolveCache struct {
 	resolved map[string]rocks.ResolvedRock
 	metadata map[string]*luarocks.Rockspec
@@ -26,6 +29,9 @@ type resolveCache struct {
 	// reproducibility warning is emitted once per run, not once per product that
 	// shares the rock (the walker is per-product, but this cache is run-wide).
 	warnedNoMD5 map[string]bool
+	// droppedPins records the rocks whose preferred version was dropped for no
+	// longer fitting, so that warning too is emitted once per run.
+	droppedPins map[string]bool
 }
 
 func newResolveCache() *resolveCache {
@@ -35,6 +41,7 @@ func newResolveCache() *resolveCache {
 		content:     map[string]string{},
 		local:       map[string]*luarocks.Rockspec{},
 		warnedNoMD5: map[string]bool{},
+		droppedPins: map[string]bool{},
 	}
 }
 
@@ -47,6 +54,19 @@ func (c *resolveCache) markNoMD5(url string) bool {
 	}
 
 	c.warnedNoMD5[url] = true
+
+	return true
+}
+
+// markPinDropped records that name's preferred version did not fit and reports
+// whether this is the first time in the run - so a pin dropped for a rock that
+// several products depend on warns once, not once per product.
+func (c *resolveCache) markPinDropped(name string) bool {
+	if c.droppedPins[name] {
+		return false
+	}
+
+	c.droppedPins[name] = true
 
 	return true
 }

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -62,11 +62,20 @@ type walker struct {
 	// since the walk order is name-sorted - the transitive edge must not silently
 	// resolve it from the default registry or drop its path source. See
 	// authoritative.
-	directs  map[string]depReq
-	chosen   map[string]*resolvedDep
-	inFlight map[string]bool
-	order    []string // post-order: deepest dependency first
-	warnings []string
+	directs map[string]depReq
+	// pins holds the versions this pass prefers, by rock name; nil for an
+	// unpinned resolution. It applies to transitive rocks as much as to direct
+	// ones - holding the whole closure steady is the point, since
+	// tt package update <name> is specified to move exactly one rock.
+	pins Pins
+	// pinnedPick records the rocks whose pin was actually honored, so a later
+	// requirement they cannot satisfy is reported as a droppable pin rather
+	// than as a dependency conflict. Per product, like chosen.
+	pinnedPick map[string]bool
+	chosen     map[string]*resolvedDep
+	inFlight   map[string]bool
+	order      []string // post-order: deepest dependency first
+	warnings   []string
 }
 
 // walk visits each requirement in reqs, recursing into a chosen rock's
@@ -102,11 +111,22 @@ func (w *walker) walk(ctx context.Context, parent string, reqs []depReq, chain [
 			// its version may be unknown (a leaf directory shipping no rockspec).
 			if existing.lockDep.Source != manifestSourcePath &&
 				!deps.Match(existing.version, req.constraints) {
-				return &conflictError{
+				conflict := &conflictError{
 					detail: fmt.Sprintf("chose %s %s but %s requires %s",
 						req.name, existing.version.Raw, parentLabel(parent), constraintLabel(req)),
 					chain: appendChain(chain, req.name),
 				}
+
+				// When the pick is only what it is because a pin asked for it,
+				// the pin is what gives way - it is a preference, and the
+				// manifest is genuinely resolvable without it. ResolvePinned
+				// drops it and re-runs the pass; the unpinned pick then either
+				// satisfies this edge or fails here as a real conflict.
+				if w.pinnedPick[req.name] {
+					return &pinConflictError{name: req.name, conflict: conflict}
+				}
+
+				return conflict
 			}
 
 			continue
@@ -164,8 +184,7 @@ func (w *walker) resolveOne(ctx context.Context, req depReq) (*resolvedDep, []de
 		return w.resolvePath(req)
 	}
 
-	resolved, err := w.cache.resolveRock(
-		ctx, w.engine.adapter, req.name, req.constraintExpr, req.registry)
+	resolved, err := w.resolveRegistry(ctx, req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolving %q: %w", req.name, err)
 	}
@@ -197,6 +216,56 @@ func (w *walker) resolveOne(ctx context.Context, req depReq) (*resolvedDep, []de
 	}
 
 	return resolvedDependency, transitiveReqs(spec.Dependencies), nil
+}
+
+// resolveRegistry resolves a registry requirement, preferring the pin held for
+// req.name when there is one.
+//
+// The pin is expressed as an extra ==<version> AND'd onto the requirement, so
+// the adapter applies it exactly like any other constraint - and so the
+// resolution cache, which is keyed on (name, constraint expression, registry),
+// cannot serve a pinned answer to an unpinned query or the reverse: the two
+// differ in the key itself. That is also why the pin has to ride in the
+// expression rather than in a field beside it.
+//
+// A pin that no longer fits is dropped rather than enforced. The two sentinels
+// checked here are the adapter's two ways of saying "no such version" -
+// ErrNotFound (no server carries the rock at all) and ErrNoMatch (a server
+// carries it, but in no version this expression allows) - which is what both
+// failure modes look like from here: a constraint the pinned version now
+// violates, and a version the registry stopped serving. Every other error - a
+// transport failure, an unparseable expression - is a real failure and
+// propagates, so the second query cannot paper over one.
+func (w *walker) resolveRegistry(ctx context.Context, req depReq) (rocks.ResolvedRock, error) {
+	pinned, held := w.pins[req.name]
+	if !held {
+		return w.cache.resolveRock(
+			ctx, w.engine.adapter, req.name, req.constraintExpr, req.registry)
+	}
+
+	resolved, err := w.cache.resolveRock(
+		ctx, w.engine.adapter, req.name, joinConstraints(req.constraintExpr, "=="+pinned),
+		req.registry)
+	if err == nil {
+		w.pinnedPick[req.name] = true
+
+		return resolved, nil
+	}
+
+	if !errors.Is(err, rocks.ErrNotFound) && !errors.Is(err, rocks.ErrNoMatch) {
+		return rocks.ResolvedRock{}, err
+	}
+
+	// Emit once per run: the walker is per-product, but a rock shared by
+	// several products loses its pin in each of them for the same reason.
+	if w.cache.markPinDropped(req.name) {
+		w.warnings = append(w.warnings, fmt.Sprintf(
+			"locked version %s of %q no longer fits its constraints or is gone from the "+
+				"registry; resolved afresh", pinned, req.name))
+	}
+
+	return w.cache.resolveRock(
+		ctx, w.engine.adapter, req.name, req.constraintExpr, req.registry)
 }
 
 // transitiveReqs turns a rockspec's dependency list into requirements. They

--- a/cli/manifest/resolve/pins.go
+++ b/cli/manifest/resolve/pins.go
@@ -1,0 +1,133 @@
+package resolve
+
+import (
+	"github.com/tarantool/go-luarocks/deps"
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Pins maps a rock name to the exact version resolution should prefer. It is
+// how "keep what the lock already chose" is expressed.
+//
+// Without it every re-resolution takes the newest version a constraint allows,
+// and since editing the manifest changes manifest_hash - which forces a
+// re-resolve - `tt package add` or `remove` would drag every unrelated
+// dependency forward. That contradicts the rule IsStale states: new registry
+// versions never make a lock stale, only an explicit `tt package update` pulls
+// them. Pins are what make that rule implementable, and they are also what
+// distinguishes `tt package update <name>` (re-resolve one rock, hold the rest)
+// from a bare `tt package update`.
+//
+// A pin is a preference, not a constraint. Where the pinned version no longer
+// fits - the manifest's constraints changed, a transitive edge demands more, or
+// the registry stopped serving that version - the pin is dropped, the rock is
+// resolved the ordinary newest-that-fits way and a warning says so. Resolution
+// never fails because of a pin.
+type Pins map[string]string
+
+// PinsFromLock collects the registry-sourced dependencies of every product in
+// lock into a pin set. Names listed in except are left out, so the caller can
+// free one dependency while holding the rest - which is exactly
+// `tt package update <name>`. A nil lock yields an empty set.
+//
+// Path dependencies are skipped: they are pinned by path and content hash
+// already, and the engine never applies a version pin to them.
+//
+// Products carry independent closures, so two of them may legitimately hold
+// different versions of the same rock (different components, different
+// constraints). A Pins maps a name to one version, so a disagreement has to be
+// decided here, and the highest version wins - deliberately, not by product
+// order:
+//
+//   - Taking the first product's version would silently downgrade every later
+//     product that had legitimately resolved higher, on an edit that had
+//     nothing to do with that rock. A downgrade is the more damaging of the two
+//     outcomes: it can take an API the code already calls away from it.
+//   - The highest version instead reproduces each product's own lock entry in
+//     the common case. A product whose constraints exclude it does not get
+//     dragged up - the pin simply does not fit there, so it is dropped for that
+//     product and the rock resolves normally, warning as usual.
+//   - It is also stable under renaming a product, which sorted order is not.
+//
+// A version that does not parse never wins the comparison, so the first one
+// seen in sorted-product order is kept for a rock whose lock entries are
+// unusable.
+func PinsFromLock(lock *manifest.Lock, except ...string) Pins {
+	pins := Pins{}
+	if lock == nil {
+		return pins
+	}
+
+	excluded := make(map[string]bool, len(except))
+	for _, name := range except {
+		excluded[name] = true
+	}
+
+	for _, product := range sortedKeys(lock.Products) {
+		for _, dependency := range lock.Products[product].Dependencies {
+			if dependency.Source != manifestSourceRegistry || dependency.Version == "" {
+				continue
+			}
+
+			if excluded[dependency.Name] {
+				continue
+			}
+
+			held, seen := pins[dependency.Name]
+			if !seen || ordersAbove(dependency.Version, held) {
+				pins[dependency.Name] = dependency.Version
+			}
+		}
+	}
+
+	return pins
+}
+
+// ordersAbove reports whether candidate sorts strictly above held. An
+// unparseable candidate never wins; an unparseable incumbent always loses, so a
+// usable version replaces one the engine could not have honored anyway.
+func ordersAbove(candidate, held string) bool {
+	parsedCandidate, candidateErr := deps.ParseVersion(candidate)
+	if candidateErr != nil {
+		return false
+	}
+
+	parsedHeld, heldErr := deps.ParseVersion(held)
+	if heldErr != nil {
+		return true
+	}
+
+	return deps.Compare(parsedCandidate, parsedHeld) > 0
+}
+
+// without returns a copy of pins with name removed. ResolvePinned drops pins as
+// it retries, and the caller's set must survive the call unchanged.
+func (p Pins) without(name string) Pins {
+	out := make(Pins, len(p))
+
+	for rock, version := range p {
+		if rock != name {
+			out[rock] = version
+		}
+	}
+
+	return out
+}
+
+// pinConflictError reports that a pinned pick, honored earlier in the walk,
+// cannot satisfy a requirement discovered later in it. The greedy walk cannot
+// un-choose a rock whose subtree it has already resolved, so this is raised as
+// a signal rather than handled in place: ResolvePinned catches it, drops that
+// one pin and starts the run over, which is what keeps a pin from turning a
+// resolvable manifest into an error.
+//
+// It carries the conflict it would otherwise have been so that, should it ever
+// escape the retry loop, it still reads like one and still matches
+// errors.Is(err, ErrConflict).
+type pinConflictError struct {
+	name     string
+	conflict *conflictError
+}
+
+func (e *pinConflictError) Error() string { return e.conflict.Error() }
+
+func (e *pinConflictError) Unwrap() error { return e.conflict }

--- a/cli/manifest/resolve/pins_test.go
+++ b/cli/manifest/resolve/pins_test.go
@@ -1,0 +1,453 @@
+package resolve_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+	"github.com/tarantool/tt/cli/manifest/rocks"
+)
+
+// twoProducts declares one rock in two components, each its own product, so a
+// pin can be observed acting on two independent closures that share the
+// resolution cache. The constraints differ on purpose: the pin fits p1 and not
+// p2.
+const twoProducts = `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[components.c1]
+path = 'a'
+[components.c1.dependencies]
+common = '>=1.0.0'
+[components.c2]
+path = 'b'
+[components.c2.dependencies]
+common = '>=2.0.0'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`
+
+// threeVersions is the registry every "pin an older version" test resolves
+// against: one rock published three times.
+func threeVersions() *fakeAdapter {
+	return newFakeAdapter().
+		add("metrics", "1.0.0-1", "aaa").
+		add("metrics", "1.5.0-1", "bbb").
+		add("metrics", "2.0.0-1", "ccc")
+}
+
+// TestResolvePinnedWithoutPinsPicksNewest is the regression guard on the
+// behaviour pinning is layered over: with no pin set, resolution is still
+// newest-that-fits, and Resolve is exactly that call.
+func TestResolvePinnedWithoutPinsPicksNewest(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(threeVersions(), "", "tt 3.4.0")
+
+	pinnedLock, warnings, err := engine.ResolvePinned(context.Background(), man, nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, "2.0.0-1",
+		findDep(t, pinnedLock.Products["default"].Dependencies, "metrics").Version)
+
+	plainLock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Equal(t, pinnedLock.Products, plainLock.Products,
+		"Resolve must be ResolvePinned with an empty pin set")
+}
+
+// TestPinHoldsOlderVersion is the core promise: a version the lock already
+// chose is kept even though the registry has newer ones that also fit.
+func TestPinHoldsOlderVersion(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(threeVersions(), "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"metrics": "1.0.0-1"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings, "an honored pin is not a diagnostic")
+
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "1.0.0-1", got.Version)
+	assert.Equal(t, "md5:aaa", got.Checksum, "the checksum must follow the pinned version")
+}
+
+// TestPinViolatingConstraintsIsDropped covers the manifest moving out from
+// under the lock - the shape `tt package add` produces when the edit tightens a
+// constraint. The pin loses, the newest that fits wins, and the caller is told.
+func TestPinViolatingConstraintsIsDropped(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.5.0'
+`)
+
+	engine := resolve.NewEngine(threeVersions(), "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"metrics": "1.0.0-1"})
+	require.NoError(t, err, "a pin that does not fit must never fail the resolution")
+
+	assert.Equal(t, "2.0.0-1",
+		findDep(t, lock.Products["default"].Dependencies, "metrics").Version)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "metrics")
+	assert.Contains(t, warnings[0], "1.0.0-1")
+}
+
+// TestPinRegistryNoLongerServesFallsBack covers the other way a pin stops
+// fitting: the constraints are unchanged, but the version the lock recorded is
+// no longer published.
+func TestPinRegistryNoLongerServesFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// 1.0.0-1 was yanked; only the two later versions remain.
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "bbb").
+		add("metrics", "2.0.0-1", "ccc")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"metrics": "1.0.0-1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0.0-1",
+		findDep(t, lock.Products["default"].Dependencies, "metrics").Version)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "metrics")
+}
+
+// TestPinDoesNotMaskAMissingRock guards the narrowness of the fallback: the
+// retry exists to un-pin, not to soften a real failure, so a rock no server has
+// at all still fails - with the adapter's own sentinel intact.
+func TestPinDoesNotMaskAMissingRock(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+ghost = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(newFakeAdapter(), "", "tt 3.4.0")
+
+	_, _, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"ghost": "1.0.0-1"})
+	require.ErrorIs(t, err, rocks.ErrNotFound)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+// TestPinOnTransitiveDependencyIsHonored is what makes `tt package update
+// <name>` mean anything: holding only the direct dependencies steady would let
+// the whole transitive closure drift on every re-resolve.
+func TestPinOnTransitiveDependencyIsHonored(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a", dep(t, "common", ">=1.0")).
+		add("common", "1.0.0-1", "c10").
+		add("common", "1.2.0-1", "c12")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"common": "1.0.0-1"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	dependencies := lock.Products["default"].Dependencies
+	// common is reached only through alpha; unpinned it would be 1.2.0-1.
+	assert.Equal(t, "1.0.0-1", findDep(t, dependencies, "common").Version)
+	assert.Equal(t, "1.0.0-1", findDep(t, dependencies, "alpha").Version)
+}
+
+// TestPinConflictingWithLaterEdgeIsDropped covers the case the greedy walk
+// cannot see coming: the pin satisfies the edge that resolves the rock and is
+// only contradicted by an edge found later, when its subtree is already walked.
+// The pin must still give way rather than turn a resolvable manifest into a
+// conflict - this is the `tt package add beta` shape, where beta needs more
+// than the lock happens to hold.
+func TestPinConflictingWithLaterEdgeIsDropped(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a", dep(t, "common", ">=1.0")).
+		add("beta", "1.0.0-1", "b", dep(t, "common", ">=1.1")).
+		add("common", "1.0.0-1", "c10").
+		add("common", "1.2.0-1", "c12")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+beta = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"common": "1.0.0-1"})
+	require.NoError(t, err, "a pin must never make a resolvable manifest fail")
+
+	assert.Equal(t, "1.2.0-1",
+		findDep(t, lock.Products["default"].Dependencies, "common").Version)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "common")
+	assert.Contains(t, warnings[0], "1.0.0-1")
+}
+
+// TestGenuineConflictStillErrorsWithPins is the other side of the retry loop:
+// dropping pins must not turn an unsatisfiable dependency graph into a silent
+// success. Here no pin is honored at all, and the conflict between the two
+// branches stands.
+func TestGenuineConflictStillErrorsWithPins(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a", dep(t, "common", ">=2.0")).
+		add("beta", "1.0.0-1", "b", dep(t, "common", "<2.0")).
+		add("common", "1.0.0-1", "c10").
+		add("common", "2.0.0-1", "c20")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+beta = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, _, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"common": "1.0.0-1"})
+	require.ErrorIs(t, err, resolve.ErrConflict)
+	assert.Contains(t, err.Error(), "common")
+}
+
+// TestPinnedProductsDoNotShareTheWrongCacheEntry is the cache guard. Both
+// products want the same rock and share one resolution cache, but the pin fits
+// only p1's constraints: p1 must get the pinned version and p2 the newest that
+// fits its own, neither served the other's answer.
+func TestPinnedProductsDoNotShareTheWrongCacheEntry(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("common", "1.0.0-1", "c10").
+		add("common", "2.0.0-1", "c20").
+		add("common", "3.0.0-1", "c30")
+
+	man := parseManifest(t, twoProducts)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"common": "1.0.0-1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.0.0-1",
+		findDep(t, lock.Products["p1"].Dependencies, "common").Version,
+		"p1 allows the pinned version and must keep it")
+	assert.Equal(t, "3.0.0-1",
+		findDep(t, lock.Products["p2"].Dependencies, "common").Version,
+		"p2 excludes the pinned version and must resolve newest-that-fits")
+
+	// The drop is reported once for the run, not once per product that hits it.
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "common")
+}
+
+// TestPinnedSharedDependencyResolvesOnce guards the other half of the cache
+// contract: two products asking for the same rock under the same pin and the
+// same constraints must still cost one adapter round trip.
+func TestPinnedSharedDependencyResolvesOnce(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("common", "1.0.0-1", "c10").
+		add("common", "2.0.0-1", "c20")
+
+	man := parseManifest(t, `manifest_version = '0.1'
+[package]
+name = 'app'
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.0.0'
+[dependencies]
+common = '>=1.0.0'
+[components.c1]
+path = 'a'
+[components.c2]
+path = 'b'
+[products.p1]
+components = ['c1']
+default = true
+[products.p2]
+components = ['c2']
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"common": "1.0.0-1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.0.0-1",
+		findDep(t, lock.Products["p1"].Dependencies, "common").Version)
+	assert.Equal(t, "1.0.0-1",
+		findDep(t, lock.Products["p2"].Dependencies, "common").Version)
+	assert.Equal(t, 1, fake.resolves["common"],
+		"a pinned requirement shared by two products must resolve once")
+}
+
+// TestPinsIgnorePathDependencies guards that a version pin cannot reach a path
+// dependency, which is pinned by path and content hash and has no registry
+// version to prefer.
+func TestPinsIgnorePathDependencies(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	vendor := writePathDep(t, projectDir, filepath.Join("vendor", "foo"))
+
+	fake := newFakeAdapter().
+		add("foo", "9.9.9-1", "registry-foo"). // Must never be reached.
+		addLocal(vendor, "foo", "1.0.0-1")
+
+	man := parseManifest(t, oneProduct+`[dependencies.foo]
+source = 'path'
+path = 'vendor/foo'
+`)
+
+	engine := resolve.NewEngine(fake, projectDir, "tt 3.4.0")
+
+	lock, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.Pins{"foo": "9.9.9-1"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	got := findDep(t, lock.Products["default"].Dependencies, "foo")
+	assert.Equal(t, "path", got.Source)
+	assert.Equal(t, "1.0.0-1", got.Version, "the local rockspec decides, not the pin")
+	assert.NotEmpty(t, got.ContentHash)
+	assert.Zero(t, fake.resolves["foo"], "a path dependency never queries the registry")
+}
+
+// TestPinsFromLockExceptFreesOneRock is the `tt package update <name>` scenario
+// end to end at the engine level: resolve, let the registry move on, then
+// re-resolve holding everything the lock recorded except the one named rock.
+func TestPinsFromLockExceptFreesOneRock(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("alpha", "1.0.0-1", "a1").
+		add("metrics", "1.0.0-1", "m1")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+alpha = '>=1.0.0'
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	first, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0-1", findDep(t, first.Products["default"].Dependencies, "alpha").Version)
+
+	// Both rocks publish a new version between the two resolutions.
+	fake.add("alpha", "2.0.0-1", "a2").add("metrics", "2.0.0-1", "m2")
+
+	pins := resolve.PinsFromLock(first, "metrics")
+	assert.Equal(t, resolve.Pins{"alpha": "1.0.0-1"}, pins)
+
+	second, warnings, err := engine.ResolvePinned(context.Background(), man, pins)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	dependencies := second.Products["default"].Dependencies
+	assert.Equal(t, "1.0.0-1", findDep(t, dependencies, "alpha").Version,
+		"an unnamed dependency must not move")
+	assert.Equal(t, "2.0.0-1", findDep(t, dependencies, "metrics").Version,
+		"the named dependency must be re-resolved against the registry")
+}
+
+func TestPinsFromLockSkipsPathDependencies(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "metrics", Version: "1.0.0-1", Source: "registry"},
+				{Name: "vendored", Version: "0.1.0-1", Source: "path", Path: "vendor/x"},
+			}},
+		},
+	}
+
+	assert.Equal(t, resolve.Pins{"metrics": "1.0.0-1"}, resolve.PinsFromLock(lock))
+}
+
+// TestPinsFromLockPrefersHighestOnDisagreement documents the tie-break: a Pins
+// holds one version per name, so two products that resolved the same rock
+// differently have to be reconciled, and the higher version wins rather than
+// the first product in sorted order. Taking p1's here would silently downgrade
+// p2 below what its own lock entry recorded.
+func TestPinsFromLockPrefersHighestOnDisagreement(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		Products: map[string]manifest.LockProduct{
+			"p1": {Dependencies: []manifest.LockDependency{
+				{Name: "common", Version: "1.5.0-1", Source: "registry"},
+			}},
+			"p2": {Dependencies: []manifest.LockDependency{
+				{Name: "common", Version: "2.0.0-1", Source: "registry"},
+			}},
+		},
+	}
+
+	assert.Equal(t, resolve.Pins{"common": "2.0.0-1"}, resolve.PinsFromLock(lock))
+}
+
+func TestPinsFromLockEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, resolve.Pins{}, resolve.PinsFromLock(nil), "a nil lock yields no pins")
+
+	lock := &manifest.Lock{
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "alpha", Version: "1.0.0-1", Source: "registry"},
+				{Name: "beta", Version: "2.0.0-1", Source: "registry"},
+				{Name: "novers", Version: "", Source: "registry"},
+			}},
+		},
+	}
+
+	assert.Equal(t, resolve.Pins{"beta": "2.0.0-1"},
+		resolve.PinsFromLock(lock, "alpha", "absent"),
+		"except drops the named rocks and tolerates names not in the lock")
+}

--- a/cli/manifest/resolve/resolve.go
+++ b/cli/manifest/resolve/resolve.go
@@ -3,11 +3,14 @@
 // lock (app.manifest.lock) - declared, resolved, locked.
 //
 // Resolution runs per product: each product gets its own closure over the
-// newest versions that satisfy every constraint. The engine takes an already
-// parsed manifest plus an adapter over go-luarocks; it never touches the
-// network itself. The adapter (cli/manifest/rocks) queries registries, fetches
-// rockspecs and reports source checksums; the policy - which versions, by which
-// product, what lands in the lock - lives here.
+// newest versions that satisfy every constraint. A caller that must not move
+// versions it already holds - every command other than tt package update -
+// passes a pin set (see Pins) so the lock's own picks are preferred over the
+// newest ones. The engine takes an already parsed manifest plus an adapter over
+// go-luarocks; it never touches the network itself. The adapter
+// (cli/manifest/rocks) queries registries, fetches rockspecs and reports source
+// checksums; the policy - which versions, by which product, what lands in the
+// lock - lives here.
 //
 // Materializing .rocks/ from a lock, editing the manifest on add/remove and
 // bundling runtimes into the lock are other packages' work. The tt package
@@ -16,6 +19,7 @@ package resolve
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	luarocks "github.com/tarantool/go-luarocks"
@@ -69,17 +73,88 @@ func NewEngine(adapter Adapter, projectDir, generatedBy string) *Engine {
 	}
 }
 
-// Resolve resolves every product of m into a lock. Each product's dependencies
-// are the transitive closure of its effective direct dependencies (see
-// effectiveDeps), pinned to exact versions in topological order.
+// Resolve resolves every product of man into a lock, taking the newest version
+// that satisfies every constraint. Each product's dependencies are the
+// transitive closure of its effective direct dependencies (see effectiveDeps),
+// pinned to exact versions in topological order.
 //
 // The returned warnings are non-fatal diagnostics - notably rocks whose
 // registry publishes no md5, whose lock entry then carries no checksum.
 //
-// The lock's manifest_hash is m.Hash(); bundled_*_version are left empty for
+// The lock's manifest_hash is man.Hash(); bundled_*_version are left empty for
 // the packaging phase to fill. generated_by carries the engine's tt version.
+//
+// This is ResolvePinned with an empty pin set: it is the "pull whatever the
+// registry has now" resolution, which is what a bare tt package update wants
+// and what a first resolution has no alternative to. Every other caller should
+// hold the lock's existing picks - see ResolvePinned.
 func (e *Engine) Resolve(
 	ctx context.Context, man *manifest.Manifest,
+) (*manifest.Lock, []string, error) {
+	return e.ResolvePinned(ctx, man, nil)
+}
+
+// ResolvePinned resolves man like Resolve, preferring each pinned version where
+// it still satisfies every constraint on that rock. PinsFromLock turns an
+// existing lock into such a set.
+//
+// A pin is a preference, not a constraint, and this is where that is enforced.
+// A pinned version that no longer fits is dropped and the rock resolves the
+// ordinary way; the reason reaches the caller as a warning, never as an error.
+// There are two ways a pin can fail to fit, and they are caught in different
+// places because the greedy walk discovers them at different times:
+//
+//   - The pinned version does not satisfy the requirement that triggers the
+//     rock's resolution, or the registry no longer serves it. resolveRegistry
+//     sees the adapter refuse and re-asks without the pin.
+//   - The pinned version satisfies the edge that resolved it but not one found
+//     later in the walk. By then its subtree is already resolved, so the walk
+//     cannot back out in place; it signals instead, and the pass is discarded
+//     and re-run below without that one pin. Each retry drops exactly one pin,
+//     so the loop runs at most len(pins) times.
+func (e *Engine) ResolvePinned(
+	ctx context.Context, man *manifest.Manifest, pins Pins,
+) (*manifest.Lock, []string, error) {
+	attempt := pins
+
+	var dropped []string
+
+	for {
+		lock, warnings, err := e.resolveOnce(ctx, man, attempt)
+		if err == nil {
+			return lock, append(dropped, warnings...), nil
+		}
+
+		var conflict *pinConflictError
+		if !errors.As(err, &conflict) {
+			return nil, nil, err
+		}
+
+		held, pinned := attempt[conflict.name]
+		if !pinned {
+			// Unreachable: only a pinned pick raises this. Returning the
+			// conflict rather than looping keeps a future bug a failed
+			// resolution instead of a hang.
+			return nil, nil, err
+		}
+
+		dropped = append(dropped, fmt.Sprintf(
+			"locked version %s of %q cannot satisfy every dependency on it; resolved afresh",
+			held, conflict.name))
+		attempt = attempt.without(conflict.name)
+	}
+}
+
+// resolveOnce is one full resolution pass over every product against a fixed
+// pin set.
+//
+// It builds a fresh cache each time it is called, which matters because
+// ResolvePinned throws a whole pass away on a pin conflict: the cache carries
+// the run-wide warning dedup (resolveCache.markNoMD5, markPinDropped), so
+// reusing it across attempts would let a discarded pass mark warnings that the
+// surviving pass then owes the caller and never emits.
+func (e *Engine) resolveOnce(
+	ctx context.Context, man *manifest.Manifest, pins Pins,
 ) (*manifest.Lock, []string, error) {
 	lock := &manifest.Lock{
 		LockVersion:      manifest.LockVersion,
@@ -99,7 +174,7 @@ func (e *Engine) Resolve(
 	cache := newResolveCache()
 
 	for _, name := range sortedKeys(man.Products) {
-		dependencies, warns, err := e.resolveProduct(ctx, cache, man, man.Products[name])
+		dependencies, warns, err := e.resolveProduct(ctx, cache, man, man.Products[name], pins)
 		if err != nil {
 			return nil, nil, fmt.Errorf("resolving product %q: %w", name, err)
 		}
@@ -112,9 +187,15 @@ func (e *Engine) Resolve(
 }
 
 // resolveProduct assembles a product's effective direct dependencies and walks
-// them into a pinned, topologically ordered closure.
+// them into a pinned, topologically ordered closure. pins is the run's
+// preferred-version set; it is read, never written, so every product of a pass
+// sees the same one.
 func (e *Engine) resolveProduct(
-	ctx context.Context, cache *resolveCache, man *manifest.Manifest, product manifest.Product,
+	ctx context.Context,
+	cache *resolveCache,
+	man *manifest.Manifest,
+	product manifest.Product,
+	pins Pins,
 ) ([]manifest.LockDependency, []string, error) {
 	directs, err := effectiveDeps(man, product)
 	if err != nil {
@@ -127,13 +208,15 @@ func (e *Engine) resolveProduct(
 	}
 
 	walk := &walker{
-		engine:   e,
-		cache:    cache,
-		directs:  directsByName,
-		chosen:   map[string]*resolvedDep{},
-		inFlight: map[string]bool{},
-		order:    nil,
-		warnings: nil,
+		engine:     e,
+		cache:      cache,
+		directs:    directsByName,
+		pins:       pins,
+		pinnedPick: map[string]bool{},
+		chosen:     map[string]*resolvedDep{},
+		inFlight:   map[string]bool{},
+		order:      nil,
+		warnings:   nil,
 	}
 
 	walkErr := walk.walk(ctx, "", directs, nil)

--- a/magefile.go
+++ b/magefile.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/apex/log"
@@ -29,6 +31,20 @@ const (
 
 	defaultLinuxConfigPath  = "/etc/tarantool"
 	defaultDarwinConfigPath = "/usr/local/etc/tarantool"
+
+	// Two golangci-lint configs live in the tree, one per major version of the
+	// linter, and they are mutually unreadable: v2 refuses a config with no
+	// `version` key and v1 refuses one that has it. lintConfigV1 is the
+	// project-wide ruleset; lintConfigV2 is the strict `default: all` one, whose
+	// own path-except rule scopes it to the packages already cleaned up for it.
+	lintConfigV1 = "golangci-lint.yml"
+	lintConfigV2 = ".golangci.yml"
+
+	// Env vars naming an alternative linter binary, one per major version. There
+	// are two because the two targets need two different majors, so a single
+	// override could not serve both.
+	lintExeEnvV1 = "GOLANGCI_LINT_V1"
+	lintExeEnvV2 = "GOLANGCI_LINT_V2"
 )
 
 var (
@@ -56,6 +72,20 @@ var (
 		"lib/integrity",
 		"lib/cluster",
 	}
+
+	// lintExeCandidates lists the binaries tried, in order, when the matching
+	// env var is unset. The version-suffixed names are what a side-by-side
+	// install provides; the bare name is the fallback for a single install, and
+	// it is checked rather than assumed - which major it happens to be is the
+	// whole question.
+	lintExeCandidates = map[int][]string{
+		1: {"golangci-lint@v1", "golangci-lint"},
+		2: {"golangci-lint@v2", "golangci-lint"},
+	}
+
+	// lintVersionRe pulls the version out of `golangci-lint version`, which
+	// prints e.g. "golangci-lint has version 2.11.4 built with go1.26.1 from ...".
+	lintVersionRe = regexp.MustCompile(`\bversion v?(\d+)\.(\d+)\.(\d+)\b`)
 )
 
 type BuildType string
@@ -202,13 +232,18 @@ type Lint mg.Namespace
 
 // Run golang and python linters.
 func (Lint) Full() error {
-	mg.Deps(Lint.Golang, Lint.Python)
+	mg.Deps(Lint.Golang, Lint.Strict, Lint.Python)
 	return nil
 }
 
 // Run golang linters.
 func (Lint) Golang() error {
-	fmt.Println("Running golangci-lint...")
+	linter, err := resolveLinter(1, lintExeEnvV1)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Running %s over %s...\n", linter, lintConfigV1)
 
 	lintDirs := append([]string{"."}, modules...)
 	root, err := os.Getwd()
@@ -218,13 +253,121 @@ func (Lint) Golang() error {
 
 	for _, dir := range lintDirs {
 		os.Chdir(dir)
-		if err := sh.RunV("golangci-lint", "run",
-			fmt.Sprintf("--config=%s/golangci-lint.yml", root)); err != nil {
+		if err := sh.RunV(linter, "run",
+			fmt.Sprintf("--config=%s/%s", root, lintConfigV1)); err != nil {
 			return err
 		}
 		os.Chdir(root)
 	}
 	return nil
+}
+
+// Run the strict golang ruleset over the packages that have been cleaned up for
+// it.
+//
+// This is a separate target rather than part of Lint.Golang because the two
+// rulesets need different linters: .golangci.yml is a v2 config and
+// golangci-lint.yml is a v1 one, and neither major can read the other's format.
+// The strict config carries its own path-except rule naming the adopted
+// packages, so no path arguments are passed here - widening the scope is an
+// edit to that rule, not to this target.
+func (Lint) Strict() error {
+	linter, err := resolveLinter(2, lintExeEnvV2)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Running %s over %s...\n", linter, lintConfigV2)
+
+	// Only the root module: the strict config's scope lives inside cli/, and
+	// lib/* are separate modules that have not been adopted.
+	return sh.RunV(linter, "run", "--config="+lintConfigV2)
+}
+
+// resolveLinter returns the golangci-lint executable to run a config of the
+// given major version, having checked that it exists and reports that major.
+//
+// The check is worth its weight because the failure it replaces is unreadable:
+// a v2 binary handed a v1 config dies with `unsupported version of the
+// configuration: ""`, and a v1 binary handed a v2 one dies complaining about
+// the Go version, neither of which names the actual problem.
+//
+// envVar names an alternative binary and is honored exactly: a binary named
+// there whose major is wrong is an error, never a silent fallback to another
+// one, because the caller asked for that binary specifically. With envVar
+// unset, the versioned names a side-by-side install provides are tried first
+// and the bare name last.
+func resolveLinter(major int, envVar string) (string, error) {
+	if specified := os.Getenv(envVar); specified != "" {
+		found, version, err := linterMajor(specified)
+		if err != nil {
+			return "", fmt.Errorf("%s=%s: %w", envVar, specified, err)
+		}
+
+		if found != major {
+			return "", fmt.Errorf(
+				"%s=%s is golangci-lint %s, but %s is a v%d config that only a v%d "+
+					"linter can read", envVar, specified, version, lintConfigFor(major),
+				major, major)
+		}
+
+		return specified, nil
+	}
+
+	var tried []string
+
+	for _, candidate := range lintExeCandidates[major] {
+		tried = append(tried, candidate)
+
+		if _, err := exec.LookPath(candidate); err != nil {
+			continue
+		}
+
+		found, _, err := linterMajor(candidate)
+		if err != nil || found != major {
+			continue
+		}
+
+		return candidate, nil
+	}
+
+	return "", fmt.Errorf(
+		"no golangci-lint v%d found for %s (tried: %s); install one or point %s at it",
+		major, lintConfigFor(major), strings.Join(tried, ", "), envVar)
+}
+
+// linterMajor runs `<exe> version` and reports the major version it prints,
+// along with the full version string for diagnostics.
+func linterMajor(exe string) (int, string, error) {
+	if _, err := exec.LookPath(exe); err != nil {
+		return 0, "", fmt.Errorf("not found: %w", err)
+	}
+
+	out, err := sh.Output(exe, "version")
+	if err != nil {
+		return 0, "", fmt.Errorf("running %q version: %w", exe, err)
+	}
+
+	match := lintVersionRe.FindStringSubmatch(out)
+	if match == nil {
+		return 0, "", fmt.Errorf("cannot parse a version out of %q", strings.TrimSpace(out))
+	}
+
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, "", fmt.Errorf("cannot parse major version from %q", match[0])
+	}
+
+	return major, match[1] + "." + match[2] + "." + match[3], nil
+}
+
+// lintConfigFor names the config a given linter major reads.
+func lintConfigFor(major int) string {
+	if major == 1 {
+		return lintConfigV1
+	}
+
+	return lintConfigV2
 }
 
 // Run python linters.

--- a/test/integration/package/conftest.py
+++ b/test/integration/package/conftest.py
@@ -1,7 +1,16 @@
+import functools
+import http.server
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
+
+# The rock repository the `tt rocks` suite already ships: a LuaRocks `manifest`
+# next to two versions of `stat`. Serving it over loopback is what lets the
+# dependency commands resolve for real without a network — the manifest
+# pipeline's remote index speaks HTTP and cannot read a directory.
+ROCKS_REPO = Path(__file__).parent.parent / "rocks" / "repo"
 
 MANIFEST_TEMPLATE = """manifest_version = '0.1'
 
@@ -226,6 +235,27 @@ def system_staging(tmp_path: Path) -> Tree:
     staging.install_guest("monitoring", "2.0.0", {"metrics": "1.0.0", "checks": "3.1.0"})
     staging.install_guest("alerting", "0.5.0", {"checks": "3.1.0"})
     return staging
+
+
+@pytest.fixture()
+def rock_server():
+    """Serve the fixture rock repository over loopback and yield its base URL.
+
+    The dependency commands re-resolve, and resolution talks to a rock server
+    over HTTP. Pointing a dependency's `registry` key at this one is what keeps
+    the suite offline: no flag routes the whole server list at a local
+    directory, and the remote index cannot read one anyway.
+    """
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(ROCKS_REPO))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 @pytest.fixture()

--- a/test/integration/package/test_package_deps.py
+++ b/test/integration/package/test_package_deps.py
@@ -1,0 +1,248 @@
+"""End-to-end coverage for `tt package add`, `remove` and `update`.
+
+Every test here drives the real binary against a real resolution: the fixture
+rock repository is served over loopback and the manifest's `registry` key points
+one dependency at it, so the closure is resolved for real without a network. The
+two commands that need no server at all — removing the last dependency, and any
+run that is refused before it resolves — are exercised directly.
+"""
+
+import hashlib
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11, which is what CI runs.
+    import tomli as tomllib
+
+MANIFEST_HEAD = """manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+"""
+
+MANIFEST_TAIL = """
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+"""
+
+# A comment the editor must leave alone. It sits above the dependency table, so
+# a splice that took one line too many would eat it.
+KEEP_COMMENT = "# keep me: the editor must not touch this line."
+
+LOCK_TEMPLATE = """lock_version = '0.1'
+manifest_version = '0.1'
+generated_by = 'tt 3.0.0'
+manifest_hash = 'sha256:{hash}'
+
+[[lock.products.default.dependencies]]
+name = 'stat'
+version = '{version}'
+source = 'registry'
+"""
+
+
+def local_dependency(table: str, server: str, constraint: str) -> str:
+    """Render a long-form dependency pinned to the loopback rock server."""
+    return (
+        f"\n{KEEP_COMMENT}\n"
+        f"[{table}.stat]\n"
+        "source = 'registry'\n"
+        f"registry = '{server}'\n"
+        f"version = '{constraint}'\n"
+    )
+
+
+def write_manifest(root: Path, body: str) -> str:
+    """Write a manifest built from head + body + tail and return its text."""
+    text = MANIFEST_HEAD + body + MANIFEST_TAIL
+    (root / "app.manifest.toml").write_text(text)
+    return text
+
+
+def read_lock(root: Path) -> dict:
+    with (root / "app.manifest.lock").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def locked_versions(root: Path) -> dict[str, str]:
+    """The default product's closure as name -> version."""
+    lock = read_lock(root)
+    closure = lock["lock"]["products"]["default"].get("dependencies", [])
+    return {entry["name"]: entry["version"] for entry in closure}
+
+
+def manifest_hash(root: Path) -> str:
+    """The hash the lock must carry: sha256 over the manifest's raw bytes."""
+    digest = hashlib.sha256((root / "app.manifest.toml").read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def test_add_rewrites_the_manifest_and_the_lock(tree, run_tt, rock_server):
+    """`add` on a declared name rewrites its constraint and re-resolves."""
+    root = tree.root
+    write_manifest(root, local_dependency("dependencies", rock_server, "==0.3.1"))
+
+    result = run_tt("package", "add", "stat", ">=0.3.2")
+    assert result.returncode == 0, result.stderr
+
+    source = (root / "app.manifest.toml").read_text()
+    assert 'version = ">=0.3.2"' in source
+    # Everything else in the declaration, and the comment above it, is untouched.
+    assert f"registry = '{rock_server}'" in source
+    assert KEEP_COMMENT in source
+
+    assert locked_versions(root) == {"stat": "0.3.2-1"}
+    # The lock must record the hash of the manifest as it now stands, not the
+    # one it had before the edit; otherwise the very next command sees a stale
+    # lock and re-resolves for no reason.
+    assert read_lock(root)["manifest_hash"] == manifest_hash(root)
+
+    assert "changed stat in [dependencies]: ==0.3.1 -> >=0.3.2" in result.stdout
+
+
+def test_add_dev_lands_in_dev_dependencies(tree, run_tt, rock_server):
+    """`--dev` targets [dev_dependencies] and leaves [dependencies] alone."""
+    root = tree.root
+    write_manifest(root, local_dependency("dev_dependencies", rock_server, "==0.3.1"))
+
+    result = run_tt("package", "add", "--dev", "stat", ">=0.3.2")
+    assert result.returncode == 0, result.stderr
+    assert "[dev_dependencies]" in result.stdout
+
+    with (root / "app.manifest.toml").open("rb") as handle:
+        parsed = tomllib.load(handle)
+
+    assert parsed["dev_dependencies"]["stat"]["version"] == ">=0.3.2"
+    assert "dependencies" not in parsed
+
+
+def test_add_of_a_new_name_declares_it_in_the_chosen_table(tree, run_tt):
+    """A brand-new entry is spliced into the table the flag names.
+
+    The rock does not exist on any server, so this also pins the documented
+    order: the edit the user asked for reaches disk first, and a resolution that
+    then fails leaves the lock alone and says so. That second half is what makes
+    this a runtime dependency rather than a `--dev` one: only [dependencies]
+    reaches the resolver here, so only a name declared there can fail the
+    resolution. The `--dev` splice itself is covered by the test above.
+    """
+    root = tree.root
+    write_manifest(root, "")
+
+    result = run_tt("package", "add", "tt-9958-no-such-rock", ">=1.0.0")
+    assert result.returncode == 1
+    assert "the manifest was edited but the lock was not updated" in result.stderr
+
+    source = (root / "app.manifest.toml").read_text()
+    assert re.search(r"\[dependencies\]\s*\ntt-9958-no-such-rock = \">=1.0.0\"", source)
+
+    with (root / "app.manifest.toml").open("rb") as handle:
+        parsed = tomllib.load(handle)
+
+    assert "tt-9958-no-such-rock" in parsed["dependencies"]
+    assert "dev_dependencies" not in parsed
+    assert not (root / "app.manifest.lock").exists()
+
+
+def test_add_failure_does_not_touch_an_existing_lock(tree, run_tt):
+    """A failed resolution leaves the lock exactly as it was."""
+    root = tree.root
+    write_manifest(root, "")
+    before = LOCK_TEMPLATE.format(hash="0" * 64, version="0.3.1-1")
+    (root / "app.manifest.lock").write_text(before)
+
+    result = run_tt("package", "add", "tt-9958-no-such-rock")
+    assert result.returncode == 1
+    assert (root / "app.manifest.lock").read_text() == before
+
+
+def test_remove_clears_both_files(tree, run_tt, rock_server):
+    """`remove` drops the declaration and re-resolves the lock without it.
+
+    Nothing is left to resolve afterwards, so this one needs no server at all —
+    the fixture only supplies a registry the removed entry pointed at.
+    """
+    root = tree.root
+    write_manifest(root, local_dependency("dependencies", rock_server, ">=0.3.1"))
+    (root / "app.manifest.lock").write_text(
+        LOCK_TEMPLATE.format(hash="0" * 64, version="0.3.1-1"),
+    )
+
+    result = run_tt("package", "remove", "stat")
+    assert result.returncode == 0, result.stderr
+
+    with (root / "app.manifest.toml").open("rb") as handle:
+        parsed = tomllib.load(handle)
+
+    assert "dependencies" not in parsed
+    assert KEEP_COMMENT in (root / "app.manifest.toml").read_text()
+
+    assert locked_versions(root) == {}
+    assert read_lock(root)["manifest_hash"] == manifest_hash(root)
+    # The rock that left the closure is reported, not silently dropped.
+    assert "stat 0.3.1-1 -> (dropped)" in result.stdout
+
+
+def test_remove_of_an_undeclared_name_fails(tree, run_tt):
+    """An unknown name is exit 1, not a no-op — it is almost always a typo."""
+    root = tree.root
+    text = write_manifest(root, "")
+
+    result = run_tt("package", "remove", "nosuchrock")
+    assert result.returncode == 1
+    assert "not declared in the manifest" in result.stderr
+    # Nothing was written: neither file moved.
+    assert (root / "app.manifest.toml").read_text() == text
+    assert not (root / "app.manifest.lock").exists()
+
+
+def test_update_pulls_a_newer_version(tree, run_tt, rock_server):
+    """A bare `update` takes the newest version the constraint allows."""
+    root = tree.root
+    write_manifest(root, local_dependency("dependencies", rock_server, ">=0.3.1"))
+    (root / "app.manifest.lock").write_text(
+        LOCK_TEMPLATE.format(hash="0" * 64, version="0.3.1-1"),
+    )
+
+    text_before = (root / "app.manifest.toml").read_text()
+
+    result = run_tt("package", "update")
+    assert result.returncode == 0, result.stderr
+
+    assert locked_versions(root) == {"stat": "0.3.2-1"}
+    assert "stat 0.3.1-1 -> 0.3.2-1" in result.stdout
+    # update changes no declaration, so the manifest is byte-for-byte the same.
+    assert (root / "app.manifest.toml").read_text() == text_before
+
+
+def test_update_of_one_name_resolves_it(tree, run_tt, rock_server):
+    """`update NAME` frees that rock; the rest of the closure is held."""
+    root = tree.root
+    write_manifest(root, local_dependency("dependencies", rock_server, ">=0.3.1"))
+    (root / "app.manifest.lock").write_text(
+        LOCK_TEMPLATE.format(hash="0" * 64, version="0.3.1-1"),
+    )
+
+    result = run_tt("package", "update", "stat")
+    assert result.returncode == 0, result.stderr
+    assert locked_versions(root) == {"stat": "0.3.2-1"}
+
+
+def test_update_of_an_undeclared_name_fails(tree, run_tt):
+    """`update NAME` refuses a name the manifest does not declare."""
+    root = tree.root
+    write_manifest(root, "")
+
+    result = run_tt("package", "update", "nosuchrock")
+    assert result.returncode == 1
+    assert "not declared in the manifest" in result.stderr

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,6 +13,8 @@ importlib-metadata<4.3
 pytest-timeout==2.4.0
 retry==0.9.2
 pytest-rerunfailures==15.1
+# tomllib is stdlib from 3.11 on; CI runs 3.10, so the tests fall back to this.
+tomli==2.2.1; python_version < "3.11"
 # HOTFIX: Workaround to avoid cmake warning that appears after upgrading cmake on CI runners.
 # The warning occurs during CI tests in 'checks' repo and finally leads to CI failure.
 # REMOVE IT as soon as proper fixes are applied to 'checks' and all dependent repos.


### PR DESCRIPTION
`Engine.Resolve` always took the newest version a constraint allowed, so any command that rewrites the manifest — `add`, `remove` — would drag every unrelated dependency forward on the re-resolve the changed `manifest_hash` forces. That contradicts the rule `IsStale` states: only an explicit `tt package update` pulls fresh registry versions.

- cli/manifest/resolve: prefer pinned versions — `ResolvePinned` prefers a caller-supplied version per rock and `PinsFromLock` builds that set from an existing lock minus the names the caller wants freed. `Resolve` is now `ResolvePinned` with an empty set, so its callers are unaffected. A pin is a preference, not a constraint: when it no longer fits it is dropped, the rock resolves normally and a warning says so.
- cli/manifest: edit dependency tables in place — an `Editor` rewrites `[dependencies]`/`[dev_dependencies]` in the manifest's own TOML text instead of re-marshaling the model, so comments, key order and the formatting of every untouched line survive an edit. Short, inline-table, sub-table and root dotted-key declarations are all editable; anything else is refused by name rather than guessed at.
- cli/manifest/deps: edit and re-resolve deps — edit the declaration with the position-preserving TOML editor, write the manifest, re-parse it so `manifest_hash` matches what is on disk, re-resolve under a per-command pin set and rewrite the lock. The pin set is what separates the three commands: `add` and `remove` hold every version the lock already chose, a bare `update` pins nothing, `update NAME` frees that one rock and holds the rest.
- cli/cmd: tt package add, remove, update — `add` takes an optional constraint and a `--dev` flag choosing the table; `remove` and `update` take a name, and `update` takes none for a whole-closure refresh. Each prints what it changed and then the closure diff, one rock per line: a rock that arrived shows only its new version, one that left is marked dropped, one that moved shows both ends.
- lint/ci: enforce the strict ruleset on every push — the strict `default: all` ruleset had a job in CI and never ran, because that job is gated on a `full-commit-check` PR label, and two packages joined its declared scope in the meantime and accumulated 254 findings between them. The scope now names the packages that are actually clean under it, the ruleset gets a job with no label condition, and both lint targets state and verify the linter major they need instead of shelling out to whatever `golangci-lint` is on `PATH`.

Closes TNTP-9958
