### PR TITLE
cli/manifest/deps: report dev dependency moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dependency forward; `tt package update` is the only command that pulls fresh
   versions from the registry, and with a name it moves that one dependency and
   holds the rest.
+- `[dev_dependencies]` are now resolved and installed. They were parsed and
+  validated but reached neither the lock nor `.rocks/`. The lock records them
+  as a single `[[lock.dev_dependencies]]` closure, resolved against the picks
+  the products just made so a rock needed by both lands in the tree once;
+  `tt package build` and `tt package fetch` install them, and `tt package pack`
+  keeps dev-only rocks out of the archive. A lock written before this change,
+  against a manifest that declares dev dependencies, is reported stale so the
+  closure is filled in on the next resolve.
 - `tt status`: add `--format` option to support JSON and YAML output formats
 for machine-readable output.
 

--- a/cli/manifest/build/build.go
+++ b/cli/manifest/build/build.go
@@ -11,6 +11,13 @@
 // tt package fetch is the same materialization step in isolation: strictly from
 // the lock, without resolving or running backends.
 //
+// Both operate on a developer's project, so both materialize the lock's dev
+// closure into the same .rocks/ tree alongside the product's: [dev_dependencies]
+// exists to be requirable while developing and testing. Nothing here keeps them
+// out of a package archive - that is cli/manifest/pack's exclusion, applied
+// where the archive content is selected, because .rocks/ is a standing tree and
+// a build run an hour ago has already put dev rocks in it.
+//
 // The build always works in project scope: <ProjectDir>/.rocks/. Selecting the
 // product, choosing versions, deriving flags and archiving are neighbouring
 // packages' jobs; this package only drives the cycle.
@@ -211,9 +218,10 @@ func runFetch(
 		return nil, fmt.Errorf("rocks path client: %w", err)
 	}
 
-	if err := materialize(ctx, registryClient, pathClient, projectDir, prod,
-		adapter.Config().Servers); err != nil {
-		return nil, err
+	matErr := materialize(ctx, registryClient, pathClient, projectDir, prod,
+		lock.DevDependencies, adapter.Config().Servers)
+	if matErr != nil {
+		return nil, matErr
 	}
 
 	return &Result{Manifest: man, Lock: lock, Product: productName, Tree: tree}, nil
@@ -272,7 +280,7 @@ func runBuild(
 	}
 
 	matErr := materialize(ctx, registryClient, pathClient, opts.ProjectDir, prod,
-		adapter.Config().Servers)
+		lock.DevDependencies, adapter.Config().Servers)
 	if matErr != nil {
 		return nil, matErr
 	}

--- a/cli/manifest/build/materialize.go
+++ b/cli/manifest/build/materialize.go
@@ -32,24 +32,51 @@ type rockBuilder interface {
 
 // materialize realizes a product's pinned closure into the rocks tree, in the
 // lock's topological order so every dependency is present before the rock that
-// needs it. This is the whole of tt package fetch and step 4 of tt package
-// build.
+// needs it, and then the lock's dev closure into the same tree. This is the
+// whole of tt package fetch and step 4 of tt package build.
 //
 // Registry rocks are installed at their exact locked version with dependency
 // resolution off (DepsNone): the closure is already complete and ordered, so no
 // rock re-resolves its own deps. Path dependencies are built from the single
 // rockspec in their directory; a leaf path dependency that ships no rockspec is
 // nothing to build and is skipped.
+//
+// Dev dependencies go into the same tree because they are meant to be
+// requirable from the project exactly like runtime ones - that is what makes
+// tt test work - and they are installed after it so a rock in both closures is
+// already present at the product's version when the dev list reaches it. Such
+// a rock is skipped rather than reinstalled: the resolver pins the dev closure
+// to the products' picks, so the two agree by construction, and installing the
+// same version twice is work with no effect. Keeping them out of the archive
+// is cli/manifest/pack's job, not this one - .rocks/ is the developer's tree
+// and holds whatever the last build put there.
 func materialize(
 	ctx context.Context, registryClient rockInstaller, pathClient rockBuilder,
-	projectDir string, prod manifest.LockProduct,
+	projectDir string, prod manifest.LockProduct, dev []manifest.LockDependency,
 	servers []string,
 ) error {
+	done := make(map[string]bool, len(prod.Dependencies))
+
 	for _, dep := range prod.Dependencies {
 		depErr := materializeDep(ctx, registryClient, pathClient, projectDir, dep, servers)
 		if depErr != nil {
 			return depErr
 		}
+
+		done[dep.Name+"\x00"+dep.Version] = true
+	}
+
+	for _, dep := range dev {
+		if done[dep.Name+"\x00"+dep.Version] {
+			continue
+		}
+
+		depErr := materializeDep(ctx, registryClient, pathClient, projectDir, dep, servers)
+		if depErr != nil {
+			return fmt.Errorf("dev dependency: %w", depErr)
+		}
+
+		done[dep.Name+"\x00"+dep.Version] = true
 	}
 
 	return nil

--- a/cli/manifest/build/materialize_test.go
+++ b/cli/manifest/build/materialize_test.go
@@ -47,7 +47,7 @@ func TestMaterialize_registryDepsPinnedNoDeps(t *testing.T) {
 
 	servers := []string{"https://rocks.example.test"}
 	require.NoError(t, materialize(context.Background(), registryClient, pathClient,
-		t.TempDir(), prod, servers))
+		t.TempDir(), prod, nil, servers))
 
 	require.Len(t, registryClient.installs, 2)
 	// Order is preserved (topological), each pinned to the exact version with
@@ -73,7 +73,7 @@ func TestMaterialize_pathDepBuildsRockspec(t *testing.T) {
 	}}
 
 	require.NoError(t, materialize(context.Background(), registryClient, pathClient,
-		project, prod, nil))
+		project, prod, nil, nil))
 
 	require.Len(t, pathClient.builds, 1)
 	assert.Equal(t, filepath.Join(project, "vendor", "mylib", "mylib-scm-1.rockspec"),
@@ -87,25 +87,94 @@ func TestMaterialize_leafPathDepIsSkipped(t *testing.T) {
 	project := t.TempDir()
 	writeFile(t, filepath.Join(project, "vendor", "leaf", "leaf.lua"), "-- leaf")
 
-	rc := &fakeRockClient{}
+	fake := &fakeRockClient{}
 	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
 		{Name: "leaf", Source: sourcePath, Path: "vendor/leaf"},
 	}}
 
