### PR TITLE
cli/cmd: tt package resolve and tt package deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dependency forward; `tt package update` is the only command that pulls fresh
   versions from the registry, and with a name it moves that one dependency and
   holds the rest.
+- `tt package resolve`: rewrite `app.manifest.lock` from the manifest without
+  building — the way to bring the lock back in step after editing
+  `[dependencies]` by hand. Nothing is fetched into `.rocks/` and no component
+  build backend runs. Every version the lock already holds is kept, exactly as
+  `add` and `remove` keep them, so a hand edit to one dependency does not drag
+  the others forward.
+- `tt package deps`: print the dependencies the current manifest declares, per
+  product plus the dev closure, each with the version the lock resolved it to
+  and whether it was declared or pulled in behind a declaration. It reads the
+  manifest and the lock and contacts no registry, so a lock that no longer
+  matches the manifest is reported as stale rather than silently re-resolved,
+  and the command works on a machine with no Tarantool installed. `-o` selects
+  the format (table, json or yaml; the default is the table on a terminal and
+  YAML otherwise). The lock state is written to stderr, so a redirected table
+  is the table alone. This is what the manifest declares — what is installed on
+  disk is `tt package list`.
 - `[dev_dependencies]` are now resolved and installed. They were parsed and
   validated but reached neither the lock nor `.rocks/`. The lock records them
   as a single `[[lock.dev_dependencies]]` closure, resolved against the picks

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -44,7 +44,8 @@ var (
 	packageYes     bool
 )
 
-// Flags specific to `tt package list`.
+// Flags shared by the commands that render a listing: tt package list and
+// tt package deps.
 var (
 	packageFormat string
 	packageTree   bool
@@ -75,6 +76,8 @@ func NewPackageCmd() *cobra.Command {
 		newPackageAddCmd(),
 		newPackageRemoveCmd(),
 		newPackageUpdateCmd(),
+		newPackageResolveCmd(),
+		newPackageDepsCmd(),
 		newPackageInstallCmd(),
 		newPackageListCmd(),
 		newPackageUninstallCmd(),
@@ -250,7 +253,108 @@ func runPackageUpdate(name string) error {
 	return nil
 }
 
-// dependencyOptions assembles the options the three dependency commands share.
+// newPackageResolveCmd wires `tt package resolve`.
+func newPackageResolveCmd() *cobra.Command {
+	resolveCmd := &cobra.Command{
+		Use:   "resolve",
+		Short: "Rewrite the lock from the manifest without building",
+		Long: "Re-resolve app.manifest.lock from app.manifest.toml, so a manifest " +
+			"edited by hand gets its lock back in step without waiting for a " +
+			"build. Nothing is fetched into .rocks/ and no component build " +
+			"backend runs. Every version the lock already holds is kept: a hand " +
+			"edit to one dependency is not a request to upgrade the others, and " +
+			"pulling newer registry versions is what tt package update is for.",
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPackageResolve(); err != nil {
+				log.Error(err.Error())
+				os.Exit(deps.ExitCode(err))
+			}
+		},
+	}
+
+	return resolveCmd
+}
+
+// runPackageResolve rewrites the lock and reports what moved.
+func runPackageResolve() error {
+	opts, err := dependencyOptions()
+	if err != nil {
+		return err
+	}
+
+	result, err := deps.Resolve(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Moves) == 0 {
+		fmt.Println("the lock is up to date")
+
+		return nil
+	}
+
+	printMoves(result.Moves)
+
+	return nil
+}
+
+// newPackageDepsCmd wires `tt package deps`.
+func newPackageDepsCmd() *cobra.Command {
+	depsCmd := &cobra.Command{
+		Use:   "deps",
+		Short: "Show the dependencies the manifest declares, at their locked versions",
+		Long: "Print the runtime dependencies of every product and the dev " +
+			"dependencies, each with the version app.manifest.lock resolved it " +
+			"to. This is what the current manifest declares — not what is " +
+			"installed on disk, which is what tt package list reports. Nothing " +
+			"is resolved and no registry is contacted: the answer comes from the " +
+			"manifest and the lock, so a lock that no longer matches the manifest " +
+			"is reported as stale rather than silently re-resolved.",
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runPackageDeps(); err != nil {
+				log.Error(err.Error())
+				os.Exit(deps.ExitCode(err))
+			}
+		},
+	}
+
+	depsCmd.Flags().StringVarP(&packageFormat, "format", "o", "",
+		"output format: table, json or yaml (default: table on a terminal, yaml otherwise)")
+
+	return depsCmd
+}
+
+// runPackageDeps reads the manifest and the lock and renders the report.
+//
+// Unlike the commands that re-resolve, this one needs no Tarantool: nothing
+// evaluates a rockspec here, so a project's dependencies can be listed on a
+// machine that has no tarantool installed at all.
+func runPackageDeps() error {
+	projectDir, err := absoluteWorkingDir()
+	if err != nil {
+		return err
+	}
+
+	format, err := deps.ParseFormat(packageFormat, isatty.IsTerminal(os.Stdout.Fd()))
+	if err != nil {
+		return err
+	}
+
+	report, err := deps.Deps(deps.Options{
+		ProjectDir: projectDir,
+		Warn:       func(msg string) { log.Warn(msg) },
+	})
+	if err != nil {
+		return err
+	}
+
+	return deps.Render(os.Stdout, os.Stderr, report, format)
+}
+
+// dependencyOptions assembles the options the re-resolving dependency commands
+// share.
 //
 // All three re-resolve, and resolution evaluates rockspecs — which are Lua and
 // may branch on the Tarantool version — so a missing tarantool is a real error

--- a/cli/manifest/deps/commands.go
+++ b/cli/manifest/deps/commands.go
@@ -201,6 +201,36 @@ func updateWith(
 		manifest.Change{Existed: false, Previous: ""})
 }
 
