### PR TITLE
cli/cmd: tt new writes the manifest skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dependency forward; `tt package update` is the only command that pulls fresh
   versions from the registry, and with a name it moves that one dependency and
   holds the rest.
+- `tt new`: create a skeleton `app.manifest.toml` in the current directory —
+  the format version, the package name, the Tarantool and tt requirements and
+  an empty `[dependencies]` table for `tt package add` to write into. The name
+  comes from `-n`, or from the directory when that is already a package name;
+  a directory named anything else is refused with the name it would have to be,
+  rather than being silently rewritten. Components and products are left as
+  commented examples, since their contents depend on a layout only the author
+  knows. An existing manifest is never overwritten: the command fails instead.
+  This is not `tt create`, which lays out a whole application from a template.
 - `tt package resolve`: rewrite `app.manifest.lock` from the manifest without
   building — the way to bring the lock back in step after editing
   `[dependencies]` by hand. Nothing is fetched into `.rocks/` and no component

--- a/cli/cmd/new.go
+++ b/cli/cmd/new.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/tarantool/tt/cli/manifest/scaffold"
+)
+
+// NewNewCmd creates `tt new`: the skeleton app.manifest.toml a package starts
+// from.
+//
+// It is a top-level command rather than a `tt package` subcommand because it is
+// what runs before a package exists — every `tt package` command reads the file
+// this one writes.
+func NewNewCmd() *cobra.Command {
+	newCmd := &cobra.Command{
+		Use:   "new",
+		Short: "Create a skeleton app.manifest.toml in the current directory",
+		Long: "Write the manifest a tt package is described by: the format " +
+			"version, the package name, the Tarantool and tt version " +
+			"requirements and an empty [dependencies] table for tt package add " +
+			"to write into. The name comes from -n, or from the directory when " +
+			"that is already a package name — lowercase letters, digits and " +
+			"dashes, starting with a letter. Components and products are left as " +
+			"commented examples, since their contents depend on a layout only " +
+			"the author knows. An existing app.manifest.toml is never " +
+			"overwritten — the command fails instead. This is not tt create, " +
+			"which lays out a whole application from a template; tt new adds one " +
+			"file to a directory that may already hold a project.",
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := runNew(); err != nil {
+				log.Error(err.Error())
+				os.Exit(scaffold.ExitCode(err))
+			}
+		},
+		Example: `
+# Create a manifest for the project in the current directory.
+
+    $ tt new
+
+# Name the package explicitly, when the directory is not named for it.
+
+    $ tt new -n my-app`,
+	}
+
+	newCmd.Flags().StringVarP(&newPackageName, "name", "n", "",
+		"package name to declare; defaults to the directory name")
+
+	return newCmd
+}
+
+// newPackageName holds the -n value.
+var newPackageName string
+
+// runNew writes the skeleton manifest and reports where it landed.
+func runNew() error {
+	projectDir, err := absoluteWorkingDir()
+	if err != nil {
+		return err
+	}
+
+	result, err := scaffold.Create(scaffold.Options{
+		ProjectDir: projectDir,
+		Name:       newPackageName,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("created %s for package %s\n", result.Path, result.Package)
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -187,6 +187,7 @@ func NewCmdRoot() *cobra.Command {
 		NewSearchCmd(),
 		NewCleanCmd(),
 		NewCreateCmd(),
+		NewNewCmd(),
 		NewInstallCmd(),
 		NewUninstallCmd(),
 		NewPackageCmd(),

--- a/cli/manifest/scaffold/scaffold.go
+++ b/cli/manifest/scaffold/scaffold.go
@@ -1,0 +1,236 @@
+// Package scaffold writes the skeleton app.manifest.toml that tt new creates.
+//
+// It is deliberately small and deliberately not cli/create: that command lays
+// out a whole application from a template, while this one writes a single file
+// into a directory that may already hold a project. A manifest is the one thing
+// every tt package command needs and the one thing a rockspec-era project does
+// not have, so tt new is the smallest possible step into the manifest pipeline
+// rather than a project generator.
+//
+// What it writes is the minimum a manifest needs to be valid — the format
+// version, the package identity, the platform requirements and an empty
+// [dependencies] table for tt package add to write into. Components and
+// products, which a package needs before it can be built, are left as commented
+// examples: guessing a layout for an existing directory would be wrong more
+// often than right, and a wrong guess costs more than an absent one.
+package scaffold
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/build"
+)
+
+// manifestFileName is the file tt new creates, next to which every other
+// package command expects to run.
+const manifestFileName = "app.manifest.toml"
+
+// filePerm is the mode the new manifest is created with: a hand-edited source
+// file, like the rest of a project's sources.
+const filePerm os.FileMode = 0o644
+
+// suggestedPackageName is what the error suggests when the directory name
+// cannot be turned into a package name at all. It is always valid, so the
+// message always names something the user can pass straight back.
+const suggestedPackageName = "app"
+
+// exitStateError is the process exit code for a usage or state failure, the
+// same one every other package command uses.
+const exitStateError = 1
+
+// ErrManifestExists reports a directory that already holds a manifest. tt new
+// refuses rather than overwriting: the existing file is hand-authored, may hold
+// a whole project's dependencies, and nothing about "create a skeleton" implies
+// consent to lose it.
+var ErrManifestExists = errors.New("a manifest already exists")
+
+// ExitError re-exports build.ExitError so tt new returns the same typed error
+// the other package commands do.
+type ExitError = build.ExitError
+
+// ExitCode returns the process exit code for err, reusing the build package's
+// mapping so every manifest command agrees. A nil error is 0.
+func ExitCode(err error) int {
+	return build.ExitCode(err)
+}
+
+// Options configures one tt new run.
+type Options struct {
+	// ProjectDir is the directory the manifest is created in. Required and must
+	// be absolute.
+	ProjectDir string
+	// Name is the package name to declare. Empty takes the name from the
+	// directory, which then has to be a package name already.
+	Name string
+}
+
+// Result reports what was created.
+type Result struct {
+	// Path is the manifest that was written.
+	Path string
+	// Package is the package name it declares.
+	Package string
+}
+
+// Create writes the skeleton manifest into opts.ProjectDir.
+//
+// The package name is opts.Name, or the directory name when that is empty. A
+// directory whose name is not already a package name is refused, with the name
+// it would have to be: silently rewriting "My_App" to "my-app" would put a name
+// in the manifest that the user never chose and would not think to look for.
+//
+// An existing manifest is never overwritten. The file is created with O_EXCL,
+// so the check and the write are one operation and a concurrent run cannot slip
+// between them.
+func Create(opts Options) (*Result, error) {
+	name, err := packageNameFor(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	source := render(name)
+
+	// Generate, then validate what was generated: this file is the one thing
+	// standing between tt new and every later command, and a skeleton that does
+	// not parse would only be discovered by the next command the user runs.
+	err = validate(source)
+	if err != nil {
+		return nil, stateErrorf("the generated manifest is not valid: %w", err)
+	}
+
+	path := filepath.Join(opts.ProjectDir, manifestFileName)
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, stateErrorf("%s: %w", manifestFileName, ErrManifestExists)
+		}
+
+		return nil, stateErrorf("creating %s: %w", manifestFileName, err)
+	}
+
+	_, err = file.WriteString(source)
+	if err != nil {
+		// Leaves a truncated file behind, which the next run then refuses. That
+		// is the honest outcome: the write failed for a reason (a full disk, a
+		// read-only mount) that removing the file would not fix and might hide.
+		file.Close()
+
+		return nil, stateErrorf("writing %s: %w", manifestFileName, err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return nil, stateErrorf("writing %s: %w", manifestFileName, err)
+	}
+
+	return &Result{Path: path, Package: name}, nil
+}
+
+// packageNameFor resolves the package name to declare: the one given, or the
+// project directory's own name.
+//
+// A name that is not a package name is refused either way. When it came from
+// the directory the message carries the name it would have to be, so the fix is
+// one flag away; when the user typed it, the shape rules are the answer.
+func packageNameFor(opts Options) (string, error) {
+	if opts.Name != "" {
+		if !manifest.ValidPackageName(opts.Name) {
+			return "", stateErrorf(
+				"%q is not a package name: use lowercase letters, digits and dashes,"+
+					" starting with a letter", opts.Name)
+		}
+
+		return opts.Name, nil
+	}
+
+	dirName := filepath.Base(opts.ProjectDir)
+	if manifest.ValidPackageName(dirName) {
+		return dirName, nil
+	}
+
+	suggestion := normalizeName(dirName)
+	if suggestion == "" {
+		suggestion = suggestedPackageName
+	}
+
+	return "", stateErrorf("%q is not a package name; run: tt new -n %s", dirName, suggestion)
+}
+
+// normalizeName turns a directory name into the package name it would have to
+// be, or returns "" when no such name falls out of it.
+//
+// Package names are [a-z][a-z0-9-]*, so the mapping lowercases, replaces every
+// other character with a dash, and collapses the runs a replacement produces —
+// "My App (v2)" becomes "my-app-v2". A name that still does not fit the shape
+// afterwards, or that is one of the reserved names, yields nothing rather than
+// being mangled further: "2do" could become "app-2do", but a suggestion with an
+// invented prefix is worse than no suggestion.
+func normalizeName(dirName string) string {
+	var out strings.Builder
+
+	for _, r := range strings.ToLower(dirName) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			out.WriteRune(r)
+		default:
+			out.WriteByte('-')
+		}
+	}
+
+	name := collapseDashes(out.String())
+	if !manifest.ValidPackageName(name) {
+		return ""
+	}
+
+	return name
+}
+
+// collapseDashes squeezes runs of dashes into one and trims the ends, so a name
+// built by replacing punctuation does not carry the punctuation's shape.
+func collapseDashes(name string) string {
+	parts := strings.Split(name, "-")
+
+	kept := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		if part != "" {
+			kept = append(kept, part)
+		}
+	}
+
+	return strings.Join(kept, "-")
+}
+
+// validate parses and validates generated source the way every command that
+// reads a manifest will.
+func validate(source string) error {
+	man, warnings, err := manifest.ParseManifest([]byte(source))
+	if err != nil {
+		return err //nolint:wrapcheck // Caller wraps with the file it came from.
+	}
+
+	if len(warnings) > 0 {
+		return fmt.Errorf("%w: %s", errUnexpectedWarning, strings.Join(warnings, "; "))
+	}
+
+	_, err = man.Validate()
+
+	return err //nolint:wrapcheck // Caller wraps with the file it came from.
+}
+
+// errUnexpectedWarning guards against a template this build of tt would itself
+// warn about — an unknown field, say, left behind by a format bump.
+var errUnexpectedWarning = errors.New("the generated manifest produced warnings")
+
+// stateErrorf wraps a formatted error as a state error (exit 1).
+//
+//nolint:err113 // Formatting helper, mirrors fmt.Errorf; callers pass %w wraps.
+func stateErrorf(format string, args ...any) error {
+	return &ExitError{Code: exitStateError, Err: fmt.Errorf(format, args...)}
+}