-	require.NoError(t, materialize(context.Background(), rc, rc, project, prod, nil))
-	assert.Empty(t, rc.builds)
-	assert.Empty(t, rc.installs)
+	require.NoError(t, materialize(context.Background(), fake, fake, project, prod, nil, nil))
+	assert.Empty(t, fake.builds)
+	assert.Empty(t, fake.installs)
+}
+
+// TestMaterialize_devDepsInstalledAfterProduct pins that the dev closure goes
+// into the same tree as the product's, after it, so a rock in both is already
+// present at the product's version when the dev list reaches it.
+func TestMaterialize_devDepsInstalledAfterProduct(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "metrics", Version: "1.5.0-1", Source: sourceRegistry},
+	}}
+	dev := []manifest.LockDependency{
+		{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+		{Name: "luatest", Version: "1.0.1-1", Source: sourceRegistry},
+	}
+
+	require.NoError(t, materialize(context.Background(), fake, fake, t.TempDir(), prod, dev, nil))
+
+	require.Len(t, fake.installs, 3)
+	assert.Equal(t, "metrics", fake.installs[0].name)
+	assert.Equal(t, "checks", fake.installs[1].name)
+	assert.Equal(t, "luatest", fake.installs[2].name)
+	assert.Equal(t, "1.0.1-1", fake.installs[2].opts.Version)
+	assert.Equal(t, client.DepsNone, fake.installs[2].opts.Deps)
+}
+
+// TestMaterialize_devDepSharedWithProductInstalledOnce covers the overlap the
+// resolver deliberately allows: a rock pinned in both closures is one rock in
+// one tree, so it is installed once rather than reinstalled at the same
+// version.
+func TestMaterialize_devDepSharedWithProductInstalledOnce(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeRockClient{}
+	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
+		{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+	}}
+	dev := []manifest.LockDependency{
+		{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+		{Name: "luatest", Version: "1.0.1-1", Source: sourceRegistry},
+	}
+
+	require.NoError(t, materialize(context.Background(), fake, fake, t.TempDir(), prod, dev, nil))
+
+	require.Len(t, fake.installs, 2)
+	assert.Equal(t, "checks", fake.installs[0].name)
+	assert.Equal(t, "luatest", fake.installs[1].name)
+}
+
+// TestMaterialize_devPathDepBuilt pins that a path-sourced dev dependency goes
+// through the same build path as a runtime one.
+func TestMaterialize_devPathDepBuilt(t *testing.T) {
+	t.Parallel()
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "dev", "helper", "helper-scm-1.rockspec"), "-- spec")
+
+	fake := &fakeRockClient{}
+	dev := []manifest.LockDependency{
+		{Name: "helper", Source: sourcePath, Path: "dev/helper"},
+	}
+
+	require.NoError(t, materialize(
+		context.Background(), fake, fake, project, manifest.LockProduct{}, dev, nil))
+
+	require.Len(t, fake.builds, 1)
+	assert.Equal(t,
+		filepath.Join(project, "dev", "helper", "helper-scm-1.rockspec"), fake.builds[0])
 }
 
 func TestMaterialize_unknownSource(t *testing.T) {
 	t.Parallel()
 
-	rc := &fakeRockClient{}
+	fake := &fakeRockClient{}
 	prod := manifest.LockProduct{Dependencies: []manifest.LockDependency{
 		{Name: "weird", Source: "http"},
 	}}
 
-	err := materialize(context.Background(), rc, rc, t.TempDir(), prod, nil)
+	err := materialize(context.Background(), fake, fake, t.TempDir(), prod, nil, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errUnknownSource)
 }

--- a/cli/manifest/deps/deps.go
+++ b/cli/manifest/deps/deps.go
@@ -398,7 +398,8 @@ func movesBetween(before, after *manifest.Lock) []Move {
 	return moves
 }
 
-// closureOf flattens a lock into rock name -> version across every product.
+// closureOf flattens a lock into rock name -> version across every product and
+// the dev closure.
 //
 // Products hold independent closures, so two of them may legitimately pin
 // different versions of one rock. The moves are a human report of what changed,
@@ -416,6 +417,12 @@ func closureOf(lock *manifest.Lock) map[string]string {
 			if _, seen := out[dependency.Name]; !seen {
 				out[dependency.Name] = dependency.Version
 			}
+		}
+	}
+
+	for _, dependency := range lock.DevDependencies {
+		if _, seen := out[dependency.Name]; !seen {
+			out[dependency.Name] = dependency.Version
 		}
 	}
 