+// Resolve rewrites the lock from the manifest, changing no declaration and
+// building nothing.
+//
+// It is what a user reaches for after editing [dependencies] by hand: the lock
+// catches up with the manifest without a build, without fetching anything into
+// .rocks/ and without pulling newer registry versions. Every version the lock
+// already holds is pinned, exactly as add and remove pin them — the edit that
+// prompted the run is the only thing allowed to move the closure, and pulling
+// newer versions is what tt package update is for.
+//
+// A resolve of an already-current lock is not an error and not a no-op: the
+// lock is rewritten from the same inputs, so it comes out identical and the
+// caller sees no moves.
+func Resolve(ctx context.Context, opts Options) (*Result, error) {
+	return resolveWith(ctx, opts, engineFor(opts))
+}
+
+// resolveWith is Resolve against an injected resolver.
+func resolveWith(ctx context.Context, opts Options, res resolver) (*Result, error) {
+	proj, err := load(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// A nil edit, like update: the manifest on disk is already the one to
+	// resolve, hash included.
+	return apply(ctx, opts, res, proj, nil, resolve.PinsFromLock(proj.lock),
+		manifest.Change{Existed: false, Previous: ""})
+}
+
 // notDeclared builds the error for a name the manifest does not declare, naming
 // the component tables that do declare it when any do — the difference between
 // "you mistyped it" and "it is there, but somewhere this command may not touch"

--- a/cli/manifest/deps/deps.go
+++ b/cli/manifest/deps/deps.go
@@ -1,7 +1,12 @@
-// Package deps implements the three commands that change what a package
-// depends on: tt package add, tt package remove and tt package update. Each is
-// the same two-step transaction — edit the declaration, then re-resolve the
-// lock — and the whole package exists to make those two steps agree.
+// Package deps implements the commands that work on what a package depends on.
+//
+// Four of them write the lock: tt package add, tt package remove and
+// tt package update, plus tt package resolve, which is the same transaction
+// with no manifest edit in front of it. Each is the two-step transaction — edit
+// the declaration, then re-resolve the lock — and the whole package exists to
+// make those two steps agree. The fifth, tt package deps, only reads: it
+// reports the declarations and the versions the lock resolved them to, without
+// touching a registry (see Deps).
 //
 // The manifest half is done by the position-preserving editor in
 // cli/manifest (NewEditor): app.manifest.toml is hand-authored, so an edit
@@ -18,9 +23,9 @@
 // edit that had nothing to do with it. resolve.Pins is what prevents that, and
 // choosing the pin set is the whole of what distinguishes the commands:
 //
-//   - Add and Remove pin everything the lock already holds. The rock being
-//     added is not in the lock, so it resolves fresh; every other rock keeps
-//     the version it had.
+//   - Add, Remove and Resolve pin everything the lock already holds. The rock
+//     being added is not in the lock, so it resolves fresh; every other rock
+//     keeps the version it had.
 //   - Update with no argument pins nothing. It is the only command that pulls
 //     newer registry versions, which is exactly the rule resolve.IsStale
 //     states.
@@ -146,23 +151,6 @@ type resolver interface {
 	ResolvePinned(
 		ctx context.Context, man *manifest.Manifest, pins resolve.Pins,
 	) (*manifest.Lock, []string, error)
-}
-
-// ReResolve re-resolves man into a fresh lock, preferring pins.
-//
-// It is exported because it is the whole of tt package resolve: that command is
-// this step with no manifest edit in front of it, and duplicating the adapter
-// and engine wiring is how the two would drift apart. It does not write
-// anything — the caller decides whether the lock reaches disk.
-func ReResolve(
-	ctx context.Context, opts Options, man *manifest.Manifest, pins resolve.Pins,
-) (*manifest.Lock, []string, error) {
-	lock, warnings, err := engineFor(opts).ResolvePinned(ctx, man, pins)
-	if err != nil {
-		return nil, nil, stateErrorf("resolving dependencies: %w", err)
-	}
-
-	return lock, warnings, nil
 }
 
 // engineFor builds the resolution engine the commands drive: the rocks adapter

--- a/cli/manifest/deps/format.go
+++ b/cli/manifest/deps/format.go
@@ -1,0 +1,229 @@
+package deps
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlIndent is tt's usual YAML indent, and tabColumnPadding the gap between
+// table columns.
+const (
+	yamlIndent       = 2
+	tabColumnPadding = 2
+)
+
+// devProduct is what the dev closure is called in the human table's first
+// column. It is not a product — the manifest declares dev dependencies
+// globally — so it is spelled differently from every product name, which the
+// name rules make impossible to collide with.
+const devProduct = "(dev)"
+
+// ErrUnknownFormat reports a -o value that is not one of the three formats.
+var ErrUnknownFormat = errors.New("unknown output format")
+
+// Format is how a report is rendered.
+type Format string
+
+const (
+	// FormatTable is the human-readable column layout.
+	FormatTable Format = "table"
+	// FormatJSON is machine-readable JSON.
+	FormatJSON Format = "json"
+	// FormatYAML is machine-readable YAML.
+	FormatYAML Format = "yaml"
+)
+
+// ParseFormat resolves the -o value against whether stdout is a terminal.
+//
+// An explicit value always wins. With none given the default follows the same
+// tt convention tt package list uses: a terminal gets the table, a pipe or a
+// file gets YAML, so output being consumed by something else is parseable
+// without the caller having to remember a flag.
+func ParseFormat(raw string, tty bool) (Format, error) {
+	switch Format(raw) {
+	case "":
+		if tty {
+			return FormatTable, nil
+		}
+
+		return FormatYAML, nil
+	case FormatTable:
+		return FormatTable, nil
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatYAML:
+		return FormatYAML, nil
+	default:
+		return "", stateErrorf("%w %q (want table, json or yaml)", ErrUnknownFormat, raw)
+	}
+}
+
+// Render writes a report in the chosen format. out carries the report itself;
+// notes carries the narrative about the lock, so a redirected table is the
+// table and nothing else. The machine formats put the lock state in the
+// document and write nothing to notes.
+func Render(out, notes io.Writer, report *Report, format Format) error {
+	switch format {
+	case FormatJSON:
+		return renderJSON(out, report)
+	case FormatYAML:
+		return renderYAML(out, report)
+	case FormatTable:
+		return renderTable(out, notes, report)
+	default:
+		return stateErrorf("%w %q", ErrUnknownFormat, format)
+	}
+}
+
+// renderJSON writes indented JSON with a trailing newline, so the output is
+// pleasant both piped into jq and read directly.
+func renderJSON(out io.Writer, report *Report) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+
+	err := encoder.Encode(report)
+	if err != nil {
+		return fmt.Errorf("rendering JSON: %w", err)
+	}
+
+	return nil
+}
+
+// renderYAML writes YAML at tt's usual two-space indent.
+func renderYAML(out io.Writer, report *Report) error {
+	encoder := yaml.NewEncoder(out)
+	encoder.SetIndent(yamlIndent)
+
+	err := encoder.Encode(report)
+	if err != nil {
+		return fmt.Errorf("rendering YAML: %w", err)
+	}
+
+	return encoder.Close() //nolint:wrapcheck // Close reports the same encode error.
+}
+
+// renderTable writes the human-readable report: one row per dependency, with
+// the product (or the dev closure) it belongs to in the first column.
+//
+// The lock state is a line on notes rather than a column, because it qualifies
+// every version below it at once: a stale lock means the whole VERSION column
+// is what the last resolution chose, not what the next one will. A manifest
+// that declares nothing gets a sentence instead of a bare header, which would
+// read like a bug.
+func renderTable(out, notes io.Writer, report *Report) error {
+	err := renderLockLine(notes, report)
+	if err != nil {
+		return err
+	}
+
+	rows := tableRows(report)
+	if len(rows) == 0 {
+		_, err = fmt.Fprintf(out, "%s declares no dependencies\n", report.Package)
+		if err != nil {
+			return fmt.Errorf("rendering table: %w", err)
+		}
+
+		return nil
+	}
+
+	table := tabwriter.NewWriter(out, 0, 0, tabColumnPadding, ' ', 0)
+
+	_, err = fmt.Fprintln(table, "PRODUCT\tNAME\tCONSTRAINT\tVERSION\tSOURCE\tORIGIN")
+	if err != nil {
+		return fmt.Errorf("rendering table: %w", err)
+	}
+
+	for _, row := range rows {
+		_, err = fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			dash(row.product), row.entry.Name, dash(row.entry.Constraint),
+			dash(row.entry.Version), dash(row.entry.Source), originOf(row.entry))
+		if err != nil {
+			return fmt.Errorf("rendering table: %w", err)
+		}
+	}
+
+	err = table.Flush()
+	if err != nil {
+		return fmt.Errorf("rendering table: %w", err)
+	}
+
+	return nil
+}
+
+// renderLockLine states what the versions below are worth, and says how to fix
+// a lock that cannot answer the question.
+func renderLockLine(out io.Writer, report *Report) error {
+	var line string
+
+	switch report.Lock {
+	case LockMissing:
+		line = "no lock yet: run tt package resolve to pin versions\n\n"
+	case LockStale:
+		line = fmt.Sprintf(
+			"lock is stale (%s): the versions below are the last resolved ones;"+
+				" run tt package resolve\n\n", report.LockReason)
+	case LockCurrent:
+		line = ""
+	default:
+		line = ""
+	}
+
+	if line == "" {
+		return nil
+	}
+
+	_, err := fmt.Fprint(out, line)
+	if err != nil {
+		return fmt.Errorf("rendering table: %w", err)
+	}
+
+	return nil
+}
+
+// tableRow is one rendered line: an entry plus the closure it came from.
+type tableRow struct {
+	product string
+	entry   Entry
+}
+
+// tableRows flattens the report into rows, products in report order and the dev
+// closure last.
+func tableRows(report *Report) []tableRow {
+	var rows []tableRow
+
+	for _, product := range report.Products {
+		for _, entry := range product.Dependencies {
+			rows = append(rows, tableRow{product: product.Name, entry: entry})
+		}
+	}
+
+	for _, entry := range report.DevDependencies {
+		rows = append(rows, tableRow{product: devProduct, entry: entry})
+	}
+
+	return rows
+}
+
+// originOf labels a row as declared by the manifest or pulled in behind a
+// declaration.
+func originOf(entry Entry) string {
+	if entry.Direct {
+		return "direct"
+	}
+
+	return "transitive"
+}
+
+// dash renders an empty field as "-", so a column never looks truncated.
+func dash(value string) string {
+	if value == "" {
+		return "-"
+	}
+
+	return value
+}