--- a/cli/manifest/scaffold/scaffold_internal_test.go
+++ b/cli/manifest/scaffold/scaffold_internal_test.go
@@ -1,0 +1,275 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/tt/cli/manifest"
+	"github.com/tarantool/tt/cli/manifest/resolve"
+)
+
+// projectDir makes a temp directory with the given name under it, so the name
+// derivation can be exercised: the package name comes from the directory, and
+// t.TempDir()'s own name is not one a test can choose.
+func projectDir(t *testing.T, name string) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+
+	return dir
+}
+
+// readManifest reads back the file Create wrote.
+func readManifest(t *testing.T, dir string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, manifestFileName)) //nolint:gosec // temp path
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// TestCreate_writesAValidManifest is the acceptance criterion: what tt new
+// writes has to survive the same parse and validation every later command runs
+// it through.
+func TestCreate_writesAValidManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := projectDir(t, "my-app")
+
+	result, err := Create(Options{ProjectDir: dir})
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(dir, manifestFileName), result.Path)
+	assert.Equal(t, "my-app", result.Package)
+
+	man, warnings, err := manifest.ParseManifest([]byte(readManifest(t, dir)))
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	validationWarnings, err := man.Validate()
+	require.NoError(t, err)
+	assert.Empty(t, validationWarnings)
+
+	assert.Equal(t, manifest.ManifestVersion, man.ManifestVersion)
+	assert.Equal(t, "my-app", man.Package.Name)
+	assert.Equal(t, defaultTarantoolConstraint, man.Platform.Tarantool.Version)
+	assert.Equal(t, defaultTtConstraint, man.Platform.Tt.Version)
+	// The table is there and empty: tt package add splices into it, and an
+	// absent table is a different edit from an empty one.
+	assert.Contains(t, readManifest(t, dir), "[dependencies]")
+	assert.Empty(t, man.Dependencies)
+}
+
+// TestCreate_secondRunRefuses: a manifest is hand-authored and may hold a whole
+// project's dependencies, so "create a skeleton" is never consent to lose it.
+func TestCreate_secondRunRefuses(t *testing.T) {
+	t.Parallel()
+
+	dir := projectDir(t, "my-app")
+
+	_, err := Create(Options{ProjectDir: dir})
+	require.NoError(t, err)
+
+	before := readManifest(t, dir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, manifestFileName), []byte(before+"\n# edited by hand\n"), 0o600))
+
+	_, err = Create(Options{ProjectDir: dir})
+	require.ErrorIs(t, err, ErrManifestExists)
+	assert.Equal(t, exitStateError, ExitCode(err))
+	// The hand edit is still there: the refusal happened before any write.
+	assert.Contains(t, readManifest(t, dir), "# edited by hand")
+}
+
+// TestCreate_takesThePackageNameFromTheDirectory covers the directory names
+// that are already package names and are therefore used as they are.
+func TestCreate_takesThePackageNameFromTheDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, dirName := range []string{"my-app", "app", "tt-project", "a1"} {
+		t.Run(dirName, func(t *testing.T) {
+			t.Parallel()
+
+			dir := projectDir(t, dirName)
+
+			result, err := Create(Options{ProjectDir: dir})
+			require.NoError(t, err)
+			assert.Equal(t, dirName, result.Package)
+
+			man, _, err := manifest.ParseManifest([]byte(readManifest(t, dir)))
+			require.NoError(t, err)
+			_, err = man.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestCreate_refusesADirectoryNameThatIsNotAPackageName: naming the package
+// after a directory that only resembles a package name would put a name in the
+// manifest the user never chose. The message carries the name that would work,
+// so the fix is one flag away, and nothing is written in the meantime.
+func TestCreate_refusesADirectoryNameThatIsNotAPackageName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"MyApp":     "myapp",
+		"My App v2": "my-app-v2",
+		"my_app":    "my-app",
+		"app.tt":    "app-tt",
+		"--weird--": "weird",
+		"2do":       suggestedPackageName, // Must start with a letter.
+		"bin":       suggestedPackageName, // Reserved.
+		"...":       suggestedPackageName, // Nothing survives normalizing.
+	}
+
+	for dirName, suggestion := range cases {
+		t.Run(dirName, func(t *testing.T) {
+			t.Parallel()
+
+			dir := projectDir(t, dirName)
+
+			_, err := Create(Options{ProjectDir: dir})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), dirName)
+			assert.Contains(t, err.Error(), "tt new -n "+suggestion)
+
+			assert.NoFileExists(t, filepath.Join(dir, manifestFileName))
+		})
+	}
+}
+
+// TestCreate_namesThePackageExplicitly: -n is what makes the refusal above
+// actionable, so the name it carries has to reach the manifest whatever the
+// directory is called.
+func TestCreate_namesThePackageExplicitly(t *testing.T) {
+	t.Parallel()
+
+	dir := projectDir(t, "Some_Directory")
+
+	result, err := Create(Options{ProjectDir: dir, Name: "my-app"})
+	require.NoError(t, err)
+	assert.Equal(t, "my-app", result.Package)
+	assert.Contains(t, readManifest(t, dir), `name = "my-app"`)
+}
+
+// TestCreate_refusesAnExplicitNameThatIsNotOne: -n is not an escape from the
+// name rules, and a manifest that fails to validate is worse than a refusal.
+func TestCreate_refusesAnExplicitNameThatIsNotOne(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"My_App", "2do", "bin", ""} {
+		t.Run("name="+name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := projectDir(t, "Some_Directory")
+
+			_, err := Create(Options{ProjectDir: dir, Name: name})
+			require.Error(t, err)
+			assert.NoFileExists(t, filepath.Join(dir, manifestFileName))
+		})
+	}
+}
+
+// TestCreate_quotesLikeTheDependencyEditor: tt package add writes double-quoted
+// values, so a skeleton quoted otherwise would make the first add read as a
+// reformat of the file.
+func TestCreate_quotesLikeTheDependencyEditor(t *testing.T) {
+	t.Parallel()
+
+	dir := projectDir(t, "my-app")
+
+	_, err := Create(Options{ProjectDir: dir})
+	require.NoError(t, err)
+
+	source := readManifest(t, dir)
+	assert.Contains(t, source, `name = "my-app"`)
+	assert.NotContains(t, source, "'")
+
+	// And the editor accepts the file: an add against the skeleton is the very
+	// next thing a user does.
+	editor, err := manifest.NewEditor([]byte(source))
+	require.NoError(t, err)
+
+	_, err = editor.SetDependency(manifest.TableDependencies, "checks", ">=3.0.0")
+	require.NoError(t, err)
+
+	edited, _, err := manifest.ParseManifest(editor.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, ">=3.0.0", edited.Dependencies["checks"].Version)
+}
+
+// TestSkeleton_commentedExamplesAreValid: the commented component and product
+// block is the next step a user takes, by uncommenting it. If it does not parse
+// and validate, it is worse than absent.
+func TestSkeleton_commentedExamplesAreValid(t *testing.T) {
+	t.Parallel()
+
+	uncommented := uncomment(render("my-app"))
+
+	man, warnings, err := manifest.ParseManifest([]byte(uncommented))
+	require.NoError(t, err, uncommented)
+	require.Empty(t, warnings)
+
+	_, err = man.Validate()
+	require.NoError(t, err)
+
+	require.Contains(t, man.Components, "app")
+	require.Contains(t, man.Products, "default")
+	assert.True(t, man.Products["default"].Default)
+	assert.Equal(t, "*", man.DevDependencies["luatest"].Version)
+
+	// Validation keeps a constraint verbatim and leaves the range to the
+	// resolver, so parsing the example proves nothing about whether it can be
+	// resolved. Every constraint the skeleton suggests is checked where the
+	// failure would actually land.
+	for name, dependency := range man.DevDependencies {
+		require.NoError(t, resolve.ValidateConstraint(dependency.Version), name)
+	}
+
+	for name, dependency := range man.Dependencies {
+		require.NoError(t, resolve.ValidateConstraint(dependency.Version), name)
+	}
+}
+
+// TestRender_isTOML guards the template itself: a stray unquoted value would
+// otherwise only be caught by the validation inside Create.
+func TestRender_isTOML(t *testing.T) {
+	t.Parallel()
+
+	var decoded map[string]any
+	require.NoError(t, toml.Unmarshal([]byte(render("my-app")), &decoded))
+	assert.Contains(t, decoded, "dependencies")
+}
+
+// tomlLine matches a commented line that is TOML rather than prose: a table
+// header, or a key assignment. Matching on "contains a bracket" instead would
+// uncomment the sentence documenting `tt package add <name> [<constraint>]`,
+// which is how this helper got written wrong the first time.
+var tomlLine = regexp.MustCompile(`^(\[[\w.]+\]|[\w-]+ = )`)
+
+// uncomment strips the leading "# " from every commented line that carries TOML,
+// which is what a user does by hand to the skeleton's examples.
+func uncomment(source string) string {
+	var out strings.Builder
+
+	for _, line := range strings.Split(source, "\n") {
+		trimmed := strings.TrimPrefix(line, "# ")
+		if trimmed != line && tomlLine.MatchString(trimmed) {
+			line = trimmed
+		}
+
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+
+	return out.String()
+}

--- a/cli/manifest/scaffold/template.go
+++ b/cli/manifest/scaffold/template.go
@@ -1,0 +1,65 @@
+package scaffold
+
+import (
+	"fmt"
+
+	"github.com/tarantool/tt/cli/manifest"
+)
+
+// Default platform constraints for a new package. The manifest pipeline itself
+// is a tt 3.x feature and the manifest format targets Tarantool 3.x, so these
+// are the floors below which nothing here works at all — not a guess at what
+// the project needs, which only its author knows.
+const (
+	defaultTarantoolConstraint = ">=3.0.0"
+	defaultTtConstraint        = ">=3.0.0"
+)
+
+// skeleton is the manifest tt new writes. It carries two placeholders: the
+// format version this build writes, and the package name.
+//
+// Quoting is double quotes throughout, which is what the manifest editor writes
+// when tt package add splices a dependency in. A skeleton quoted differently
+// would make the first add look like a reformat in the diff.
+//
+// Components and products are commented rather than declared. A package needs
+// both before tt package build has anything to build, but their contents depend
+// on a layout only the author knows, and a wrong products.default is worse than
+// an absent one: it builds, quietly, from the wrong files. The commented block
+// is there so the next step is visible without a trip to the documentation.
+const skeleton = `manifest_version = "%s"
+
+[package]
+name = "%s"
+
+# The Tarantool and tt versions this package needs to run.
+[platform]
+tarantool = "%s"
+tt = "%s"
+
+# Runtime dependencies. tt package add <name> [<constraint>] writes here;
+# tt package deps shows what they resolved to.
+[dependencies]
+
+# Dependencies only the tests and tooling need:
+#
+# [dev_dependencies]
+# luatest = "*"
+
+# A package is built per product, and a product is built from components.
+# Declare at least one of each to make tt package build do something:
+#
+# [components.app]
+# path = "."
+#
+# [products.default]
+# components = ["app"]
+# default = true
+`
+
+// render fills the skeleton in for one package name.
+func render(name string) string {
+	return fmt.Sprintf(skeleton,
+		manifest.ManifestVersion, name,
+		defaultTarantoolConstraint, defaultTtConstraint)
+}

--- a/test/integration/completion/test_completion.py
+++ b/test/integration/completion/test_completion.py
@@ -36,6 +36,7 @@ tt_root_command: set[str] = set(
         "status",
         "cfg",
         "create",
+        "new",
         "replicaset",
         "stop",
         "check",

--- a/test/integration/package/test_tt_new.py
+++ b/test/integration/package/test_tt_new.py
@@ -1,0 +1,102 @@
+"""End-to-end coverage for `tt new`.
+
+The command writes one file, so the tests are about what that file is worth: it
+has to be a manifest the rest of the pipeline accepts, and it must never replace
+one that is already there.
+"""
+
+import json
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11, which is what CI runs.
+    import tomli as tomllib
+
+
+def read_manifest(root):
+    with (root / "app.manifest.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_new_writes_a_manifest_the_pipeline_accepts(tree, run_tt):
+    """The skeleton parses, validates and is readable by another command.
+
+    `tt package deps` is the cheapest proof of that: it parses and validates the
+    manifest and would fail on a skeleton that does not hold up.
+    """
+    root = tree.root
+
+    result = run_tt("new", "-n", "my-app")
+    assert result.returncode == 0, result.stderr
+    assert "app.manifest.toml" in result.stdout
+
+    parsed = read_manifest(root)
+    assert parsed["manifest_version"] == "0.1"
+    assert parsed["package"]["name"] == "my-app"
+    assert parsed["platform"]["tarantool"].startswith(">=3.")
+    assert parsed["dependencies"] == {}
+
+    deps = run_tt("package", "deps", "-o", "json")
+    assert deps.returncode == 0, deps.stderr
+
+    report = json.loads(deps.stdout)
+    assert report["package"] == parsed["package"]["name"]
+    assert report["lock"] == "missing"
+
+
+def test_new_refuses_a_directory_name_that_is_not_a_package_name(tree, run_tt):
+    """The pytest tmpdir is named with underscores, which is the case itself.
+
+    The refusal has to name the flag that fixes it, or the user is left
+    renaming a directory to satisfy a tool.
+    """
+    root = tree.root
+
+    result = run_tt("new")
+    assert result.returncode == 1
+    assert "is not a package name" in result.stderr
+    assert "tt new -n " in result.stderr
+    assert not (root / "app.manifest.toml").exists()
+
+
+def test_new_refuses_to_overwrite(tree, run_tt):
+    """A second run is an error, and the existing file is left as it is."""
+    root = tree.root
+
+    assert run_tt("new", "-n", "my-app").returncode == 0
+
+    (root / "app.manifest.toml").write_text(
+        (root / "app.manifest.toml").read_text() + "\n# hand-written\n",
+    )
+    before = (root / "app.manifest.toml").read_text()
+
+    result = run_tt("new", "-n", "my-app")
+    assert result.returncode == 1
+    assert "already exists" in result.stderr
+    assert (root / "app.manifest.toml").read_text() == before
+
+
+def test_new_then_add_declares_a_dependency(tree, run_tt, rock_server):
+    """The skeleton is what `tt package add` writes into.
+
+    Going through the real add is what proves the empty `[dependencies]` table
+    is a table the editor can splice into, rather than merely valid TOML.
+    """
+    root = tree.root
+
+    assert run_tt("new", "-n", "my-app").returncode == 0
+
+    # Point the default registry list at the loopback server for this one run,
+    # so the resolution behind `add` stays offline.
+    manifest = (root / "app.manifest.toml").read_text()
+    manifest = manifest.replace(
+        "[dependencies]",
+        f'[dependencies.stat]\nsource = "registry"\nregistry = "{rock_server}"\nversion = "*"\n',
+    )
+    (root / "app.manifest.toml").write_text(manifest)
+
+    result = run_tt("package", "add", "stat", ">=0.3.1")
+    assert result.returncode == 0, result.stderr
+
+    parsed = read_manifest(root)
+    assert parsed["dependencies"]["stat"]["version"] == ">=0.3.1"


### PR DESCRIPTION
Every `tt package` command reads `app.manifest.toml`, and nothing wrote one: a project entering the manifest pipeline had to type the file from the specification. `tt new` writes the skeleton — the format version, the package identity, the platform floors and an empty `[dependencies]` table for `tt package add` to splice into.

Components and products are commented examples rather than declarations. Both are needed before `tt package build` has anything to build, but their contents follow a layout only the author knows, and a guessed `products.default` is worse than an absent one: it builds, quietly, from the wrong files.

The package name is `-n`, or the directory's own name when that is already a package name. A directory called anything else is refused, with the name it would have to be: rewriting `My_App` to `my-app` behind the user's back puts a name in the manifest nobody chose and nobody would think to look for, and the whole file exists to be read by other commands. `-n` is what makes that refusal actionable without renaming a directory to satisfy a tool.

An existing manifest is never overwritten, and the file is created with `O_EXCL` so the check and the write are one operation. The skeleton is parsed and validated before it is written, since the alternative is discovering a broken template through whatever command the user runs next.

Closes TNTP-9956