--- a/cli/manifest/deps/helpers_internal_test.go
+++ b/cli/manifest/deps/helpers_internal_test.go
@@ -76,6 +76,7 @@ func (f *fakeResolver) ResolvePinned(
 
 	if f.lock != nil {
 		out.Products = f.lock.Products
+		out.DevDependencies = f.lock.DevDependencies
 	}
 
 	return &out, f.warnings, nil

--- a/cli/manifest/lock.go
+++ b/cli/manifest/lock.go
@@ -25,6 +25,15 @@ type Lock struct {
 	// Products maps product name to its resolution snapshot. On disk this is
 	// the [lock.products.<name>] table tree.
 	Products map[string]LockProduct `toml:"-"`
+
+	// DevDependencies is the closure of [dev_dependencies], as
+	// [[lock.dev_dependencies]]. It is one list rather than one per product:
+	// the manifest declares dev dependencies globally, so there is nothing to
+	// key them by. Empty for a manifest that declares none, and then absent
+	// from the file entirely - a lock written before dev dependencies existed
+	// is therefore indistinguishable from one whose manifest declares none,
+	// which is why IsStale checks the manifest side too.
+	DevDependencies []LockDependency `toml:"-"`
 }
 
 // LockProduct is one product's resolution snapshot - the full transitive
@@ -44,9 +53,10 @@ type LockDependency struct {
 	ContentHash string `toml:"content_hash,omitempty"` // Path: sha256 of contents.
 }
 
-// lockWire is the on-disk shape of the lock. It nests Products under a [lock]
-// table so the file reads [lock.products.<name>]; go-toml does not split dotted
-// struct tags, so the nesting is expressed with a real struct.
+// lockWire is the on-disk shape of the lock. It nests Products and the dev
+// closure under a [lock] table so the file reads [lock.products.<name>] and
+// [[lock.dev_dependencies]]; go-toml does not split dotted struct tags, so the
+// nesting is expressed with a real struct.
 type lockWire struct {
 	LockVersion      string `toml:"lock_version"`
 	ManifestVersion  string `toml:"manifest_version"`
@@ -57,6 +67,10 @@ type lockWire struct {
 	BundledTcm       string `toml:"bundled_tcm_version,omitempty"`
 	Lock             struct {
 		Products map[string]LockProduct `toml:"products,omitempty"`
+		// omitempty keeps the key out of a lock with no dev closure, so every
+		// lock written before dev dependencies were resolved still round-trips
+		// byte-for-byte.
+		DevDependencies []LockDependency `toml:"dev_dependencies,omitempty"`
 	} `toml:"lock"`
 }
 
@@ -123,6 +137,7 @@ func (l Lock) toWire() lockWire {
 	wire.BundledTt = l.BundledTt
 	wire.BundledTcm = l.BundledTcm
 	wire.Lock.Products = l.Products
+	wire.Lock.DevDependencies = l.DevDependencies
 
 	return wire
 }
@@ -137,5 +152,6 @@ func (w lockWire) toLock() Lock {
 		BundledTt:        w.BundledTt,
 		BundledTcm:       w.BundledTcm,
 		Products:         w.Lock.Products,
+		DevDependencies:  w.Lock.DevDependencies,
 	}
 }

--- a/cli/manifest/lock_test.go
+++ b/cli/manifest/lock_test.go
@@ -69,6 +69,80 @@ func TestLockRoundTrip(t *testing.T) {
 	assert.Equal(t, "tt 3.1.0", back.GeneratedBy)
 }
 
+// TestLockDevDependenciesRoundTrip pins the dev closure's on-disk shape: one
+// global [[lock.dev_dependencies]] array beside the per-product tables, both
+// registry and path entries surviving a marshal/parse cycle intact.
+func TestLockDevDependenciesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		GeneratedBy:     "tt 3.1.0",
+		ManifestHash:    "sha256:abc123",
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "metrics", Version: "1.5.0-1", Source: "registry"},
+			}},
+		},
+		DevDependencies: []manifest.LockDependency{
+			{
+				Name:     "luatest",
+				Version:  "1.0.1-1",
+				Source:   "registry",
+				Checksum: "md5:deadbeef",
+			},
+			{
+				Name:        "dev-helper",
+				Version:     "0.1.0",
+				Source:      "path",
+				Path:        "../dev-helper",
+				ContentHash: "sha256:cafe",
+			},
+		},
+	}
+
+	out, err := lock.Marshal()
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.Contains(t, text, "[[lock.dev_dependencies]]")
+	assert.Contains(t, text, "[lock.products.default]")
+	assert.NotContains(t, text, "'lock.dev_dependencies'", "must not be a single quoted key")
+
+	back, err := manifest.ParseLock(out)
+	require.NoError(t, err)
+	assert.Equal(t, lock.DevDependencies, back.DevDependencies)
+	assert.Equal(t, lock.Products, back.Products)
+}
+
+// TestLockWithoutDevDependenciesOmitsKey pins that a lock with no dev closure
+// carries no dev_dependencies key at all, so locks written before dev
+// dependencies were resolved keep marshaling byte-for-byte as they did.
+func TestLockWithoutDevDependenciesOmitsKey(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		GeneratedBy:     "tt 3.1.0",
+		ManifestHash:    "sha256:abc123",
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "metrics", Version: "1.5.0-1", Source: "registry"},
+			}},
+		},
+	}
+
+	out, err := lock.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "dev_dependencies")
+
+	back, err := manifest.ParseLock(out)
+	require.NoError(t, err)
+	assert.Empty(t, back.DevDependencies)
+}
+
 func TestLockNewerMajorRefused(t *testing.T) {
 	t.Parallel()
 

--- a/cli/manifest/pack/devdeps_test.go
+++ b/cli/manifest/pack/devdeps_test.go
@@ -1,0 +1,289 @@
+//nolint:testpackage // white-box: exercises the unexported devOnlyRocks directly.
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// devTreeLock is the lock the tree below was materialized from: one runtime
+// rock, one rock in both closures, and two rocks only the dev closure brings.
+func devTreeLock() *manifest.Lock {
+	return &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "inspect", Version: "3.1.3-1", Source: "registry"},
+				{Name: "checks", Version: "3.1.0-1", Source: "registry"},
+			}},
+		},
+		DevDependencies: []manifest.LockDependency{
+			// Shared with the product closure at the same version, which is
+			// what the resolver's pinning guarantees. It must survive the pack.
+			{Name: "checks", Version: "3.1.0-1", Source: "registry"},
+			{Name: "luatest", Version: "1.0.1-1", Source: "registry"},
+			{Name: "luacov", Version: "0.15.0-1", Source: "registry"},
+		},
+	}
+}
+
+// devRocksTree lays a .rocks/ tree in the shape a build leaves behind, with the
+// dev closure already materialized into it - which is the situation the pack
+// exclusion exists for: .rocks/ is the developer's standing tree, so the dev
+// rocks are there whether or not this particular pack installed them.
+//
+// luatest carries the awkward shapes on purpose: a console script in bin/ and a
+// bare share/tarantool/<name>.lua rather than a directory. Both are outside the
+// name-keyed directories, and both are what a rock_manifest is read for.
+func devRocksTree(t *testing.T, projectDir string) string {
+	t.Helper()
+
+	tree := filepath.Join(projectDir, ".rocks")
+
+	writeTree(t, tree, map[string]string{
+		// The package's own laid-out component files.
+		"share/tarantool/my-app/init.lua":    "-- app",
+		"share/tarantool/my-app/version.lua": "-- version",
+		"lib/tarantool/my-app/fast.so":       "ELF",
+
+		// Runtime closure.
+		"share/tarantool/inspect/init.lua": "-- inspect",
+		"share/tarantool/rocks/inspect/3.1.3-1/rock_manifest": rockManifest(
+			`lua = { ["inspect/init.lua"] = "d0" }`),
+		"share/tarantool/checks.lua": "-- checks",
+		"share/tarantool/rocks/checks/3.1.0-1/rock_manifest": rockManifest(
+			`lua = { ["checks.lua"] = "d1" }`),
+
+		// Dev closure.
+		"share/tarantool/luatest.lua":        "-- luatest",
+		"share/tarantool/luatest/runner.lua": "-- runner",
+		"lib/tarantool/luatest/helper.so":    "ELF",
+		"bin/luatest":                        "#!/usr/bin/env tarantool",
+		"share/tarantool/luacov/init.lua":    "-- luacov",
+		"share/tarantool/rocks/luacov/0.15.0-1/rock_manifest": rockManifest(
+			`lua = { ["luacov/init.lua"] = "d3" }`),
+		"share/tarantool/rocks/luatest/1.0.1-1/rock_manifest": rockManifest(
+			`lua = { ["luatest.lua"] = "d4", ["luatest/runner.lua"] = "d5" },` + "\n" +
+				`lib = { ["luatest/helper.so"] = "d6" },` + "\n" +
+				`bin = { ["luatest"] = "d7" }`),
+	})
+
+	return tree
+}
+
+// rockManifest wraps a rock_manifest body in the assignments-mode envelope
+// LuaRocks writes on disk.
+func rockManifest(body string) string {
+	return "rock_manifest = {\n" + body + "\n}\n"
+}
+
+// packArchive stages a tree and writes the archive, returning its entry names.
+// This is the archive-selection path in full: whatever it drops here is what a
+// .tt file does not carry.
+func packArchive(t *testing.T, req stageRequest) []string {
+	t.Helper()
+
+	stageDir := t.TempDir()
+	require.NoError(t, stage(stageDir, req))
+
+	dest := filepath.Join(t.TempDir(), "my-app-1.0.0-any.tt")
+	_, err := writeArchive(stageDir, dest)
+	require.NoError(t, err)
+
+	entries := readArchive(t, dest)
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// TestPackExcludesDevOnlyRocks is the acceptance test for the exclusion, in the
+// shape that can actually fail: the tree handed to pack already holds the dev
+// closure, exactly as a tt package build run earlier that day would have left
+// it, and the assertion is on the bytes of the archive rather than on the
+// staging directory.
+func TestPackExcludesDevOnlyRocks(t *testing.T) {
+	t.Parallel()
+
+	projectDir, man := testProject(t, nil)
+	tree := devRocksTree(t, projectDir)
+
+	req := baseRequest(projectDir, man, tree)
+
+	req.DevOnly = devOnlyRocks(devTreeLock())
+
+	names := packArchive(t, req)
+
+	// The runtime closure and the package's own files are all there.
+	assert.Contains(t, names, ".rocks/share/tarantool/inspect/init.lua")
+	assert.Contains(t, names, ".rocks/share/tarantool/checks.lua")
+	assert.Contains(t, names, ".rocks/share/tarantool/my-app/init.lua")
+	assert.Contains(t, names, ".rocks/lib/tarantool/my-app/fast.so")
+
+	// A rock both closures hold is a runtime rock and survives, metadata
+	// included: excluding it would break the archive it belongs to.
+	assert.Contains(t, names, ".rocks/share/tarantool/rocks/checks/3.1.0-1/rock_manifest")
+
+	// Every dev-only file is gone - including the two shapes the name-keyed
+	// directories would have missed.
+	for _, gone := range []string{
+		".rocks/share/tarantool/luatest.lua",
+		".rocks/share/tarantool/luatest/runner.lua",
+		".rocks/lib/tarantool/luatest/helper.so",
+		".rocks/bin/luatest",
+		".rocks/share/tarantool/luacov/init.lua",
+		".rocks/share/tarantool/rocks/luatest/1.0.1-1/rock_manifest",
+		".rocks/share/tarantool/rocks/luacov/0.15.0-1/rock_manifest",
+	} {
+		assert.NotContains(t, names, gone, "dev-only file must not reach the archive")
+	}
+}
+
+// TestPackWithoutDevDependenciesIsUnchanged is the control: with no dev closure
+// in the lock the same tree packs whole, so the test above is measuring the
+// exclusion rather than some other thing that drops files.
+func TestPackWithoutDevDependenciesIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	projectDir, man := testProject(t, nil)
+	tree := devRocksTree(t, projectDir)
+
+	req := baseRequest(projectDir, man, tree)
+
+	req.DevOnly = devOnlyRocks(&manifest.Lock{
+		Products: devTreeLock().Products,
+	})
+
+	names := packArchive(t, req)
+
+	assert.Contains(t, names, ".rocks/share/tarantool/luatest.lua")
+	assert.Contains(t, names, ".rocks/bin/luatest")
+}
+
+// TestPackWithoutDepsAlsoDropsDevRocks pins that the two filters compose. A
+// dev-only rock would not normally survive --without-deps anyway, since only
+// the package's own namespaces are copied - so the case that matters is a dev
+// rock sharing a name with one of them, where the namespace filter alone lets
+// it through.
+func TestPackWithoutDepsAlsoDropsDevRocks(t *testing.T) {
+	t.Parallel()
+
+	projectDir, man := testProject(t, nil)
+	tree := devRocksTree(t, projectDir)
+
+	// A dev-only rock installing into the package's own namespace directory.
+	writeTree(t, tree, map[string]string{
+		"share/tarantool/my-app/devtool.lua": "-- devtool",
+		"share/tarantool/rocks/devtool/1.0.0-1/rock_manifest": rockManifest(
+			`lua = { ["my-app/devtool.lua"] = "d8" }`),
+	})
+
+	lock := devTreeLock()
+
+	lock.DevDependencies = append(lock.DevDependencies,
+		manifest.LockDependency{Name: "devtool", Version: "1.0.0-1", Source: "registry"})
+
+	req := baseRequest(projectDir, man, tree)
+
+	req.WithDeps = false
+	req.DevOnly = devOnlyRocks(lock)
+
+	names := packArchive(t, req)
+
+	assert.Contains(t, names, ".rocks/share/tarantool/my-app/init.lua",
+		"--without-deps must still keep the package's own namespace")
+	assert.NotContains(t, names, ".rocks/share/tarantool/my-app/devtool.lua",
+		"a dev rock inside the package namespace must still be excluded")
+	assert.NotContains(t, names, ".rocks/share/tarantool/inspect/init.lua",
+		"--without-deps still drops foreign runtime rocks")
+}
+
+// TestDevOnlyRocksExcludesSharedNames covers the ownership rule on its own: a
+// rock any product's closure holds is not dev-only, however the dev table
+// declares it.
+func TestDevOnlyRocksExcludesSharedNames(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "inspect", Version: "3.1.3-1", Source: "registry"},
+			}},
+			// A second product the archive is not for. Its rocks are in the
+			// tree all the same, so they are not dev-only either.
+			"minimal": {Dependencies: []manifest.LockDependency{
+				{Name: "checks", Version: "3.1.0-1", Source: "registry"},
+			}},
+		},
+		DevDependencies: []manifest.LockDependency{
+			{Name: "inspect", Version: "3.1.3-1", Source: "registry"},
+			{Name: "checks", Version: "3.1.0-1", Source: "registry"},
+			{Name: "luatest", Version: "1.0.1-1", Source: "registry"},
+		},
+	}
+
+	devOnly := devOnlyRocks(lock)
+	require.Len(t, devOnly, 1)
+	assert.Equal(t, "luatest", devOnly[0].Name)
+
+	assert.Nil(t, devOnlyRocks(nil))
+	assert.Nil(t, devOnlyRocks(&manifest.Lock{Products: lock.Products}))
+}
+
+// TestDevRockFilterFallsBackWithoutRockManifest pins the degraded path: a rock
+// whose rock_manifest is missing is excluded by the name-keyed directories
+// instead, the same ones cli/manifest/state.RockPaths uses.
+func TestDevRockFilterFallsBackWithoutRockManifest(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+
+	skip := devRockFilter(tree, []manifest.LockDependency{
+		{Name: "luatest", Version: "1.0.1-1", Source: "registry"},
+	})
+	require.NotNil(t, skip)
+
+	assert.True(t, skip("share/tarantool/luatest"))
+	assert.True(t, skip("share/tarantool/luatest/runner.lua"))
+	assert.True(t, skip("lib/tarantool/luatest/helper.so"))
+	assert.True(t, skip("share/tarantool/rocks/luatest"))
+
+	// Under-excluding is the safe direction: without a rock_manifest the flat
+	// module and the console script are unknown and are kept.
+	assert.False(t, skip("share/tarantool/luatest.lua"))
+	assert.False(t, skip("bin/luatest"))
+	assert.False(t, skip("share/tarantool/inspect/init.lua"))
+
+	assert.Nil(t, devRockFilter(tree, nil))
+}
+
+// TestStageRocksMissingTreeWithDevOnly guards the interaction of the filter
+// with the pure-metadata case: no tree to copy is still not an error.
+func TestStageRocksMissingTreeWithDevOnly(t *testing.T) {
+	t.Parallel()
+
+	projectDir, man := testProject(t, nil)
+
+	req := baseRequest(projectDir, man, filepath.Join(projectDir, ".rocks"))
+
+	req.DevOnly = devOnlyRocks(devTreeLock())
+
+	stageDir := t.TempDir()
+	require.NoError(t, stage(stageDir, req))
+
+	_, err := os.Stat(filepath.Join(stageDir, rocksDirName))
+	assert.True(t, os.IsNotExist(err))
+}