--- a/cli/manifest/deps/format_internal_test.go
+++ b/cli/manifest/deps/format_internal_test.go
@@ -1,0 +1,191 @@
+package deps
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// sampleReport is one report covering every shape the renderers have to carry:
+// a direct dependency, an indirect one, a dev dependency, and a stale lock.
+func sampleReport() *Report {
+	return &Report{
+		Package:    "my-app",
+		Lock:       LockStale,
+		LockReason: "manifest changed since the lock was written",
+		Products: []ProductEntries{{
+			Name: "default",
+			Dependencies: []Entry{
+				{
+					Name: "checks", Constraint: ">=3.0.0", Version: "3.1.0-1",
+					Source: "registry", Direct: true, DeclaredIn: []string{"[dependencies]"},
+				},
+				{Name: "luasocket", Version: "3.0.0-1", Source: "registry"},
+			},
+		}},
+		DevDependencies: []Entry{{
+			Name: "luatest", Constraint: "*", Version: "1.0.1-1",
+			Source: "registry", Direct: true, DeclaredIn: []string{"[dev_dependencies]"},
+		}},
+	}
+}
+
+// TestParseFormat_defaultFollowsStdout: a terminal gets the table, anything
+// else gets YAML, so piped output is parseable without a flag.
+func TestParseFormat_defaultFollowsStdout(t *testing.T) {
+	t.Parallel()
+
+	tty, err := ParseFormat("", true)
+	require.NoError(t, err)
+	assert.Equal(t, FormatTable, tty)
+
+	piped, err := ParseFormat("", false)
+	require.NoError(t, err)
+	assert.Equal(t, FormatYAML, piped)
+}
+
+// TestParseFormat_unknownIsRefused: a mistyped -o must not silently fall back
+// to a format the caller did not ask for.
+func TestParseFormat_unknownIsRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseFormat("xml", true)
+	require.ErrorIs(t, err, ErrUnknownFormat)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}
+
+// TestRender_jsonIsValidAndCarriesEveryGroup is the acceptance criterion for
+// -o json: something else parses it, and finds both closures in it.
+func TestRender_jsonIsValidAndCarriesEveryGroup(t *testing.T) {
+	t.Parallel()
+
+	var out, notes bytes.Buffer
+
+	require.NoError(t, Render(&out, &notes, sampleReport(), FormatJSON))
+
+	// A machine format carries the lock state in the document, so nothing is
+	// left for a caller to scrape off the side channel.
+	assert.Empty(t, notes.String())
+
+	var decoded struct {
+		Package  string `json:"package"`
+		Lock     string `json:"lock"`
+		Products []struct {
+			Name         string `json:"name"`
+			Dependencies []struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+				Direct  bool   `json:"direct"`
+			} `json:"dependencies"`
+		} `json:"products"`
+		DevDependencies []struct {
+			Name string `json:"name"`
+		} `json:"dev_dependencies"`
+	}
+
+	require.NoError(t, json.Unmarshal(out.Bytes(), &decoded))
+
+	assert.Equal(t, "my-app", decoded.Package)
+	assert.Equal(t, "stale", decoded.Lock)
+	require.Len(t, decoded.Products, 1)
+	require.Len(t, decoded.Products[0].Dependencies, 2)
+	assert.True(t, decoded.Products[0].Dependencies[0].Direct)
+	assert.False(t, decoded.Products[0].Dependencies[1].Direct)
+	require.Len(t, decoded.DevDependencies, 1)
+	assert.Equal(t, "luatest", decoded.DevDependencies[0].Name)
+}
+
+// TestRender_yamlIsValid covers the format a piped run gets by default.
+func TestRender_yamlIsValid(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	require.NoError(t, Render(&out, io.Discard, sampleReport(), FormatYAML))
+
+	var decoded map[string]any
+
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &decoded))
+
+	assert.Equal(t, "my-app", decoded["package"])
+	assert.Contains(t, decoded, "dev_dependencies")
+}
+
+// TestRender_tableStatesTheLockAndEveryRow: the human view has to say what the
+// versions are worth before showing them, and put the dev closure somewhere a
+// reader can tell apart from a product.
+func TestRender_tableStatesTheLockAndEveryRow(t *testing.T) {
+	t.Parallel()
+
+	var out, notes bytes.Buffer
+
+	require.NoError(t, Render(&out, &notes, sampleReport(), FormatTable))
+
+	// The narrative qualifies the table without being part of it, so a reader
+	// redirecting the table keeps every row and loses no warning.
+	assert.Contains(t, notes.String(), "lock is stale")
+	assert.Contains(t, notes.String(), "tt package resolve")
+	assert.NotContains(t, out.String(), "lock is stale")
+
+	text := out.String()
+	assert.Contains(t, text, "PRODUCT")
+
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	joined := strings.Join(lines, "\n")
+
+	assert.Regexp(t, `default\s+checks\s+>=3\.0\.0\s+3\.1\.0-1\s+registry\s+direct`, joined)
+	assert.Regexp(t, `default\s+luasocket\s+-\s+3\.0\.0-1\s+registry\s+transitive`, joined)
+	assert.Regexp(t, `\(dev\)\s+luatest\s+\*\s+1\.0\.1-1\s+registry\s+direct`, joined)
+}
+
+// TestRender_tableSaysSoWhenNothingIsDeclared: a bare header over an empty
+// table reads as a bug, so the empty case gets a sentence.
+func TestRender_tableSaysSoWhenNothingIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	report := &Report{
+		Package:  "my-app",
+		Lock:     LockCurrent,
+		Products: []ProductEntries{{Name: "default"}},
+	}
+	require.NoError(t, Render(&out, io.Discard, report, FormatTable))
+
+	assert.Equal(t, "my-app declares no dependencies\n", out.String())
+}
+
+// TestRender_tablePointsAMissingLockAtResolve: the answer to "why is the
+// VERSION column empty" belongs in the output, not in the documentation.
+func TestRender_tablePointsAMissingLockAtResolve(t *testing.T) {
+	t.Parallel()
+
+	var out, notes bytes.Buffer
+
+	report := sampleReport()
+
+	report.Lock = LockMissing
+	report.LockReason = ""
+
+	require.NoError(t, Render(&out, &notes, report, FormatTable))
+	assert.Contains(t, notes.String(), "no lock yet: run tt package resolve")
+	assert.NotContains(t, out.String(), "no lock yet")
+}
+
+// TestRender_unknownFormatIsRefused guards the switch's default arm: a format
+// that reached Render unchecked must fail rather than print nothing.
+func TestRender_unknownFormatIsRefused(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+
+	err := Render(&out, io.Discard, sampleReport(), Format("xml"))
+	require.ErrorIs(t, err, ErrUnknownFormat)
+	assert.Empty(t, out.String())
+}

