### PR TITLE
cli/manifest: fix dependency resolution defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ for machine-readable output.
 - `tt enable` and `tt instances` commands removed.
 - `tt init`, `tt pack`, and `tt build` commands removed. Use
   `tt package build` and `tt package pack` for manifest-based applications.
+- `tt package list`: the table's `KIND` column is now `ORIGIN`. `kind` names
+  what a component is (`library` or `binary`); what this column reports is
+  where a package came from — the project itself or an installed archive.
 - `tt status`: deprecate `--pretty` option in favor of `--format=pretty-table`.
 - tarantoolctl layout is no longer supported.
 - `tt create`: cartridge support removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@ for machine-readable output.
 - Table formatter: fix a potential panic when the scalar encoder receives a
   `float32` value. Format it with 32-bit precision while preserving the existing
   `float64` formatting.
+- `tt package build`: a stale lock is re-resolved holding every version it
+  already recorded, so a build no longer pulls newer releases from the
+  registry behind the user's back. `tt package update` remains the way to move
+  dependencies forward.
 - `tt package`: a dependency declared as `*` — which is what `tt package add`
   writes when no version is given — now resolves to whatever the registry
   serves instead of failing with `cannot parse constraint "*"`. A constraint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   installing it needs no network. `--without-deps` drops both and leaves the
   `bundled_*_version` lock fields empty. Runtime components are taken from
   `<user cache>/tt/runtimes/<component>/<flavor>/<version>/`, falling back to
-  the active tt environment when it satisfies `[platform]`, with a warning.
+  the active tt environment when it satisfies `[platform]`, with a warning. An
+  Enterprise build satisfies a `[ce]` requirement (the default) as well as an
+  `[ee]` one; a Community build satisfies only `[ce]`.
   Archives are byte-reproducible for a given commit; set `SOURCE_DATE_EPOCH` to
   pin the build timestamp explicitly.
 - `tt package install`: unpack a `.tt` archive into a scope and bring the tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `<user cache>/tt/runtimes/<component>/<flavor>/<version>/`, falling back to
   the active tt environment when it satisfies `[platform]`, with a warning. An
   Enterprise build satisfies a `[ce]` requirement (the default) as well as an
-  `[ee]` one; a Community build satisfies only `[ce]`.
+  `[ee]` one; a Community build satisfies only `[ce]`. The bundled Tarantool's
+  license file travels with it when the build ships one, wherever it sits
+  relative to the binary; the Enterprise SDK ships none, and the pack then says
+  so and continues.
   Archives are byte-reproducible for a given commit; set `SOURCE_DATE_EPOCH` to
   pin the build timestamp explicitly.
 - `tt package install`: unpack a `.tt` archive into a scope and bring the tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ for machine-readable output.
 - Table formatter: fix a potential panic when the scalar encoder receives a
   `float32` value. Format it with 32-bit precision while preserving the existing
   `float64` formatting.
+- `tt package`: a dependency declared as `*` — which is what `tt package add`
+  writes when no version is given — now resolves to whatever the registry
+  serves instead of failing with `cannot parse constraint "*"`. A constraint
+  the resolver cannot act on is also refused before the manifest is edited, so
+  a rejected `tt package add` no longer leaves a declaration behind with the
+  lock out of step.
 - `tt`: return non-zero exit code on unknown command.
 - `tt run`: report `tarantool executable is not found` instead of a raw
   `open "": no such file or directory` error when Tarantool is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,10 +126,17 @@ for machine-readable output.
 - Table formatter: fix a potential panic when the scalar encoder receives a
   `float32` value. Format it with 32-bit precision while preserving the existing
   `float64` formatting.
+- `tt package`: dependency resolution prefers released versions over `scm` and
+  `dev`. LuaRocks orders a branch above every number, so an ordinary constraint
+  like `>=3.0.0` used to select the development branch and pin the lock to code
+  that changes underneath it. A branch is chosen only when the constraint names
+  one (`==scm`) or when the rock has no released version at all, and that case
+  is now reported.
 - `tt package build`: a stale lock is re-resolved holding every version it
   already recorded, so a build no longer pulls newer releases from the
   registry behind the user's back. `tt package update` remains the way to move
-  dependencies forward.
+  dependencies forward. `--locked` on a stale lock now names `tt package
+  resolve` in the error instead of only reporting the staleness.
 - `tt package`: a dependency declared as `*` — which is what `tt package add`
   writes when no version is given — now resolves to whatever the registry
   serves instead of failing with `cannot parse constraint "*"`. A constraint

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -651,6 +651,7 @@ func runtimeRequest(ctx context.Context, tntInfo manifestrocks.TarantoolInfo) pa
 		ActiveTarantool:        tntInfo.Executable,
 		ActiveTarantoolVersion: tntInfo.Version,
 		ActiveTarantoolFlavor:  pack.DetectTarantoolFlavor(ctx, tntInfo.Executable),
+		ActiveTarantoolPrefix:  tntInfo.Prefix,
 		ActiveTt:               selfPath,
 		// The short form is the bare "x.y.z"; the long form is a human-readable
 		// sentence that no version constraint can match.

--- a/cli/manifest/build/hooks.go
+++ b/cli/manifest/build/hooks.go
@@ -21,6 +21,13 @@ const (
 // component TT_OUTPUT_DIR / TT_COMPONENT_NAME). An absent hook is a no-op. The
 // hook runs in its own cwd (default: the project root), so pre_build can
 // generate files anywhere in the tree before components are gathered.
+//
+// pre_build runs before the dependency closure is materialized, so .rocks/ may
+// not exist yet and PATH is not extended to reach it. That ordering is what
+// lets a hook produce the contents of a path dependency, whose hash and
+// rockspec the resolver reads immediately afterwards. Generation that feeds the
+// artifact belongs in a component's build backend instead, which runs after
+// materialization and is handed TT_OUTPUT_DIR.
 func runHook(
 	ctx context.Context, man *manifest.Manifest, ver version.Version,
 	name, projectDir string, showOutput bool,

--- a/cli/manifest/build/lockgate.go
+++ b/cli/manifest/build/lockgate.go
@@ -90,7 +90,12 @@ func gateLock(
 	}
 
 	if locked {
-		return nil, nil, exitErrorf(exitStateError, "%w: %s (--locked)", errLockStale, reason)
+		// Naming the command that fixes it matters more here than elsewhere:
+		// --locked is what a release pipeline passes, so whoever reads this is
+		// looking at a failed build rather than at a shell.
+		return nil, nil, exitErrorf(exitStateError,
+			"%w: %s (--locked); run tt package resolve to bring the lock back in step",
+			errLockStale, reason)
 	}
 
 	// Every version the stale lock already chose is held: a manifest edit moves

--- a/cli/manifest/build/lockgate.go
+++ b/cli/manifest/build/lockgate.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
 )
 
 // resolver is the slice of resolve.Engine the lock gate drives: report whether
@@ -16,7 +17,9 @@ import (
 // exercised without a registry.
 type resolver interface {
 	IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, string, error)
-	Resolve(ctx context.Context, man *manifest.Manifest) (*manifest.Lock, []string, error)
+	ResolvePinned(
+		ctx context.Context, man *manifest.Manifest, pins resolve.Pins,
+	) (*manifest.Lock, []string, error)
 }
 
 // loadLock reads and parses the lock next to the manifest. It never resolves —
@@ -65,7 +68,7 @@ func gateLock(
 				"%w: %s not found and --locked forbids resolving", errLockStale, lockFileName)
 		}
 
-		return resolveAndWrite(ctx, res, man, path)
+		return resolveAndWrite(ctx, res, man, path, nil)
 	}
 
 	if readErr != nil {
@@ -90,14 +93,18 @@ func gateLock(
 		return nil, nil, exitErrorf(exitStateError, "%w: %s (--locked)", errLockStale, reason)
 	}
 
-	return resolveAndWrite(ctx, res, man, path)
+	// Every version the stale lock already chose is held: a manifest edit moves
+	// what it touches and what that drags in, and nothing else. Pulling newer
+	// versions from the registry is tt package update's job.
+	return resolveAndWrite(ctx, res, man, path, resolve.PinsFromLock(lock))
 }
 
-// resolveAndWrite resolves man into a fresh lock and writes it to path.
+// resolveAndWrite resolves man into a fresh lock, preferring pins, and writes
+// it to path.
 func resolveAndWrite(
-	ctx context.Context, res resolver, man *manifest.Manifest, path string,
+	ctx context.Context, res resolver, man *manifest.Manifest, path string, pins resolve.Pins,
 ) (*manifest.Lock, []string, error) {
-	lock, warnings, err := res.Resolve(ctx, man)
+	lock, warnings, err := res.ResolvePinned(ctx, man, pins)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolving dependencies: %w", err)
 	}

--- a/cli/manifest/build/lockgate_test.go
+++ b/cli/manifest/build/lockgate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
 )
 
 // fakeResolver drives the lock gate without a registry.