--- a/cli/manifest/pack/pack.go
+++ b/cli/manifest/pack/pack.go
@@ -7,6 +7,12 @@
 // network. The --without-deps mode drops both, leaving the package's own
 // namespace subtrees; installing that archive extracts it and refetches the
 // dependencies from the registry using the lock's pins.
+//
+// Neither mode carries the dev closure. The build pack runs first materializes
+// [dev_dependencies] into .rocks/ like any other build, and so did every build
+// the developer ran before it, so the archive is kept clean here - where its
+// content is selected - rather than by declining to install them. See
+// devOnlyRocks and stageRocks.
 package pack
 
 import (
@@ -99,6 +105,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		WithDeps:         !opts.WithoutDeps,
 		Namespaces:       namespaces,
 		HasFlatNamespace: hasFlat,
+		DevOnly:          devOnlyRocks(built.Lock),
 	}); err != nil {
 		return nil, err
 	}
@@ -262,6 +269,44 @@ func packageNamespaces(man *manifest.Manifest, productName string) ([]string, bo
 	}
 
 	return namespaces, flat
+}
+
+// devOnlyRocks lists the dev closure's rocks that no product closure holds -
+// the ones the archive must not carry. A nil lock, or one with no dev closure,
+// yields nothing and the staging tree is copied exactly as before.
+//
+// Not installing dev dependencies during a pack-driven build would not do this
+// job: .rocks/ is the developer's standing tree, so a tt package build run an
+// hour earlier has already put them there, and pack would stage them. The
+// exclusion therefore belongs where the archive content is selected.
+//
+// "No product closure holds it" is deliberately checked against every product,
+// not just the one being packed. A with-deps archive copies the whole tree,
+// which may incidentally carry another product's rocks; a rock that is dev in
+// this reading and runtime in another product's is not a dev-only rock, and
+// stripping it would under-pack a tree the archive promises to reproduce.
+func devOnlyRocks(lock *manifest.Lock) []manifest.LockDependency {
+	if lock == nil || len(lock.DevDependencies) == 0 {
+		return nil
+	}
+
+	runtime := map[string]bool{}
+
+	for _, product := range lock.Products {
+		for _, dependency := range product.Dependencies {
+			runtime[dependency.Name] = true
+		}
+	}
+
+	var devOnly []manifest.LockDependency
+
+	for _, dependency := range lock.DevDependencies {
+		if !runtime[dependency.Name] {
+			devOnly = append(devOnly, dependency)
+		}
+	}
+
+	return devOnly
 }
 
 // hasNativeArtifacts reports whether the staged tree carries any compiled

--- a/cli/manifest/pack/stage.go
+++ b/cli/manifest/pack/stage.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tarantool/go-luarocks/manif"
+
 	"github.com/tarantool/tt/cli/manifest"
 )
 
@@ -61,6 +63,11 @@ type stageRequest struct {
 	// HasFlatNamespace records that some component declares namespace = "",
 	// which --without-deps cannot express (see stageRocks).
 	HasFlatNamespace bool
+	// DevOnly lists the locked rocks that only the dev closure brings. Their
+	// files are dropped from .rocks/ in both packing modes: they are the
+	// developer's tools, and the spec is explicit that they never reach the
+	// archive. See devOnlyRocks.
+	DevOnly []manifest.LockDependency
 }
 
 // stageMetadata writes the three tt-owned metadata files.