--- a/cli/manifest/deps/report.go
+++ b/cli/manifest/deps/report.go
@@ -1,0 +1,346 @@
+package deps
+
+import (
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// LockState says what the lock next to the manifest is worth as an answer to
+// "which version is this dependency at".
+type LockState string
+
+const (
+	// LockCurrent is a lock that still reflects the manifest: every version it
+	// records is the one a build would use.
+	LockCurrent LockState = "current"
+	// LockStale is a lock the manifest has moved away from. Its versions are
+	// what the last resolution chose, not what the next one will, so a report
+	// over it says so rather than presenting them as current.
+	LockStale LockState = "stale"
+	// LockMissing is a project that has never resolved. Only the declarations
+	// are known then; nothing carries a version yet.
+	LockMissing LockState = "missing"
+)
+
+// Entry is one dependency in a report: what the manifest declares, and what the
+// lock resolved it to.
+//
+// A direct entry is one the manifest declares — globally or through a component
+// of the product — and it carries the constraint that was declared. An indirect
+// one is in the closure because something else required it; it has a version
+// and no constraint, because no declaration in this manifest asked for it.
+type Entry struct {
+	// Name is the rock name.
+	Name string `json:"name" yaml:"name"`
+	// Constraint is the declared version constraint, comma-joined when the name
+	// is declared in more than one place — the same AND the resolver applies, so
+	// the report shows what actually constrains the pick. Empty for an indirect
+	// dependency.
+	Constraint string `json:"constraint,omitempty" yaml:"constraint,omitempty"`
+	// Version is the version the lock records, empty when no lock does.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	// Source is "registry" or "path", from the declaration when there is one and
+	// from the lock otherwise.
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	// Path is the directory a path dependency points at, relative to the
+	// manifest.
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	// Registry is the per-dependency server override, when one is declared.
+	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	// Direct marks a dependency the manifest declares itself.
+	Direct bool `json:"direct" yaml:"direct"`
+	// DeclaredIn names the manifest tables that declare it, in the order
+	// declaredIn reports them. Empty for an indirect dependency.
+	DeclaredIn []string `json:"declared_in,omitempty" yaml:"declared_in,omitempty"`
+}
+
+// ProductEntries is one product's dependencies: what it declares, then what its
+// closure pulled in behind those declarations.
+type ProductEntries struct {
+	// Name is the product name. A manifest that declares no products at all
+	// reports one group with an empty name — its [dependencies] are declared and
+	// worth showing even though nothing resolves them into a closure yet.
+	Name string `json:"name" yaml:"name"`
+	// Dependencies are the product's dependencies: direct ones first, then
+	// indirect ones, each group in name order.
+	Dependencies []Entry `json:"dependencies" yaml:"dependencies"`
+}
+
+// Report is the answer tt package deps prints: every dependency of the current
+// manifest with the version the lock resolved it to.
+type Report struct {
+	// Package is the manifest's package name.
+	Package string `json:"package" yaml:"package"`
+	// Lock says how far the lock's versions can be trusted.
+	Lock LockState `json:"lock" yaml:"lock"`
+	// LockReason explains a stale lock, in the resolver's own words. Empty
+	// otherwise.
+	LockReason string `json:"lock_reason,omitempty" yaml:"lock_reason,omitempty"`
+	// Products are the runtime dependencies, one group per product.
+	Products []ProductEntries `json:"products" yaml:"products"`
+	// DevDependencies are the dev closure, which the manifest declares globally
+	// rather than per product.
+	DevDependencies []Entry `json:"dev_dependencies,omitempty" yaml:"dev_dependencies,omitempty"`
+}
+
+// declaration is one dependency as the manifest declares it, merged across
+// every table that declares it.
+type declaration struct {
+	constraint string
+	source     string
+	path       string
+	registry   string
+	places     []string
+}
+
+// Deps reports what the current manifest depends on, at the versions the lock
+// resolved.
+//
+// It reads the manifest and the lock and nothing else: no registry is queried,
+// nothing is fetched and the lock is not rewritten. That is the whole point of
+// the command — it answers "what does this project depend on" in the time it
+// takes to read two files, and a project whose lock is stale gets that fact
+// reported (Report.Lock) rather than a silently re-resolved answer that the
+// files on disk do not agree with.
+//
+// It is deliberately not tt package list: this is what the manifest declares,
+// whether or not any of it was ever installed.
+func Deps(opts Options) (*Report, error) {
+	proj, err := load(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	state, reason, err := lockState(opts.ProjectDir, proj)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &Report{
+		Package:         proj.manifest.Package.Name,
+		Lock:            state,
+		LockReason:      reason,
+		Products:        productEntries(proj),
+		DevDependencies: devEntries(proj),
+	}
+
+	return report, nil
+}
+
+// lockState classifies the lock the report is read against.
+//
+// Staleness is asked of the resolver rather than re-implemented here, so the
+// command cannot drift from what a build would decide. It needs no adapter: the
+// check reads the manifest hash and the path dependencies' contents, both of
+// which are on disk.
+func lockState(projectDir string, proj *project) (LockState, string, error) {
+	if proj.lock == nil {
+		return LockMissing, "", nil
+	}
+
+	stale, reason, err := resolve.IsStale(projectDir, proj.manifest, proj.lock)
+	if err != nil {
+		return "", "", stateErrorf("checking whether the lock is up to date: %w", err)
+	}
+
+	if stale {
+		return LockStale, reason, nil
+	}
+
+	return LockCurrent, "", nil
+}
+
+// productEntries builds one group per product, merging what the product
+// declares with what its locked closure holds.
+//
+// A manifest declaring no products still reports its [dependencies]: they are
+// declared, the user asked what this project depends on, and answering
+// "nothing" over a populated [dependencies] table would be wrong. The group is
+// then unnamed, which is what it is — no product owns them yet.
+func productEntries(proj *project) []ProductEntries {
+	man := proj.manifest
+
+	names := sortedKeys(man.Products)
+	if len(names) == 0 {
+		names = []string{""}
+	}
+
+	out := make([]ProductEntries, 0, len(names))
+
+	for _, name := range names {
+		declared := declaredFor(man, name)
+
+		var locked []manifest.LockDependency
+
+		if proj.lock != nil {
+			locked = proj.lock.Products[name].Dependencies
+		}
+
+		out = append(out, ProductEntries{
+			Name:         name,
+			Dependencies: entriesOf(declared, locked),
+		})
+	}
+
+	return out
+}
+
+// devEntries builds the dev group: [dev_dependencies] against the lock's dev
+// closure, which is global rather than per product.
+func devEntries(proj *project) []Entry {
+	man := proj.manifest
+	if len(man.DevDependencies) == 0 {
+		return nil
+	}
+
+	declared := map[string]*declaration{}
+	mergeDeclarations(declared, "[dev_dependencies]", man.DevDependencies)
+
+	var locked []manifest.LockDependency
+
+	if proj.lock != nil {
+		locked = proj.lock.DevDependencies
+	}
+
+	return entriesOf(declared, locked)
+}
+
+// declaredFor collects the declarations that apply to one product: the
+// document-level [dependencies] plus the tables of the components the product
+// is built from. It mirrors the resolver's effectiveDeps — same tables, same
+// comma-joined merge — without reaching for the resolver's unexported types.
+//
+// An empty product name is the no-products case: only the global table applies.
+func declaredFor(man *manifest.Manifest, product string) map[string]*declaration {
+	out := map[string]*declaration{}
+
+	mergeDeclarations(out, "[dependencies]", man.Dependencies)
+
+	if product == "" {
+		return out
+	}
+
+	for _, name := range man.Products[product].Components {
+		component, defined := man.Components[name]
+		if !defined {
+			// Validation refuses this; a report over an unvalidated manifest
+			// simply has nothing to add for the missing component.
+			continue
+		}
+
+		mergeDeclarations(out, "[components."+name+".dependencies]", component.Dependencies)
+	}
+
+	return out
+}
+
+// mergeDeclarations folds one declaration table into the accumulator, recording
+// every place a name is declared and AND-ing repeated constraints the way the
+// resolver does.
+func mergeDeclarations(
+	out map[string]*declaration, place string, declared map[string]manifest.Dependency,
+) {
+	for _, name := range sortedKeys(declared) {
+		dependency := declared[name]
+
+		existing, seen := out[name]
+		if !seen {
+			out[name] = &declaration{
+				constraint: dependency.Version,
+				source:     dependency.Source,
+				path:       dependency.Path,
+				registry:   dependency.Registry,
+				places:     []string{place},
+			}
+
+			continue
+		}
+
+		existing.constraint = joinConstraints(existing.constraint, dependency.Version)
+		existing.places = append(existing.places, place)
+
+		if existing.registry == "" {
+			existing.registry = dependency.Registry
+		}
+	}
+}
+
+// joinConstraints AND's two constraint expressions the way the resolver's own
+// merge does: comma-joined, skipping empty halves.
+func joinConstraints(left, right string) string {
+	switch {
+	case left == "":
+		return right
+	case right == "":
+		return left
+	default:
+		return left + "," + right
+	}
+}
+
+// entriesOf turns one closure into report entries: the declared dependencies
+// first, in name order, then whatever the closure holds that no declaration
+// asked for.
+//
+// A declared dependency the closure does not hold is still reported, without a
+// version. That is the ordinary state of a project that has not resolved since
+// the declaration was added, and dropping it would answer "you do not depend on
+// it" over a line the user just wrote.
+func entriesOf(declared map[string]*declaration, locked []manifest.LockDependency) []Entry {
+	versions := make(map[string]manifest.LockDependency, len(locked))
+	for _, dependency := range locked {
+		versions[dependency.Name] = dependency
+	}
+
+	direct := make([]Entry, 0, len(declared))
+
+	for _, name := range sortedKeys(declared) {
+		decl := declared[name]
+		pick := versions[name]
+
+		direct = append(direct, Entry{
+			Name:       name,
+			Constraint: decl.constraint,
+			Version:    pick.Version,
+			Source:     orElse(decl.source, pick.Source),
+			Path:       orElse(decl.path, pick.Path),
+			Registry:   decl.registry,
+			Direct:     true,
+			DeclaredIn: decl.places,
+		})
+	}
+
+	indirect := make([]Entry, 0, len(locked))
+
+	for _, name := range sortedKeys(versions) {
+		if _, isDirect := declared[name]; isDirect {
+			continue
+		}
+
+		pick := versions[name]
+
+		indirect = append(indirect, Entry{
+			Name:       name,
+			Constraint: "",
+			Version:    pick.Version,
+			Source:     pick.Source,
+			Path:       pick.Path,
+			Registry:   "",
+			Direct:     false,
+			DeclaredIn: nil,
+		})
+	}
+
+	return append(direct, indirect...)
+}
+
+// orElse prefers the declaration's own value and falls back to the lock's, so
+// an indirect-only field (the lock's source for a rock nothing declares) still
+// reaches the report.
+func orElse(declared, locked string) string {
+	if declared != "" {
+		return declared
+	}
+
+	return locked
+}

--- a/cli/manifest/deps/report_internal_test.go
+++ b/cli/manifest/deps/report_internal_test.go
@@ -1,0 +1,305 @@
+package deps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// mergedManifest declares the same rock twice — globally and in the one
+// component the product builds — plus a dev dependency. It is what the report
+// has to merge: one entry, both constraints, both places.
+const mergedManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+
+[dependencies]
+checks = '>=3.0.0'
+
+[dev_dependencies]
+luatest = '*'
+
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+
+[components.lua.dependencies]
+checks = '<4.0.0'
+metrics = '>=1.0.0'
+`
+
+// bareManifest declares a dependency and no product at all. Nothing resolves it
+// into a closure, and the report still has to show it.
+const bareManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+
+[dependencies]
+checks = '>=3.0.0'
+`
+
+// currentLock builds a lock whose hash matches source, so the report reads it
+// as current rather than stale. The engine stamps that hash on every lock it
+// writes; a fixture that skips it tests the stale path by accident.
+func currentLock(
+	t *testing.T, source string, pins map[string]string, dev map[string]string,
+) *manifest.Lock {
+	t.Helper()
+
+	man, warnings, err := manifest.ParseManifest([]byte(source))
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	lock := lockOf(pins)
+
+	lock.ManifestHash = man.Hash()
+	lock.DevDependencies = lockOf(dev).Products["default"].Dependencies
+
+	return lock
+}
+
+// entryByName finds one entry of a rendered group.
+func entryByName(t *testing.T, entries []Entry, name string) Entry {
+	t.Helper()
+
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry
+		}
+	}
+
+	require.Failf(t, "no such entry", "%q is not in the report", name)
+
+	return Entry{}
+}
+
+// TestDeps_reportsDeclaredAndLockedVersions is the core of the command: a
+// declared rock carries its constraint and the locked version, and a rock only
+// the closure holds is reported as indirect.
+func TestDeps_reportsDeclaredAndLockedVersions(t *testing.T) {
+	t.Parallel()
+
+	lock := currentLock(t, baseManifest,
+		map[string]string{"checks": "3.1.0-1", "luasocket": "3.0.0-1"}, nil)
+	dir := writeProject(t, baseManifest, lock)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", report.Package)
+	assert.Equal(t, LockCurrent, report.Lock)
+	assert.Empty(t, report.LockReason)
+	require.Len(t, report.Products, 1)
+	assert.Equal(t, "default", report.Products[0].Name)
+
+	entries := report.Products[0].Dependencies
+	require.Len(t, entries, 2)
+
+	// Declared first, then whatever came in behind it.
+	assert.Equal(t, Entry{
+		Name: "checks", Constraint: ">=3.0.0", Version: "3.1.0-1", Source: "registry",
+		Direct: true, DeclaredIn: []string{"[dependencies]"},
+	}, entries[0])
+	assert.Equal(t, Entry{
+		Name: "luasocket", Version: "3.0.0-1", Source: "registry", Direct: false,
+	}, entries[1])
+}
+
+// TestDeps_mergesComponentDeclarations covers a rock declared both globally and
+// by a component of the product: one entry, the constraints AND-ed the way the
+// resolver ANDs them, and both places named.
+func TestDeps_mergesComponentDeclarations(t *testing.T) {
+	t.Parallel()
+
+	lock := currentLock(t, mergedManifest,
+		map[string]string{"checks": "3.1.0-1", "metrics": "1.0.0-1"},
+		map[string]string{"luatest": "1.0.1-1"})
+	dir := writeProject(t, mergedManifest, lock)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	require.Len(t, report.Products, 1)
+
+	checks := entryByName(t, report.Products[0].Dependencies, "checks")
+
+	assert.Equal(t, ">=3.0.0,<4.0.0", checks.Constraint)
+	assert.Equal(t, []string{"[dependencies]", "[components.lua.dependencies]"}, checks.DeclaredIn)
+	assert.True(t, checks.Direct)
+
+	metrics := entryByName(t, report.Products[0].Dependencies, "metrics")
+	assert.Equal(t, []string{"[components.lua.dependencies]"}, metrics.DeclaredIn)
+}
+
+// TestDeps_reportsTheDevClosure pins that dev dependencies are reported, and
+// reported apart from the products: the manifest declares them globally, so
+// there is no product to file them under.
+func TestDeps_reportsTheDevClosure(t *testing.T) {
+	t.Parallel()
+
+	lock := currentLock(t, mergedManifest,
+		map[string]string{"checks": "3.1.0-1"},
+		map[string]string{"luatest": "1.0.1-1", "checks": "3.1.0-1"})
+	dir := writeProject(t, mergedManifest, lock)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	require.Len(t, report.DevDependencies, 2)
+
+	luatest := entryByName(t, report.DevDependencies, "luatest")
+	assert.Equal(t, "1.0.1-1", luatest.Version)
+	assert.True(t, luatest.Direct)
+	assert.Equal(t, []string{"[dev_dependencies]"}, luatest.DeclaredIn)
+
+	// checks is in the dev closure because the runtime side pinned it there; it
+	// is not declared as a dev dependency and must not be reported as one.
+	assert.False(t, entryByName(t, report.DevDependencies, "checks").Direct)
+}
+
+// TestDeps_missingLockReportsDeclarationsWithoutVersions covers a project that
+// has never resolved. Dropping the declarations there would answer "you depend
+// on nothing" over a populated [dependencies] table.
+func TestDeps_missingLockReportsDeclarationsWithoutVersions(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	assert.Equal(t, LockMissing, report.Lock)
+	require.Len(t, report.Products, 1)
+	require.Len(t, report.Products[0].Dependencies, 1)
+
+	checks := report.Products[0].Dependencies[0]
+	assert.Equal(t, "checks", checks.Name)
+	assert.Equal(t, ">=3.0.0", checks.Constraint)
+	assert.Empty(t, checks.Version)
+	assert.True(t, checks.Direct)
+}
+
+// scopedManifest declares one dependency in the long form, pinning both the
+// source and a registry override so the report has something to carry that the
+// lock cannot supply.
+const scopedManifest = `manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+
+[dependencies.checks]
+version = '>=3.0.0'
+source = 'registry'
+registry = 'https://rocks.example.org'
+
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+`
+
+// TestDeps_declaredSourceSurvivesAMissingLock: before the first resolve there
+// is no locked entry to read a source from, and the declaration is the only
+// thing that knows one. Reporting the lock's empty source instead would blank
+// the column for every dependency of an unresolved project.
+func TestDeps_declaredSourceSurvivesAMissingLock(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, scopedManifest, nil)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	require.Len(t, report.Products, 1)
+	require.Len(t, report.Products[0].Dependencies, 1)
+
+	checks := report.Products[0].Dependencies[0]
+	assert.Empty(t, checks.Version)
+	assert.Equal(t, "registry", checks.Source)
+}
+
+// TestDeps_reportsTheDeclaredRegistry: a dependency pointed at a registry other
+// than the default resolves against that one, so a report that omits it cannot
+// explain where a version came from.
+func TestDeps_reportsTheDeclaredRegistry(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, scopedManifest, lockOf(map[string]string{"checks": "3.1.0-1"}))
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	require.Len(t, report.Products, 1)
+	require.Len(t, report.Products[0].Dependencies, 1)
+
+	assert.Equal(t, "https://rocks.example.org", report.Products[0].Dependencies[0].Registry)
+}
+
+// TestDeps_staleLockIsReportedNotHidden is the honesty requirement: the command
+// resolves nothing, so a lock the manifest has moved away from is labelled
+// rather than presented as the current answer.
+func TestDeps_staleLockIsReportedNotHidden(t *testing.T) {
+	t.Parallel()
+
+	// lockOf stamps a hash that no manifest can have.
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.0.0-1"}))
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	assert.Equal(t, LockStale, report.Lock)
+	assert.Equal(t, "manifest changed since the lock was written", report.LockReason)
+	// The stale versions are still shown: they are what a build would use until
+	// the next resolution, and the label says exactly what they are worth.
+	assert.Equal(t, "3.0.0-1",
+		entryByName(t, report.Products[0].Dependencies, "checks").Version)
+}
+
+// TestDeps_manifestWithoutProductsStillReportsDeclarations covers the skeleton
+// tt new writes: dependencies declared, no product to resolve them into.
+func TestDeps_manifestWithoutProductsStillReportsDeclarations(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, bareManifest, nil)
+
+	report, err := Deps(optsFor(dir))
+	require.NoError(t, err)
+
+	require.Len(t, report.Products, 1)
+	assert.Empty(t, report.Products[0].Name)
+	require.Len(t, report.Products[0].Dependencies, 1)
+	assert.Equal(t, "checks", report.Products[0].Dependencies[0].Name)
+}
+
+// TestDeps_missingManifestIsAnError guards the one state that is not a state at
+// all: a directory that holds no package.
+func TestDeps_missingManifestIsAnError(t *testing.T) {
+	t.Parallel()
+
+	report, err := Deps(optsFor(t.TempDir()))
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Equal(t, exitStateError, ExitCode(err))
+}