@@ -19,16 +20,20 @@ type fakeResolver struct {
 	reason        string
 	fresh         *manifest.Lock
 	resolveCalled bool
+	// pins records the pin set of every resolve, in order.
+	pins []resolve.Pins
 }
 
 func (f *fakeResolver) IsStale(*manifest.Manifest, *manifest.Lock) (bool, string, error) {
 	return f.stale, f.reason, nil
 }
 
-func (f *fakeResolver) Resolve(
-	context.Context, *manifest.Manifest,
+func (f *fakeResolver) ResolvePinned(
+	_ context.Context, _ *manifest.Manifest, pins resolve.Pins,
 ) (*manifest.Lock, []string, error) {
 	f.resolveCalled = true
+	f.pins = append(f.pins, pins)
+
 	return f.fresh, nil, nil
 }
 
@@ -119,6 +124,46 @@ func TestGateLock_staleUnlockedRewrites(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, r.resolveCalled)
 	assert.Equal(t, "sha256:new", lockOnDisk(t, dir).ManifestHash)
+}
+
+// TestGateLock_staleRewriteHoldsLockedVersions pins what separates a build's
+// re-resolve from an update: a stale lock still decides the versions, so a
+// build never pulls a newer release than the one already recorded.
+func TestGateLock_staleRewriteHoldsLockedVersions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existing := freshLock()
+	existing.ManifestHash = "sha256:existing"
+	existing.Products["default"] = manifest.LockProduct{
+		Dependencies: []manifest.LockDependency{
+			{Name: "checks", Version: "3.1.0-1", Source: sourceRegistry},
+			{Name: "metrics", Version: "1.0.0-1", Source: sourceRegistry},
+		},
+	}
+	writeLock(t, dir, existing)
+
+	r := &fakeResolver{stale: true, reason: "manifest changed", fresh: freshLock()}
+	_, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, false)
+	require.NoError(t, err)
+
+	require.Len(t, r.pins, 1)
+	assert.Equal(t, resolve.Pins{"checks": "3.1.0-1", "metrics": "1.0.0-1"}, r.pins[0])
+}
+
+// TestGateLock_noLockPinsNothing covers the first resolve of a project: there
+// is no recorded version to hold, so the registry decides every pick.
+func TestGateLock_noLockPinsNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	r := &fakeResolver{stale: false, reason: "", fresh: freshLock()}
+	_, _, err := gateLock(context.Background(), r, &manifest.Manifest{}, dir, false)
+	require.NoError(t, err)
+
+	require.Len(t, r.pins, 1)
+	assert.Empty(t, r.pins[0])
 }
 
 func TestGateLock_staleLockedFails(t *testing.T) {

--- a/cli/manifest/constraint.go
+++ b/cli/manifest/constraint.go
@@ -2,6 +2,24 @@ package manifest
 
 import "strings"
 
+// AnyConstraint is how a dependency declares that any version will do. It is
+// what tt package add writes when the user names no version.
+const AnyConstraint = "*"
+
+// ConstraintExpr renders a declared dependency constraint for the resolver.
+// AnyConstraint becomes the empty expression, which bounds the version from
+// neither side; every other expression is passed through verbatim.
+//
+// The empty expression is also what an omitted constraint yields, so the two
+// spellings of "any version" reach the resolver as one.
+func ConstraintExpr(declared string) string {
+	if strings.TrimSpace(declared) == AnyConstraint {
+		return ""
+	}
+
+	return declared
+}
+
 // Constraint is a platform version requirement parsed into its semver part and
 // an optional flavor. It is stored as "<semver-constraint>[<flavor>]" in TOML,
 // where <flavor> is [ce] or [ee].

--- a/cli/manifest/constraint_test.go
+++ b/cli/manifest/constraint_test.go
@@ -1,0 +1,35 @@
+package manifest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+func TestConstraintExpr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		declared string
+		want     string
+	}{
+		{name: "any version", declared: "*", want: ""},
+		{name: "any version padded", declared: "  *  ", want: ""},
+		{name: "omitted", declared: "", want: ""},
+		{name: "single bound", declared: ">=3.0.0", want: ">=3.0.0"},
+		{name: "range", declared: ">=3.0.0,<4.0.0", want: ">=3.0.0,<4.0.0"},
+		{name: "bare version", declared: "1.2.3", want: "1.2.3"},
+		{name: "star is not a wildcard character", declared: "1.*", want: "1.*"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, manifest.ConstraintExpr(testCase.declared))
+		})
+	}
+}

--- a/cli/manifest/deps/commands.go
+++ b/cli/manifest/deps/commands.go
@@ -40,6 +40,11 @@ func addWith(
 		constraint = defaultConstraint
 	}
 