@@ -144,6 +151,12 @@ func stageEntry(stageDir, projectDir, entry, field string) error {
 // namespace subtrees under share/tarantool/ and lib/tarantool/ survive, which
 // is what leaves the dependency closure to be refetched from the lock at
 // install time.
+//
+// Dev-only rocks are dropped in both modes. The two filters compose rather than
+// override: --without-deps decides which subtrees are copied at all, the dev
+// filter decides which files inside a copied subtree are skipped, and the skip
+// predicate is evaluated against the tree-relative path either way, so a
+// namespace that happens to share a dev rock's name is not a hole in it.
 func stageRocks(stageDir string, req stageRequest) error {
 	if _, err := os.Stat(req.Tree); os.IsNotExist(err) {
 		// A pure-metadata package need not have produced a tree.
@@ -151,9 +164,10 @@ func stageRocks(stageDir string, req stageRequest) error {
 	}
 
 	dstRocks := filepath.Join(stageDir, rocksDirName)
+	skip := devRockFilter(req.Tree, req.DevOnly)
 
 	if req.WithDeps {
-		return copyTree(req.Tree, dstRocks)
+		return copyTreeFiltered(req.Tree, dstRocks, "", skip)
 	}
 
 	if req.HasFlatNamespace {
@@ -181,8 +195,10 @@ func stageRocks(stageDir string, req stageRequest) error {
 			}
 
 			dst := filepath.Join(dstRocks, filepath.FromSlash(sub), ns)
-			if err := copyTree(src, dst); err != nil {
-				return err
+
+			copyErr := copyTreeFiltered(src, dst, sub+"/"+ns, skip)
+			if copyErr != nil {
+				return copyErr
 			}
 		}
 	}
@@ -194,7 +210,93 @@ func stageRocks(stageDir string, req stageRequest) error {
 const (
 	shareTarantool = "share/tarantool"
 	libTarantool   = "lib/tarantool"
+	// rocksInstallDir is where LuaRocks keeps per-rock metadata:
+	// <tree>/share/tarantool/rocks/<name>/<version>/.
+	rocksInstallDir = shareTarantool + "/rocks"
+	// binDir holds the console scripts a rock installs. luatest - the canonical
+	// dev dependency - ships one, which is why the filter has to reach here and
+	// not only into the two module trees.
+	binDir = "bin"
+	// rockManifestFile enumerates, per rock, every file it deployed.
+	rockManifestFile = "rock_manifest"
 )
+
+// devRockFilter builds the predicate stageRocks skips paths by: it reports
+// whether a tree-relative slash path belongs to one of the dev-only rocks. A
+// nil DevOnly yields nil, which copyTreeFiltered reads as "copy everything".
+//
+// A rock's footprint is taken from its own rock_manifest, which lists every
+// file it deployed - the authoritative answer, and the only one that catches a
+// rock installing a bare share/tarantool/<name>.lua rather than a directory, or
+// a console script in bin/. Its per-rock metadata directory is excluded whole
+// and separately, since that is where the rock_manifest itself, the rockspec,
+// doc/ and conf/ live.
+//
+// A rock whose rock_manifest is missing or unreadable falls back to the
+// name-keyed directories cli/manifest/state.RockPaths uses. That under-excludes
+// a rock laying files outside them, which is the safe direction to be wrong in:
+// the archive keeps a file it did not need rather than losing one it did.
+func devRockFilter(tree string, devOnly []manifest.LockDependency) func(string) bool {
+	if len(devOnly) == 0 {
+		return nil
+	}
+
+	excluded := map[string]bool{}
+
+	for _, rock := range devOnly {
+		excluded[rocksInstallDir+"/"+rock.Name] = true
+
+		deployed, ok := deployedPaths(tree, rock)
+		if !ok {
+			excluded[shareTarantool+"/"+rock.Name] = true
+			excluded[libTarantool+"/"+rock.Name] = true
+
+			continue
+		}
+
+		for _, path := range deployed {
+			excluded[path] = true
+		}
+	}
+
+	return func(rel string) bool {
+		for path := range excluded {
+			if rel == path || strings.HasPrefix(rel, path+"/") {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// deployedPaths reads one rock's rock_manifest and returns the tree-relative
+// paths it deployed outside its own metadata directory. The second result is
+// false when the rock_manifest cannot be read, which is the caller's signal to
+// fall back to the name-keyed directories.
+func deployedPaths(tree string, rock manifest.LockDependency) ([]string, bool) {
+	specPath := filepath.Join(tree, filepath.FromSlash(rocksInstallDir),
+		rock.Name, rock.Version, rockManifestFile)
+
+	rockManifest, err := manif.FileStore{}.ReadRock(specPath)
+	if err != nil || rockManifest == nil {
+		return nil, false
+	}
+
+	var paths []string
+
+	for root, files := range map[string]map[string]string{
+		shareTarantool: rockManifest.Lua,
+		libTarantool:   rockManifest.Lib,
+		binDir:         rockManifest.Bin,
+	} {
+		for file := range files {
+			paths = append(paths, root+"/"+filepath.ToSlash(file))
+		}
+	}
+
+	return paths, true
+}
 
 // copyTree recursively copies src to dst, creating parents as needed. The
 // archive carries no link structure, so symlinks are dereferenced: a link to a
@@ -205,6 +307,15 @@ const (
 // directory down the file-copy path. Package prefixes hit this routinely
 // (Homebrew's share/tarantool is a link into the Cellar).
 func copyTree(src, dst string) error {
+	return copyTreeFiltered(src, dst, "", nil)
+}
+
+// copyTreeFiltered is copyTree with an optional skip predicate. relBase is the
+// slash path src sits at inside the rocks tree, so the predicate always sees a
+// tree-relative path however deep the copy root is - which is what lets the
+// same filter apply to a whole-tree copy and to a per-namespace one. A nil skip
+// copies everything.
+func copyTreeFiltered(src, dst, relBase string, skip func(string) bool) error {
 	if resolved, err := filepath.EvalSymlinks(src); err == nil {
 		src = resolved
 	}
@@ -228,6 +339,14 @@ func copyTree(src, dst string) error {
 			return err
 		}
 
+		if skip != nil && skip(joinRel(relBase, rel)) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
 		target := filepath.Join(dst, rel)
 
 		if d.IsDir() {
@@ -248,7 +367,7 @@ func copyTree(src, dst string) error {
 			}
 
 			if resolved.IsDir() {
-				return copyTree(path, target)
+				return copyTreeFiltered(path, target, joinRel(relBase, rel), skip)
 			}
 
 			return copyFile(path, target)
@@ -261,6 +380,22 @@ func copyTree(src, dst string) error {
 
 		return copyFile(path, target)
 	})
+}
+
+// joinRel appends a walk-relative path to the copy root's tree-relative base,
+// in slash form. WalkDir reports the root itself as ".", which contributes
+// nothing to the path.
+func joinRel(base, rel string) string {
+	slashed := filepath.ToSlash(rel)
+	if slashed == "." {
+		return base
+	}
+
+	if base == "" {
+		return slashed
+	}
+
+	return base + "/" + slashed
 }
 
 // within reports whether path is inside root (or is root itself). Both sides

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -317,6 +317,28 @@ func effectiveDeps(man *manifest.Manifest, product manifest.Product) ([]depReq, 
 		}
 	}
 
+	return finalizeDeps(byName)
+}
+
+// devDeps assembles the direct dependencies of the dev closure: the global
+// [dev_dependencies] table and nothing else. Unlike runtime dependencies there
+// is no per-component dev table, so the dev closure is global too - one per
+// manifest, not one per product.
+func devDeps(man *manifest.Manifest) ([]depReq, error) {
+	byName := map[string]*depReq{}
+
+	err := mergeDeps(byName, "dev_dependencies", man.DevDependencies)
+	if err != nil {
+		return nil, err
+	}
+
+	return finalizeDeps(byName)
+}
+
+// finalizeDeps turns a merged declaration set into the sorted, constraint-parsed
+// requirement list the walker consumes, rejecting a multiply-declared
+// dependency whose merged constraints cannot be jointly satisfied.
+func finalizeDeps(byName map[string]*depReq) ([]depReq, error) {
 	out := make([]depReq, 0, len(byName))
 
 	for _, name := range sortedKeys(byName) {

--- a/cli/manifest/resolve/dev_test.go
+++ b/cli/manifest/resolve/dev_test.go
@@ -1,0 +1,263 @@
+package resolve_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// devHelperDir creates a path-dependency directory under root and returns its
+// absolute path.
+func devHelperDir(t *testing.T, root, name string) string {
+	t.Helper()
+
+	dir := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.lua"), []byte("return {}\n"), 0o600))
+
+	return dir
+}
+
+// TestResolveDevDependenciesLandInLock is the base case: [dev_dependencies]
+// resolves into its own closure, transitives included, and the runtime closure
+// is untouched by their presence.
+func TestResolveDevDependenciesLandInLock(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "aaa").
+		add("luatest", "1.0.1-1", "bbb", dep(t, "checks", ">=3.0")).
+		add("checks", "3.1.0-1", "ccc")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+[dev_dependencies]
+luatest = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	// The runtime closure stays exactly what it was: one rock, no dev rocks.
+	assert.Equal(t, []string{"metrics"}, depNames(lock.Products["default"].Dependencies))
+
+	// The dev closure is transitive, in the same deepest-first order.
+	assert.Equal(t, []string{"checks", "luatest"}, depNames(lock.DevDependencies))
+	assert.Equal(t, "1.0.1-1", findDep(t, lock.DevDependencies, "luatest").Version)
+	assert.Equal(t, "md5:ccc", findDep(t, lock.DevDependencies, "checks").Checksum)
+}
+
+// TestResolveNoDevDependenciesLeavesClosureEmpty pins that a manifest without
+// the table resolves to no dev closure at all rather than an empty-but-present
+// one, which is what keeps existing locks byte-identical.
+func TestResolveNoDevDependenciesLeavesClosureEmpty(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(newFakeAdapter().add("metrics", "1.5.0-1", "aaa"), "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Nil(t, lock.DevDependencies)
+}
+
+// TestResolveDevSharedRockTakesRuntimePick is the reason the dev closure is
+// resolved against the products rather than beside them: both land in one
+// .rocks/ tree, which cannot hold two versions of a rock. The dev constraint
+// here would take the newest on its own; pinned to the runtime pick it does
+// not.
+func TestResolveDevSharedRockTakesRuntimePick(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("common", "1.5.0-1", "aaa").
+		add("common", "2.0.0-1", "bbb").
+		add("luatest", "1.0.1-1", "ccc", dep(t, "common", ">=1.0.0"))
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+common = '>=1.0.0,<2.0.0'
+[dev_dependencies]
+luatest = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	runtimePick := findDep(t, lock.Products["default"].Dependencies, "common").Version
+	devPick := findDep(t, lock.DevDependencies, "common").Version
+
+	assert.Equal(t, "1.5.0-1", runtimePick)
+	assert.Equal(t, runtimePick, devPick,
+		"a rock in both closures must resolve to one version, the runtime pick")
+}
+
+// TestResolveDevIncompatibleConstraintDropsPin covers the accepted escape
+// hatch: a dev-only constraint the runtime pick cannot satisfy drops the pin
+// and warns rather than failing the resolution. The tree then genuinely holds
+// two versions, which the warning is there to say.
+func TestResolveDevIncompatibleConstraintDropsPin(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("common", "1.5.0-1", "aaa").
+		add("common", "2.0.0-1", "bbb")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+common = '<2.0.0'
+[dev_dependencies]
+common = '>=2.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.5.0-1",
+		findDep(t, lock.Products["default"].Dependencies, "common").Version)
+	assert.Equal(t, "2.0.0-1", findDep(t, lock.DevDependencies, "common").Version)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "common")
+}
+
+// TestResolveDevPathDependency pins that a path-sourced dev dependency goes
+// through the ordinary path machinery: it is content-hashed into the dev
+// closure like any runtime path dependency, with no special case.
+func TestResolveDevPathDependency(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.5.0-1", "aaa").
+		addLocal(devHelperDir(t, projectDir, "helper"), "helper", "0.1.0")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+[dev_dependencies.helper]
+source = 'path'
+path = 'helper'
+`)
+
+	engine := resolve.NewEngine(fake, projectDir, "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	helper := findDep(t, lock.DevDependencies, "helper")
+	assert.Equal(t, "path", helper.Source)
+	assert.Equal(t, "helper", helper.Path)
+	assert.NotEmpty(t, helper.ContentHash)
+}
+
+// TestIsStaleDevClosureMissing is the upgrade case: a lock written before tt
+// resolved [dev_dependencies] carries none, and its manifest_hash still
+// matches because the manifest never changed. Nothing but this check can
+// notice, so without it such a project silently never gets its dev
+// dependencies again.
+func TestIsStaleDevClosureMissing(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dev_dependencies]
+luatest = '>=1.0.0'
+`)
+
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		ManifestHash:    man.Hash(),
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: nil},
+		},
+	}
+
+	engine := resolve.NewEngine(newFakeAdapter(), "", "tt 3.4.0")
+
+	stale, reason, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.True(t, stale)
+	assert.Contains(t, reason, "dev dependencies")
+}
+
+// TestIsStaleDevClosurePresent is the other half: once the closure is in the
+// lock, the same manifest is not stale. Without it the check above would pass
+// for an implementation that reported every manifest with dev dependencies as
+// permanently stale.
+func TestIsStaleDevClosurePresent(t *testing.T) {
+	t.Parallel()
+
+	man := parseManifest(t, oneProduct+`[dev_dependencies]
+luatest = '>=1.0.0'
+`)
+
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		ManifestHash:    man.Hash(),
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: nil},
+		},
+		DevDependencies: []manifest.LockDependency{
+			{Name: "luatest", Version: "1.0.1-1", Source: "registry"},
+		},
+	}
+
+	engine := resolve.NewEngine(newFakeAdapter(), "", "tt 3.4.0")
+
+	stale, reason, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.False(t, stale, "reason: %s", reason)
+}
+
+// TestIsStaleDevPathDependencyChanged pins that a dev path dependency is
+// content-hashed like a runtime one: editing the directory makes the lock
+// stale, rather than the dev closure being a hole in the check.
+func TestIsStaleDevPathDependencyChanged(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	devHelperDir(t, projectDir, "helper")
+
+	man := parseManifest(t, oneProduct+`[dev_dependencies.helper]
+source = 'path'
+path = 'helper'
+`)
+
+	lock := &manifest.Lock{
+		LockVersion:     manifest.LockVersion,
+		ManifestVersion: manifest.ManifestVersion,
+		ManifestHash:    man.Hash(),
+		Products:        map[string]manifest.LockProduct{"default": {}},
+		DevDependencies: []manifest.LockDependency{{
+			Name:        "helper",
+			Version:     "0.1.0",
+			Source:      "path",
+			Path:        "helper",
+			ContentHash: "sha256:stale",
+		}},
+	}
+
+	engine := resolve.NewEngine(newFakeAdapter(), projectDir, "tt 3.4.0")
+
+	stale, reason, err := engine.IsStale(man, lock)
+	require.NoError(t, err)
+	assert.True(t, stale)
+	assert.Contains(t, reason, "helper")
+}

