### PR TITLE
cli: finish removing instances.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 # Tarantool CLI
 
 > [!WARNING]
-> The `v3` branch is under heavy development. Expect breaking changes and unstable APIs.
+> The `v3` branch is under heavy development. Expect breaking changes and
+> unstable APIs.
 
 [![Go Reference][godoc-badge]][godoc-url]
 [![Go Report][report-badge]][report-url]
@@ -31,6 +32,7 @@ Tarantool-based applications.
 - [Configuration](#configuration)
   + [Configuration file](#configuration-file)
 - [Creating a local tt configuration](#creating-a-local-tt-configuration)
+- [Migrating from instances.enabled](#migrating-from-instancesenabled)
 - [External modules](#external-modules)
 - [CLI Args](#cli-args)
   + [Autocompletion](#autocompletion)
@@ -293,8 +295,6 @@ file format:
 
 ``` yaml
 env:
-  # Deprecated compatibility option. Application discovery ignores it.
-  instances_enabled: .
   bin_dir: path/to/bin_dir
   inc_dir: path/to/inc_dir
   restart_on_failure: bool
@@ -318,9 +318,6 @@ templates:
 
 #### env
 
-- `instances_enabled` (string) - deprecated compatibility option. `tt` ignores
-    it and always loads the application from the directory containing
-    `tt.yaml`.
 - `bin_dir` (string) - directory that stores binary files.
 - `inc_dir` (string) - directory that stores header files. The path
     will be padded with a directory named include.
@@ -397,6 +394,11 @@ Where:
 - `tt.yaml` - tt environment configuration file.
 - `templates` - the directory where external templates are stored.
 - `var` - default directory for application runtime artifacts and data.
+
+## Migrating from instances.enabled
+
+See the [2.x to 3.0 migration guide](doc/migration_from_older_versions.md#2x---300)
+for converting a symlink-based environment to the single-application layout.
 
 ## External modules
 

--- a/cli/cfg/dump_test.go
+++ b/cli/cfg/dump_test.go
@@ -89,7 +89,6 @@ modules:
 env:
   bin_dir: %[1]s/bin
   inc_dir: %[1]s/test_inc
-  instances_enabled: .
   restart_on_failure: false
 modules:
   directory: /root/modules
@@ -124,7 +123,6 @@ repo:
 env:
   bin_dir: %[1]s/bin
   inc_dir: %[1]s/include
-  instances_enabled: .
   restart_on_failure: false
 modules:
   directory:
@@ -161,7 +159,6 @@ repo:
 env:
   bin_dir: %[1]s/bin
   inc_dir: %[1]s/include
-  instances_enabled: .
   restart_on_failure: false
 modules:
   directory: %[1]s/my_modules
@@ -197,7 +194,6 @@ repo:
 env:
   bin_dir: %[1]s/bin
   inc_dir: %[1]s/test_inc
-  instances_enabled: .
   restart_on_failure: false
 modules:
   directory: /root/modules

--- a/cli/cfg/testdata/tt_cfg2.yaml
+++ b/cli/cfg/testdata/tt_cfg2.yaml
@@ -1,5 +1,3 @@
-env:
-  instances_enabled: ./instances.enabled
 modules:
   directory: my_modules
 templates:

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -56,9 +56,6 @@ type TtEnvOpts struct {
 	// IncludeDir is the directory where all the header files
 	// are stored.
 	IncludeDir string `mapstructure:"inc_dir" yaml:"inc_dir"`
-	// InstancesEnabled is kept for configuration compatibility.
-	// Application discovery always uses the directory containing tt.yaml.
-	InstancesEnabled string `mapstructure:"instances_enabled" yaml:"instances_enabled"`
 	// Restartable - if set the instance is started under the watchdog it should
 	// restart on if it crashes.
 	Restartable bool `mapstructure:"restart_on_failure" yaml:"restart_on_failure"`

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	ConfigName        = "tt.yaml"
-	DefaultAppPath    = "."
 	cliExecutableName = "tt"
 	// systemConfigDirEnvName is an environment variable that contains a path to
 	// search system config.
@@ -75,10 +74,9 @@ func getDefaultAppOpts() *config.AppOpts {
 // getDefaultAppOpts generates default app config.
 func getDefaultTtEnvOpts() *config.TtEnvOpts {
 	return &config.TtEnvOpts{
-		InstancesEnabled: DefaultAppPath,
-		Restartable:      false,
-		BinDir:           BinPath,
-		IncludeDir:       IncludePath,
+		Restartable: false,
+		BinDir:      BinPath,
+		IncludeDir:  IncludePath,
 	}
 }
 
@@ -196,8 +194,6 @@ func adjustListPathWithConfigLocation(listPaths []string, configDir string,
 // sets uninitialized values to defaults.
 func updateCliOpts(cliOpts *config.CliOpts, configDir string) error {
 	var err error
-
-	cliOpts.Env.InstancesEnabled = DefaultAppPath
 
 	for _, dir := range []struct {
 		path       *string

--- a/cli/configure/configure_test.go
+++ b/cli/configure/configure_test.go
@@ -342,7 +342,6 @@ func TestUpdateCliOpts(t *testing.T) {
 	assert.Equal(t, filepath.Join(configDir, "..", "include_dir"), cliOpts.Env.IncludeDir)
 	assert.Equal(t, 1, len(cliOpts.Modules.Directories))
 	assert.Equal(t, filepath.Join(configDir, ModulesPath), cliOpts.Modules.Directories[0])
-	assert.Equal(t, DefaultAppPath, cliOpts.Env.InstancesEnabled)
 }
 
 func TestGetCliOpts_modules_directory(t *testing.T) {

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -5,6 +5,7 @@ This file contains various examples of working with tt.
 ## Contents
 
 - [Working with a set of instances](#working-with-a-set-of-instances)
+- [Migrating from instances.enabled](#migrating-from-instancesenabled)
 - [Working with application templates](#working-with-application-templates)
 - [Working with tt cluster (experimental)](#working-with-tt-cluster-experimental)
 - [Packaging applications](#packaging-applications)
@@ -71,7 +72,7 @@ replica:
 Run the commands from the application root:
 
 ```console
-$ cd demo
+cd demo
 ```
 
 Now we can run all instances at once:
@@ -99,6 +100,11 @@ $ tt start
 • Starting an instance [demo:master]...
 • Starting an instance [demo:replica]...
 ```
+
+## Migrating from instances.enabled
+
+See the [2.x to 3.0 migration guide](migration_from_older_versions.md#2x---300)
+for the legacy layout and the complete upgrade procedure.
 
 ## Working with application templates
 

--- a/doc/migration_from_older_versions.md
+++ b/doc/migration_from_older_versions.md
@@ -6,7 +6,73 @@ contains breaking changes descriptions.
 
 ## Contents
 
+- [2.x -> 3.0.0](#2x---300)
 - [1.3.1 -> 2.0.0](#131---200)
+
+## 2.x -> 3.0.0
+
+### Migrate applications from instances.enabled
+
+`tt` 3.0 uses the directory containing `tt.yaml` as the only application root.
+It no longer reads `env.instances_enabled` or scans an `instances.enabled`
+directory. A legacy environment can therefore no longer manage several
+applications through symlinks such as these:
+
+```text
+<environment>/
+├── tt.yaml
+├── instances.available/
+│   ├── app1/
+│   │   ├── init.lua
+│   │   └── instances.yml
+│   └── app2/
+│       ├── init.lua
+│       └── instances.yml
+└── instances.enabled/
+    ├── app1 -> ../instances.available/app1
+    └── app2 -> ../instances.available/app2
+```
+
+Migrate every application while still using `tt` 2.x:
+
+1. Stop the application and resolve its `instances.enabled` symlink. Use the
+   real target directory as the application root, or copy it to a new
+   standalone location. Do not copy the symlink itself.
+2. Put a separate `tt.yaml` into the application root. If it is copied from the
+   shared environment, check all relative paths because they are now resolved
+   from the new configuration location.
+3. Set `env.instances_enabled` to `.` in the application configuration:
+
+   ```yaml
+   env:
+     instances_enabled: .
+   ```
+
+   This is a compatibility step that lets `tt` 2.x manage the application
+   directly from its future root.
+4. Run `tt` with that application's configuration and verify that lifecycle
+   commands work without going through the symlink. For example:
+
+   ```console
+   tt --cfg /srv/apps/app1/tt.yaml status app1
+   ```
+
+The final layout has one configuration and no registry symlink per
+application:
+
+```text
+/srv/apps/app1/
+├── tt.yaml
+├── init.lua
+├── instances.yml
+└── var/
+```
+
+Repeat the procedure for every application before upgrading to `tt` 3.0.
+After the upgrade, remove `instances_enabled` from each `tt.yaml`: the option no
+longer exists. Run `tt` from the application root or pass its configuration via
+`--cfg`. Remove the old `instances.enabled` directory only after every
+application has been verified.
 
 ## 1.3.1 -> 2.0.0
 
@@ -23,11 +89,12 @@ All relative paths in this section are relative to the config file location.
 
 Runtime artifacts layout is changed:
 
-- Relative paths are relative to the application directory.
+- Relative paths are relative to the application directory. In case of
+single script instance, a directory is created in the instances
+enabled directory.
 - Since relative paths already contains an application name,
 only instance name is appended to the result directory. Here is an
-example of the legacy 2.0.0 layout, in which applications were discovered
-under `instances.enabled`:
+example of 2.0.0 default layout for a local environment:
 
 ```text
 instances.enabled/app/
@@ -45,33 +112,12 @@ instances.enabled/app/
         └── inst2
 ```
 
-Current versions do not scan `instances.enabled`. Move each application that
-still uses this legacy layout into its own root and put `tt.yaml` there:
-
-```text
-<app_dir>/
-├── tt.yaml
-├── init.lua
-├── instances.yml
-└── var
-    ├── lib
-    │   ├── inst1
-    │   └── inst2
-    ├── log
-    │   ├── inst1
-    │   └── inst2
-    └── run
-        ├── inst1
-        └── inst2
-```
-
 Moving artifacts from 1.* versions:
 
-- Create artifact directories in the new application root: `var/lib`,
-  `var/log`, and `var/run`.
+- Create artifacts directories in application dir: var/lib, var/log, var/run.
 - Copy instance sub-directories from 1.* environment to application
 dir. Data artifacts copying example:
-`cp -r <env_dir>/var/lib/app/* <app_dir>/var/lib/`
+`cp -r <env_dir>/var/lib/app/* <instances_enabled>/app/var/lib/`
 
 Absolute paths are not affected by these layout changes, because an application
 name is always appended for them.

--- a/package/tt.yaml.default
+++ b/package/tt.yaml.default
@@ -1,8 +1,4 @@
 env:
-  # Compatibility option. The application is always loaded from the directory
-  # containing tt.yaml.
-  instances_enabled: .
-
   # Directory that stores binary files.
   bin_dir: /opt/tarantool/bin
 

--- a/test/integration/cfg/test_dump.py
+++ b/test/integration/cfg/test_dump.py
@@ -34,7 +34,6 @@ def test_cfg_dump_default(tt_cmd, tmp_path):
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
     assert f"modules:\n  directory: {os.path.join(tmp_path, 'new_modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
-    assert "instances_enabled: ." in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output
 
@@ -119,7 +118,6 @@ def test_cfg_dump_default_no_config(tt_cmd, tmp_path):
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
     assert f"modules:\n  directory: {os.path.join(tmp_path, 'modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
-    assert "instances_enabled: ." in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output
 
@@ -153,6 +151,5 @@ def test_cfg_dump_default_no_config(tt_cmd, tmp_path):
     assert f"inc_dir: {os.path.join(tmp_path, 'include')}" in output
     assert f"modules:\n  directory: {os.path.join(tmp_path, 'modules')}" in output
     assert f"distfiles: {os.path.join(tmp_path, 'distfiles')}" in output
-    assert "instances_enabled: ." in output
     assert f"templates:\n- path: {os.path.join(tmp_path, 'templates')}" in output
     assert 'credential_path: ""' in output


### PR DESCRIPTION
Remove env.instances_enabled from configuration, defaults, and cfg dump.

Document how to migrate symlink-based environments to the single-application layout before upgrading to tt 3.0 was also added.

Closes TNTP-9935
Closes TNTP-9938