--- a/cli/manifest/deps/resolve_internal_test.go
+++ b/cli/manifest/deps/resolve_internal_test.go
@@ -1,0 +1,106 @@
+package deps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// TestResolve_holdsEveryLockedVersion is what separates resolve from update:
+// the lock is rewritten from the manifest, but the versions it already holds
+// are preferred. Without the pins a hand edit to one dependency would drag
+// every unrelated one to its newest release.
+func TestResolve_holdsEveryLockedVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{
+		"checks":    "3.1.0-1",
+		"luasocket": "3.0.0-1",
+	}))
+	res := &fakeResolver{}
+
+	_, err := resolveWith(context.Background(), optsFor(dir), res)
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Equal(t, resolve.Pins{"checks": "3.1.0-1", "luasocket": "3.0.0-1"}, res.pins[0])
+}
+
+// TestResolve_leavesTheManifestAlone: resolve changes no declaration, so the
+// file the user hand-edited must come back byte for byte — including the
+// comment the position-preserving editor exists to protect.
+func TestResolve_leavesTheManifestAlone(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.1.0-1"}))
+	res := &fakeResolver{}
+
+	_, err := resolveWith(context.Background(), optsFor(dir), res)
+	require.NoError(t, err)
+
+	assert.Equal(t, baseManifest, manifestOnDisk(t, dir))
+}
+
+// TestResolve_writesTheLockWithTheManifestHash pins the reason the command
+// exists: after it runs the lock matches the manifest on disk, so the very next
+// build does not find it stale.
+func TestResolve_writesTheLockWithTheManifestHash(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.0.0-1"}))
+	res := &fakeResolver{lock: lockOf(map[string]string{"checks": "3.1.0-1"})}
+
+	result, err := resolveWith(context.Background(), optsFor(dir), res)
+	require.NoError(t, err)
+
+	man, warnings, err := manifest.ParseManifest([]byte(manifestOnDisk(t, dir)))
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	assert.Equal(t, man.Hash(), result.Lock.ManifestHash)
+
+	written := lockOnDisk(t, dir)
+	assert.Equal(t, man.Hash(), written.ManifestHash)
+
+	stale, reason, err := resolve.IsStale(dir, man, written)
+	require.NoError(t, err)
+	assert.False(t, stale, reason)
+}
+
+// TestResolve_reportsWhatMoved: the lock is the command's whole output, so the
+// closure changes are what it has to report.
+func TestResolve_reportsWhatMoved(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, lockOf(map[string]string{"checks": "3.0.0-1"}))
+	res := &fakeResolver{lock: lockOf(map[string]string{"checks": "3.1.0-1"})}
+
+	result, err := resolveWith(context.Background(), optsFor(dir), res)
+	require.NoError(t, err)
+
+	assert.Equal(t, []Move{{Name: "checks", From: "3.0.0-1", To: "3.1.0-1"}}, result.Moves)
+	assert.Equal(t, manifest.Change{}, result.Change)
+}
+
+// TestResolve_withoutALockPinsNothing covers the first resolution of a project
+// that has never been built: nothing to hold, and that is a normal state.
+func TestResolve_withoutALockPinsNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := writeProject(t, baseManifest, nil)
+	res := &fakeResolver{lock: lockOf(map[string]string{"checks": "3.1.0-1"})}
+
+	result, err := resolveWith(context.Background(), optsFor(dir), res)
+	require.NoError(t, err)
+
+	require.Len(t, res.pins, 1)
+	assert.Empty(t, res.pins[0])
+	assert.Equal(t, []Move{{Name: "checks", From: "", To: "3.1.0-1"}}, result.Moves)
+	assert.Equal(t, "3.1.0-1",
+		lockOnDisk(t, dir).Products["default"].Dependencies[0].Version)
+}