--- a/cli/manifest/resolve/pins.go
+++ b/cli/manifest/resolve/pins.go
@@ -1,6 +1,8 @@
 package resolve
 
 import (
+	"maps"
+
 	"github.com/tarantool/go-luarocks/deps"
 	"github.com/tarantool/tt/cli/manifest"
 )
@@ -25,9 +27,15 @@ import (
 type Pins map[string]string
 
 // PinsFromLock collects the registry-sourced dependencies of every product in
-// lock into a pin set. Names listed in except are left out, so the caller can
-// free one dependency while holding the rest - which is exactly
-// `tt package update <name>`. A nil lock yields an empty set.
+// lock, and of its dev closure, into a pin set. Names listed in except are left
+// out, so the caller can free one dependency while holding the rest - which is
+// exactly `tt package update <name>`. A nil lock yields an empty set.
+//
+// The dev closure is walked for the same reason the products are: editing the
+// manifest changes manifest_hash and forces a re-resolve, so a dev dependency
+// left out of the pin set would be dragged to its newest version by a
+// `tt package add` that had nothing to do with it - the very bug pins exist to
+// prevent, reintroduced for half the manifest.
 //
 // Path dependencies are skipped: they are pinned by path and content hash
 // already, and the engine never applies a version pin to them.
@@ -63,23 +71,49 @@ func PinsFromLock(lock *manifest.Lock, except ...string) Pins {
 	}
 
 	for _, product := range sortedKeys(lock.Products) {
-		for _, dependency := range lock.Products[product].Dependencies {
-			if dependency.Source != manifestSourceRegistry || dependency.Version == "" {
-				continue
-			}
-
-			if excluded[dependency.Name] {
-				continue
-			}
-
-			held, seen := pins[dependency.Name]
-			if !seen || ordersAbove(dependency.Version, held) {
-				pins[dependency.Name] = dependency.Version
-			}
-		}
+		pins.absorb(lock.Products[product].Dependencies, excluded)
 	}
 
+	// The dev closure is absorbed last, but order does not decide anything: the
+	// same highest-version-wins tie-break settles a rock that appears in both a
+	// product closure and the dev closure at different versions, for the reason
+	// spelled out above - a downgrade is the more damaging outcome.
+	pins.absorb(lock.DevDependencies, excluded)
+
 	return pins
+}
+
+// absorb folds one locked closure into the pin set, skipping path sources,
+// versionless entries and excluded names, and keeping the highest version where
+// a rock is already pinned.
+func (p Pins) absorb(dependencies []manifest.LockDependency, excluded map[string]bool) {
+	for _, dependency := range dependencies {
+		if dependency.Source != manifestSourceRegistry || dependency.Version == "" {
+			continue
+		}
+
+		if excluded[dependency.Name] {
+			continue
+		}
+
+		held, seen := p[dependency.Name]
+		if !seen || ordersAbove(dependency.Version, held) {
+			p[dependency.Name] = dependency.Version
+		}
+	}
+}
+
+// merge returns a copy of p with other's pins layered on top, other winning
+// where both hold a name. It is how the dev resolution states its precedence:
+// the runtime picks this pass just made are authoritative over whatever the
+// caller was holding, because they are what is already going into the tree.
+func (p Pins) merge(other Pins) Pins {
+	out := make(Pins, len(p)+len(other))
+
+	maps.Copy(out, p)
+	maps.Copy(out, other)
+
+	return out
 }
 
 // ordersAbove reports whether candidate sorts strictly above held. An