+	constraintErr := resolve.ValidateConstraint(constraint)
+	if constraintErr != nil {
+		return nil, stateErrorf("%w", constraintErr)
+	}
+
 	table := manifest.TableDependencies
 	if dev {
 		table = manifest.TableDevDependencies

--- a/cli/manifest/deps/commands_internal_test.go
+++ b/cli/manifest/deps/commands_internal_test.go
@@ -48,6 +48,43 @@ func TestAdd_noLockPinsNothing(t *testing.T) {
 	assert.Contains(t, manifestOnDisk(t, dir), "metrics = \"*\"")
 }
 
+// TestAdd_refusesAConstraintNoResolverCanUse pins that the constraint is
+// checked before the manifest is opened for editing: a declaration the resolver
+// could never act on leaves the file exactly as it was, and no resolve is
+// attempted.
+func TestAdd_refusesAConstraintNoResolverCanUse(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "metrics", "~~1.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "~~1.0")
+
+	assert.Equal(t, baseManifest, manifestOnDisk(t, dir))
+	assert.Empty(t, res.pins)
+}
+
+// TestAdd_acceptsTheAnyConstraint covers the constraint tt package add writes
+// when the user names no version: it reaches the resolver as "no bound at all"
+// rather than as a literal the version grammar rejects.
+func TestAdd_acceptsTheAnyConstraint(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{}
+
+	_, err := addWith(context.Background(), optsFor(dir), res, "metrics", "*", false)
+	require.NoError(t, err)
+
+	assert.Contains(t, manifestOnDisk(t, dir), "metrics = \"*\"")
+
+	declared := res.seen[0].Dependencies["metrics"]
+	assert.Equal(t, "*", declared.Version)
+	assert.Empty(t, manifest.ConstraintExpr(declared.Version))
+}
+
 // TestAdd_lockRecordsTheEditedManifestHash pins the invariant the whole
 // read-edit-write-reparse-resolve order exists for. manifest_hash is taken over
 // the raw source bytes a Manifest was parsed from, so resolving the pre-edit

--- a/cli/manifest/install/reconcile.go
+++ b/cli/manifest/install/reconcile.go
@@ -7,6 +7,8 @@ import (
 
 	luarocks "github.com/tarantool/go-luarocks"
 	"github.com/tarantool/go-luarocks/deps"
+
+	"github.com/tarantool/tt/cli/manifest"
 )
 
 // contribution is one package's stake in a shared dependency: the version that
@@ -106,11 +108,12 @@ func gatherConstraints(
 	all := make([]luarocks.VersionConstraint, 0, len(contributions))
 
 	for _, contrib := range contributions {
-		if contrib.constraint == "" {
+		expr := manifest.ConstraintExpr(contrib.constraint)
+		if expr == "" {
 			continue
 		}
 
-		parsed, err := deps.ParseConstraints(contrib.constraint)
+		parsed, err := deps.ParseConstraints(expr)
 		if err != nil {
 			return nil, fmt.Errorf("%w %q: package %q declared unparseable constraint %q: %w",
 				errIncompatibleDeps, dep, contrib.pkg, contrib.constraint, err)

--- a/cli/manifest/inventory/format.go
+++ b/cli/manifest/inventory/format.go
@@ -123,14 +123,14 @@ func renderTable(out io.Writer, listing *Listing) error {
 
 	table := tabwriter.NewWriter(out, 0, 0, tabColumnPadding, ' ', 0)
 
-	_, err := fmt.Fprintln(table, "NAME\tVERSION\tKIND\tDESCRIPTION")
+	_, err := fmt.Fprintln(table, "NAME\tVERSION\tORIGIN\tDESCRIPTION")
 	if err != nil {
 		return fmt.Errorf("rendering table: %w", err)
 	}
 
 	for _, entry := range listing.Packages {
 		_, err = fmt.Fprintf(table, "%s\t%s\t%s\t%s\n",
-			entry.Name, dash(entry.Version), kindOf(entry), oneLine(entry.Description))
+			entry.Name, dash(entry.Version), originOf(entry), oneLine(entry.Description))
 		if err != nil {
 			return fmt.Errorf("rendering table: %w", err)
 		}
@@ -426,8 +426,8 @@ func shareNote(owner string, dep RockEntry) string {
 	return " (shared with " + strings.Join(others, ", ") + ")"
 }
 
-// kindOf labels a row as the project's own package or a guest.
-func kindOf(entry Entry) string {
+// originOf labels a row as the project's own package or a guest.
+func originOf(entry Entry) string {
 	if entry.Primary {
 		return "primary"
 	}

--- a/cli/manifest/inventory/format_test.go
+++ b/cli/manifest/inventory/format_test.go
@@ -109,7 +109,7 @@ func TestRenderTable(t *testing.T) {
 	require.Len(t, lines, 3)
 	assert.Contains(t, lines[0], "NAME")
 	assert.Contains(t, lines[0], "VERSION")
-	assert.Contains(t, lines[0], "KIND")
+	assert.Contains(t, lines[0], "ORIGIN")
 
 	assert.Contains(t, lines[1], "my-app")
 	assert.Contains(t, lines[1], "1.2.3")

--- a/cli/manifest/lock.go
+++ b/cli/manifest/lock.go
@@ -29,7 +29,13 @@ type Lock struct {
 	// DevDependencies is the closure of [dev_dependencies], as
 	// [[lock.dev_dependencies]]. It is one list rather than one per product:
 	// the manifest declares dev dependencies globally, so there is nothing to
-	// key them by. Empty for a manifest that declares none, and then absent
+	// key them by.
+	//
+	// It is pinned like any other closure because it can shape the artifact:
+	// the dev tree is materialized into .rocks/ before the component build
+	// backends run, so a generator installed as a dev dependency writes files
+	// that are then laid out and packed. Recording the versions is what makes
+	// such a build reproducible. Empty for a manifest that declares none, and then absent
 	// from the file entirely - a lock written before dev dependencies existed
 	// is therefore indistinguishable from one whose manifest declares none,
 	// which is why IsStale checks the manifest side too.

--- a/cli/manifest/pack/errors.go
+++ b/cli/manifest/pack/errors.go
@@ -44,9 +44,6 @@ var (
 	// files flat in the rocks tree, where its own files cannot be separated
 	// from its dependencies'.
 	errFlatNamespace = errors.New("cannot pack a flat namespace without deps")
-	// errNoTarantoolLicense reports a bundled Tarantool whose LICENSE file is
-	// missing; shipping the binary without it is not permitted.
-	errNoTarantoolLicense = errors.New("bundled Tarantool has no LICENSE")
 	// errMissingInclude reports an include or license_files entry that matched
 	// nothing on disk.
 	errMissingInclude = errors.New("no such file")

--- a/cli/manifest/pack/flavor_test.go
+++ b/cli/manifest/pack/flavor_test.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,6 +158,133 @@ func TestBundleRuntimeRejectsWrongFlavorFallback(t *testing.T) {
 	assert.Contains(t, err.Error(), "matches the version but not the flavor",
 		"a version that fits must not be reported as a version mismatch")
 	assert.Contains(t, err.Error(), "3.0.5[ce]", "the error must describe the active build")
+}
+
+// TestBundleRuntimeFallbackSDKLayout covers the Enterprise SDK layout, where
+// tarantool sits at the root of the unpacked bundle beside env.sh with no bin/
+// level: a license and a share/ tree there must be found next to the binary,
+// not one directory above the bundle.
+//
+// The bundle here carries a LICENSE, which a released SDK does not - see
+// TestBundleRuntimeFallbackSDKWithoutLicense for that shape. What this pins is
+// the search path, which is also what a hand-populated cache entry relies on.
+func TestBundleRuntimeFallbackSDKLayout(t *testing.T) {
+	sdk := filepath.Join(t.TempDir(), "te350")
+	writeTree(t, sdk, map[string]string{
+		"tarantool":             "#!/bin/sh\n",
+		"LICENSE":               "Tarantool Enterprise",
+		"env.sh":                "export PATH=$PATH\n",
+		"share/tarantool/x.lua": "return 1\n",
+		"bin/tt":                "#!/bin/sh\n",
+	})
+
+	stage := t.TempDir()
+
+	bundled, err := bundleRuntime(stage, RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(sdk, "tarantool"),
+		ActiveTarantoolVersion: "3.5.0-0-g0823718c2",
+		ActiveTarantoolFlavor:  flavorEE,
+		ActiveTt:               filepath.Join(sdk, "bin", "tt"),
+		ActiveTtVersion:        "2.4.0",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "3.5.0-0-g0823718c2", bundled.Tarantool)
+
+	tnt := filepath.Join(stage, runtimeDirName, runtimeTarantool)
+	assert.FileExists(t, filepath.Join(tnt, "LICENSE"))
+	assert.FileExists(t, filepath.Join(tnt, "share", "tarantool", "x.lua"),
+		"the SDK's share/ tree lives beside the binary and must come along")
+}
+
+// TestBundleRuntimeFallbackSDKWithoutLicense covers the Enterprise SDK as it
+// is actually shipped: no LICENSE, no COPYING and no share/tarantool anywhere
+// in the bundle or in the tarball it comes from. Requiring a license here would
+// make an EE runtime unpackable, so the pack goes through and says what it
+// could not find.
+func TestBundleRuntimeFallbackSDKWithoutLicense(t *testing.T) {
+	sdk := filepath.Join(t.TempDir(), "3.7.0-r137")
+	writeTree(t, sdk, map[string]string{
+		"tarantool":   "#!/bin/sh\n",
+		"tt":          "#!/bin/sh\n",
+		"tcm":         "#!/bin/sh\n",
+		"env.sh":      "export PATH=$PATH\n",
+		"VERSION":     "TARANTOOL_EE=3.7.0-0-g1f1ec9fdf\n",
+		"README.md":   "# Tarantool Enterprise\n",
+		"include/x.h": "\n",
+	})
+
+	var warnings []string
+
+	stage := t.TempDir()
+
+	bundled, err := bundleRuntime(stage, RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(sdk, "tarantool"),
+		ActiveTarantoolVersion: "3.7.0-0-g1f1ec9fdf",
+		ActiveTarantoolFlavor:  flavorEE,
+		ActiveTt:               filepath.Join(sdk, "tt"),
+		ActiveTtVersion:        "2.4.0",
+		Warn:                   func(msg string) { warnings = append(warnings, msg) },
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "3.7.0-0-g1f1ec9fdf", bundled.Tarantool)
+
+	tnt := filepath.Join(stage, runtimeDirName, runtimeTarantool)
+	assert.FileExists(t, filepath.Join(tnt, "bin", runtimeTarantool))
+	assert.NoFileExists(t, filepath.Join(tnt, "LICENSE"))
+
+	var licenseWarnings []string
+
+	for _, w := range warnings {
+		if strings.Contains(w, "without a license") {
+			licenseWarnings = append(licenseWarnings, w)
+		}
+	}
+
+	require.Len(t, licenseWarnings, 1)
+	assert.Contains(t, licenseWarnings[0], sdk,
+		"the warning must name where the license was looked for")
+}
+
+// TestBundleRuntimeFallbackUsesResolvedPrefix: when tt already knows the
+// install prefix (TT_CLI_TARANTOOL_PREFIX, the build banner), that is where
+// the license and share/ are looked for first, ahead of any guess from the
+// binary's location.
+func TestBundleRuntimeFallbackUsesResolvedPrefix(t *testing.T) {
+	bin := t.TempDir()
+	writeTree(t, bin, map[string]string{"tarantool": "#!/bin/sh\n", "tt": "#!/bin/sh\n"})
+
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{"LICENSE": "BSD-2-Clause"})
+
+	stage := t.TempDir()
+
+	_, err := bundleRuntime(stage, RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(bin, "tarantool"),
+		ActiveTarantoolVersion: "3.0.5",
+		ActiveTarantoolPrefix:  prefix,
+		ActiveTt:               filepath.Join(bin, "tt"),
+		ActiveTtVersion:        "2.4.0",
+	})
+
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(stage, runtimeDirName, runtimeTarantool, "LICENSE"))
 }
 
 // TestBundleRuntimeVersionMismatchIsNotAFlavorMismatch keeps the two failure

--- a/cli/manifest/pack/flavor_test.go
+++ b/cli/manifest/pack/flavor_test.go
@@ -35,9 +35,9 @@ func TestFlavorFromBanner(t *testing.T) {
 	}
 }
 
-// TestFindInCacheSeparatesFlavors is the core of the flavor fix: a [ce]
-// requirement must never resolve to an EE tree, and vice versa. Before the
-// cache grew a flavor level the two were indistinguishable.
+// TestFindInCacheSeparatesFlavors pins the cache layout: findInCache searches
+// exactly one flavor tree, so the two flavors of one version can coexist.
+// Which trees a requirement may draw from is resolveRuntime's decision.
 func TestFindInCacheSeparatesFlavors(t *testing.T) {
 	cache := fakeFlavorCache(t, flavorEE, map[string][]string{
 		runtimeTarantool: {"3.0.5"},
@@ -45,13 +45,89 @@ func TestFindInCacheSeparatesFlavors(t *testing.T) {
 
 	_, _, ok, err := findInCache(cache, runtimeTarantool, flavorCE, constraint(">=3.0.0"))
 	require.NoError(t, err)
-	assert.False(t, ok, "a ce requirement must not resolve to the ee tree")
+	assert.False(t, ok, "the ce tree is empty, so a ce lookup misses")
 
 	dir, ver, ok, err := findInCache(cache, runtimeTarantool, flavorEE, constraint(">=3.0.0"))
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "3.0.5", ver)
 	assert.Equal(t, filepath.Join(cache, runtimeTarantool, flavorEE, "3.0.5"), dir)
+}
+
+// TestResolveRuntimeCEAcceptsEETree: Enterprise is a superset of Community, so
+// a [ce] requirement is satisfied by a cached EE build when no CE one is.
+func TestResolveRuntimeCEAcceptsEETree(t *testing.T) {
+	cache := fakeFlavorCache(t, flavorEE, map[string][]string{
+		runtimeTarantool: {"3.0.5"},
+	})
+
+	src, err := resolveRuntime(RuntimeOptions{CacheDir: cache}, runtimeTarantool,
+		constraint(">=3.0.0"), activeBinary{})
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.5", src.Version)
+	assert.Equal(t, filepath.Join(cache, runtimeTarantool, flavorEE, "3.0.5"), src.Dir)
+	assert.False(t, src.Fallback)
+}
+
+// TestResolveRuntimeCEPrefersCETree: with both trees populated, a [ce]
+// requirement takes the CE build even when the EE tree holds a higher version.
+// The requirement's own flavor is what the project asked for; EE is a
+// stand-in, not an upgrade.
+func TestResolveRuntimeCEPrefersCETree(t *testing.T) {
+	cache := fakeFlavorCache(t, flavorCE, map[string][]string{
+		runtimeTarantool: {"3.0.5"},
+	})
+	writeTree(t, filepath.Join(cache, runtimeTarantool, flavorEE, "3.9.0"), map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "Tarantool Enterprise",
+	})
+
+	src, err := resolveRuntime(RuntimeOptions{CacheDir: cache}, runtimeTarantool,
+		constraint(">=3.0.0"), activeBinary{})
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.5", src.Version)
+	assert.Equal(t, filepath.Join(cache, runtimeTarantool, flavorCE, "3.0.5"), src.Dir)
+}
+
+// TestResolveRuntimeEERejectsCETree is the other direction, which stays
+// strict: an [ee] requirement never resolves to a CE build.
+func TestResolveRuntimeEERejectsCETree(t *testing.T) {
+	cache := fakeFlavorCache(t, flavorCE, map[string][]string{
+		runtimeTarantool: {"3.0.5"},
+	})
+
+	_, err := resolveRuntime(RuntimeOptions{CacheDir: cache}, runtimeTarantool,
+		flavored(">=3.0.0", flavorEE), activeBinary{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoRuntime)
+}
+
+// TestBundleRuntimeCEAcceptsEEFallback covers the SDK case: a manifest with no
+// flavor (the [ce] default) packed in an Enterprise environment bundles the
+// active EE Tarantool instead of refusing.
+func TestBundleRuntimeCEAcceptsEEFallback(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "Tarantool Enterprise",
+		"bin/tt":        "#!/bin/sh\n",
+	})
+
+	bundled, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "3.5.0-0-g0823718c2",
+		ActiveTarantoolFlavor:  flavorEE,
+		ActiveTt:               filepath.Join(prefix, "bin", "tt"),
+		ActiveTtVersion:        "2.4.0",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "3.5.0-0-g0823718c2", bundled.Tarantool)
 }
 
 // TestBundleRuntimeRejectsWrongFlavorFallback is the regression test for the
@@ -76,7 +152,38 @@ func TestBundleRuntimeRejectsWrongFlavorFallback(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errNoRuntime)
-	assert.Contains(t, err.Error(), "[ee]", "the error must name the wanted flavor")
+	assert.Contains(t, err.Error(), "[ee] requires a [ee] build",
+		"the error must name the wanted flavor")
+	assert.Contains(t, err.Error(), "matches the version but not the flavor",
+		"a version that fits must not be reported as a version mismatch")
+	assert.Contains(t, err.Error(), "3.0.5[ce]", "the error must describe the active build")
+}
+
+// TestBundleRuntimeVersionMismatchIsNotAFlavorMismatch keeps the two failure
+// texts apart: a version that does not fit is reported as such, without the
+// flavor hint that would send the user to edit the wrong field.
+func TestBundleRuntimeVersionMismatchIsNotAFlavorMismatch(t *testing.T) {
+	prefix := t.TempDir()
+	writeTree(t, prefix, map[string]string{
+		"bin/tarantool": "#!/bin/sh\n",
+		"LICENSE":       "BSD-2-Clause",
+	})
+
+	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+		CacheDir: filepath.Join(t.TempDir(), "empty"),
+		Platform: manifest.Platform{
+			Tarantool: constraint(">=3.0.0,<4.0.0"),
+			Tt:        constraint(">=2.0.0,<3.0.0"),
+		},
+		ActiveTarantool:        filepath.Join(prefix, "bin", "tarantool"),
+		ActiveTarantoolVersion: "2.11.0",
+		ActiveTarantoolFlavor:  flavorCE,
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoRuntime)
+	assert.Contains(t, err.Error(), "does not satisfy it")
+	assert.NotContains(t, err.Error(), "not the flavor")
 }
 
 // TestBundleRuntimeAcceptsMatchingFlavorFallback is the positive counterpart.

--- a/cli/manifest/pack/pack.go
+++ b/cli/manifest/pack/pack.go
@@ -8,11 +8,17 @@
 // namespace subtrees; installing that archive extracts it and refetches the
 // dependencies from the registry using the lock's pins.
 //
-// Neither mode carries the dev closure. The build pack runs first materializes
-// [dev_dependencies] into .rocks/ like any other build, and so did every build
-// the developer ran before it, so the archive is kept clean here - where its
-// content is selected - rather than by declining to install them. See
+// Neither mode carries the dev closure's rocks. The build pack runs first
+// materializes [dev_dependencies] into .rocks/ like any other build, and so did
+// every build the developer ran before it, so the archive is kept clean here -
+// where its content is selected - rather than by declining to install them. See
 // devOnlyRocks and stageRocks.
+//
+// The lock inside the archive still lists that closure. The archived lock is a
+// record of the build, not an inventory of the archive - it also carries
+// generated_by and the bundled runtime versions - and the dev versions belong
+// to that record, since a generator run from the dev tree can shape what was
+// packed. Nothing on the install side reads the section.
 package pack
 
 import (

--- a/cli/manifest/pack/pack_test.go
+++ b/cli/manifest/pack/pack_test.go
@@ -181,7 +181,8 @@ func TestHasNativeArtifacts(t *testing.T) {
 	})
 }
 
-// TestOutputDir pins where the archive lands: RFC 0010 puts it in _build/pack.
+// TestOutputDir pins where the archive lands: _build/pack under the project,
+// unless an explicit output directory overrides it.
 func TestOutputDir(t *testing.T) {
 	assert.Equal(t, filepath.Join("/proj", "_build", "pack"),
 		outputDir(Options{ProjectDir: "/proj"}))

--- a/cli/manifest/pack/runtime.go
+++ b/cli/manifest/pack/runtime.go
@@ -27,7 +27,7 @@ const (
 )
 
 // tarantoolLicenseNames are the file names a bundled Tarantool's license may
-// carry. Shipping the binary without one is refused.
+// carry. The first one found beside the binary is bundled as LICENSE.
 var tarantoolLicenseNames = []string{"LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"}
 
 // runtimeSource describes one resolved runtime component ready to be bundled.
@@ -42,6 +42,9 @@ type runtimeSource struct {
 	Dir string
 	// Binary is a single executable to copy into <name>/bin/.
 	Binary string
+	// Prefix is the install prefix of Binary as the caller knows it; empty
+	// when the caller has none, in which case it is guessed from Binary.
+	Prefix string
 	// Fallback marks a component resolved from the active tt environment
 	// rather than the runtime cache, which is worth warning about.
 	Fallback bool
@@ -63,11 +66,16 @@ type RuntimeOptions struct {
 	ActiveTarantool        string
 	ActiveTarantoolVersion string
 	ActiveTarantoolFlavor  string
-	ActiveTt               string
-	ActiveTtVersion        string
-	ActiveTtFlavor         string
-	ActiveTcm              string
-	ActiveTcmVersion       string
+	// ActiveTarantoolPrefix is the install prefix tt resolved for the active
+	// Tarantool (TT_CLI_TARANTOOL_PREFIX or the build banner), where its
+	// LICENSE and share/tarantool are looked for first. Empty means unknown,
+	// and the binary's own location is searched instead.
+	ActiveTarantoolPrefix string
+	ActiveTt              string
+	ActiveTtVersion       string
+	ActiveTtFlavor        string
+	ActiveTcm             string
+	ActiveTcmVersion      string
 	// Warn receives the fallback diagnostics; nil drops them.
 	Warn func(string)
 }
@@ -102,21 +110,25 @@ func bundleRuntime(stageDir string, req RuntimeOptions) (BundledVersions, error)
 	wanted := []struct {
 		name       string
 		constraint manifest.Constraint
-		binary     string
-		binVersion string
-		binFlavor  string
+		active     activeBinary
 	}{
-		{
-			runtimeTarantool, req.Platform.Tarantool,
-			req.ActiveTarantool, req.ActiveTarantoolVersion, req.ActiveTarantoolFlavor,
-		},
-		{
-			runtimeTt, req.Platform.Tt,
-			req.ActiveTt, req.ActiveTtVersion, req.ActiveTtFlavor,
-		},
+		{runtimeTarantool, req.Platform.Tarantool, activeBinary{
+			path:    req.ActiveTarantool,
+			version: req.ActiveTarantoolVersion,
+			flavor:  req.ActiveTarantoolFlavor,
+			prefix:  req.ActiveTarantoolPrefix,
+		}},
+		{runtimeTt, req.Platform.Tt, activeBinary{
+			path:    req.ActiveTt,
+			version: req.ActiveTtVersion,
+			flavor:  req.ActiveTtFlavor,
+		}},
 		// TCM is Enterprise-only and carries no flavor (manifest validation
 		// rejects one), so its effective flavor is never compared.
-		{runtimeTcm, req.Platform.Tcm, req.ActiveTcm, req.ActiveTcmVersion, ""},
+		{runtimeTcm, req.Platform.Tcm, activeBinary{
+			path:    req.ActiveTcm,
+			version: req.ActiveTcmVersion,
+		}},
 	}
 
 	var bundled BundledVersions
@@ -127,8 +139,7 @@ func bundleRuntime(stageDir string, req RuntimeOptions) (BundledVersions, error)
 			continue
 		}
 
-		src, err := resolveRuntime(req, w.name, w.constraint,
-			activeBinary{path: w.binary, version: w.binVersion, flavor: w.binFlavor})
+		src, err := resolveRuntime(req, w.name, w.constraint, w.active)
 		if err != nil {
 			return BundledVersions{}, err
 		}
@@ -148,7 +159,7 @@ func bundleRuntime(stageDir string, req RuntimeOptions) (BundledVersions, error)
 				w.name, src.Version, w.constraint.Version))
 		}
 
-		if err := placeRuntime(stageDir, src); err != nil {
+		if err := placeRuntime(stageDir, src, req.Warn); err != nil {
 			return BundledVersions{}, err
 		}
 
@@ -175,6 +186,8 @@ type activeBinary struct {
 	version string
 	// flavor is "ce", "ee", or "" for undetermined.
 	flavor string
+	// prefix is the install prefix as the caller knows it; empty for unknown.
+	prefix string
 }
 
 // acceptedFlavors lists the build flavors that satisfy a requirement, in the
@@ -223,6 +236,7 @@ func resolveRuntime(
 			Name:     name,
 			Version:  normalizeVersion(active.version),
 			Binary:   active.path,
+			Prefix:   active.prefix,
 			Fallback: true,
 		}, nil
 	}
@@ -432,7 +446,7 @@ func normalizeVersion(ver string) string {
 }
 
 // placeRuntime copies one resolved component into <stage>/_runtime/<name>/.
-func placeRuntime(stageDir string, src runtimeSource) error {
+func placeRuntime(stageDir string, src runtimeSource, warn func(string)) error {
 	dst := filepath.Join(stageDir, runtimeDirName, src.Name)
 
 	if src.Dir != "" {
@@ -444,7 +458,7 @@ func placeRuntime(stageDir string, src runtimeSource) error {
 	}
 
 	if src.Name == runtimeTarantool {
-		return checkTarantoolLicense(dst, src)
+		return bundleTarantoolLicense(dst, src, warn)
 	}
 
 	return nil
@@ -464,24 +478,52 @@ func placeBinaryRuntime(dst string, src runtimeSource) error {
 		return nil
 	}
 
-	prefix := filepath.Dir(filepath.Dir(src.Binary))
+	for _, prefix := range binaryPrefixes(src) {
+		share := filepath.Join(prefix, "share", "tarantool")
+		if _, err := os.Stat(share); err != nil {
+			continue
+		}
 
-	share := filepath.Join(prefix, "share", "tarantool")
-	if _, err := os.Stat(share); err != nil {
-		return nil //nolint:nilerr // No share tree to bundle.
-	}
+		if err := copyTree(share, filepath.Join(dst, "share", "tarantool")); err != nil {
+			return fmt.Errorf("bundling Tarantool share/: %w", err)
+		}
 
-	if err := copyTree(share, filepath.Join(dst, "share", "tarantool")); err != nil {
-		return fmt.Errorf("bundling Tarantool share/: %w", err)
+		return nil
 	}
 
 	return nil
 }
 
-// checkTarantoolLicense enforces that a bundled Tarantool ships its LICENSE.
-// A cache entry is expected to carry one; the single-binary fallback cannot, so
-// the license is looked up next to the binary's install prefix.
-func checkTarantoolLicense(dst string, src runtimeSource) error {
+// binaryPrefixes lists the directories that may be the install prefix of a
+// single-binary source, most trustworthy first: the prefix the caller
+// resolved, then the parent of the binary's directory (the <prefix>/bin/
+// layout of a packaged install), then the binary's own directory (the flat
+// layout of the Enterprise SDK, where tarantool sits beside env.sh with no
+// bin/ in between). Duplicates are dropped so a caller prefix that equals
+// one of the guesses is not searched twice.
+func binaryPrefixes(src runtimeSource) []string {
+	binDir := filepath.Dir(src.Binary)
+	candidates := []string{src.Prefix, filepath.Dir(binDir), binDir}
+
+	prefixes := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if c != "" && !slices.Contains(prefixes, c) {
+			prefixes = append(prefixes, c)
+		}
+	}
+
+	return prefixes
+}
+
+// bundleTarantoolLicense brings a bundled Tarantool's LICENSE along. A cache
+// entry is expected to carry one already; the single-binary fallback cannot, so
+// the license is looked up next to the binary's install prefix and copied in.
+//
+// A missing license is reported and does not stop the pack: the Enterprise SDK
+// ships no license file at all - not in the unpacked bundle and not in the
+// tarball - so refusing here would make an EE runtime unpackable rather than
+// making a license appear.
+func bundleTarantoolLicense(dst string, src runtimeSource, warn func(string)) error {
 	for _, name := range tarantoolLicenseNames {
 		if _, err := os.Stat(filepath.Join(dst, name)); err == nil {
 			return nil
@@ -489,14 +531,20 @@ func checkTarantoolLicense(dst string, src runtimeSource) error {
 	}
 
 	if src.Dir != "" {
-		return stateErrorf("%w: none of %s found in %s",
-			errNoTarantoolLicense, strings.Join(tarantoolLicenseNames, ", "), src.Dir)
+		if warn != nil {
+			warn(fmt.Sprintf("bundling Tarantool without a license: none of %s in %s",
+				strings.Join(tarantoolLicenseNames, ", "), src.Dir))
+		}
+
+		return nil
 	}
 
-	// Fallback path: look beside the binary, i.e. <prefix>/bin/tarantool =>
-	// <prefix>/ and <prefix>/share/tarantool/.
-	prefix := filepath.Dir(filepath.Dir(src.Binary))
-	candidates := []string{prefix, filepath.Join(prefix, "share", "tarantool")}
+	// Fallback path: look in every directory that may be the binary's install
+	// prefix, and in its share/tarantool/, where a packaged install keeps it.
+	var candidates []string
+	for _, prefix := range binaryPrefixes(src) {
+		candidates = append(candidates, prefix, filepath.Join(prefix, "share", "tarantool"))
+	}
 
 	for _, dir := range candidates {
 		for _, name := range tarantoolLicenseNames {
@@ -507,6 +555,10 @@ func checkTarantoolLicense(dst string, src runtimeSource) error {
 		}
 	}
 
-	return stateErrorf("%w: looked beside %s in %s", errNoTarantoolLicense,
-		src.Binary, strings.Join(candidates, ", "))
+	if warn != nil {
+		warn(fmt.Sprintf("bundling Tarantool without a license: looked beside %s in %s",
+			src.Binary, strings.Join(candidates, ", ")))
+	}
+
+	return nil
 }

--- a/cli/manifest/pack/runtime.go
+++ b/cli/manifest/pack/runtime.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -176,37 +177,67 @@ type activeBinary struct {
 	flavor string
 }
 
+// acceptedFlavors lists the build flavors that satisfy a requirement, in the
+// order the cache is searched. Enterprise is a superset of Community, so a
+// [ce] requirement is met by either build; an [ee] requirement only by an
+// Enterprise one, since a CE build lacks what the manifest asked for in a way
+// nothing downstream detects. The requirement's own flavor comes first so that
+// a [ce] project bundles the CE tree whenever one is cached, and reaches for
+// EE only when nothing else satisfies it.
+func acceptedFlavors(flavor string) []string {
+	if flavor == flavorCE {
+		return []string{flavorCE, flavorEE}
+	}
+
+	return []string{flavor}
+}
+
 // resolveRuntime picks the source for one runtime component: cache first,
-// active binary second. Both must match the constraint's flavor as well as its
-// version - bundling a CE build for an [ee] requirement produces an archive
-// that is wrong in a way nothing downstream detects.
+// active binary second. Both must satisfy the constraint's flavor as well as
+// its version; see acceptedFlavors for what satisfies a flavor.
 func resolveRuntime(
 	req RuntimeOptions, name string, constraint manifest.Constraint,
 	active activeBinary,
 ) (runtimeSource, error) {
 	flavor := constraint.EffectiveFlavor()
+	accepted := acceptedFlavors(flavor)
 
-	dir, ver, ok, err := findInCache(req.CacheDir, name, flavor, constraint)
+	for _, f := range accepted {
+		dir, ver, ok, err := findInCache(req.CacheDir, name, f, constraint)
+		if err != nil {
+			return runtimeSource{}, err
+		}
+
+		if ok {
+			return runtimeSource{Name: name, Version: ver, Dir: dir}, nil
+		}
+	}
+
+	versionOK, err := activeVersionOK(active, constraint)
 	if err != nil {
 		return runtimeSource{}, err
 	}
 
-	if ok {
-		return runtimeSource{Name: name, Version: ver, Dir: dir}, nil
-	}
-
-	usable, err := activeUsable(active, flavor, constraint)
-	if err != nil {
-		return runtimeSource{}, err
-	}
-
-	if usable {
+	if versionOK && activeFlavorOK(active, flavor) {
 		return runtimeSource{
 			Name:     name,
 			Version:  normalizeVersion(active.version),
 			Binary:   active.path,
 			Fallback: true,
 		}, nil
+	}
+
+	// The version matched and only the flavor did not: say so, because the
+	// generic "does not satisfy" reads as a version mismatch, and the fix is a
+	// different one - the manifest's [flavor], not the cache.
+	if versionOK {
+		return runtimeSource{}, stateErrorf(
+			"%w: no %s satisfying %s found in the runtime cache %s, and the active "+
+				"%s (%s) matches the version but not the flavor: %s requires %s; "+
+				"place a matching build under %s or change [platform].%s",
+			errNoRuntime, name, constraint.String(), req.CacheDir, name,
+			describeActive(active), "["+flavor+"]", describeFlavors(accepted),
+			filepath.Join(req.CacheDir, name, flavor, "<version>"), name)
 	}
 
 	return runtimeSource{}, stateErrorf(
@@ -217,34 +248,38 @@ func resolveRuntime(
 		filepath.Join(req.CacheDir, name, flavor, "<version>"))
 }
 
-// activeUsable reports whether the active binary may stand in for the cache.
-// An undetermined flavor is accepted only for a [ce] requirement: ce is the
-// default and overwhelmingly the common case, whereas silently treating an
-// unverified build as Enterprise would be a licensing error, not just a bug.
-func activeUsable(
-	active activeBinary, flavor string, constraint manifest.Constraint,
-) (bool, error) {
+// activeVersionOK reports whether the active binary exists and its version
+// satisfies the constraint.
+func activeVersionOK(active activeBinary, constraint manifest.Constraint) (bool, error) {
 	if active.path == "" {
 		return false, nil
 	}
 
-	versionOK, err := satisfies(active.version, constraint)
-	if err != nil {
-		return false, err
+	return satisfies(active.version, constraint)
+}
+
+// activeFlavorOK reports whether the active binary's flavor satisfies the
+// requirement's. An undetermined flavor is accepted only for a [ce]
+// requirement: ce is the default and overwhelmingly the common case, whereas
+// silently treating an unverified build as Enterprise would be a licensing
+// error, not just a bug.
+func activeFlavorOK(active activeBinary, flavor string) bool {
+	if active.flavor == "" {
+		return flavor == flavorCE
 	}
 
-	if !versionOK {
-		return false, nil
+	return slices.Contains(acceptedFlavors(flavor), active.flavor)
+}
+
+// describeFlavors renders the accepted flavors for an error message, e.g.
+// "a [ce] or [ee] build".
+func describeFlavors(flavors []string) string {
+	parts := make([]string, 0, len(flavors))
+	for _, f := range flavors {
+		parts = append(parts, "["+f+"]")
 	}
 
-	switch active.flavor {
-	case flavor:
-		return true, nil
-	case "":
-		return flavor == flavorCE, nil
-	default:
-		return false, nil
-	}
+	return "a " + strings.Join(parts, " or ") + " build"
 }
 
 // describeActive renders the active binary for an error message, saying plainly
@@ -263,9 +298,9 @@ func describeActive(active activeBinary) string {
 }
 
 // findInCache returns the highest cached version of a component satisfying the
-// constraint. Cache entries are directories laid out as
+// constraint within one flavor. Cache entries are directories laid out as
 // <cache>/<component>/<flavor>/<version>/, so a CE and an EE build of the same
-// version can coexist and a [ce] requirement can never resolve to an EE tree.
+// version can coexist and an [ee] requirement can never resolve to a CE tree.
 func findInCache(
 	cacheDir, name, flavor string, constraint manifest.Constraint,
 ) (string, string, bool, error) {

--- a/cli/manifest/pack/runtime_test.go
+++ b/cli/manifest/pack/runtime_test.go
@@ -287,8 +287,9 @@ func TestBundleRuntimeNoSourceAtAll(t *testing.T) {
 	assert.ErrorIs(t, err, errNoRuntime)
 }
 
-// TestBundleRuntimeRequiresTarantoolLicense enforces the RFC rule that a
-// bundled Tarantool ships its LICENSE.
+// TestBundleRuntimeRequiresTarantoolLicense pins that a bundled Tarantool
+// ships its LICENSE: an archive that redistributes the binary carries the
+// terms it is redistributed under.
 func TestBundleRuntimeRequiresTarantoolLicense(t *testing.T) {
 	cache := t.TempDir()
 	writeTree(t, filepath.Join(cache, runtimeTarantool, flavorCE, "3.0.5"), map[string]string{

--- a/cli/manifest/pack/runtime_test.go
+++ b/cli/manifest/pack/runtime_test.go
@@ -16,8 +16,8 @@ func constraint(spec string) manifest.Constraint {
 }
 
 // fakeCache builds a runtime cache with the given component versions, all under
-// the ce flavor. Every tarantool entry gets a LICENSE, since bundling one
-// without it is refused.
+// the ce flavor. Every tarantool entry gets a LICENSE, the shape of a CE
+// install; an entry without one is packed with a warning instead.
 func fakeCache(t *testing.T, entries map[string][]string) string {
 	t.Helper()
 
@@ -287,25 +287,33 @@ func TestBundleRuntimeNoSourceAtAll(t *testing.T) {
 	assert.ErrorIs(t, err, errNoRuntime)
 }
 
-// TestBundleRuntimeRequiresTarantoolLicense pins that a bundled Tarantool
-// ships its LICENSE: an archive that redistributes the binary carries the
-// terms it is redistributed under.
-func TestBundleRuntimeRequiresTarantoolLicense(t *testing.T) {
-	cache := t.TempDir()
+// TestBundleRuntimeWarnsWithoutTarantoolLicense pins that a cache entry with
+// no license file is packed and reported rather than refused: an archive that
+// redistributes the binary should carry the terms it is redistributed under,
+// but a bundle that ships none - the Enterprise SDK does not - must still be
+// packable.
+func TestBundleRuntimeWarnsWithoutTarantoolLicense(t *testing.T) {
+	cache := fakeCache(t, map[string][]string{runtimeTt: {"2.0.0"}})
 	writeTree(t, filepath.Join(cache, runtimeTarantool, flavorCE, "3.0.5"), map[string]string{
 		"bin/tarantool": "#!/bin/sh\n",
 	})
 
-	_, err := bundleRuntime(t.TempDir(), RuntimeOptions{
+	var warnings []string
+
+	stage := t.TempDir()
+	_, err := bundleRuntime(stage, RuntimeOptions{
 		CacheDir: cache,
 		Platform: manifest.Platform{
 			Tarantool: constraint(">=3.0.0,<4.0.0"),
 			Tt:        constraint(">=2.0.0,<3.0.0"),
 		},
+		Warn: func(msg string) { warnings = append(warnings, msg) },
 	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errNoTarantoolLicense)
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(stage, runtimeDirName, runtimeTarantool, "bin", "tarantool"))
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "bundling Tarantool without a license")
 }
 
 func TestPlaceRuntimeKeepsExecutableBit(t *testing.T) {
@@ -317,7 +325,7 @@ func TestPlaceRuntimeKeepsExecutableBit(t *testing.T) {
 	stageDir := t.TempDir()
 	require.NoError(t, placeRuntime(stageDir, runtimeSource{
 		Name: runtimeTt, Version: "2.0.0", Dir: src,
-	}))
+	}, nil))
 
 	info, err := os.Stat(filepath.Join(stageDir, "_runtime", "tt", "bin", "tt"))
 	require.NoError(t, err)

--- a/cli/manifest/pack/token.go
+++ b/cli/manifest/pack/token.go
@@ -11,7 +11,7 @@ const anyToken = "any"
 
 // hostToken returns the platform token of the machine pack runs on:
 // "<os>-<arch>", e.g. linux-amd64, linux-arm64, darwin-amd64, darwin-arm64.
-// Go's GOARCH names already match the RFC's token vocabulary for the four
+// Go's GOOS and GOARCH names are already the token spelling for the four
 // supported pairs, so no translation table is needed.
 func hostToken() string {
 	return runtime.GOOS + "-" + runtime.GOARCH

--- a/cli/manifest/resolve/cache.go
+++ b/cli/manifest/resolve/cache.go
@@ -32,16 +32,20 @@ type resolveCache struct {
 	// droppedPins records the rocks whose preferred version was dropped for no
 	// longer fitting, so that warning too is emitted once per run.
 	droppedPins map[string]bool
+	// warnedMoving records the rocks pinned to a branch rather than a release,
+	// so that warning too is emitted once per run.
+	warnedMoving map[string]bool
 }
 
 func newResolveCache() *resolveCache {
 	return &resolveCache{
-		resolved:    map[string]rocks.ResolvedRock{},
-		metadata:    map[string]*luarocks.Rockspec{},
-		content:     map[string]string{},
-		local:       map[string]*luarocks.Rockspec{},
-		warnedNoMD5: map[string]bool{},
-		droppedPins: map[string]bool{},
+		resolved:     map[string]rocks.ResolvedRock{},
+		metadata:     map[string]*luarocks.Rockspec{},
+		content:      map[string]string{},
+		local:        map[string]*luarocks.Rockspec{},
+		warnedNoMD5:  map[string]bool{},
+		droppedPins:  map[string]bool{},
+		warnedMoving: map[string]bool{},
 	}
 }
 
@@ -54,6 +58,19 @@ func (c *resolveCache) markNoMD5(url string) bool {
 	}
 
 	c.warnedNoMD5[url] = true
+
+	return true
+}
+
+// markMoving records that name resolved to a branch rather than a release and
+// reports whether this is the first time in the run - so a rock several
+// products depend on warns once, not once per product.
+func (c *resolveCache) markMoving(name string) bool {
+	if c.warnedMoving[name] {
+		return false
+	}
+
+	c.warnedMoving[name] = true
 
 	return true
 }

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -194,6 +194,14 @@ func (w *walker) resolveOne(ctx context.Context, req depReq) (*resolvedDep, []de
 		return nil, nil, fmt.Errorf("metadata for %q: %w", req.name, err)
 	}
 
+	// A branch version is only ever chosen deliberately or for lack of a
+	// release, and either way the lock stops describing fixed code.
+	if (resolved.Version.IsSCM || resolved.Version.IsDev) && w.cache.markMoving(resolved.Name) {
+		w.warnings = append(w.warnings, fmt.Sprintf(
+			"%s resolved to %s, which tracks a branch; the lock will not pin fixed code",
+			resolved.Name, resolved.Version.Raw))
+	}
+
 	checksum, ok := rocks.Checksum(spec)
 	if !ok && w.cache.markNoMD5(resolved.URL) {
 		// Emit once per run: resolveOne re-runs per product (the walker is

--- a/cli/manifest/resolve/closure.go
+++ b/cli/manifest/resolve/closure.go
@@ -382,7 +382,7 @@ func mergeDeps(
 		if !seen {
 			byName[name] = &depReq{
 				name:           name,
-				constraintExpr: dependency.Version,
+				constraintExpr: manifest.ConstraintExpr(dependency.Version),
 				constraints:    nil,
 				registry:       dependency.Registry,
 				source:         dependency.Source,
@@ -438,7 +438,8 @@ func mergeInto(existing *depReq, name string, dependency manifest.Dependency) er
 		existing.registry = dependency.Registry
 	}
 
-	existing.constraintExpr = joinConstraints(existing.constraintExpr, dependency.Version)
+	existing.constraintExpr = joinConstraints(
+		existing.constraintExpr, manifest.ConstraintExpr(dependency.Version))
 
 	return nil
 }

--- a/cli/manifest/resolve/constraints.go
+++ b/cli/manifest/resolve/constraints.go
@@ -1,9 +1,28 @@
 package resolve
 
 import (
+	"fmt"
+
 	luarocks "github.com/tarantool/go-luarocks"
 	"github.com/tarantool/go-luarocks/deps"
+
+	"github.com/tarantool/tt/cli/manifest"
 )
+
+// ValidateConstraint reports whether expr is a version constraint the resolver
+// can act on: "*", the empty expression, or a comma- or space-separated list of
+// "<operator><version>" segments.
+//
+// It is the check a command runs before writing a declaration, so an expression
+// no resolver can use is refused while the manifest is still untouched.
+func ValidateConstraint(expr string) error {
+	_, err := deps.ParseConstraints(manifest.ConstraintExpr(expr))
+	if err != nil {
+		return fmt.Errorf("invalid version constraint %q: %w", expr, err)
+	}
+
+	return nil
+}
 
 // satisfiable reports whether some version could satisfy every constraint at
 // once. It is a structural check over the version order (deps.Compare), so a

--- a/cli/manifest/resolve/constraints_test.go
+++ b/cli/manifest/resolve/constraints_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/tarantool/go-luarocks/deps"
 )
 
+func TestValidateConstraint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		expr string
+		ok   bool
+	}{
+		{name: "any version", expr: "*", ok: true},
+		{name: "any version padded", expr: "  *  ", ok: true},
+		{name: "omitted", expr: "", ok: true},
+		{name: "single bound", expr: ">=3.0.0", ok: true},
+		{name: "range", expr: ">=3.0.0,<4.0.0", ok: true},
+		{name: "bare version", expr: "1.2.3", ok: true},
+		{name: "unknown operator", expr: "~~1.0", ok: false},
+		{name: "star inside a range", expr: ">=1.0.0,*", ok: false},
+		{name: "not a version", expr: ">=nope!", ok: false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateConstraint(testCase.expr)
+			if testCase.ok {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), testCase.expr)
+		})
+	}
+}
+
 func TestSatisfiable(t *testing.T) {
 	t.Parallel()
 

--- a/cli/manifest/resolve/resolve_test.go
+++ b/cli/manifest/resolve/resolve_test.go
@@ -258,6 +258,53 @@ metrics = '>=1.0.0,<2.0.0'
 	assert.Equal(t, "md5:bbb", got.Checksum)
 }
 
+func TestAnyConstraintTakesTheHighestVersion(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "aaa").
+		add("metrics", "2.0.0-1", "ccc")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '*'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "2.0.0-1", got.Version)
+}
+
+func TestAnyConstraintMergesWithABound(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().
+		add("metrics", "1.0.0-1", "aaa").
+		add("metrics", "1.5.0-1", "bbb").
+		add("metrics", "2.0.0-1", "ccc")
+
+	// The global declaration places no bound, so the component's bound is the
+	// only one the closure must honour.
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '*'
+
+[components.app.dependencies]
+metrics = '<2.0.0'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, _, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "1.5.0-1", got.Version)
+}
+
 func TestTransitiveClosure(t *testing.T) {
 	t.Parallel()
 

--- a/cli/manifest/resolve/resolve_test.go
+++ b/cli/manifest/resolve/resolve_test.go
@@ -305,6 +305,49 @@ metrics = '<2.0.0'
 	assert.Equal(t, "1.5.0-1", got.Version)
 }
 
+// TestMovingVersionIsReported: a lock holding a branch looks exactly like a
+// lock holding a release, so the one moment a user can be told is the resolve
+// that chose it.
+func TestMovingVersionIsReported(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "scm-1", "aaa")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '*'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	lock, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+
+	got := findDep(t, lock.Products["default"].Dependencies, "metrics")
+	assert.Equal(t, "scm-1", got.Version)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "metrics")
+	assert.Contains(t, warnings[0], "tracks a branch")
+}
+
+// TestReleasedVersionIsNotReported is the other half: the warning has to be
+// about the branch, not about every resolve.
+func TestReleasedVersionIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeAdapter().add("metrics", "1.0.0-1", "aaa")
+
+	man := parseManifest(t, oneProduct+`[dependencies]
+metrics = '*'
+`)
+
+	engine := resolve.NewEngine(fake, "", "tt 3.4.0")
+
+	_, warnings, err := engine.Resolve(context.Background(), man)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+}
+
 func TestTransitiveClosure(t *testing.T) {
 	t.Parallel()
 

--- a/cli/manifest/rocks/resolve.go
+++ b/cli/manifest/rocks/resolve.go
@@ -124,14 +124,70 @@ func resolveWith(
 // pickNewest returns the highest-versioned candidate satisfying every
 // constraint. An empty constraint list matches all. ok is false when nothing
 // matches.
+//
+// Released versions win over moving ones. LuaRocks orders scm and dev above
+// every number, so an ordinary lower bound like ">=3.0.0" would otherwise
+// select the development branch and pin a lock to something that changes
+// underneath it. A moving version is chosen only when the constraints name one
+// outright, or when the rock has no released version at all.
+//
+// The fallback deliberately turns on the rock's publication history rather than
+// on whether the stable pass matched: were it the latter, a constraint no
+// release satisfies would quietly be answered with the branch, which is the
+// same surprise by a narrower door.
 func pickNewest(
 	candidates []luarocks.VersionedRock, constraints []luarocks.VersionConstraint,
+) (luarocks.VersionedRock, bool) {
+	stableOnly := hasRelease(candidates) && !wantsMoving(constraints)
+
+	return pickNewestAmong(candidates, constraints, stableOnly)
+}
+
+// hasRelease reports whether any candidate names a release, as opposed to the
+// rock being published only as a branch.
+func hasRelease(candidates []luarocks.VersionedRock) bool {
+	for _, candidate := range candidates {
+		if !moving(candidate.Version) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// moving reports whether a version tracks a branch rather than naming a
+// release, and so may resolve to different code on a later day.
+func moving(version luarocks.Version) bool {
+	return version.IsSCM || version.IsDev
+}
+
+// wantsMoving reports whether the constraints name a moving version outright,
+// which is how a project asks for the development branch on purpose.
+func wantsMoving(constraints []luarocks.VersionConstraint) bool {
+	for _, constraint := range constraints {
+		if moving(constraint.Version) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pickNewestAmong is pickNewest over one class of candidates: stableOnly skips
+// the moving versions, otherwise every candidate is considered.
+func pickNewestAmong(
+	candidates []luarocks.VersionedRock, constraints []luarocks.VersionConstraint,
+	stableOnly bool,
 ) (luarocks.VersionedRock, bool) {
 	var best luarocks.VersionedRock
 
 	found := false
 
 	for _, candidate := range candidates {
+		if stableOnly && moving(candidate.Version) {
+			continue
+		}
+
 		if !deps.Match(candidate.Version, constraints) {
 			continue
 		}

--- a/cli/manifest/rocks/resolve_test.go
+++ b/cli/manifest/rocks/resolve_test.go
@@ -137,6 +137,75 @@ func TestResolveConstraintPicksNewestMatch(t *testing.T) {
 	assert.Equal(t, "1.0.0-1", resolved.Version.Raw)
 }
 
+// TestResolveSkipsMovingVersions: LuaRocks orders scm above every number, so an
+// ordinary lower bound would otherwise select the development branch and pin a
+// lock to code that changes underneath it.
+func TestResolveSkipsMovingVersions(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+
+	server := manifestServer(t, repoJSON("metrics", "1.0.0-1", "2.0.0-1", "scm-1"), &hits)
+
+	adapter := newAdapter(server.URL)
+
+	resolved, err := adapter.Resolve(context.Background(), "metrics", ">=1.0.0", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0.0-1", resolved.Version.Raw)
+}
+
+// TestResolveTakesMovingWhenAskedFor: naming the branch is how a project asks
+// for it on purpose, and that request must still be honoured.
+func TestResolveTakesMovingWhenAskedFor(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+
+	server := manifestServer(t, repoJSON("metrics", "1.0.0-1", "scm-1"), &hits)
+
+	adapter := newAdapter(server.URL)
+
+	resolved, err := adapter.Resolve(context.Background(), "metrics", "==scm", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "scm-1", resolved.Version.Raw)
+}
+
+// TestResolveFallsBackToMoving: a rock published only as a branch is the
+// ordinary state for much of the ecosystem, so refusing it would resolve
+// nothing at all.
+func TestResolveFallsBackToMoving(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+
+	server := manifestServer(t, repoJSON("metrics", "scm-1"), &hits)
+
+	adapter := newAdapter(server.URL)
+
+	resolved, err := adapter.Resolve(context.Background(), "metrics", ">=1.0.0", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "scm-1", resolved.Version.Raw)
+}
+
+// TestResolveSkipsMovingOutOfRange: the stable pass narrows the candidates, it
+// does not widen them - a released version outside the range stays refused
+// rather than being replaced by the branch.
+func TestResolveSkipsMovingOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+
+	server := manifestServer(t, repoJSON("metrics", "1.0.0-1", "scm-1"), &hits)
+
+	adapter := newAdapter(server.URL)
+
+	_, err := adapter.Resolve(context.Background(), "metrics", ">=2.0.0", "")
+	assert.ErrorIs(t, err, rocks.ErrNoMatch)
+}
+
 func TestResolveNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/package/test_package_list.py
+++ b/test/integration/package/test_package_list.py
@@ -11,7 +11,7 @@ def test_list_shows_primary_and_guests(run_tt):
     assert result.returncode == 0, result.stderr
 
     lines = result.stdout.strip().splitlines()
-    assert lines[0].split() == ["NAME", "VERSION", "KIND", "DESCRIPTION"]
+    assert lines[0].split() == ["NAME", "VERSION", "ORIGIN", "DESCRIPTION"]
     assert len(lines) == 4
 
     rows = {line.split()[0]: line for line in lines[1:]}


### PR DESCRIPTION
Eight fixes in the manifest package pipeline.

- `cli/manifest: accept the '*' constraint` - a dependency declared as `*`, which is what `tt package add` writes when no version is given, failed to resolve at all: `*` is manifest syntax, and the resolver's grammar spells the unbounded case as the empty expression. It is now translated where the two meet, and a constraint no resolver can act on is refused before the manifest is opened for editing, so a rejected `add` no longer leaves a declaration behind with the lock out of step.
- `cli/manifest/build: hold the locked versions` - a build that found a stale lock re-resolved it with no pins, so editing one line of the manifest could silently move every other dependency to whatever the registry served. The gate now hands the stale lock's versions to the resolver as pins, the same pin set `add`, `remove` and `resolve` already use. `tt package update` stays the one command that pulls newer versions.
- `cli/manifest/pack: state the rules directly` - three comments justified the code by pointing at a document that does not live in this repository. Each now states the rule the code actually enforces.
- `cli/manifest/inventory: name the origin column` - the `KIND` column of `tt package list` becomes `ORIGIN`. `kind` already names what a component is (`library` or `binary`); this column reports where a package came from.
- `cli/manifest/rocks: prefer released versions` - LuaRocks orders `scm` and `dev` above every number, so a constraint as ordinary as `>=3.0.0` selected the development branch whenever the rock published one, and the lock then recorded a version that means different code on different days. A branch is chosen only when the constraint names one or the rock has no release at all, and that case is now reported.
- `cli/manifest: document what the lock covers` - why the dev closure is recorded, why the archived lock lists it, and what the `pre_build` ordering is for. `--locked` on a stale lock now names `tt package resolve` instead of only reporting the staleness.
- `cli/manifest/pack: let an EE build satisfy [ce]` - Enterprise is a superset of Community, but the runtime resolver treated the two flavors as disjoint, so a manifest with no flavor refused to pack in an Enterprise environment, and the refusal read as a version mismatch for a version that fit. A `[ce]` requirement now accepts an EE build, from the cache or from the active environment, searching its own tree first so a `[ce]` project still bundles CE whenever one is cached; `[ee]` stays strict. When the version matches and only the flavor is off, the error says so and names the flavor it would take, since the fix belongs in the manifest's `[flavor]` rather than in the cache.
- `cli/manifest/pack: bundle the license the SDK actually has` - the single-binary fallback assumed the `<prefix>/bin/tarantool` layout of a packaged install and looked for `LICENSE` and `share/tarantool` two levels above the binary, which for the flat Enterprise SDK climbs out of the bundle. It now searches the prefix tt already resolved for the active Tarantool (`TT_CLI_TARANTOOL_PREFIX` or the build banner) first, then the parent of the binary's directory, then the directory itself. That alone does not make an EE runtime packable: the SDK carries no license file at all, in the bundle or in its tarball, so a missing license is now reported and the pack continues rather than being refused. The test for the flat layout had built its fixture with a `LICENSE` at the root, a shape no released SDK has; a second test covers the real one.

Related to TNTP-9959