--- a/cli/manifest/resolve/stale.go
+++ b/cli/manifest/resolve/stale.go
@@ -28,6 +28,21 @@ import (
 // re-resolves and rewrites it (Engine.Resolve); a --locked build treats
 // staleness as a hard error. The engine only reports the fact.
 func (e *Engine) IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, string, error) {
+	return IsStale(e.projectDir, man, lock)
+}
+
+// IsStale is Engine.IsStale without an engine: the check reads the manifest's
+// hash and the path dependencies' contents under projectDir, and queries no
+// registry at all.
+//
+// It is exported in this form for tt package deps, which reports the lock's
+// versions and has to say whether they still stand. That command builds no
+// adapter — it neither resolves nor fetches — and constructing an engine around
+// a nil one to reach a method that never touches it is how a later change to
+// the engine turns into a nil dereference in a read-only command.
+func IsStale(
+	projectDir string, man *manifest.Manifest, lock *manifest.Lock,
+) (bool, string, error) {
 	if lock.ManifestHash != man.Hash() {
 		return true, "manifest changed since the lock was written", nil
 	}
@@ -57,7 +72,7 @@ func (e *Engine) IsStale(man *manifest.Manifest, lock *manifest.Lock) (bool, str
 
 			hash, cached := hashes[dependency.Path]
 			if !cached {
-				computed, err := contentHash(filepath.Join(e.projectDir, dependency.Path))
+				computed, err := contentHash(filepath.Join(projectDir, dependency.Path))
 				if err != nil {
 					return false, "", fmt.Errorf(
 						"checking path dependency %q: %w", dependency.Name, err)

--- a/test/integration/package/conftest.py
+++ b/test/integration/package/conftest.py
@@ -266,13 +266,20 @@ def run_tt(tt_cmd, tree: Tree):
         *args: str,
         stdin: str | None = None,
         cwd: Path | None = None,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess:
+        """`env` replaces the environment outright rather than adding to it.
+
+        That is what makes it useful here: the only caller uses it to take
+        `tarantool` off `PATH`, and an inherited `PATH` would leave it findable.
+        """
         return subprocess.run(
             [str(tt_cmd), *args],
             cwd=cwd or tree.root,
             input=stdin,
             capture_output=True,
             text=True,
+            env=env,
         )
 
     return run

--- a/test/integration/package/test_package_resolve.py
+++ b/test/integration/package/test_package_resolve.py
@@ -1,0 +1,337 @@
+"""End-to-end coverage for `tt package resolve` and `tt package deps`.
+
+`resolve` drives a real resolution against the fixture rock repository served
+over loopback, exactly like the add/remove/update suite next to it: the
+manifest's `registry` key points the one dependency at that server, so the
+closure is resolved for real without a network.
+
+`deps` resolves nothing at all — it reads the manifest and the lock — so its
+tests build the two files by hand and never start a server. That is as much the
+property under test as the output is: the command has to answer from disk.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+import yaml
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11, which is what CI runs.
+    import tomli as tomllib
+
+MANIFEST_HEAD = """manifest_version = '0.1'
+
+[package]
+name = 'my-app'
+
+[platform]
+tarantool = '>=3.0.0'
+tt = '>=3.1.0'
+"""
+
+MANIFEST_TAIL = """
+[products.default]
+components = ['lua']
+default = true
+
+[components.lua]
+path = '.'
+"""
+
+# A comment the resolve path must leave alone: it changes no declaration, so the
+# manifest has to come back byte for byte.
+KEEP_COMMENT = "# keep me: resolve must not rewrite the manifest."
+
+# The hash placeholder every lock fixture below carries; `current_lock` swaps it
+# for the real one when the lock is meant to look current.
+NO_HASH = "0" * 64
+
+LOCK_HEAD = f"""lock_version = '0.1'
+manifest_version = '0.1'
+generated_by = 'tt 3.0.0'
+manifest_hash = 'sha256:{NO_HASH}'
+"""
+
+LOCK_ENTRY = """
+[[lock.products.default.dependencies]]
+name = '{name}'
+version = '{version}'
+source = 'registry'
+"""
+
+
+def local_dependency(server: str, constraint: str) -> str:
+    """Render a long-form dependency pinned to the loopback rock server."""
+    return (
+        f"\n{KEEP_COMMENT}\n"
+        "[dependencies.stat]\n"
+        "source = 'registry'\n"
+        f"registry = '{server}'\n"
+        f"version = '{constraint}'\n"
+    )
+
+
+def write_manifest(root: Path, body: str, tail: str = MANIFEST_TAIL) -> str:
+    """Write a manifest built from head + body + tail and return its text."""
+    text = MANIFEST_HEAD + body + tail
+    (root / "app.manifest.toml").write_text(text)
+    return text
+
+
+def render_lock(pins: dict[str, str]) -> str:
+    return LOCK_HEAD + "".join(
+        LOCK_ENTRY.format(name=name, version=version) for name, version in sorted(pins.items())
+    )
+
+
+def write_lock(root: Path, pins: dict[str, str], *, current: bool) -> None:
+    """Write a lock over the given pins.
+
+    With `current=True` it carries the hash of the manifest as it stands on
+    disk, which is what makes tt read it as up to date; otherwise it keeps the
+    all-zero placeholder, which no manifest can hash to, and tt reads it as
+    stale.
+    """
+    text = render_lock(pins)
+    if current:
+        digest = hashlib.sha256((root / "app.manifest.toml").read_bytes()).hexdigest()
+        text = text.replace(NO_HASH, digest)
+    (root / "app.manifest.lock").write_text(text)
+
+
+def read_lock(root: Path) -> dict:
+    with (root / "app.manifest.lock").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def locked_versions(root: Path, product: str = "default") -> dict[str, str]:
+    """One product's closure as name -> version."""
+    closure = read_lock(root)["lock"]["products"][product].get("dependencies", [])
+    return {entry["name"]: entry["version"] for entry in closure}
+
+
+def manifest_hash(root: Path) -> str:
+    digest = hashlib.sha256((root / "app.manifest.toml").read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def test_resolve_rewrites_the_lock_without_building(tree, run_tt, rock_server):
+    """`resolve` brings a hand-edited manifest's lock back in step.
+
+    Nothing is materialized into `.rocks/` and no backend runs: the point of the
+    command is that it costs a resolution and nothing more.
+    """
+    root = tree.root
+    write_manifest(root, local_dependency(rock_server, ">=0.3.1"))
+
+    result = run_tt("package", "resolve")
+    assert result.returncode == 0, result.stderr
+
+    assert locked_versions(root) == {"stat": "0.3.2-1"}
+    # The lock records the manifest as it stands, so the next command does not
+    # find it stale.
+    assert read_lock(root)["manifest_hash"] == manifest_hash(root)
+    # And the manifest is byte for byte what the user wrote.
+    assert KEEP_COMMENT in (root / "app.manifest.toml").read_text()
+
+
+def test_resolve_holds_the_versions_the_lock_already_has(tree, run_tt, rock_server):
+    """A resolve is not an update: a locked version that still fits is kept.
+
+    `stat` is served at 0.3.1 and 0.3.2 and the manifest allows both. An
+    unpinned re-resolution would take 0.3.2; holding what the lock has is what
+    keeps a hand edit to one dependency from moving the others.
+    """
+    root = tree.root
+    write_manifest(root, local_dependency(rock_server, ">=0.3.1"))
+    write_lock(root, {"stat": "0.3.1-1"}, current=True)
+
+    result = run_tt("package", "resolve")
+    assert result.returncode == 0, result.stderr
+
+    assert locked_versions(root) == {"stat": "0.3.1-1"}
+    assert "the lock is up to date" in result.stdout
+
+
+def test_resolve_holds_pins_from_a_stale_lock(tree, run_tt, rock_server):
+    """The pins hold even when the lock is the stale one that prompted the run.
+
+    This is the case the command exists for — a manifest edited by hand, so its
+    hash no longer matches — and it is where holding the pins matters most: the
+    edit is allowed to move the closure, the rest of it is not. `stat` is served
+    at 0.3.2 as well, and an unpinned resolution would take it.
+    """
+    root = tree.root
+    write_manifest(root, local_dependency(rock_server, ">=0.3.1"))
+    write_lock(root, {"stat": "0.3.1-1"}, current=False)
+
+    result = run_tt("package", "resolve")
+    assert result.returncode == 0, result.stderr
+
+    assert locked_versions(root) == {"stat": "0.3.1-1"}
+    # Stale no more: the rewritten lock carries the current manifest's hash.
+    assert read_lock(root)["manifest_hash"] == manifest_hash(root)
+
+
+def test_resolve_satisfies_a_locked_build(tree, run_tt, rock_server):
+    """The lock `resolve` writes is one a `--locked` build accepts as it is.
+
+    A `--locked` build refuses a stale lock and re-resolves nothing, so it
+    passing over the freshly resolved lock — and leaving its pins alone — is the
+    assertion that `resolve` produces what a build would have.
+
+    The project has never resolved, so nothing is pinned and the resolution is
+    the same unpinned one a first build would run.
+    """
+    root = tree.root
+    write_manifest(root, local_dependency(rock_server, ">=0.3.1"))
+
+    resolved = run_tt("package", "resolve")
+    assert resolved.returncode == 0, resolved.stderr
+    after_resolve = read_lock(root)
+
+    build = run_tt("package", "build", "--locked")
+    assert build.returncode == 0, build.stderr
+
+    assert read_lock(root)["lock"] == after_resolve["lock"]
+    assert locked_versions(root) == {"stat": "0.3.2-1"}
+
+
+def test_resolve_without_a_manifest_fails(run_tt):
+    """A directory holding no package is an error, not an empty success."""
+    result = run_tt("package", "resolve")
+
+    assert result.returncode == 1
+    assert "app.manifest.toml" in result.stderr
+
+
+def test_deps_reports_declared_and_locked_versions(tree, run_tt):
+    """`deps` answers from the manifest and the lock, with no server at all."""
+    root = tree.root
+    write_manifest(root, "\n[dependencies]\nstat = '>=0.3.1'\n")
+    write_lock(root, {"stat": "0.3.2-1", "luasocket": "3.0.0-1"}, current=True)
+
+    result = run_tt("package", "deps")
+    assert result.returncode == 0, result.stderr
+
+    # Piped output defaults to YAML, so this is parseable without a flag.
+    report = yaml.safe_load(result.stdout)
+    assert report["package"] == "my-app"
+    assert report["lock"] == "current"
+
+    entries = {entry["name"]: entry for entry in report["products"][0]["dependencies"]}
+    assert entries["stat"]["constraint"] == ">=0.3.1"
+    assert entries["stat"]["version"] == "0.3.2-1"
+    assert entries["stat"]["direct"] is True
+    # Nothing declares luasocket: it is in the closure behind stat.
+    assert entries["luasocket"]["version"] == "3.0.0-1"
+    assert entries["luasocket"]["direct"] is False
+
+
+def test_deps_json_is_valid(tree, run_tt):
+    """`-o json` is the machine-readable contract; it has to parse."""
+    root = tree.root
+    write_manifest(
+        root,
+        "\n[dependencies]\nstat = '>=0.3.1'\n\n[dev_dependencies]\nluatest = '*'\n",
+    )
+
+    result = run_tt("package", "deps", "-o", "json")
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(result.stdout)
+    assert report["package"] == "my-app"
+    # Never resolved: the declarations are known, the versions are not.
+    assert report["lock"] == "missing"
+
+    declared = report["products"][0]["dependencies"][0]
+    assert declared["name"] == "stat"
+    assert "version" not in declared
+    assert report["dev_dependencies"][0]["name"] == "luatest"
+
+
+def test_deps_reports_a_stale_lock_rather_than_re_resolving(tree, run_tt):
+    """A lock the manifest moved away from is labelled, not silently refreshed.
+
+    The command contacts no registry, so presenting its versions as current
+    would be a lie — and re-resolving behind the user's back would make a
+    read-only command write files.
+    """
+    root = tree.root
+    write_manifest(root, "\n[dependencies]\nstat = '>=0.3.1'\n")
+    write_lock(root, {"stat": "0.3.1-1"}, current=False)
+    before = (root / "app.manifest.lock").read_text()
+
+    result = run_tt("package", "deps")
+    assert result.returncode == 0, result.stderr
+
+    report = yaml.safe_load(result.stdout)
+    assert report["lock"] == "stale"
+    assert "manifest changed" in report["lock_reason"]
+    # Read-only: the lock on disk is untouched.
+    assert (root / "app.manifest.lock").read_text() == before
+
+
+def test_deps_reports_each_product_separately(tree, run_tt):
+    """Products hold independent closures, so each is reported on its own."""
+    root = tree.root
+    write_manifest(
+        root,
+        "\n[dependencies]\nstat = '>=0.3.1'\n",
+        tail="""
+[products.default]
+components = ['lua']
+default = true
+
+[products.extra]
+components = ['native']
+
+[components.lua]
+path = '.'
+
+[components.native]
+path = 'native'
+
+[components.native.dependencies]
+luasocket = '>=3.0.0'
+""",
+    )
+
+    result = run_tt("package", "deps", "-o", "json")
+    assert result.returncode == 0, result.stderr
+
+    products = {product["name"]: product for product in json.loads(result.stdout)["products"]}
+    assert set(products) == {"default", "extra"}
+
+    def names(product: str) -> set[str]:
+        return {entry["name"] for entry in products[product]["dependencies"]}
+
+    # The global table applies to both; the component's table only to the
+    # product built from that component.
+    assert names("default") == {"stat"}
+    assert names("extra") == {"stat", "luasocket"}
+
+
+def test_deps_without_a_manifest_fails(run_tt):
+    """Same as resolve: no package here is an error, not an empty report."""
+    result = run_tt("package", "deps")
+
+    assert result.returncode == 1
+    assert "app.manifest.toml" in result.stderr
+
+
+def test_deps_needs_no_tarantool(tree, run_tt):
+    """The report is a read of two files, so no tarantool has to be around.
+
+    `PATH` is emptied, which is what a machine that never installed Tarantool
+    looks like to the command. Every re-resolving command fails there; this one
+    must not, because it resolves nothing.
+    """
+    root = tree.root
+    write_manifest(root, "\n[dependencies]\nstat = '>=0.3.1'\n")
+
+    result = run_tt("package", "deps", "-o", "json", env={"PATH": "/nonexistent"})
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["package"] == "my-app"


### PR DESCRIPTION
Two thin commands over machinery that was already there.

`tt package resolve` rewrites the lock from the manifest without building — the way back into step after editing `[dependencies]` by hand, without waiting for a build to notice. It holds every version the lock already pinned, so a hand edit to one dependency is not a request to move the others; pulling newer versions from the registry stays `tt package update`'s job.

`tt package deps` prints what the manifest declares — per product, plus the dev closure — at the versions the lock resolved. It reads two files and queries nothing, which is why it needs no Tarantool at all and why a lock the manifest has moved away from is reported as stale instead of being silently re-resolved: a read-only command must not write, and presenting last week's picks as current would be worse than saying so. A declared dependency the closure does not hold is still listed, without a version, since that is the ordinary state right after a declaration is added.

The table's first column is `PRODUCT` and its last is `ORIGIN`, spelling each closure's name and whether a row was declared or pulled in behind a declaration; `kind` and `scope` already mean other things on this surface, so neither word is reused. The lock state goes to stderr, so a redirected table is rows alone while a reader watching the terminal still learns the versions are stale. The machine formats carry the same state as `lock` and `lock_reason` fields.

Closes TNTP-9959