--- a/cli/manifest/resolve/pins_test.go
+++ b/cli/manifest/resolve/pins_test.go
@@ -432,6 +432,79 @@ func TestPinsFromLockPrefersHighestOnDisagreement(t *testing.T) {
 	assert.Equal(t, resolve.Pins{"common": "2.0.0-1"}, resolve.PinsFromLock(lock))
 }
 
+// TestPinsFromLockIncludesDevClosure pins that the dev closure is pinned like
+// any product closure, under the same three rules: path sources are skipped,
+// except is honoured, and the highest version wins where a rock is in both a
+// product closure and the dev closure. Without it a tt package add - which
+// re-resolves with these pins precisely so unrelated dependencies stay put -
+// would drag every dev dependency to its newest version.
+func TestPinsFromLockIncludesDevClosure(t *testing.T) {
+	t.Parallel()
+
+	lock := &manifest.Lock{
+		Products: map[string]manifest.LockProduct{
+			"default": {Dependencies: []manifest.LockDependency{
+				{Name: "metrics", Version: "1.0.0-1", Source: "registry"},
+				{Name: "common", Version: "1.5.0-1", Source: "registry"},
+			}},
+		},
+		DevDependencies: []manifest.LockDependency{
+			{Name: "luatest", Version: "1.0.1-1", Source: "registry"},
+			{Name: "luacov", Version: "0.15.0-1", Source: "registry"},
+			{Name: "dev-helper", Version: "0.1.0", Source: "path", Path: "dev/helper"},
+			// Higher than the product's pick of the same rock: the tie-break
+			// takes the highest, exactly as it does between two products.
+			{Name: "common", Version: "2.0.0-1", Source: "registry"},
+		},
+	}
+
+	assert.Equal(t, resolve.Pins{
+		"metrics": "1.0.0-1",
+		"common":  "2.0.0-1",
+		"luatest": "1.0.1-1",
+		"luacov":  "0.15.0-1",
+	}, resolve.PinsFromLock(lock))
+
+	assert.Equal(t, resolve.Pins{
+		"metrics": "1.0.0-1",
+		"common":  "2.0.0-1",
+		"luacov":  "0.15.0-1",
+	}, resolve.PinsFromLock(lock, "luatest"),
+		"except must free a dev dependency like any other")
+}
+
+// TestPinsFromLockHoldsDevDependencyAcrossReresolve is the end-to-end shape of
+// the same rule: a dev dependency that published a newer version between two
+// resolutions stays where the lock put it.
+func TestPinsFromLockHoldsDevDependencyAcrossReresolve(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "m1").
+		add("luatest", "1.0.0-1", "l1")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '>=1.0.0'
+[dev_dependencies]
+luatest = '>=1.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	first, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0-1", findDep(t, first.DevDependencies, "luatest").Version)
+
+	fake.add("luatest", "2.0.0-1", "l2")
+
+	second, warnings, err := engine.ResolvePinned(
+		context.Background(), man, resolve.PinsFromLock(first))
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, "1.0.0-1", findDep(t, second.DevDependencies, "luatest").Version,
+		"a new registry version must not move a pinned dev dependency")
+}
+
 func TestPinsFromLockEdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/cli/manifest/resolve/resolve.go
+++ b/cli/manifest/resolve/resolve.go
@@ -3,9 +3,12 @@
 // lock (app.manifest.lock) - declared, resolved, locked.
 //
 // Resolution runs per product: each product gets its own closure over the
-// newest versions that satisfy every constraint. A caller that must not move
-// versions it already holds - every command other than tt package update -
-// passes a pin set (see Pins) so the lock's own picks are preferred over the
+// newest versions that satisfy every constraint. [dev_dependencies] adds one
+// further closure, global rather than per-product, resolved last and against
+// the products' own picks - it lands in the same .rocks/ tree, which can hold
+// only one version of a rock. A caller that must not move versions it already
+// holds - every command other than tt package update - passes a pin set (see
+// Pins) so the lock's own picks are preferred over the
 // newest ones. The engine takes an already parsed manifest plus an adapter over
 // go-luarocks; it never touches the network itself. The adapter
 // (cli/manifest/rocks) queries registries, fetches rockspecs and reports source
@@ -165,6 +168,7 @@ func (e *Engine) resolveOnce(
 		BundledTt:        "",
 		BundledTcm:       "",
 		Products:         map[string]manifest.LockProduct{},
+		DevDependencies:  nil, // Filled by resolveDev once the products are in.
 	}
 
 	var warnings []string
@@ -183,7 +187,76 @@ func (e *Engine) resolveOnce(
 		lock.Products[name] = manifest.LockProduct{Dependencies: dependencies}
 	}
 
+	devDependencies, devWarnings, err := e.resolveDev(ctx, man, pins, lock)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	warnings = append(warnings, devWarnings...)
+	lock.DevDependencies = devDependencies
+
 	return lock, warnings, nil
+}
+
+// resolveDev resolves the closure of [dev_dependencies] against the products
+// already resolved into lock. A manifest declaring none resolves to nothing.
+//
+// Dev dependencies are installed into the same .rocks/ tree as the runtime
+// closure, and one tree cannot hold two versions of a rock. So the dev closure
+// is resolved with every product's pick pinned - PinsFromLock over the lock
+// this very pass just built, layered over the caller's own pins so a dev-only
+// rock still holds the version it already had. A dev constraint that cannot
+// accept the runtime pick drops that pin and warns, which is the ordinary pin
+// semantics: the tree then genuinely holds two versions, and saying so is
+// better than refusing to resolve.
+//
+// The pin retry lives here rather than in ResolvePinned because these pins are
+// derived from the pass's own output: dropping one from the caller's set would
+// not remove it, since the next pass would re-derive it from the same products.
+// Each attempt gets a fresh cache for the reason resolveOnce documents - the
+// cache carries the warning dedup, and a discarded attempt must not mark
+// warnings the surviving one then owes the caller and never emits.
+func (e *Engine) resolveDev(
+	ctx context.Context, man *manifest.Manifest, pins Pins, lock *manifest.Lock,
+) ([]manifest.LockDependency, []string, error) {
+	if len(man.DevDependencies) == 0 {
+		return nil, nil, nil
+	}
+
+	directs, err := devDeps(man)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving dev dependencies: %w", err)
+	}
+
+	attempt := pins.merge(PinsFromLock(lock))
+
+	var dropped []string
+
+	for {
+		dependencies, warnings, err := e.resolveClosure(
+			ctx, newResolveCache(), directs, attempt)
+		if err == nil {
+			return dependencies, append(dropped, warnings...), nil
+		}
+
+		var conflict *pinConflictError
+		if !errors.As(err, &conflict) {
+			return nil, nil, fmt.Errorf("resolving dev dependencies: %w", err)
+		}
+
+		held, pinned := attempt[conflict.name]
+		if !pinned {
+			// Unreachable: only a pinned pick raises this. Returning the
+			// conflict rather than looping keeps a future bug a failed
+			// resolution instead of a hang.
+			return nil, nil, fmt.Errorf("resolving dev dependencies: %w", err)
+		}
+
+		dropped = append(dropped, fmt.Sprintf(
+			"version %s of %q cannot satisfy every dev dependency on it; resolved afresh",
+			held, conflict.name))
+		attempt = attempt.without(conflict.name)
+	}
 }
 
 // resolveProduct assembles a product's effective direct dependencies and walks
@@ -202,6 +275,17 @@ func (e *Engine) resolveProduct(
 		return nil, nil, err
 	}
 
+	return e.resolveClosure(ctx, cache, directs, pins)
+}
+
+// resolveClosure walks a set of direct requirements into a pinned,
+// topologically ordered closure. It is the shared body of a product resolution
+// and of the dev resolution, which differ only in where their direct
+// requirements come from. pins is read, never written, so every closure of a
+// pass sees the same one.
+func (e *Engine) resolveClosure(
+	ctx context.Context, cache *resolveCache, directs []depReq, pins Pins,
+) ([]manifest.LockDependency, []string, error) {
 	directsByName := make(map[string]depReq, len(directs))
 	for _, direct := range directs {
 		directsByName[direct.name] = direct

--- a/cli/manifest/resolve/stale.go
+++ b/cli/manifest/resolve/stale.go
@@ -8,11 +8,21 @@ import (
 )
 
 // IsStale reports whether lock no longer reflects m, and why. A lock goes stale
-// from exactly two things: the manifest's raw bytes changed (manifest_hash
-// diverged), or a path dependency's local content changed (its content_hash
-// diverged). New registry versions never make a lock stale - only an explicit
+// from exactly three things: the manifest's raw bytes changed (manifest_hash
+// diverged), a path dependency's local content changed (its content_hash
+// diverged), or the manifest declares dev dependencies the lock holds no
+// closure for. New registry versions never make a lock stale - only an explicit
 // tt package update pulls them; a changed tt version or package VERSION does
 // not either.
+//
+// The third case is not a change in the project at all but a change in tt: a
+// lock written before tt resolved [dev_dependencies] carries none, and its
+// manifest_hash still matches because the manifest never changed. Without this
+// case such a project would silently never get its dev dependencies again -
+// nothing else can notice, because the only evidence is the lock's own
+// emptiness. The check is one-directional on purpose: a dev closure in the lock
+// for a manifest that declares none is not staleness (nothing to install), and
+// dev picks that merely aged are not either, by the rule above.
 //
 // What to do with a stale lock is the caller's call: an unflagged build
 // re-resolves and rewrites it (Engine.Resolve); a --locked build treats
@@ -22,12 +32,25 @@ func (e *Engine) IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, str
 		return true, "manifest changed since the lock was written", nil
 	}
 
-	// A path dependency shared by several products is hashed once, not once per
-	// product referencing it.
+	if len(man.DevDependencies) > 0 && len(lock.DevDependencies) == 0 {
+		return true, "manifest declares dev dependencies the lock has no closure for", nil
+	}
+
+	// A path dependency shared by several products, or by a product and the dev
+	// closure, is hashed once rather than once per closure referencing it.
 	hashes := map[string]string{}
 
+	closures := make([][]manifest.LockDependency, 0, len(lock.Products)+1)
 	for _, product := range sortedKeys(lock.Products) {
-		for _, dependency := range lock.Products[product].Dependencies {
+		closures = append(closures, lock.Products[product].Dependencies)
+	}
+
+	// Dev path dependencies go through the same content hashing: a dev-only
+	// helper directory that changed has to re-resolve exactly like a runtime one.
+	closures = append(closures, lock.DevDependencies)
+
+	for _, closure := range closures {
+		for _, dependency := range closure {
 			if dependency.Source != manifestSourcePath {
 				continue
 			}


### PR DESCRIPTION
`Lock` gains `DevDependencies`, serialized under the existing `[lock]` table as `[[lock.dev_dependencies]]` beside `[lock.products.<name>]`. It is one global list rather than one per product, because `[dev_dependencies]` is a single top-level table with nothing to key it by.

- cli/manifest/lock: record the dev closure — the key is omitted entirely when the closure is empty, so every lock written before this still marshals byte-for-byte as it did.
- cli/manifest/resolve: resolve dev dependencies — `[dev_dependencies]` was parsed and validated and then ignored by the whole pipeline, so it never reached the lock or `.rocks/`. The engine now resolves it into `Lock.DevDependencies`, after the products and with every product pick applied as a pin, so both closures land in one `.rocks/` tree, which cannot hold two versions of a rock. `IsStale` gains a third case: a manifest declaring dev dependencies over a lock with no closure.
- cli/manifest/build: install dev dependencies — `tt package build` and `tt package fetch` now materialize the lock's dev closure into the same `.rocks/` tree as the product's, after it, so a rock in both is already present at the product's version when the dev list reaches it and is skipped rather than reinstalled.
- cli/manifest/pack: keep dev rocks out — the `.tt` archive must not carry `[dev_dependencies]`, and the exclusion belongs where the archive content is selected, since `.rocks/` is the developer's standing tree. A rock's footprint comes from its own `rock_manifest`, which catches a flat `share/tarantool/<name>.lua` and a console script in `bin/` that the name-keyed directories miss. Dev-only is judged against every product, not just the packed one.
- cli/manifest/deps: report dev dependency moves — the version report `tt package add/remove/update` prints is built by flattening the lock, which until now meant the product closures only, so a dev dependency that moved was resolved, written and installed without a word. The dev closure now folds into the same flattening, first occurrence wins.

Closes TNTP-9989
