### PR TITLE
lint: enable gocritic and unparam

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
     - noinlineerr
     - paralleltest
     - perfsprint
-    - protogetter
     - revive
     - staticcheck
     - testifylint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - gochecknoglobals
     - gocognit
     - goconst
-    - gocritic
     - gocyclo
     - godox
     - gomodguard
@@ -58,8 +57,6 @@ linters:
     - testifylint
     - testpackage
     - tparallel
-    - unparam
-    - usetesting
     - varnamelen
     - wrapcheck
     - wsl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - maintidx
     - mnd
     - modernize
-    - nestif
     - nlreturn
     - noctx
     - noinlineerr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - gochecknoglobals
     - gocognit
     - goconst
-    - gocyclo
     - godox
     - gomodguard
     - gosec
@@ -133,6 +132,8 @@ linters:
     exhaustive:
       # A switch with a default clause is treated as exhaustive.
       default-signifies-exhaustive: true
+    gocyclo:
+      min-complexity: 30
     godot:
       scope: all
     lll:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ linters:
     - mnd
     - modernize
     - nestif
-    - nilnil
     - nlreturn
     - noctx
     - noinlineerr
@@ -100,6 +99,11 @@ linters:
         text: don't use `init` function
         linters:
           - gochecknoinits
+      # Protobuf null is represented by an untyped nil value.
+      - path: ^cli/aeon/decode\.go$
+        source: ^\s*return nil, nil$
+        linters:
+          - nilnil
 
   settings:
     gomoddirectives:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters:
     - exhaustruct
     - exhaustruct_v5
     - forbidigo
-    - funcorder
     - funlen
     - gochecknoglobals
     - gocognit
@@ -50,7 +49,6 @@ linters:
     - paralleltest
     - perfsprint
     - revive
-    - staticcheck
     - testifylint
     - testpackage
     - tparallel
@@ -103,6 +101,18 @@ linters:
         source: ^\s*return nil, nil$
         linters:
           - nilnil
+      # Request push messages use box.session.push(); NewWatcher handles the
+      # different box.broadcast protocol and is not a drop-in replacement.
+      - path: ^cli/connector/binary\.go$
+        source: \bfuture\.GetIterator\(\)
+        linters:
+          - staticcheck
+      # etcd still uses grpc.DialContext and documents WithBlock for waiting
+      # until the connection is ready within DialTimeout.
+      - path: ^lib/cluster/storage\.go$
+        source: \bgrpc\.WithBlock\(\)
+        linters:
+          - staticcheck
 
   settings:
     gomoddirectives:

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -114,19 +114,6 @@ func NewAeonHandler(ctx cmd.ConnectCtx) (*Client, error) {
 	return &c, nil
 }
 
-func (c *Client) ping() error {
-	log.Infof("Start ping aeon server")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	diag := pb.NewDiagServiceClient(c.conn)
-	_, err := diag.Ping(ctx, &pb.PingRequest{})
-	if err != nil {
-		log.Warnf("Aeon ping %s", err)
-	}
-	return err
-}
-
 // Title implements console.Handler interface.
 func (c *Client) Title() string {
 	return c.title
@@ -171,6 +158,19 @@ func (c *Client) Close() {
 func (c *Client) Complete(input prompt.Document) []prompt.Suggest {
 	// TODO: waiting until there is support from Aeon side.
 	return nil
+}
+
+func (c *Client) ping() error {
+	log.Infof("Start ping aeon server")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	diag := pb.NewDiagServiceClient(c.conn)
+	_, err := diag.Ping(ctx, &pb.PingRequest{})
+	if err != nil {
+		log.Warnf("Aeon ping %s", err)
+	}
+	return err
 }
 
 // parseSQLResponse returns result as table in map.

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -142,8 +142,12 @@ func (c *Client) Validate(input string) bool {
 		log.Warnf("Aeon validate %s\nFor request: %q", err, input)
 		return false
 	}
+	if check == nil {
+		log.Warnf("Aeon validate returned an empty response for request: %q", input)
+		return false
+	}
 
-	return check.Status == pb.SQLCheckStatus_SQL_QUERY_VALID
+	return check.GetStatus() == pb.SQLCheckStatus_SQL_QUERY_VALID
 }
 
 // Execute implements console.Handler interface.
@@ -173,25 +177,34 @@ func (c *Client) Complete(input prompt.Document) []prompt.Suggest {
 // Where keys is name of columns. And body is array of values.
 // On any issue return an error.
 func parseSQLResponse(resp *pb.SQLResponse) any {
-	if resp.Error != nil {
-		return resultError{resp.Error}
+	if resp == nil {
+		return errors.New("empty Aeon SQL response")
 	}
-	if resp.TupleFormat == nil {
+	if responseError := resp.GetError(); responseError != nil {
+		return resultError{responseError}
+	}
+	tupleFormat := resp.GetTupleFormat()
+	if tupleFormat == nil {
 		return resultType{}
 	}
+	names := tupleFormat.GetNames()
+	tuples := resp.GetTuples()
 	res := resultType{
-		names: slices.Clone(resp.TupleFormat.Names),
-		rows:  make([]resultRow, len(resp.Tuples)),
+		names: slices.Clone(names),
+		rows:  make([]resultRow, len(tuples)),
 	}
-	for i := range resp.Tuples {
-		res.rows[i] = make([]any, 0, len(resp.TupleFormat.Names))
+	for i := range tuples {
+		res.rows[i] = make([]any, 0, len(names))
 	}
 
-	for r, row := range resp.Tuples {
-		for _, v := range row.Fields {
+	for r, row := range tuples {
+		if row == nil {
+			return fmt.Errorf("tuple %d is nil", r)
+		}
+		for _, v := range row.GetFields() {
 			val, err := decodeValue(v)
 			if err != nil {
-				return fmt.Errorf("tuple %d can't decode %s: %w", r, v.String(), err)
+				return fmt.Errorf("tuple %d can't decode value %v: %w", r, v, err)
 			}
 			res.rows[r] = append(res.rows[r], val)
 		}

--- a/cli/aeon/decode.go
+++ b/cli/aeon/decode.go
@@ -15,7 +15,11 @@ import (
 //
 // Copy from https://github.com/tarantool/aeon/blob/master/aeon/grpc/server/pb/decode.go
 func decodeValue(val *pb.Value) (any, error) {
-	switch casted := val.Kind.(type) {
+	if val == nil {
+		return nil, fmt.Errorf("protobuf value is nil")
+	}
+
+	switch val.GetKind().(type) {
 	case *pb.Value_UnsignedValue:
 		return val.GetUnsignedValue(), nil
 	case *pb.Value_StringValue:
@@ -43,11 +47,15 @@ func decodeValue(val *pb.Value) (any, error) {
 		}
 		return res, nil
 	case *pb.Value_DatetimeValue:
-		sec := casted.DatetimeValue.Seconds
-		nsec := casted.DatetimeValue.Nsec
+		dateTime := val.GetDatetimeValue()
+		if dateTime == nil {
+			return nil, fmt.Errorf("protobuf datetime value is nil")
+		}
+		sec := dateTime.GetSeconds()
+		nsec := dateTime.GetNsec()
 		t := time.Unix(sec, nsec)
-		if len(casted.DatetimeValue.Location) > 0 {
-			locStr := casted.DatetimeValue.Location
+		if len(dateTime.GetLocation()) > 0 {
+			locStr := dateTime.GetLocation()
 			loc, err := time.LoadLocation(locStr)
 			if err != nil {
 				return nil, err
@@ -60,22 +68,30 @@ func decodeValue(val *pb.Value) (any, error) {
 		}
 		return res, nil
 	case *pb.Value_IntervalValue:
+		interval := val.GetIntervalValue()
+		if interval == nil {
+			return nil, fmt.Errorf("protobuf interval value is nil")
+		}
 		res := datetime.Interval{
-			Year:   casted.IntervalValue.Year,
-			Month:  casted.IntervalValue.Month,
-			Week:   casted.IntervalValue.Week,
-			Day:    casted.IntervalValue.Day,
-			Hour:   casted.IntervalValue.Hour,
-			Min:    casted.IntervalValue.Min,
-			Sec:    casted.IntervalValue.Sec,
-			Nsec:   casted.IntervalValue.Nsec,
-			Adjust: datetime.Adjust(casted.IntervalValue.Adjust),
+			Year:   interval.GetYear(),
+			Month:  interval.GetMonth(),
+			Week:   interval.GetWeek(),
+			Day:    interval.GetDay(),
+			Hour:   interval.GetHour(),
+			Min:    interval.GetMin(),
+			Sec:    interval.GetSec(),
+			Nsec:   interval.GetNsec(),
+			Adjust: datetime.Adjust(interval.GetAdjust()),
 		}
 		return res, nil
 	case *pb.Value_ArrayValue:
 		array := val.GetArrayValue()
-		res := make([]any, len(array.Fields))
-		for k, v := range array.Fields {
+		if array == nil {
+			return nil, fmt.Errorf("protobuf array value is nil")
+		}
+		fields := array.GetFields()
+		res := make([]any, len(fields))
+		for k, v := range fields {
 			field, err := decodeValue(v)
 			if err != nil {
 				return nil, err
@@ -84,8 +100,13 @@ func decodeValue(val *pb.Value) (any, error) {
 		}
 		return res, nil
 	case *pb.Value_MapValue:
-		res := make(map[any]any, len(casted.MapValue.Fields))
-		for k, v := range casted.MapValue.Fields {
+		mapValue := val.GetMapValue()
+		if mapValue == nil {
+			return nil, fmt.Errorf("protobuf map value is nil")
+		}
+		fields := mapValue.GetFields()
+		res := make(map[any]any, len(fields))
+		for k, v := range fields {
 			item, err := decodeValue(v)
 			if err != nil {
 				return nil, err

--- a/cli/aeon/results.go
+++ b/cli/aeon/results.go
@@ -22,6 +22,18 @@ type resultError struct {
 	*pb.Error
 }
 
+// Format produce formatted string according required console.Format settings.
+func (r resultType) Format(f console.Format) (string, error) {
+	if len(r.names) == 0 {
+		return "", nil
+	}
+	output, err := formatter.MakeOutput(f.Mode, r.asYaml(), f.Opts)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
 // asYaml prepare results for formatter.MakeOutput.
 func (r resultType) asYaml() string {
 	yaml := "---\n"
@@ -34,18 +46,6 @@ func (r resultType) asYaml() string {
 		}
 	}
 	return yaml
-}
-
-// Format produce formatted string according required console.Format settings.
-func (r resultType) Format(f console.Format) (string, error) {
-	if len(r.names) == 0 {
-		return "", nil
-	}
-	output, err := formatter.MakeOutput(f.Mode, r.asYaml(), f.Opts)
-	if err != nil {
-		return "", err
-	}
-	return output, nil
 }
 
 // Format produce formatted string according required console.Format settings.

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -73,26 +73,28 @@ func ParseBinaries(fileList []fs.DirEntry, program search.Program,
 	versionPrefix := program.String() + version.FsSeparator
 	var err error
 	for _, f := range fileList {
-		if strings.HasPrefix(f.Name(), versionPrefix) {
-			versionStr := strings.TrimPrefix(strings.TrimPrefix(f.Name(), versionPrefix), "v")
-			var ver version.Version
-			isRightFormat, _ := util.IsValidCommitHash(versionStr)
-			if versionStr == "master" {
-				ver.Major = math.MaxUint // Small hack to make master the newest version.
-			} else if !isRightFormat {
-				ver, err = version.Parse(versionStr)
-				if err != nil {
-					return binaryVersions, err
-				}
-			}
-
-			if binActive == f.Name() {
-				ver.Str = versionStr + " [active]"
-			} else {
-				ver.Str = versionStr
-			}
-			binaryVersions = append(binaryVersions, ver)
+		if !strings.HasPrefix(f.Name(), versionPrefix) {
+			continue
 		}
+
+		versionStr := strings.TrimPrefix(strings.TrimPrefix(f.Name(), versionPrefix), "v")
+		var ver version.Version
+		isRightFormat, _ := util.IsValidCommitHash(versionStr)
+		if versionStr == "master" {
+			ver.Major = math.MaxUint // Small hack to make master the newest version.
+		} else if !isRightFormat {
+			ver, err = version.Parse(versionStr)
+			if err != nil {
+				return binaryVersions, err
+			}
+		}
+
+		if binActive == f.Name() {
+			ver.Str = versionStr + " [active]"
+		} else {
+			ver.Str = versionStr
+		}
+		binaryVersions = append(binaryVersions, ver)
 	}
 
 	return binaryVersions, nil

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -41,8 +41,9 @@ func ParseBinaries(fileList []fs.DirEntry, program search.Program,
 	binActive := ""
 	programPath := filepath.Join(binDir, symlinkName)
 	if fileInfo, err := os.Lstat(programPath); err == nil {
-		if program == search.ProgramDev &&
-			fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+		switch {
+		case program == search.ProgramDev &&
+			fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink:
 			binActive, isTarantoolBinary, err := install.IsTarantoolDev(programPath, binDir)
 			if err != nil {
 				return binaryVersions, err
@@ -52,7 +53,7 @@ func ParseBinaries(fileList []fs.DirEntry, program search.Program,
 					version.Version{Str: program.String() + " -> " + binActive + " [active]"})
 			}
 			return binaryVersions, nil
-		} else if program == search.ProgramCe && fileInfo.Mode()&os.ModeSymlink == 0 {
+		case program == search.ProgramCe && fileInfo.Mode()&os.ModeSymlink == 0:
 			tntCli := cmdcontext.TarantoolCli{Executable: programPath}
 			binaryVersion, err := tntCli.GetVersion()
 			if err != nil {
@@ -60,7 +61,7 @@ func ParseBinaries(fileList []fs.DirEntry, program search.Program,
 			}
 			binaryVersion.Str += " [active]"
 			binaryVersions = append(binaryVersions, binaryVersion)
-		} else {
+		default:
 			binActive, err = util.ResolveSymlink(programPath)
 			if err != nil && !os.IsNotExist(err) {
 				return binaryVersions, err

--- a/cli/binary/switch_test.go
+++ b/cli/binary/switch_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,10 +23,8 @@ func TestCleanString(t *testing.T) {
 }
 
 func TestSwitchTarantool(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "switch_test")
-	defer os.RemoveAll(tempDir)
-	assert.Nil(t, err)
-	err = copy.Copy("./testdata/switch_test", tempDir)
+	tempDir := t.TempDir()
+	err := copy.Copy("./testdata/switch_test", tempDir)
 	assert.Nil(t, err)
 
 	var testCtx SwitchCtx

--- a/cli/cluster/cluster_test.go
+++ b/cli/cluster/cluster_test.go
@@ -27,8 +27,8 @@ func clearAmbientTTEnv(t *testing.T) {
 		}
 		k := strings.SplitN(kv, "=", 2)[0]
 		saved := os.Getenv(k)
-		os.Unsetenv(k)
-		t.Cleanup(func() { os.Setenv(k, saved) })
+		t.Setenv(k, saved)
+		require.NoError(t, os.Unsetenv(k))
 	}
 }
 
@@ -258,7 +258,7 @@ groups:
 
 	// Calling readStorageFromConfig indirectly through GetClusterConfig with a
 	// temp file that has the above content.
-	f, err := os.CreateTemp("", "tt-tcs-test-*.yaml")
+	f, err := os.CreateTemp(t.TempDir(), "tt-tcs-test-*.yaml")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(f.Name()) })
 	_, err = f.WriteString(cfgYAML)
@@ -297,7 +297,7 @@ groups:
         instances:
           i: {}
 `
-	f, err := os.CreateTemp("", "tt-etcd-env-test-*.yaml")
+	f, err := os.CreateTemp(t.TempDir(), "tt-etcd-env-test-*.yaml")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(f.Name()) })
 	_, err = f.WriteString(cfgYAML)

--- a/cli/cluster/cmd/common_test.go
+++ b/cli/cluster/cmd/common_test.go
@@ -176,7 +176,7 @@ groups:
 		for _, full := range tc.Full {
 			t.Run(tc.Name+"_"+fmt.Sprint(full), func(t *testing.T) {
 				for k, v := range tc.Env {
-					os.Setenv(k, v)
+					t.Setenv(k, v)
 				}
 
 				view, err := cluster.BuildGoConfigFromBytes(context.Background(), []byte(tc.Data))

--- a/cli/cluster/cmd/failover.go
+++ b/cli/cluster/cmd/failover.go
@@ -118,39 +118,7 @@ func Switch(url string, switchCtx SwitchCtx) error {
 	key := uriOpts.Prefix + failoverPath + uuid
 
 	if switchCtx.Wait {
-		ctxWatch, cancelWatch := context.WithTimeout(context.Background(),
-			time.Duration(switchCtx.Timeout)*time.Second+cmdAdditionalWait)
-		defer cancelWatch()
-		watchChan, err := conn.Watch(ctxWatch, key)
-		if err != nil {
-			return fmt.Errorf("unable to create watch channel: %w", err)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), defaultEtcdTimeout)
-		err = conn.Put(ctx, key, string(yamlCmd))
-		cancel()
-
-		if err != nil {
-			return err
-		}
-
-		for ev := range watchChan {
-			var result switchCmdResult
-			err = yaml.Unmarshal(ev.Value, &result)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("%s", ev.Value)
-			if result.Status == "success" || result.Status == "failed" {
-				return nil
-			}
-		}
-		if ctxWatch.Err() == context.DeadlineExceeded {
-			log.Info("Timeout for command execution reached.")
-			return nil
-		}
-
-		return fmt.Errorf("unexpected problem with watch context: %w", ctxWatch.Err())
+		return waitForSwitch(conn, key, yamlCmd, switchCtx.Timeout)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultEtcdTimeout)
@@ -167,6 +135,42 @@ func Switch(url string, switchCtx SwitchCtx) error {
 		url, uuid)
 
 	return nil
+}
+
+func waitForSwitch(conn *libcluster.RawStorage, key string, yamlCmd []byte, timeout uint64) error {
+	ctxWatch, cancelWatch := context.WithTimeout(context.Background(),
+		time.Duration(timeout)*time.Second+cmdAdditionalWait)
+	defer cancelWatch()
+	watchChan, err := conn.Watch(ctxWatch, key)
+	if err != nil {
+		return fmt.Errorf("unable to create watch channel: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultEtcdTimeout)
+	err = conn.Put(ctx, key, string(yamlCmd))
+	cancel()
+
+	if err != nil {
+		return err
+	}
+
+	for ev := range watchChan {
+		var result switchCmdResult
+		err = yaml.Unmarshal(ev.Value, &result)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s", ev.Value)
+		if result.Status == "success" || result.Status == "failed" {
+			return nil
+		}
+	}
+	if ctxWatch.Err() == context.DeadlineExceeded {
+		log.Info("Timeout for command execution reached.")
+		return nil
+	}
+
+	return fmt.Errorf("unexpected problem with watch context: %w", ctxWatch.Err())
 }
 
 // SwitchStatus shows master switching status.

--- a/cli/cluster/cmd/publish.go
+++ b/cli/cluster/cmd/publish.go
@@ -128,17 +128,7 @@ func setInstanceConfig(group, replicaset, instance string, instanceMap map[strin
 	snap := mut.Snapshot()
 
 	gname, rname, found := cluster.FindInstance(snap, instance)
-	if found {
-		// Instance already exists: validate group/replicaset names.
-		if replicaset != "" && replicaset != rname {
-			return fmt.Errorf("wrong replicaset name, expected %q, have %q", rname, replicaset)
-		}
-		if group != "" && group != gname {
-			return fmt.Errorf("wrong group name, expected %q, have %q", gname, group)
-		}
-		group = gname
-		replicaset = rname
-	} else {
+	if !found {
 		// Instance not found: resolve group/replicaset.
 		if replicaset == "" {
 			return fmt.Errorf(
@@ -151,6 +141,17 @@ func setInstanceConfig(group, replicaset, instance string, instanceMap map[strin
 				return fmt.Errorf("failed to determine the group of the %q replicaset", replicaset)
 			}
 		}
+	}
+	if found {
+		// Instance already exists: validate group/replicaset names.
+		if replicaset != "" && replicaset != rname {
+			return fmt.Errorf("wrong replicaset name, expected %q, have %q", rname, replicaset)
+		}
+		if group != "" && group != gname {
+			return fmt.Errorf("wrong group name, expected %q, have %q", gname, group)
+		}
+		group = gname
+		replicaset = rname
 	}
 
 	keyPath := goconfig.NewKeyPath(

--- a/cli/cluster/integration_test.go
+++ b/cli/cluster/integration_test.go
@@ -4,7 +4,6 @@ package cluster_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -198,7 +197,7 @@ func TestGetClusterConfig_etcd(t *testing.T) {
 
 	// Etcd config from file.
 	assert.Equal(t, endpoints[0], cfgGet[string](t, snap,
-		fmt.Sprintf("config/etcd/endpoints/0")))
+		"config/etcd/endpoints/0"))
 	assert.Equal(t, "root", cfgGet[string](t, snap, "config/etcd/username"))
 	assert.Equal(t, "pass", cfgGet[string](t, snap, "config/etcd/password"))
 	assert.Equal(t, "/test", cfgGet[string](t, snap, "config/etcd/prefix"))

--- a/cli/cluster/integration_test.go
+++ b/cli/cluster/integration_test.go
@@ -162,9 +162,7 @@ func TestGetClusterConfig_etcd(t *testing.T) {
 	defer inst.Terminate()
 	endpoints := inst.EndpointsGRPC()
 
-	tmpDir, err := os.MkdirTemp("", "work_dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	renderEtcdAppConfig(t, endpoints[0], "testdata/etcdapp/config.yaml.template", configPath)
@@ -231,9 +229,7 @@ func TestGetClusterConfig_etcd_connect_from_env(t *testing.T) {
 	defer inst.Terminate()
 	endpoints := inst.EndpointsGRPC()
 
-	tmpDir, err := os.MkdirTemp("", "work_dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	renderEtcdAppConfig(t, endpoints[0], "testdata/etcdapp/config.yaml.template", configPath)

--- a/cli/cluster/integration_test.go
+++ b/cli/cluster/integration_test.go
@@ -66,55 +66,57 @@ func startEtcd(t *testing.T, opts etcdOpts) *etcdtest.LazyCluster {
 	config := etcdtest.ClusterConfig{Size: 1, PeerTLS: tls}
 	inst := etcdtest.NewLazyCluster(config)
 
-	if opts.Username != "" {
-		etcd, err := clientv3.New(clientv3.Config{
-			Endpoints: inst.EndpointsGRPC(),
-		})
-		require.NoError(t, err)
-		defer etcd.Close()
+	if opts.Username == "" {
+		return inst
+	}
 
+	etcd, err := clientv3.New(clientv3.Config{
+		Endpoints: inst.EndpointsGRPC(),
+	})
+	require.NoError(t, err)
+	defer etcd.Close()
+
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to create user in etcd: %s", err)
+	}
+
+	if opts.Username != "root" {
+		// We need the root user for auth enable anyway.
 		if err := doWithCtx(func(ctx context.Context) error {
-			_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
+			_, err := etcd.UserAdd(ctx, "root", "")
 			return err
 		}); err != nil {
 			inst.Terminate()
-			t.Fatalf("Failed to create user in etcd: %s", err)
-		}
-
-		if opts.Username != "root" {
-			// We need the root user for auth enable anyway.
-			if err := doWithCtx(func(ctx context.Context) error {
-				_, err := etcd.UserAdd(ctx, "root", "")
-				return err
-			}); err != nil {
-				inst.Terminate()
-				t.Fatalf("Failed to create root in etcd: %s", err)
-			}
-
-			if err := doWithCtx(func(ctx context.Context) error {
-				_, err := etcd.UserGrantRole(ctx, "root", "root")
-				return err
-			}); err != nil {
-				inst.Terminate()
-				t.Fatalf("Failed to grant root in etcd: %s", err)
-			}
+			t.Fatalf("Failed to create root in etcd: %s", err)
 		}
 
 		if err := doWithCtx(func(ctx context.Context) error {
-			_, err := etcd.UserGrantRole(ctx, opts.Username, "root")
+			_, err := etcd.UserGrantRole(ctx, "root", "root")
 			return err
 		}); err != nil {
 			inst.Terminate()
-			t.Fatalf("Failed to grant user in etcd: %s", err)
+			t.Fatalf("Failed to grant root in etcd: %s", err)
 		}
+	}
 
-		if err := doWithCtx(func(ctx context.Context) error {
-			_, err = etcd.AuthEnable(ctx)
-			return err
-		}); err != nil {
-			inst.Terminate()
-			t.Fatalf("Failed to enable auth in etcd: %s", err)
-		}
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err := etcd.UserGrantRole(ctx, opts.Username, "root")
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to grant user in etcd: %s", err)
+	}
+
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err = etcd.AuthEnable(ctx)
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to enable auth in etcd: %s", err)
 	}
 
 	return inst

--- a/cli/cluster/storage.go
+++ b/cli/cluster/storage.go
@@ -168,12 +168,12 @@ func readStorageFromConfig(
 	}
 
 	// Try TCS (Tarantool Config Storage).
-	tcsResult, err := readTcsEndpoints(ctx, cfg, collectorFactory)
+	tcsResult, tcsFound, err := readTcsEndpoints(ctx, cfg, collectorFactory)
 	if err != nil {
 		return goconfig.Config{}, nil, err
 	}
-	if tcsResult != nil {
-		return *tcsResult, nil, nil
+	if tcsFound {
+		return tcsResult, nil, nil
 	}
 
 	return goconfig.Config{}, nil, nil
@@ -308,7 +308,7 @@ func readEtcdEndpoints(
 
 // readTcsEndpoints reads TCS (Tarantool Config Storage) configuration from cfg,
 // connects to the first reachable endpoint, and returns the parsed goconfig.Config.
-// Returns (nil, nil) if no TCS endpoints are configured.
+// The boolean result is false if no TCS endpoints are configured.
 //
 // Per TCS semantics: stop on first successful connect, aggregate errors only if
 // all endpoints fail.
@@ -316,29 +316,29 @@ func readTcsEndpoints(
 	ctx context.Context,
 	cfg goconfig.Config,
 	collectorFactory libcluster.Factory,
-) (*goconfig.Config, error) {
+) (goconfig.Config, bool, error) {
 	// Read endpoints list as []any (each element is a map[string]any).
 	var rawEndpoints any
 	_, err := cfg.Get(goconfig.NewKeyPath("config/storage/endpoints"), &rawEndpoints)
 	if err != nil {
 		if errors.Is(err, goconfig.ErrKeyNotFound) {
-			return nil, nil
+			return goconfig.Config{}, false, nil
 		}
-		return nil, fmt.Errorf("read storage endpoints: %w", err)
+		return goconfig.Config{}, false, fmt.Errorf("read storage endpoints: %w", err)
 	}
 
 	endpointList, ok := rawEndpoints.([]any)
 	if !ok || len(endpointList) == 0 {
-		return nil, nil
+		return goconfig.Config{}, false, nil
 	}
 
 	prefix, err := cfgGetString(cfg, "config/storage/prefix")
 	if err != nil {
-		return nil, fmt.Errorf("read storage prefix: %w", err)
+		return goconfig.Config{}, false, fmt.Errorf("read storage prefix: %w", err)
 	}
 	timeoutSec, err := cfgGetFloat64(cfg, "config/storage/timeout")
 	if err != nil {
-		return nil, fmt.Errorf("read storage timeout: %w", err)
+		return goconfig.Config{}, false, fmt.Errorf("read storage timeout: %w", err)
 	}
 	timeout := time.Duration(timeoutSec * float64(time.Second))
 
@@ -444,12 +444,12 @@ func readTcsEndpoints(
 		}
 
 		// First reachable endpoint wins.
-		return &parsedCfg, nil
+		return parsedCfg, true, nil
 	}
 
 	if len(connectionErrors) > 0 {
-		return nil, errors.Join(connectionErrors...)
+		return goconfig.Config{}, false, errors.Join(connectionErrors...)
 	}
 
-	return nil, nil
+	return goconfig.Config{}, false, nil
 }

--- a/cli/cmd/clean.go
+++ b/cli/cmd/clean.go
@@ -113,11 +113,12 @@ func internalCleanModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			var statusMsg string
 
 			err := clean(&run)
-			if errors.Is(err, ErrCanceledByUser) {
+			switch {
+			case errors.Is(err, ErrCanceledByUser):
 				statusMsg = ErrCanceledByUser.Error()
-			} else if err != nil {
+			case err != nil:
 				statusMsg = "[ERR] " + err.Error()
-			} else {
+			default:
 				statusMsg = "[OK]"
 			}
 

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tarantool/tt/cli/running"
 	"github.com/tarantool/tt/cli/util"
 	libconnect "github.com/tarantool/tt/lib/connect"
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 )
 
 var (

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -137,7 +137,8 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 	var runningCtx running.RunningCtx
 	fillErr := running.FillCtx(cliOpts, cmdCtx, &runningCtx, []string{target},
 		running.ConfigLoadCluster)
-	if fillErr == nil {
+	switch {
+	case fillErr == nil:
 		if len(runningCtx.Instances) > 1 {
 			err = fmt.Errorf("specify instance name")
 			return connOpts, err
@@ -156,7 +157,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 				connector.UnixNetwork, runningCtx.Instances[0].ConsoleSocket, *connectCtx,
 			)
 		}
-	} else if libconnect.IsCredentialsURI(target) {
+	case libconnect.IsCredentialsURI(target):
 		if connectCtx.Username != "" || connectCtx.Password != "" {
 			err = fmt.Errorf("username and password are specified with" +
 				" flags and a URI")
@@ -168,7 +169,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 		connectCtx.Password = pass
 		connOpts = makeConnOpts(network, address, *connectCtx)
 		connectCtx.ConnectTarget = newURI
-	} else if libconnect.IsBaseURI(target) {
+	case libconnect.IsBaseURI(target):
 		// Environment variables do not overwrite values.
 		if connectCtx.Username == "" {
 			connectCtx.Username = os.Getenv(libconnect.TarantoolUsernameEnv)
@@ -178,7 +179,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 		}
 		network, address := libconnect.ParseBaseURI(target)
 		connOpts = makeConnOpts(network, address, *connectCtx)
-	} else {
+	default:
 		err = fillErr
 		return connOpts, err
 	}

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -105,11 +105,12 @@ func createValidArgsFunction(
 		for _, entry := range entries {
 			eName := entry.Name()
 			ext := filepath.Ext(eName)
-			if entry.IsDir() {
+			switch {
+			case entry.IsDir():
 				templates = append(templates, eName)
-			} else if ext == ".tgz" {
+			case ext == ".tgz":
 				templates = append(templates, eName[:len(eName)-4])
-			} else if ext == ".gz" && filepath.Ext(eName[:len(eName)-3]) == ".tar" {
+			case ext == ".gz" && filepath.Ext(eName[:len(eName)-3]) == ".tar":
 				templates = append(templates, eName[:len(eName)-7])
 			}
 		}

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestCreateValidArgsFunction(t *testing.T) {
-	tempDir := os.TempDir()
-	tempsDir1, _ := os.MkdirTemp(tempDir, "create_test")
-	tempsDir2, _ := os.MkdirTemp(tempDir, "create_test")
+	tempsDir1 := t.TempDir()
+	tempsDir2 := t.TempDir()
 	oldOpts := cliOpts
 	cliOpts = &config.CliOpts{
 		Templates: []config.TemplateOpts{
@@ -23,16 +22,16 @@ func TestCreateValidArgsFunction(t *testing.T) {
 	}
 	defer func() {
 		cliOpts = oldOpts
-		os.RemoveAll(tempsDir1)
-		os.RemoveAll(tempsDir2)
 	}()
 	os.Create(tempsDir1 + "/" + "excess.A")
 	os.Create(tempsDir1 + "/" + "archive.tgz")
-	tDir1, _ := os.MkdirTemp(tempsDir1, "template1")
+	tDir1 := filepath.Join(tempsDir1, "template1")
+	assert.NoError(t, os.Mkdir(tDir1, 0o755))
 
 	os.Create(tempsDir2 + "/" + "excess.B")
 	os.Create(tempsDir2 + "/" + "template2.tar.gz")
-	tDir2, _ := os.MkdirTemp(tempsDir2, "template2")
+	tDir2 := filepath.Join(tempsDir2, "template2")
+	assert.NoError(t, os.Mkdir(tDir2, 0o755))
 
 	_, tDir1Name := filepath.Split(tDir1)
 	_, tDir2Name := filepath.Split(tDir2)

--- a/cli/cmd/kill.go
+++ b/cli/cmd/kill.go
@@ -43,23 +43,19 @@ func NewKillCmd() *cobra.Command {
 }
 
 func askConfirmation(args []string) (bool, error) {
-	var err error
-	confirm := true
-	if !forceKill {
-		confirmationMsg := "Kill all instances?"
-		if len(args) > 0 {
-			if strings.ContainsRune(args[0], running.InstanceDelimiter) {
-				confirmationMsg = fmt.Sprintf("Kill %s instance?", args[0])
-			} else {
-				confirmationMsg = fmt.Sprintf("Kill instances of %s?", args[0])
-			}
-		}
-		confirm, err = util.AskConfirm(os.Stdin, confirmationMsg)
-		if err != nil {
-			return confirm, err
+	if forceKill {
+		return true, nil
+	}
+
+	confirmationMsg := "Kill all instances?"
+	if len(args) > 0 {
+		if strings.ContainsRune(args[0], running.InstanceDelimiter) {
+			confirmationMsg = fmt.Sprintf("Kill %s instance?", args[0])
+		} else {
+			confirmationMsg = fmt.Sprintf("Kill instances of %s?", args[0])
 		}
 	}
-	return confirm, nil
+	return util.AskConfirm(os.Stdin, confirmationMsg)
 }
 
 // internalKillModule is a kill module.
@@ -73,22 +69,24 @@ func internalKillModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return fmt.Errorf("error asking for confirmation: %s", err)
 	}
 
-	if confirm {
-		var runningCtx running.RunningCtx
-		err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, args, running.ConfigLoadSkip)
-		if err != nil {
-			return err
-		}
+	if !confirm {
+		return nil
+	}
 
-		for _, run := range runningCtx.Instances {
-			if dumpQuit {
-				if err = running.Quit(run); err != nil {
-					log.Infof(err.Error())
-				}
-			} else {
-				if err = running.Kill(run); err != nil {
-					log.Infof(err.Error())
-				}
+	var runningCtx running.RunningCtx
+	err = running.FillCtx(cliOpts, cmdCtx, &runningCtx, args, running.ConfigLoadSkip)
+	if err != nil {
+		return err
+	}
+
+	for _, run := range runningCtx.Instances {
+		if dumpQuit {
+			if err = running.Quit(run); err != nil {
+				log.Infof(err.Error())
+			}
+		} else {
+			if err = running.Kill(run); err != nil {
+				log.Infof(err.Error())
 			}
 		}
 	}

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -102,7 +102,8 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	// FillCtx returns error if no instances found.
 	var runningCtx running.RunningCtx
 	err := running.FillCtx(cliOpts, cmdCtx, &runningCtx, []string{args[0]}, running.ConfigLoadAll)
-	if err == nil {
+	switch {
+	case err == nil:
 		if len(runningCtx.Instances) > 1 {
 			return util.InternalError(
 				"Internal error: specify instance name",
@@ -117,7 +118,7 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		}
 
 		args[0] = runningCtx.Instances[0].BinaryPort
-	} else if libconnect.IsCredentialsURI(args[0]) {
+	case libconnect.IsCredentialsURI(args[0]):
 		if playUsername != "" || playPassword != "" {
 			return errors.New("username and password are specified with" +
 				" flags and a URI")
@@ -126,14 +127,14 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		playUsername = user
 		playPassword = pass
 		args[0] = uri
-	} else if libconnect.IsBaseURI(args[0]) {
+	case libconnect.IsBaseURI(args[0]):
 		if playUsername == "" {
 			playUsername = os.Getenv(libconnect.TarantoolUsernameEnv)
 		}
 		if playPassword == "" {
 			playPassword = os.Getenv(libconnect.TarantoolPasswordEnv)
 		}
-	} else {
+	default:
 		return util.InternalError("could not resolve URI or application: %q (%s)",
 			version.GetVersion, args[0], err)
 	}

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -427,61 +427,7 @@ func replicasetFillCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target str
 	}
 	var connOpts connector.ConnectOpts
 	err = running.FillCtx(cliOpts, cmdCtx, &ctx.RunningCtx, []string{target}, loadConfig)
-	if err == nil {
-		ctx.IsApplication = true
-		if len(ctx.RunningCtx.Instances) == 1 {
-			if connectCtx.Username != "" || connectCtx.Password != "" {
-				err = fmt.Errorf("username and password are not supported" +
-					" with a connection via a control socket")
-				return err
-			}
-			connOpts = makeConnOpts(
-				connector.UnixNetwork,
-				ctx.RunningCtx.Instances[0].ConsoleSocket,
-				connectCtx,
-			)
-			ctx.IsInstanceConnect = true
-			appName, instName, found := strings.Cut(target, string(running.InstanceDelimiter))
-			if found {
-				if instName != ctx.RunningCtx.Instances[0].InstName {
-					return fmt.Errorf("instance %q not found", instName)
-				}
-				// Re-fill context for an application.
-				ctx.InstName = instName
-				err := running.FillCtx(cliOpts, cmdCtx, &ctx.RunningCtx, []string{appName},
-					loadConfig)
-				if err != nil {
-					// Should not happen.
-					return err
-				}
-			}
-		}
-		// In case of adding/removing role when user may not provide an instance.
-		if (cmdCtx.CommandName == "add" || cmdCtx.CommandName == "remove") && ctx.InstName == "" {
-			if len(ctx.RunningCtx.Instances) == 0 {
-				return fmt.Errorf("there are no running instances")
-			}
-			// Trying to find alive instance to create connection with it.
-			var err error
-			for _, i := range ctx.RunningCtx.Instances {
-				connOpts = makeConnOpts(
-					connector.UnixNetwork,
-					i.ConsoleSocket,
-					connectCtx,
-				)
-				var conn connector.Connector
-				conn, err = connector.Connect(connOpts)
-				if err == nil {
-					ctx.IsInstanceConnect = true
-					conn.Close()
-					break
-				}
-			}
-			if err != nil {
-				return fmt.Errorf("cannot connect to any instance from replicaset")
-			}
-		}
-	} else {
+	if err != nil {
 		if isRunningCtxRequired {
 			return err
 		}
@@ -490,6 +436,11 @@ func replicasetFillCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target str
 			return err
 		}
 		ctx.IsInstanceConnect = true
+	} else {
+		connOpts, err = fillReplicasetAppCtx(cmdCtx, ctx, target, loadConfig, connectCtx)
+		if err != nil {
+			return err
+		}
 	}
 
 	if ctx.IsInstanceConnect {
@@ -502,6 +453,80 @@ func replicasetFillCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target str
 	}
 
 	return nil
+}
+
+func fillReplicasetAppCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target string,
+	loadConfig running.ConfigLoad, connectCtx connect.ConnectCtx,
+) (connector.ConnectOpts, error) {
+	ctx.IsApplication = true
+	var connOpts connector.ConnectOpts
+	if len(ctx.RunningCtx.Instances) == 1 {
+		var err error
+		connOpts, err = fillSingleReplicasetInstance(
+			cmdCtx, ctx, target, loadConfig, connectCtx)
+		if err != nil {
+			return connOpts, err
+		}
+	}
+
+	// In case of adding/removing role when user may not provide an instance.
+	if (cmdCtx.CommandName != "add" && cmdCtx.CommandName != "remove") || ctx.InstName != "" {
+		return connOpts, nil
+	}
+	if len(ctx.RunningCtx.Instances) == 0 {
+		return connOpts, fmt.Errorf("there are no running instances")
+	}
+	// Trying to find alive instance to create connection with it.
+	var err error
+	for _, i := range ctx.RunningCtx.Instances {
+		connOpts = makeConnOpts(
+			connector.UnixNetwork,
+			i.ConsoleSocket,
+			connectCtx,
+		)
+		var conn connector.Connector
+		conn, err = connector.Connect(connOpts)
+		if err == nil {
+			ctx.IsInstanceConnect = true
+			conn.Close()
+			break
+		}
+	}
+	if err != nil {
+		return connOpts, fmt.Errorf("cannot connect to any instance from replicaset")
+	}
+	return connOpts, nil
+}
+
+func fillSingleReplicasetInstance(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx,
+	target string, loadConfig running.ConfigLoad, connectCtx connect.ConnectCtx,
+) (connector.ConnectOpts, error) {
+	var connOpts connector.ConnectOpts
+	if connectCtx.Username != "" || connectCtx.Password != "" {
+		return connOpts, fmt.Errorf("username and password are not supported" +
+			" with a connection via a control socket")
+	}
+	connOpts = makeConnOpts(
+		connector.UnixNetwork,
+		ctx.RunningCtx.Instances[0].ConsoleSocket,
+		connectCtx,
+	)
+	ctx.IsInstanceConnect = true
+	appName, instName, found := strings.Cut(target, string(running.InstanceDelimiter))
+	if !found {
+		return connOpts, nil
+	}
+	if instName != ctx.RunningCtx.Instances[0].InstName {
+		return connOpts, fmt.Errorf("instance %q not found", instName)
+	}
+	// Re-fill context for an application.
+	ctx.InstName = instName
+	if err := running.FillCtx(cliOpts, cmdCtx, &ctx.RunningCtx, []string{appName},
+		loadConfig); err != nil {
+		// Should not happen.
+		return connOpts, err
+	}
+	return connOpts, nil
 }
 
 // internalReplicasetUpgradeModule is a "upgrade" command for the replicaset module.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -499,26 +499,8 @@ func configureLocalCli(cmdCtx *cmdcontext.CmdCtx) error {
 		return err
 	}
 
-	if cmdCtx.Cli.ConfigPath == "" {
-		cmdCtx.Cli.ConfigPath, err = util.GetYamlFileName(filepath.Join(launchDir, ConfigName),
-			true)
-		if err != nil {
-			// TODO: Add warning messages, discussion what if the file
-			// exists, but access is denied, etc.
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to get access to configuration file: %s", err)
-			}
-			if cmdCtx.Cli.ConfigPath, err = getConfigPath(); err != nil {
-				return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
-			}
-			if cmdCtx.Cli.ConfigPath == "" {
-				if cmdCtx.Cli.LocalLaunchDir != "" {
-					return fmt.Errorf("failed to find Tarantool CLI config for '%s'",
-						cmdCtx.Cli.LocalLaunchDir)
-				}
-				cmdCtx.Cli.ConfigPath = getSystemConfigPath()
-			}
-		}
+	if err := ensureCliConfigPath(cmdCtx, launchDir); err != nil {
+		return err
 	}
 
 	cliOpts, _, err := GetCliOpts(cmdCtx.Cli.ConfigPath, cmdCtx.Integrity.Repository)
@@ -560,35 +542,68 @@ func configureLocalCli(cmdCtx *cmdcontext.CmdCtx) error {
 		return err
 	}
 
-	// This should save us from exec looping.
-	if localCli != "" && localCli != currentCli {
-		if _, err := os.Stat(localCli); err == nil {
-			if _, err := exec.LookPath(localCli); err != nil {
-				return fmt.Errorf(
-					`found tt binary in local directory "%s" isn't executable: %s`, launchDir, err)
-			}
+	return switchToLocalCli(cmdCtx, localCli, currentCli, launchDir)
+}
 
-			// Before switching to local cli, we shall check its integrity.
-			f, err := cmdCtx.Integrity.Repository.Read(localCli)
-			if err != nil {
-				return err
-			}
-			f.Close()
-
-			// We are not using the "RunExec" function because we have no reason to have several
-			// "tt" processes. Moreover, it looks strange when we start "tt", which starts "tt",
-			// which starts tarantool or some external module.
-			err = syscall.Exec(localCli, append([]string{localCli},
-				excludeArgumentsForChildTt(os.Args[1:])...), os.Environ())
-			if err != nil {
-				return err
-			}
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to get access to tt binary file: %s", err)
-		}
+func ensureCliConfigPath(cmdCtx *cmdcontext.CmdCtx, launchDir string) error {
+	if cmdCtx.Cli.ConfigPath != "" {
+		return nil
 	}
 
+	configPath, err := util.GetYamlFileName(filepath.Join(launchDir, ConfigName), true)
+	if err == nil {
+		cmdCtx.Cli.ConfigPath = configPath
+		return nil
+	}
+	// TODO: Add warning messages, discussion what if the file
+	// exists, but access is denied, etc.
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to get access to configuration file: %s", err)
+	}
+	configPath, err = getConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
+	}
+	if configPath != "" {
+		cmdCtx.Cli.ConfigPath = configPath
+		return nil
+	}
+	if cmdCtx.Cli.LocalLaunchDir != "" {
+		return fmt.Errorf("failed to find Tarantool CLI config for '%s'",
+			cmdCtx.Cli.LocalLaunchDir)
+	}
+	cmdCtx.Cli.ConfigPath = getSystemConfigPath()
 	return nil
+}
+
+func switchToLocalCli(cmdCtx *cmdcontext.CmdCtx, localCli, currentCli, launchDir string) error {
+	// This should save us from exec looping.
+	if localCli == "" || localCli == currentCli {
+		return nil
+	}
+	if _, err := os.Stat(localCli); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get access to tt binary file: %s", err)
+	}
+	if _, err := exec.LookPath(localCli); err != nil {
+		return fmt.Errorf(
+			`found tt binary in local directory "%s" isn't executable: %s`, launchDir, err)
+	}
+
+	// Before switching to local cli, we shall check its integrity.
+	f, err := cmdCtx.Integrity.Repository.Read(localCli)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	// We are not using the "RunExec" function because we have no reason to have several
+	// "tt" processes. Moreover, it looks strange when we start "tt", which starts "tt",
+	// which starts tarantool or some external module.
+	return syscall.Exec(localCli, append([]string{localCli},
+		excludeArgumentsForChildTt(os.Args[1:])...), os.Environ())
 }
 
 // configureLocalLaunch configures the context using the specified local launch path.

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -261,7 +261,8 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 	// Config could not be processed.
 	configPath, err := util.GetYamlFileName(configurePath, true)
 	// Before loading configure file, we'll initialize integrity checking.
-	if err == nil {
+	switch {
+	case err == nil:
 		if configPath, err = filepath.Abs(configPath); err != nil {
 			return nil, "", fmt.Errorf("cannot determine config file path: %s", err)
 		}
@@ -287,11 +288,11 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 			return nil, "",
 				fmt.Errorf("failed to parse Tarantool CLI configuration: missing tt section")
 		}
-	} else if err != nil && !os.IsNotExist(err) {
+	case err != nil && !os.IsNotExist(err):
 		// TODO: Add warning in next patches, discussion
 		// what if the file exists, but access is denied, etc.
 		return nil, "", fmt.Errorf("failed to get access to configuration file: %s", err)
-	} else if os.IsNotExist(err) {
+	case os.IsNotExist(err):
 		configPath = ""
 	}
 
@@ -375,11 +376,9 @@ func ValidateCliOpts(cliCtx *cmdcontext.CliCtx) error {
 			return fmt.Errorf(
 				"you can specify only one of -L(--local), -c(--cfg) and 'TT_CLI_CFG' options")
 		}
-	} else {
-		if cliCtx.IsSystem && cliCtx.ConfigPath != "" {
-			return fmt.Errorf(
-				"you can specify only one of -S(--system), -c(--cfg) and 'TT_CLI_CFG' options")
-		}
+	} else if cliCtx.IsSystem && cliCtx.ConfigPath != "" {
+		return fmt.Errorf(
+			"you can specify only one of -S(--system), -c(--cfg) and 'TT_CLI_CFG' options")
 	}
 	if len(cliCtx.IntegrityCheck) == 0 && cliCtx.IntegrityCheckPeriod != 0 {
 		return fmt.Errorf("need to specify public key in --integrity-check to " +
@@ -509,7 +508,7 @@ func configureLocalCli(cmdCtx *cmdcontext.CmdCtx) error {
 			if !os.IsNotExist(err) {
 				return fmt.Errorf("failed to get access to configuration file: %s", err)
 			}
-			if cmdCtx.Cli.ConfigPath, err = getConfigPath(ConfigName); err != nil {
+			if cmdCtx.Cli.ConfigPath, err = getConfigPath(); err != nil {
 				return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
 			}
 			if cmdCtx.Cli.ConfigPath == "" {
@@ -617,7 +616,7 @@ func excludeArgumentsForChildTt(args []string) []string {
 	skip := 0
 	for _, arg := range args {
 		if skip > 0 {
-			skip = skip - 1
+			skip--
 			continue
 		}
 		switch arg {
@@ -667,7 +666,7 @@ func configureDefaultCli(cmdCtx *cmdcontext.CmdCtx) error {
 		// If the config is found, we assume that it is a local launch in this directory.
 		// If the config is not found, then we take it from the standard place (/etc/tarantool).
 
-		if cmdCtx.Cli.ConfigPath, err = getConfigPath(ConfigName); err != nil {
+		if cmdCtx.Cli.ConfigPath, err = getConfigPath(); err != nil {
 			return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
 		}
 	}
@@ -682,7 +681,7 @@ func configureDefaultCli(cmdCtx *cmdcontext.CmdCtx) error {
 // getConfigPath looks for the path to the tt.yaml configuration file,
 // looking through all directories from the current one to the root.
 // This search pattern is chosen for the convenience of the user.
-func getConfigPath(configName string) (string, error) {
+func getConfigPath() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to detect current directory: %s", err)

--- a/cli/configure/configure_test.go
+++ b/cli/configure/configure_test.go
@@ -44,6 +44,8 @@ func newMockRepository() mockRepository {
 // Test Tarantool CLI configuration (system and local).
 func TestConfigureCli(t *testing.T) {
 	assert := assert.New(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
 
 	mockRepository := newMockRepository()
 
@@ -66,6 +68,9 @@ func TestConfigureCli(t *testing.T) {
 	assert.Equal(cmdCtx.Cli.ConfigPath, ConfigName)
 
 	testDir := t.TempDir()
+	// Cli changes the process working directory for a local launch. Register
+	// restoration before calling it and before the temporary directory cleanup.
+	t.Chdir(cwd)
 
 	// Test local configuration.
 	cmdCtx.Cli.IsSystem = false
@@ -86,10 +91,6 @@ func TestConfigureCli(t *testing.T) {
 
 	defer os.Remove(expectedTarantoolPath)
 
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(wd) // Chdir from local launch dir after the Cli call.
-
 	require.NoError(t, Cli(&cmdCtx))
 	assert.Equal(cmdCtx.Cli.ConfigPath, expectedConfigPath)
 	assert.Equal(cmdCtx.Cli.TarantoolCli.Executable, expectedTarantoolPath)
@@ -107,7 +108,7 @@ func TestConfigureCli(t *testing.T) {
 	// Check if it will go down to the bottom of the directory looking
 	// for the tt.yaml configuration file, specifically skip a file
 	// in the working directory.
-	os.Chdir(dir)
+	t.Chdir(dir)
 	expectedConfigPath = filepath.Join(filepath.Dir(dir), ConfigName)
 
 	assert.Nil(os.WriteFile(
@@ -249,11 +250,7 @@ func TestDetectLocalTarantool(t *testing.T) {
 	require.Equal(t, expected, cmdCtx.Cli.TarantoolCli.Executable)
 
 	// Chdir to temporary directory to avoid loading tt.yaml from parent directories.
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	err = os.Chdir(t.TempDir())
-	require.NoError(t, err)
-	defer os.Chdir(wd)
+	t.Chdir(t.TempDir())
 
 	// Tarantool executable is in PATH.
 	cliOpts.Env.BinDir = "./testdata"
@@ -280,8 +277,7 @@ func TestDetectLocalTt(t *testing.T) {
 
 func TestGetSystemConfigPath(t *testing.T) {
 	require.Equal(t, filepath.Join(defaultConfigPath, ConfigName), getSystemConfigPath())
-	os.Setenv(systemConfigDirEnvName, "/system_config_dir")
-	defer os.Unsetenv(getSystemConfigPath())
+	t.Setenv(systemConfigDirEnvName, "/system_config_dir")
 	require.Equal(t, filepath.Join("/system_config_dir", ConfigName), getSystemConfigPath())
 }
 
@@ -295,20 +291,17 @@ func TestGetConfigPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "tt.yaml"), []byte(""),
 		0o664))
 
-	if wd, err := os.Getwd(); err == nil {
-		require.NoError(t, os.Chdir(filepath.Join(tempDir, "a", "b")))
-		defer os.Chdir(wd)
-	}
+	t.Chdir(filepath.Join(tempDir, "a", "b"))
 	workdir, _ := os.Getwd()
 	workdir = strings.TrimSuffix(workdir, "/a/b")
 
-	configName, err := getConfigPath(ConfigName)
+	configName, err := getConfigPath()
 	assert.Equal(t, "", configName)
 	assert.True(t, strings.Contains(err.Error(), "more than one YAML files are found"))
 
 	require.NoError(t, os.Remove(filepath.Join(tempDir, "a", ConfigName)))
 
-	configName, err = getConfigPath(ConfigName)
+	configName, err = getConfigPath()
 
 	assert.Equal(t, filepath.Join(workdir, "a", "tt.yml"), configName)
 	assert.NoError(t, err)

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -53,30 +53,26 @@ const (
 
 // getEvalCmd returns a command from the input source (file or stdin).
 func getEvalCmd(connectCtx ConnectCtx) (string, error) {
-	var cmd string
-
 	if connectCtx.SrcFile == "-" {
-		if !terminal.IsTerminal(syscall.Stdin) {
-			cmdByte, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return "", err
-			}
-			cmd = string(cmdByte)
-		} else {
+		if terminal.IsTerminal(syscall.Stdin) {
 			return "", fmt.Errorf("can't use interactive input as a source file")
 		}
-	} else {
-		cmdPath := path.Clean(connectCtx.SrcFile)
-		if _, err := os.Stat(cmdPath); err == nil {
-			cmdByte, err := os.ReadFile(cmdPath)
-			if err != nil {
-				return "", err
-			}
-			cmd = string(cmdByte)
+		cmdByte, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", err
 		}
+		return string(cmdByte), nil
 	}
 
-	return cmd, nil
+	cmdPath := path.Clean(connectCtx.SrcFile)
+	if _, err := os.Stat(cmdPath); err == nil {
+		cmdByte, err := os.ReadFile(cmdPath)
+		if err != nil {
+			return "", err
+		}
+		return string(cmdByte), nil
+	}
+	return "", nil
 }
 
 // Connect establishes a connection to the instance and starts the console.

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tarantool/tt/cli/connect/internal/luabody"
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/formatter"
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 	"gopkg.in/yaml.v2"
 )
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -6,14 +6,13 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/adam-hanna/arrayOperations"
 	"github.com/apex/log"
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 	"gopkg.in/yaml.v2"
 
 	"github.com/tarantool/go-prompt"
@@ -334,12 +333,11 @@ func getCompleter(console *Console, connectCtx ConnectCtx) prompt.Completer {
 			return nil
 		}
 
-		suggestionsTexts = arrayOperations.DifferenceString(suggestionsTexts)
+		slices.Sort(suggestionsTexts)
+		suggestionsTexts = slices.Compact(suggestionsTexts)
 		if len(suggestionsTexts) == 0 {
 			return nil
 		}
-
-		sort.Strings(suggestionsTexts)
 
 		suggestions := make([]prompt.Suggest, len(suggestionsTexts))
 		for i, suggestionText := range suggestionsTexts {

--- a/cli/connect/history.go
+++ b/cli/connect/history.go
@@ -98,7 +98,7 @@ func (history *commandHistory) appendCommand(command string) {
 func (history *commandHistory) writeToFile() error {
 	historyContent := bytes.Buffer{}
 	for i, command := range history.commands {
-		historyContent.WriteString(fmt.Sprintf("#%d\n%s\n", history.timestamps[i], command))
+		fmt.Fprintf(&historyContent, "#%d\n%s\n", history.timestamps[i], command)
 	}
 	if err := os.WriteFile(history.filepath, historyContent.Bytes(), 0o640); err != nil {
 		return fmt.Errorf("failed to write to history file: %s", err)

--- a/cli/connect/input.go
+++ b/cli/connect/input.go
@@ -93,9 +93,7 @@ func cleanupDelimiter(stmt, delim string) (string, bool) {
 	if delim == "" {
 		return stmt, true
 	}
-	no_space := strings.TrimRightFunc(stmt, func(r rune) bool {
-		return unicode.IsSpace(r)
-	})
+	no_space := strings.TrimRightFunc(stmt, unicode.IsSpace)
 	no_delim := strings.TrimSuffix(no_space, delim)
 	if len(no_space) > len(no_delim) {
 		return no_delim, true

--- a/cli/connector/binary.go
+++ b/cli/connector/binary.go
@@ -46,25 +46,8 @@ func (conn *BinaryConnector) Eval(expr string, args []interface{},
 	var data []interface{}
 	future := conn.conn.Do(evalReq)
 	if opts.PushCallback != nil {
-		var timeout time.Duration
-		if opts.ReadTimeout != 0 {
-			timeout = opts.ReadTimeout
-		} else {
-			timeout = time.Duration(math.MaxInt64)
-		}
-		for it := future.GetIterator().WithTimeout(timeout); it.Next(); {
-			if err := it.Err(); err != nil {
-				return nil, replaceContextDone(err)
-			}
-			if !it.IsPush() {
-				break
-			}
-			resp := it.Value()
-			pushData, err := resp.Decode()
-			if err != nil {
-				return nil, replaceContextDone(err)
-			}
-			opts.PushCallback(pushData[0])
+		if err := processPushes(future, opts); err != nil {
+			return nil, err
 		}
 	}
 
@@ -84,6 +67,30 @@ func (conn *BinaryConnector) Eval(expr string, args []interface{},
 	}
 
 	return data, nil
+}
+
+func processPushes(future *tarantool.Future, opts RequestOpts) error {
+	var timeout time.Duration
+	if opts.ReadTimeout != 0 {
+		timeout = opts.ReadTimeout
+	} else {
+		timeout = time.Duration(math.MaxInt64)
+	}
+	for it := future.GetIterator().WithTimeout(timeout); it.Next(); {
+		if err := it.Err(); err != nil {
+			return replaceContextDone(err)
+		}
+		if !it.IsPush() {
+			break
+		}
+		resp := it.Value()
+		pushData, err := resp.Decode()
+		if err != nil {
+			return replaceContextDone(err)
+		}
+		opts.PushCallback(pushData[0])
+	}
+	return nil
 }
 
 // Close closes the tarantool.Connector created from.

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -363,17 +363,7 @@ func processEvalTarantoolRes(resBytes []byte, result interface{}) ([]interface{}
 func getPlainTextEvalResYaml(resBytes []byte) (string, error) {
 	evalResults := []PlainTextEvalRes{}
 	if err := yaml.UnmarshalStrict(resBytes, &evalResults); err != nil {
-		errorStrings := make([]map[string]string, 0)
-		if err := yaml.UnmarshalStrict(resBytes, &errorStrings); err == nil {
-			if len(errorStrings) > 0 {
-				errStr, found := errorStrings[0]["error"]
-				if found {
-					return "", errors.New(errStr)
-				}
-			}
-		}
-
-		return "", fmt.Errorf("failed to parse eval result: %s", err)
+		return "", getPlainTextEvalError(resBytes, err)
 	}
 
 	if len(evalResults) != 1 {
@@ -382,6 +372,21 @@ func getPlainTextEvalResYaml(resBytes []byte) (string, error) {
 
 	evalResult := evalResults[0]
 	return evalResult.DataEncBase64, nil
+}
+
+func getPlainTextEvalError(resBytes []byte, parseErr error) error {
+	errorStrings := make([]map[string]string, 0)
+	if err := yaml.UnmarshalStrict(resBytes, &errorStrings); err != nil {
+		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+	}
+	if len(errorStrings) == 0 {
+		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+	}
+	errStr, found := errorStrings[0]["error"]
+	if !found {
+		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+	}
+	return errors.New(errStr)
 }
 
 func getPlainTextEvalResLua(resBytes []byte) (string, error) {

--- a/cli/connector/protocol_test.go
+++ b/cli/connector/protocol_test.go
@@ -80,12 +80,13 @@ func TestGetProtocol(t *testing.T) {
 			s := &greetingReadStub{err: c.err, data: []byte(c.greeting)}
 			p, err := GetProtocol(s)
 			assert.Equal(t, c.expected, p)
-			if c.err != nil {
+			switch {
+			case c.err != nil:
 				assert.ErrorContains(t, err, "failed to read Tarantool greeting:")
 				assert.ErrorContains(t, err, c.err.Error())
-			} else if !c.ok {
+			case !c.ok:
 				assert.ErrorContains(t, err, "failed to parse Tarantool greeting:")
-			} else {
+			default:
 				assert.NoError(t, err)
 			}
 		})

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -63,23 +63,6 @@ func NewConsole(opts ConsoleOpts) (Console, error) {
 	return c, nil
 }
 
-func (c *Console) runOnPipe() error {
-	pipe := bufio.NewScanner(os.Stdin)
-	log.Infof("Processing piped input")
-	for pipe.Scan() {
-		line := pipe.Text()
-		c.execute(line)
-	}
-
-	err := pipe.Err()
-	if err == nil {
-		log.Info("EOF on pipe")
-	} else {
-		log.Warnf("Error on pipe %v", err)
-	}
-	return err
-}
-
 // Run starts console.
 func (c *Console) Run() error {
 	if c.quit {
@@ -106,6 +89,23 @@ func (c *Console) Close() {
 	if c.impl.History != nil {
 		c.impl.History.Close()
 	}
+}
+
+func (c *Console) runOnPipe() error {
+	pipe := bufio.NewScanner(os.Stdin)
+	log.Infof("Processing piped input")
+	for pipe.Scan() {
+		line := pipe.Text()
+		c.execute(line)
+	}
+
+	err := pipe.Err()
+	if err == nil {
+		log.Info("EOF on pipe")
+	} else {
+		log.Warnf("Error on pipe %v", err)
+	}
+	return err
 }
 
 // executeEmbeddedCommand try process additional backslash commands.

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -129,9 +129,7 @@ func (c *Console) cleanupDelimiter() bool {
 	if c.delimiter == "" {
 		return true
 	}
-	no_space := strings.TrimRightFunc(c.input, func(r rune) bool {
-		return unicode.IsSpace(r)
-	})
+	no_space := strings.TrimRightFunc(c.input, unicode.IsSpace)
 	no_delim := strings.TrimSuffix(no_space, c.delimiter)
 	if len(no_space) > len(no_delim) {
 		c.input = no_delim

--- a/cli/console/history.go
+++ b/cli/console/history.go
@@ -50,6 +50,27 @@ func DefaultHistoryFile() (History, error) {
 	return NewHistory(file, DefaultHistoryLines)
 }
 
+// AppendCommand insert new command to the history file.
+// Implements HistoryKeeper.AppendCommand interface method.
+func (h *History) AppendCommand(input string) {
+	h.commands = append(h.commands, input)
+	h.timestamps = append(h.timestamps, time.Now().Unix())
+	if len(h.commands) > h.maxCommands {
+		h.commands = h.commands[1:]
+		h.timestamps = h.timestamps[1:]
+	}
+	h.writeToFile()
+}
+
+// Commands implements HistoryKeeper.Commands interface method.
+func (h *History) Commands() []string {
+	return h.commands
+}
+
+// Close implements HistoryKeeper.Close interface method.
+func (h *History) Close() {
+}
+
 func (h *History) load() error {
 	if !util.IsRegularFile(h.filepath) {
 		return nil
@@ -108,32 +129,11 @@ func (h *History) parseCells(lines []string) {
 func (h *History) writeToFile() error {
 	buff := bytes.Buffer{}
 	for i, c := range h.commands {
-		buff.WriteString(fmt.Sprintf("#%d\n%s\n", h.timestamps[i], c))
+		fmt.Fprintf(&buff, "#%d\n%s\n", h.timestamps[i], c)
 	}
 	if err := os.WriteFile(h.filepath, buff.Bytes(), 0o640); err != nil {
 		return fmt.Errorf("failed to write to history file: %s", err)
 	}
 
 	return nil
-}
-
-// AppendCommand insert new command to the history file.
-// Implements HistoryKeeper.AppendCommand interface method.
-func (h *History) AppendCommand(input string) {
-	h.commands = append(h.commands, input)
-	h.timestamps = append(h.timestamps, time.Now().Unix())
-	if len(h.commands) > h.maxCommands {
-		h.commands = h.commands[1:]
-		h.timestamps = h.timestamps[1:]
-	}
-	h.writeToFile()
-}
-
-// Commands implements HistoryKeeper.Commands interface method.
-func (h *History) Commands() []string {
-	return h.commands
-}
-
-// Close implements HistoryKeeper.Close interface method.
-func (h *History) Close() {
 }

--- a/cli/console/history_test.go
+++ b/cli/console/history_test.go
@@ -76,7 +76,7 @@ func TestHistory_AppendCommand(t *testing.T) {
 			[]string{"1"},
 		},
 	}
-	tmp, _ := os.MkdirTemp(os.TempDir(), "history_test*")
+	tmp := t.TempDir()
 
 	// Write and ensure last command in buffer.
 	for i, tt := range tests {

--- a/cli/create/internal/steps/cleanup.go
+++ b/cli/create/internal/steps/cleanup.go
@@ -45,17 +45,17 @@ func (hook Cleanup) Run(createCtx *create_ctx.CreateCtx,
 			if err != nil {
 				return err
 			}
-			found := filesToKeep[filePath]
-			if !found {
-				if fileInfo.IsDir() {
-					if filePath != templateCtx.AppPath {
-						dirsToRemove = append(dirsToRemove, filePath)
-					}
-				} else if fileInfo.Mode().IsRegular() {
-					log.Debugf("Removing %s", filePath)
-					if err := os.Remove(filePath); err != nil {
-						log.Errorf("failed to remove %s: %s", filePath, err)
-					}
+			if filesToKeep[filePath] {
+				return nil
+			}
+			if fileInfo.IsDir() {
+				if filePath != templateCtx.AppPath {
+					dirsToRemove = append(dirsToRemove, filePath)
+				}
+			} else if fileInfo.Mode().IsRegular() {
+				log.Debugf("Removing %s", filePath)
+				if err := os.Remove(filePath); err != nil {
+					log.Errorf("failed to remove %s: %s", filePath, err)
 				}
 			}
 

--- a/cli/create/internal/steps/collect_template_vars.go
+++ b/cli/create/internal/steps/collect_template_vars.go
@@ -20,11 +20,31 @@ type CollectTemplateVarsFromUser struct {
 	Reader stringReader
 }
 
+func validateExistingValue(createCtx *create_ctx.CreateCtx, varInfo app_template.UserPrompt,
+	existingValue string, found bool,
+) (bool, error) {
+	if !found || varInfo.Re == "" {
+		return found, nil
+	}
+
+	matched, err := regexp.MatchString(varInfo.Re, existingValue)
+	if err != nil {
+		return false, fmt.Errorf("failed to validate user input: %s", err)
+	}
+	if matched {
+		return true, nil
+	}
+	if createCtx.SilentMode {
+		return false, fmt.Errorf("invalid format of %s variable", varInfo.Name)
+	}
+	fmt.Printf("Invalid format of %s variable.\n", varInfo.Name)
+	return false, nil
+}
+
 // Run collects template variables from user in interactive mode.
 func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 	createCtx *create_ctx.CreateCtx, templateCtx *app_template.TemplateCtx,
 ) error {
-	var err error
 	if !templateCtx.IsManifestPresent {
 		return nil
 	}
@@ -32,24 +52,12 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 	for _, varInfo := range templateCtx.Manifest.Vars {
 		// Check if var is present, and validate it.
 		existingValue, found := templateCtx.Vars[varInfo.Name]
-		if found {
-			if varInfo.Re != "" {
-				matched, err := regexp.MatchString(varInfo.Re, existingValue)
-				if err != nil {
-					return fmt.Errorf("failed to validate user input: %s", err)
-				}
-				if !matched {
-					if createCtx.SilentMode {
-						return fmt.Errorf("invalid format of %s variable", varInfo.Name)
-					} else {
-						fmt.Printf("Invalid format of %s variable.\n", varInfo.Name)
-					}
-				} else {
-					continue
-				}
-			} else {
-				continue
-			}
+		valid, err := validateExistingValue(createCtx, varInfo, existingValue, found)
+		if err != nil {
+			return err
+		}
+		if valid {
+			continue
 		}
 
 		matched := false
@@ -83,22 +91,22 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 					input = varInfo.Default
 				}
 			}
-			if input != "" {
-				if varInfo.Re != "" {
-					matched, err = regexp.MatchString(varInfo.Re, input)
-					if err != nil {
-						return fmt.Errorf("failed to validate user input: %s", err)
-					}
-					if !matched {
-						if createCtx.SilentMode {
-							return fmt.Errorf("invalid format of %s variable", varInfo.Name)
-						} else {
-							fmt.Println("Invalid format. Try again.")
-						}
-					}
-				} else {
-					matched = true
+			if input == "" {
+				continue
+			}
+			if varInfo.Re == "" {
+				matched = true
+				continue
+			}
+			matched, err = regexp.MatchString(varInfo.Re, input)
+			if err != nil {
+				return fmt.Errorf("failed to validate user input: %s", err)
+			}
+			if !matched {
+				if createCtx.SilentMode {
+					return fmt.Errorf("invalid format of %s variable", varInfo.Name)
 				}
+				fmt.Println("Invalid format. Try again.")
 			}
 		}
 		templateCtx.Vars[varInfo.Name] = input

--- a/cli/create/internal/steps/copy_app_template_test.go
+++ b/cli/create/internal/steps/copy_app_template_test.go
@@ -98,10 +98,7 @@ func TestCopyTemplateDirectoryRelative(t *testing.T) {
 	templateCtx := app_template.NewTemplateContext()
 	templateCtx.AppPath = filepath.Join(dstDir, "app1")
 
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(workDir2))
-	defer os.Chdir(cwd)
+	t.Chdir(workDir2)
 
 	// CopyAppTemplate must copy "src" template from workdir2 to workdir1 using "app1" as dst name.
 	copyAppTemplate := CopyAppTemplate{}

--- a/cli/create/internal/steps/render_template.go
+++ b/cli/create/internal/steps/render_template.go
@@ -17,30 +17,31 @@ type RenderTemplate struct{}
 func render(templateCtx *app_template.TemplateCtx, templateFileNamePattern *regexp.Regexp,
 	filePath string, fileInfo os.FileInfo,
 ) error {
-	if !fileInfo.Mode().IsDir() {
-		if matches := templateFileNamePattern.FindStringSubmatch(
-			fileInfo.Name()); matches != nil {
-			// File name matches template pattern. Render the file.
-			resultFilePath := path.Join(path.Dir(filePath), matches[1])
-			if err := templateCtx.Engine.RenderFile(filePath,
-				resultFilePath, templateCtx.Vars); err != nil {
-				return err
-			}
-			// Remove original template file.
-			if err := os.Remove(filePath); err != nil {
-				return fmt.Errorf("error removing %s: %s", filePath, err)
-			}
-			filePath = resultFilePath
+	if fileInfo.Mode().IsDir() {
+		return nil
+	}
+	if matches := templateFileNamePattern.FindStringSubmatch(
+		fileInfo.Name()); matches != nil {
+		// File name matches template pattern. Render the file.
+		resultFilePath := path.Join(path.Dir(filePath), matches[1])
+		if err := templateCtx.Engine.RenderFile(filePath,
+			resultFilePath, templateCtx.Vars); err != nil {
+			return err
 		}
-		// Render file name.
-		newFileName, err := templateCtx.Engine.RenderText(filePath, templateCtx.Vars)
-		if err != nil {
-			return fmt.Errorf("failed file name processing %s: %s", filePath, err)
+		// Remove original template file.
+		if err := os.Remove(filePath); err != nil {
+			return fmt.Errorf("error removing %s: %s", filePath, err)
 		}
-		if newFileName != filePath {
-			if err = os.Rename(filePath, newFileName); err != nil {
-				return fmt.Errorf("error renaming %s to %s: %s", filePath, newFileName, err)
-			}
+		filePath = resultFilePath
+	}
+	// Render file name.
+	newFileName, err := templateCtx.Engine.RenderText(filePath, templateCtx.Vars)
+	if err != nil {
+		return fmt.Errorf("failed file name processing %s: %s", filePath, err)
+	}
+	if newFileName != filePath {
+		if err = os.Rename(filePath, newFileName); err != nil {
+			return fmt.Errorf("error renaming %s to %s: %s", filePath, newFileName, err)
 		}
 	}
 	return nil

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -30,25 +30,6 @@ type errorResult struct {
 	Err string `json:"err"`
 }
 
-// callCommand invokes the command and returns the execution result.
-func (handler *DaemonHandler) callCommand(ttCmd *command) (string, error) {
-	newArgs := append([]string{ttCmd.Name}, ttCmd.Params...)
-
-	cmd := exec.Command(handler.cmdPath, newArgs...)
-
-	var stderr bytes.Buffer
-	var stdout bytes.Buffer
-
-	cmd.Stderr = &stderr
-	cmd.Stdout = &stdout
-	err := cmd.Run()
-	if err != nil {
-		err = errors.New(fmt.Sprint(err) + ": " + stderr.String())
-	}
-
-	return stdout.String() + stderr.String(), err
-}
-
 // NewDaemonHandler creates DaemonHandler.
 func NewDaemonHandler(cmdPath string) *DaemonHandler {
 	return &DaemonHandler{
@@ -61,54 +42,6 @@ func NewDaemonHandler(cmdPath string) *DaemonHandler {
 func (handler *DaemonHandler) Logger(logger ttlog.Logger) *DaemonHandler {
 	handler.logger = logger
 	return handler
-}
-
-// getClientIP gets the IP address of the client for an incoming HTTP request.
-func (handler *DaemonHandler) getClientIP(req *http.Request) (string, error) {
-	// Get IP from the X-REAL-IP header.
-	// X-REAL-IP header contains only one
-	// IP address of the client machine.
-	// Note: this header can easily be spoofed
-	// by the client.
-	ip := req.Header.Get("X-Real-IP")
-	// Check IP is correct.
-	netIP := net.ParseIP(ip)
-	if netIP != nil {
-		return ip, nil
-	}
-
-	// Get IP from X-FORWARDED-FOR header.
-	// X-FORWARDED-FOR is a list of IP
-	// addresses – proxy chaining.
-	// Note: it can also be easily spoofed
-	// by the client.
-	ips := req.Header.Get("X-Forwarded-For")
-	splitIps := strings.Split(ips, ",")
-	for _, ip := range splitIps {
-		// Check IP is correct.
-		netIP := net.ParseIP(ip)
-		if netIP != nil {
-			return ip, nil
-		}
-	}
-
-	// Get IP from RemoteAddr attr.
-	// RemoteAddr contains the IP address that
-	// the response will be sent to. But in case the
-	// client is connected through a proxy it will
-	// give the IP address of the proxy.
-	ip, _, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		return "", err
-	}
-
-	// Check IP is correct.
-	netIP = net.ParseIP(ip)
-	if netIP != nil {
-		return req.RemoteAddr, nil
-	}
-
-	return "", fmt.Errorf("no valid IP found")
 }
 
 // ServeHTTP handles requests to the tt daemon.
@@ -158,4 +91,71 @@ func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Reques
 	if err := json.NewEncoder(wr).Encode(res); err != nil {
 		handler.logger.Printf("An error occurred while encoding the response: \"%v\"\n", err)
 	}
+}
+
+// callCommand invokes the command and returns the execution result.
+func (handler *DaemonHandler) callCommand(ttCmd *command) (string, error) {
+	newArgs := append([]string{ttCmd.Name}, ttCmd.Params...)
+
+	cmd := exec.Command(handler.cmdPath, newArgs...)
+
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		err = errors.New(fmt.Sprint(err) + ": " + stderr.String())
+	}
+
+	return stdout.String() + stderr.String(), err
+}
+
+// getClientIP gets the IP address of the client for an incoming HTTP request.
+func (handler *DaemonHandler) getClientIP(req *http.Request) (string, error) {
+	// Get IP from the X-REAL-IP header.
+	// X-REAL-IP header contains only one
+	// IP address of the client machine.
+	// Note: this header can easily be spoofed
+	// by the client.
+	ip := req.Header.Get("X-Real-IP")
+	// Check IP is correct.
+	netIP := net.ParseIP(ip)
+	if netIP != nil {
+		return ip, nil
+	}
+
+	// Get IP from X-FORWARDED-FOR header.
+	// X-FORWARDED-FOR is a list of IP
+	// addresses – proxy chaining.
+	// Note: it can also be easily spoofed
+	// by the client.
+	ips := req.Header.Get("X-Forwarded-For")
+	splitIps := strings.Split(ips, ",")
+	for _, ip := range splitIps {
+		// Check IP is correct.
+		netIP := net.ParseIP(ip)
+		if netIP != nil {
+			return ip, nil
+		}
+	}
+
+	// Get IP from RemoteAddr attr.
+	// RemoteAddr contains the IP address that
+	// the response will be sent to. But in case the
+	// client is connected through a proxy it will
+	// give the IP address of the proxy.
+	ip, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return "", err
+	}
+
+	// Check IP is correct.
+	netIP = net.ParseIP(ip)
+	if netIP != nil {
+		return req.RemoteAddr, nil
+	}
+
+	return "", fmt.Errorf("no valid IP found")
 }

--- a/cli/daemon/httpserver.go
+++ b/cli/daemon/httpserver.go
@@ -32,55 +32,6 @@ type HTTPServer struct {
 	logger ttlog.Logger
 }
 
-// listenIP discovers IP address on the specified interface.
-// If interface name is not specified returned value is 0.0.0.0;
-// returns the first discovered IP address on the specified interface.
-func (httpServer *HTTPServer) listenIP() (string, error) {
-	if httpServer.listenIface == "" {
-		return net.IPv4zero.String(), nil
-	}
-
-	iface, err := net.InterfaceByName(httpServer.listenIface)
-	if err != nil {
-		return "", err
-	}
-
-	if iface.Flags&net.FlagUp == 0 {
-		return "", fmt.Errorf("interface down")
-	}
-
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return "", err
-	}
-
-	// The socket will bind to the first discovered
-	// IP address on the specified interface.
-	for _, addr := range addrs {
-		var ip net.IP
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		}
-
-		if ip == nil {
-			continue
-		}
-
-		// TODO: Support IPv6 by option
-		// Not an IPv4 address.
-		if ip.To4() == nil {
-			continue
-		}
-
-		return ip.String(), nil
-	}
-
-	return "", fmt.Errorf("listen IP is not available")
-}
-
 // NewHTTPServer creates new HTTPServer.
 func NewHTTPServer(listenInterface string, port int) *HTTPServer {
 	return &HTTPServer{
@@ -144,4 +95,53 @@ func (httpServer *HTTPServer) Stop() error {
 	cancel()
 
 	return err
+}
+
+// listenIP discovers IP address on the specified interface.
+// If interface name is not specified returned value is 0.0.0.0;
+// returns the first discovered IP address on the specified interface.
+func (httpServer *HTTPServer) listenIP() (string, error) {
+	if httpServer.listenIface == "" {
+		return net.IPv4zero.String(), nil
+	}
+
+	iface, err := net.InterfaceByName(httpServer.listenIface)
+	if err != nil {
+		return "", err
+	}
+
+	if iface.Flags&net.FlagUp == 0 {
+		return "", fmt.Errorf("interface down")
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+
+	// The socket will bind to the first discovered
+	// IP address on the specified interface.
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+
+		if ip == nil {
+			continue
+		}
+
+		// TODO: Support IPv6 by option
+		// Not an IPv4 address.
+		if ip.To4() == nil {
+			continue
+		}
+
+		return ip.String(), nil
+	}
+
+	return "", fmt.Errorf("listen IP is not available")
 }

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -46,20 +46,6 @@ type Process struct {
 	DaemonTag string
 }
 
-// startSignalHandling adds "SIGTERM" and "SIGINT"
-// signal handling to terminate gracefully.
-func (process *Process) startSignalHandling() {
-	sigTermChan := make(chan os.Signal, 1)
-	signal.Notify(sigTermChan, syscall.SIGINT, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-sigTermChan:
-			process.Stop()
-		}
-	}
-}
-
 // NewProcess creates new Process.
 func NewProcess(worker Worker, pidFileName string, logOpts ttlog.LoggerOpts) *Process {
 	process := &Process{
@@ -142,4 +128,15 @@ func (process *Process) Stop() {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+// startSignalHandling adds "SIGTERM" and "SIGINT"
+// signal handling to terminate gracefully.
+func (process *Process) startSignalHandling() {
+	sigTermChan := make(chan os.Signal, 1)
+	signal.Notify(sigTermChan, syscall.SIGINT, syscall.SIGTERM)
+
+	for range sigTermChan {
+		process.Stop()
+	}
 }

--- a/cli/daemon/test_process/test_process.go
+++ b/cli/daemon/test_process/test_process.go
@@ -30,12 +30,7 @@ func (w *TestWorker) Start(ttPath string) {
 	w.logger.Println(daemon.StartTestWorkerMsg)
 
 	go func() {
-		for {
-			select {
-			case <-w.done:
-				return
-			}
-		}
+		<-w.done
 	}()
 }
 

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -139,8 +139,7 @@ func createContainer(dockerClient *mobyclient.Client, runOptions RunOptions) (st
 
 // RunContainer builds docker image and runs a container.
 func RunContainer(runOptions RunOptions, writer io.Writer) error {
-	dockerClient, err := mobyclient.New(mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation())
+	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	if err != nil {
 		return err
 	}

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -79,23 +79,25 @@ func buildDockerImage(dockerClient *mobyclient.Client, imageTag, buildContextDir
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer interruptHandler(cancelFunc)()
-	if buildResult, err := dockerClient.ImageBuild(ctx, buildCtx, opts); err == nil {
-		if buildResult.Body != nil {
-			defer buildResult.Body.Close()
-			if !verbose {
-				writer = io.Discard
-			}
-			termFd, isTerm := term.GetFdInfo(writer)
-			if err = jsonmessage.DisplayJSONMessagesStream(buildResult.Body,
-				writer, termFd, isTerm, nil); err != nil {
-				if ctx.Err() == context.Canceled {
-					return fmt.Errorf("the operation is interrupted")
-				}
-				return err
-			}
-		}
-	} else {
+	buildResult, err := dockerClient.ImageBuild(ctx, buildCtx, opts)
+	if err != nil {
 		return fmt.Errorf("docker image build failed: %s", err)
+	}
+	if buildResult.Body == nil {
+		return nil
+	}
+
+	defer buildResult.Body.Close()
+	if !verbose {
+		writer = io.Discard
+	}
+	termFd, isTerm := term.GetFdInfo(writer)
+	if err = jsonmessage.DisplayJSONMessagesStream(buildResult.Body,
+		writer, termFd, isTerm, nil); err != nil {
+		if ctx.Err() == context.Canceled {
+			return fmt.Errorf("the operation is interrupted")
+		}
+		return err
 	}
 	return nil
 }

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -35,8 +35,7 @@ func findAndRemoveBuiltImage(t *testing.T, dockerClient *mobyclient.Client) {
 }
 
 func TestBuildImage(t *testing.T) {
-	dockerClient, err := mobyclient.New(mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation())
+	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
 	defer dockerClient.Close()
 
@@ -53,8 +52,7 @@ func TestBuildImageFail(t *testing.T) {
 	COPY /non-existing-file /
 	`), 0o664))
 
-	dockerClient, err := mobyclient.New(mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation())
+	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
 	defer dockerClient.Close()
 
@@ -64,8 +62,7 @@ func TestBuildImageFail(t *testing.T) {
 }
 
 func TestBuildImageOutputVerbose(t *testing.T) {
-	dockerClient, err := mobyclient.New(mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation())
+	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
 	defer dockerClient.Close()
 
@@ -91,8 +88,7 @@ func TestBuildImageOutputVerbose(t *testing.T) {
 }
 
 func TestBuildImageOutput(t *testing.T) {
-	dockerClient, err := mobyclient.New(mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation())
+	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
 	defer dockerClient.Close()
 
@@ -115,10 +111,7 @@ func checkNoContainers(t *testing.T, imageTag string) {
 	t.Helper()
 
 	ctx := context.Background()
-	cli, err := mobyclient.New(
-		mobyclient.FromEnv,
-		mobyclient.WithAPIVersionNegotiation(),
-	)
+	cli, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
 	defer cli.Close()
 

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func findAndRemoveBuiltImage(t *testing.T, dockerClient *mobyclient.Client, expectedTag string) {
+func findAndRemoveBuiltImage(t *testing.T, dockerClient *mobyclient.Client) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -42,7 +42,7 @@ func TestBuildImage(t *testing.T) {
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", false,
 		os.Stdout))
-	findAndRemoveBuiltImage(t, dockerClient, "ubuntu:tt_test")
+	findAndRemoveBuiltImage(t, dockerClient)
 }
 
 func TestBuildImageFail(t *testing.T) {
@@ -75,7 +75,7 @@ func TestBuildImageOutputVerbose(t *testing.T) {
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", true, out))
 	out.Close()
-	findAndRemoveBuiltImage(t, dockerClient, "ubuntu:tt_test")
+	findAndRemoveBuiltImage(t, dockerClient)
 
 	in, err := os.Open(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestBuildImageOutput(t *testing.T) {
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", false, out))
 	out.Close()
-	findAndRemoveBuiltImage(t, dockerClient, "ubuntu:tt_test")
+	findAndRemoveBuiltImage(t, dockerClient)
 
 	in, err := os.Open(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)

--- a/cli/formatter/table.go
+++ b/cli/formatter/table.go
@@ -274,7 +274,7 @@ func transposeRows(rowsRaw []table.Row) []table.Row {
 }
 
 // createMarkdownTable creates a table in markdown notation.
-func createMarkdownTable(table []string, columns int, opts Opts) string {
+func createMarkdownTable(table []string, columns int) string {
 	empty := "| "
 	separator := "|-"
 	for i := 1; i < columns; i++ {
@@ -332,7 +332,7 @@ func renderEqualMaps(maps []unorderedMap[any], transpose bool, opts Opts) (strin
 
 	if opts.TableDialect == MarkdownTableDialect {
 		markdown := strings.Split(t.RenderMarkdown(), "\n")
-		return createMarkdownTable(markdown, columnsAmount, opts) + "\n", nil
+		return createMarkdownTable(markdown, columnsAmount) + "\n", nil
 	}
 	if opts.TableDialect == JiraTableDialect {
 		return t.RenderMarkdown() + "\n\n", nil
@@ -374,9 +374,10 @@ func isMapKeysEqual(x, y unorderedMap[any]) bool {
 
 // renderBatch parses renders batch and return tables as string for it.
 func renderBatch(batch []any, transpose bool, opts Opts) (string, error) {
-	if isSingleType(batch, scalarNodeType) {
+	switch {
+	case isSingleType(batch, scalarNodeType):
 		return renderScalars(batch, transpose, opts)
-	} else if isSingleType(batch, mapNodeType) {
+	case isSingleType(batch, mapNodeType):
 		var anyMaps []unorderedMap[any]
 		for _, node := range batch {
 			var castedMap unorderedMap[any]
@@ -418,9 +419,9 @@ func renderBatch(batch []any, transpose bool, opts Opts) (string, error) {
 		}
 
 		return res, nil
-	} else if isSingleType(batch, arrayNodeType) {
+	case isSingleType(batch, arrayNodeType):
 		return renderArrays(batch, transpose, opts)
-	} else {
+	default:
 		return "", fmt.Errorf("unknown parsing case with current render batch")
 	}
 }

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -454,6 +454,60 @@ type resolvedInstallVersion struct {
 	pullRequestHash string
 }
 
+func matchRequestedInstallVersion(result resolvedInstallVersion, installCtx InstallCtx,
+	distfiles, programName, repo string,
+) (resolvedInstallVersion, error) {
+	if !version.IsVersion(result.version, false) {
+		return result, nil
+	}
+	log.Infof("Searching in versions...")
+	versions, err := getVersionsFromRepo(installCtx.Local, distfiles, programName, repo)
+	if err != nil {
+		return resolvedInstallVersion{}, err
+	}
+	match, err := version.MatchVersion(result.version, versions)
+	if err != nil {
+		var errNotFound version.NotFoundError
+		if !errors.As(err, &errNotFound) {
+			return resolvedInstallVersion{}, err
+		}
+		return result, nil
+	}
+	result.versionFound = true
+	result.version = match
+	return result, nil
+}
+
+func resolveRequestedInstallVersion(result resolvedInstallVersion, installCtx InstallCtx,
+	distfiles, programName, repo string,
+) (resolvedInstallVersion, error) {
+	if result.version == "master" {
+		return result, nil
+	}
+	result, err := matchRequestedInstallVersion(
+		result, installCtx, distfiles, programName, repo)
+	if err != nil {
+		return resolvedInstallVersion{}, err
+	}
+	if result.versionFound {
+		return result, nil
+	}
+
+	result.isPullRequest, result.pullRequestID = util.IsPullRequest(result.version)
+	if result.isPullRequest {
+		log.Infof("Searching in pull-requests...")
+	} else {
+		log.Infof("Searching in commits...")
+	}
+
+	result.version, result.pullRequestHash, err = checkCommit(
+		result.version, programName, installCtx, distfiles)
+	if err != nil {
+		return resolvedInstallVersion{}, err
+	}
+	return result, nil
+}
+
 func resolveTtInstallVersion(installCtx InstallCtx, distfiles string) (
 	resolvedInstallVersion,
 	error,
@@ -474,40 +528,11 @@ func resolveTtInstallVersion(installCtx InstallCtx, distfiles string) (
 	}
 
 	// The tag format in tt is vX.Y.Z, but the user can use X.Y.Z.
-	if result.version != "master" {
-		if version.IsVersion(result.version, false) {
-			log.Infof("Searching in versions...")
-			versions, err := getVersionsFromRepo(
-				installCtx.Local, distfiles, "tt", search.GitRepoTT)
-			if err != nil {
-				return resolvedInstallVersion{}, err
-			}
-			match, err := version.MatchVersion(result.version, versions)
-			if err != nil {
-				var errNotFound version.NotFoundError
-				if !errors.As(err, &errNotFound) {
-					return resolvedInstallVersion{}, err
-				}
-			} else {
-				result.versionFound = true
-				result.version = match
-			}
-		}
-		if !result.versionFound {
-			result.isPullRequest, result.pullRequestID = util.IsPullRequest(result.version)
-			if result.isPullRequest {
-				log.Infof("Searching in pull-requests...")
-			} else {
-				log.Infof("Searching in commits...")
-			}
-
-			var err error
-			result.version, result.pullRequestHash, err = checkCommit(
-				result.version, "tt", installCtx, distfiles)
-			if err != nil {
-				return resolvedInstallVersion{}, err
-			}
-		}
+	var err error
+	result, err = resolveRequestedInstallVersion(
+		result, installCtx, distfiles, "tt", search.GitRepoTT)
+	if err != nil {
+		return resolvedInstallVersion{}, err
 	}
 
 	switch {
@@ -543,40 +568,11 @@ func resolveTarantoolInstallVersion(installCtx InstallCtx, distfiles string) (
 		}
 	}
 
-	if result.version != "master" {
-		if version.IsVersion(result.version, false) {
-			log.Infof("Searching in versions...")
-			versions, err := getVersionsFromRepo(
-				installCtx.Local, distfiles, "tarantool", search.GitRepoTarantool)
-			if err != nil {
-				return resolvedInstallVersion{}, err
-			}
-			match, err := version.MatchVersion(result.version, versions)
-			if err != nil {
-				var errNotFound version.NotFoundError
-				if !errors.As(err, &errNotFound) {
-					return resolvedInstallVersion{}, err
-				}
-			} else {
-				result.versionFound = true
-				result.version = match
-			}
-		}
-		if !result.versionFound {
-			result.isPullRequest, result.pullRequestID = util.IsPullRequest(result.version)
-			if result.isPullRequest {
-				log.Infof("Searching in pull-requests...")
-			} else {
-				log.Infof("Searching in commits...")
-			}
-
-			var err error
-			result.version, result.pullRequestHash, err = checkCommit(
-				result.version, "tarantool", installCtx, distfiles)
-			if err != nil {
-				return resolvedInstallVersion{}, err
-			}
-		}
+	var err error
+	result, err = resolveRequestedInstallVersion(
+		result, installCtx, distfiles, "tarantool", search.GitRepoTarantool)
+	if err != nil {
+		return resolvedInstallVersion{}, err
 	}
 
 	switch {
@@ -607,6 +603,90 @@ func prepareTarantoolInstall(binDir, incDir string, installCtx InstallCtx, distf
 	return resolveTarantoolInstallVersion(installCtx, distfiles)
 }
 
+func prepareExistingTt(installCtx *InstallCtx, binDir, versionStr, ttVersion,
+	distfiles string,
+) (bool, error) {
+	if installCtx.Reinstall {
+		return false, nil
+	}
+	log.Infof("Checking existing...")
+	pathToBin := filepath.Join(binDir, versionStr)
+	if !util.IsRegularFile(pathToBin) {
+		return false, nil
+	}
+	isBinExecutable, err := util.IsExecOwner(pathToBin)
+	if err != nil {
+		return false, err
+	}
+
+	updatePossible, err := isUpdatePossible(*installCtx, pathToBin, search.ProgramTt,
+		ttVersion, distfiles, isBinExecutable)
+	if err != nil {
+		return false, err
+	}
+	if updatePossible {
+		log.Info("Found newest commit of tt in master")
+		// Reduce the case to a reinstallation.
+		installCtx.Reinstall = true
+		return false, nil
+	}
+
+	log.Infof("%s version of tt already exists, updating symlink...", versionStr)
+	if err := util.CreateSymlink(versionStr,
+		filepath.Join(binDir, search.ProgramTt.Exec()), true); err != nil {
+		return false, err
+	}
+	log.Infof("Done")
+	return true, nil
+}
+
+func downloadTtSource(path, ttVersion, distfiles string, resolved resolvedInstallVersion,
+	installCtx InstallCtx, logFile *os.File,
+) error {
+	if installCtx.Local {
+		if !util.IsDir(filepath.Join(distfiles, "tt")) {
+			return fmt.Errorf("can't find distfiles directory")
+		}
+		log.Infof("Local files found, installing from them...")
+		localPath, _ := util.JoinAbspath(distfiles, "tt")
+		if err := copy.Copy(localPath, path); err != nil {
+			return err
+		}
+		err := gitCheckout(path, ttVersion, installCtx.verbose, logFile)
+		if err != nil {
+			printLog(logFile.Name())
+		}
+		return err
+	}
+
+	log.Infof("Downloading tt...")
+	if resolved.versionFound {
+		err := downloadRepo(search.GitRepoTT, ttVersion, path, logFile, installCtx.verbose)
+		if err != nil {
+			printLog(logFile.Name())
+		}
+		return err
+	}
+	if err := downloadRepo(search.GitRepoTT, "master", path, logFile,
+		installCtx.verbose); err != nil {
+		printLog(logFile.Name())
+		return err
+	}
+	if resolved.isPullRequest {
+		pullRequestCommand := "pull/" + resolved.pullRequestID + "/head:" + ttVersion
+		if err := util.ExecuteCommand("git", installCtx.verbose, logFile, path,
+			"fetch", "origin", pullRequestCommand); err != nil {
+			printLog(logFile.Name())
+			return err
+		}
+	}
+	err := gitCheckout(path, ttVersion, installCtx.verbose, logFile)
+	if err != nil {
+		printLog(logFile.Name())
+	}
+	return err
+}
+
 // installTt installs selected version of tt.
 func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	resolved, err := resolveTtInstallVersion(installCtx, distfiles)
@@ -615,46 +695,17 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	}
 	ttVersion := resolved.version
 	versionStr := resolved.versionStr
-	versionFound := resolved.versionFound
 	isPullRequest := resolved.isPullRequest
-	pullRequestID := resolved.pullRequestID
 	pullRequestHash := resolved.pullRequestHash
 
 	// Check if that version is already installed.
 	// If it is installed, check if the newest version exists.
-	if !installCtx.Reinstall {
-		log.Infof("Checking existing...")
-		pathToBin := filepath.Join(binDir, versionStr)
-		if util.IsRegularFile(pathToBin) {
-			isBinExecutable, err := util.IsExecOwner(pathToBin)
-			if err != nil {
-				return err
-			}
-
-			isUpdatePossible, err := isUpdatePossible(installCtx,
-				pathToBin,
-				search.ProgramTt,
-				ttVersion,
-				distfiles,
-				isBinExecutable)
-			if err != nil {
-				return err
-			}
-
-			if !isUpdatePossible {
-				log.Infof("%s version of tt already exists, updating symlink...", versionStr)
-				err := util.CreateSymlink(versionStr,
-					filepath.Join(binDir, search.ProgramTt.Exec()), true)
-				if err != nil {
-					return err
-				}
-				log.Infof("Done")
-				return nil
-			}
-			log.Info("Found newest commit of tt in master")
-			// Reduce the case to a reinstallation.
-			installCtx.Reinstall = true
-		}
+	done, err := prepareExistingTt(&installCtx, binDir, versionStr, ttVersion, distfiles)
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
 	}
 
 	// Check binary directory.
@@ -689,44 +740,8 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	}
 
 	// Download tt.
-	if installCtx.Local {
-		if util.IsDir(filepath.Join(distfiles, "tt")) {
-			log.Infof("Local files found, installing from them...")
-			localPath, _ := util.JoinAbspath(distfiles, "tt")
-			err = copy.Copy(localPath, path)
-			if err != nil {
-				return err
-			}
-			err = gitCheckout(path, ttVersion, installCtx.verbose, logFile)
-		} else {
-			return fmt.Errorf("can't find distfiles directory")
-		}
-	} else {
-		log.Infof("Downloading tt...")
-		if versionFound {
-			err = downloadRepo(search.GitRepoTT, ttVersion, path, logFile, installCtx.verbose)
-		} else {
-			err = downloadRepo(search.GitRepoTT, "master", path, logFile, installCtx.verbose)
-			if err != nil {
-				printLog(logFile.Name())
-				return err
-			}
-			if isPullRequest {
-				pullRequestCommand := "pull/" + pullRequestID +
-					"/head:" + ttVersion
-				err = util.ExecuteCommand("git", installCtx.verbose, logFile, path,
-					"fetch", "origin", pullRequestCommand)
-				if err != nil {
-					printLog(logFile.Name())
-					return err
-				}
-			}
-			err = gitCheckout(path, ttVersion, installCtx.verbose, logFile)
-		}
-	}
-
+	err = downloadTtSource(path, ttVersion, distfiles, resolved, installCtx, logFile)
 	if err != nil {
-		printLog(logFile.Name())
 		return err
 	}
 	// Build tt.
@@ -997,6 +1012,67 @@ func changeActiveTarantoolVersion(versionStr, binDir, incDir string) error {
 	return err
 }
 
+func prepareExistingTarantool(installCtx InstallCtx, binDir, incDir, versionStr,
+	tarVersion, distfiles string,
+) (bool, error) {
+	if installCtx.Reinstall {
+		return false, nil
+	}
+	log.Infof("Checking existing...")
+	pathToBin := filepath.Join(binDir, versionStr)
+	if !util.IsRegularFile(pathToBin) || !util.IsDir(filepath.Join(incDir, versionStr)) {
+		return false, nil
+	}
+	isBinExecutable, err := util.IsExecOwner(pathToBin)
+	if err != nil {
+		return false, err
+	}
+
+	updatePossible, err := isUpdatePossible(installCtx, pathToBin, search.ProgramCe,
+		tarVersion, distfiles, isBinExecutable)
+	if err != nil {
+		return false, err
+	}
+	if updatePossible {
+		log.Infof("Found newest commit of tarantool in master")
+		return false, nil
+	}
+
+	log.Infof("%s version of tarantool already exists, updating symlinks...", versionStr)
+	if err := changeActiveTarantoolVersion(versionStr, binDir, incDir); err != nil {
+		return false, err
+	}
+	log.Infof("Done")
+	return true, nil
+}
+
+func downloadTarantoolSource(path, tarVersion, distfiles string,
+	resolved resolvedInstallVersion, installCtx InstallCtx, logFile *os.File,
+) error {
+	if installCtx.Local {
+		log.Infof("Checking local files...")
+		return copyLocalTarantool(distfiles, path, tarVersion, installCtx, logFile)
+	}
+
+	log.Infof("Downloading tarantool...")
+	if resolved.versionFound {
+		return downloadRepo(search.GitRepoTarantool, tarVersion, path, logFile,
+			installCtx.verbose)
+	}
+	if err := downloadRepo(search.GitRepoTarantool, "master", path, logFile,
+		installCtx.verbose); err != nil {
+		return err
+	}
+	if resolved.isPullRequest {
+		pullRequestCommand := "pull/" + resolved.pullRequestID + "/head:" + tarVersion
+		if err := util.ExecuteCommand("git", installCtx.verbose, logFile, path,
+			"fetch", "origin", pullRequestCommand); err != nil {
+			return err
+		}
+	}
+	return gitCheckout(path, tarVersion, installCtx.verbose, logFile)
+}
+
 // installTarantool installs selected version of tarantool.
 func installTarantool(binDir string, installCtx InstallCtx, distfiles string) error {
 	incDir := installCtx.IncDir
@@ -1006,46 +1082,18 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	}
 	tarVersion := resolved.version
 	versionStr := resolved.versionStr
-	versionFound := resolved.versionFound
 	isPullRequest := resolved.isPullRequest
-	pullRequestID := resolved.pullRequestID
 	pullRequestHash := resolved.pullRequestHash
 
 	// Check if program is already installed.
 	// If it is installed, check if newest version exists.
-	if !installCtx.Reinstall {
-		log.Infof("Checking existing...")
-		pathToBin := filepath.Join(binDir, versionStr)
-		if util.IsRegularFile(pathToBin) &&
-			util.IsDir(filepath.Join(incDir, versionStr)) {
-			isBinExecutable, err := util.IsExecOwner(pathToBin)
-			if err != nil {
-				return err
-			}
-
-			isUpdatePossible, err := isUpdatePossible(installCtx,
-				pathToBin,
-				search.ProgramCe,
-				tarVersion,
-				distfiles,
-				isBinExecutable)
-			if err != nil {
-				return err
-			}
-
-			if !isUpdatePossible {
-				log.Infof("%s version of tarantool already exists, updating symlinks...",
-					versionStr)
-				err = changeActiveTarantoolVersion(versionStr, binDir, incDir)
-				if err != nil {
-					return err
-				}
-				log.Infof("Done")
-				return nil
-			}
-
-			log.Infof("Found newest commit of tarantool in master")
-		}
+	done, err := prepareExistingTarantool(
+		installCtx, binDir, incDir, versionStr, tarVersion, distfiles)
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
 	}
 
 	if installCtx.BuildInDocker {
@@ -1078,34 +1126,7 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	}
 
 	// Download tarantool.
-	if installCtx.Local {
-		log.Infof("Checking local files...")
-		err = copyLocalTarantool(distfiles, path, tarVersion, installCtx,
-			logFile)
-	} else {
-		log.Infof("Downloading tarantool...")
-		if versionFound {
-			err = downloadRepo(search.GitRepoTarantool, tarVersion, path, logFile,
-				installCtx.verbose)
-		} else {
-			err = downloadRepo(search.GitRepoTarantool, "master", path, logFile, installCtx.verbose)
-			if err != nil {
-				printLog(logFile.Name())
-				return err
-			}
-			if isPullRequest {
-				pullRequestCommand := "pull/" + pullRequestID +
-					"/head:" + tarVersion
-				err = util.ExecuteCommand("git", installCtx.verbose, logFile, path,
-					"fetch", "origin", pullRequestCommand)
-				if err != nil {
-					printLog(logFile.Name())
-					return err
-				}
-			}
-			err = gitCheckout(path, tarVersion, installCtx.verbose, logFile)
-		}
-	}
+	err = downloadTarantoolSource(path, tarVersion, distfiles, resolved, installCtx, logFile)
 	if err != nil {
 		printLog(logFile.Name())
 		return err
@@ -1174,55 +1195,52 @@ func isUpdatePossible(installCtx InstallCtx,
 	distfiles string,
 	isBinExecutable bool,
 ) (bool, error) {
-	var curBinHash, lastCommitHash string
 	// We need to make sure that we check newest commits only for
 	// production 'master' branch. Also we want to ask if user wants
 	// to check for updates.
-	if isBinExecutable && progVer == "master" {
-		var err error
-		answer := false
-		if !installCtx.skipMasterUpdate {
-			answer, err = util.AskConfirm(os.Stdin, "The 'master' version of the "+
-				program.String()+" has already been installed.\n"+
-				"Would you like to update it if there are newer commits available?")
-			if err != nil {
-				return false, err
-			}
-		}
+	if !isBinExecutable || progVer != "master" || installCtx.skipMasterUpdate {
+		return false, nil
+	}
+	answer, err := util.AskConfirm(os.Stdin, "The 'master' version of the "+
+		program.String()+" has already been installed.\n"+
+		"Would you like to update it if there are newer commits available?")
+	if err != nil {
+		return false, err
+	}
+	if !answer {
+		return false, nil
+	}
 
-		if answer {
-			lastCommitHash, err = getCommit(installCtx.Local, distfiles,
-				program.String(), progVer)
-			if err != nil {
-				return false, err
-			}
+	lastCommitHash, err := getCommit(installCtx.Local, distfiles, program.String(), progVer)
+	if err != nil {
+		return false, err
+	}
 
-			switch program {
-			case search.ProgramCe:
-				tarantoolBin := cmdcontext.TarantoolCli{
-					Executable: pathToBin,
-				}
-				binVersion, err := tarantoolBin.GetVersion()
-				if err != nil {
-					return false, err
-				}
-				// We need to trim first rune to get commit hash
-				// from string structure 'g<commitHash>'.
-				if len(binVersion.Hash) < 1 {
-					return false, fmt.Errorf("could not get commit hash of the version"+
-						"of an installed %s", program)
-				}
-				curBinHash = binVersion.Hash[1:]
-			case search.ProgramTt:
-				ttVer, err := cmdcontext.GetTtVersion(pathToBin)
-				if err != nil {
-					return false, err
-				}
-				curBinHash = ttVer.Hash
-			case search.ProgramUnknown, search.ProgramEe, search.ProgramDev, search.ProgramTcm:
-				// Current callers only pass Tarantool CE or tt.
-			}
+	var curBinHash string
+	switch program {
+	case search.ProgramCe:
+		tarantoolBin := cmdcontext.TarantoolCli{
+			Executable: pathToBin,
 		}
+		binVersion, err := tarantoolBin.GetVersion()
+		if err != nil {
+			return false, err
+		}
+		// We need to trim first rune to get commit hash
+		// from string structure 'g<commitHash>'.
+		if len(binVersion.Hash) < 1 {
+			return false, fmt.Errorf("could not get commit hash of the version"+
+				"of an installed %s", program)
+		}
+		curBinHash = binVersion.Hash[1:]
+	case search.ProgramTt:
+		ttVer, err := cmdcontext.GetTtVersion(pathToBin)
+		if err != nil {
+			return false, err
+		}
+		curBinHash = ttVer.Hash
+	case search.ProgramUnknown, search.ProgramEe, search.ProgramDev, search.ProgramTcm:
+		// Current callers only pass Tarantool CE or tt.
 	}
 
 	if strings.HasPrefix(lastCommitHash, curBinHash) {
@@ -1286,47 +1304,49 @@ func installTarantoolDev(ttBinDir, ttIncludeDir, buildDir,
 
 		var isExecOwner bool
 		isExecOwner, err = util.IsExecOwner(binaryPath)
-		if err == nil && isExecOwner && !util.IsDir(binaryPath) {
-			// Check that tt directories exist.
-			if err = util.CreateDirectory(ttBinDir, defaultDirPermissions); err != nil {
-				return err
-			}
-			if err = util.CreateDirectory(ttIncludeDir, defaultDirPermissions); err != nil {
-				return err
-			}
-
-			log.Infof("Changing symlinks...")
-			err = util.CreateSymlink(binaryPath, filepath.Join(ttBinDir, "tarantool"), true)
-			if err != nil {
-				return err
-			}
-
-			includeDir, err = searchTarantoolHeaders(buildDir, includeDir)
-			if err != nil {
-				return err
-			}
-			tarantoolIncludeSymlink := filepath.Join(ttIncludeDir, "tarantool")
-			// Remove old symlink to the tarantool headers.
-			// RemoveAll is used to perform deletion even if the file is not a symlink.
-			err = os.RemoveAll(tarantoolIncludeSymlink)
-			if err != nil {
-				return err
-			}
-			if includeDir == "" {
-				log.Warn("Tarantool headers location was not specified. " +
-					"`tt package build`, `tt rocks` may not work properly.\n" +
-					"  To specify include files location use --include-dir option.")
-			} else {
-				err = util.CreateSymlink(includeDir, tarantoolIncludeSymlink, true)
-				if err != nil {
-					return err
-				}
-				log.Infof("tarantool headers directory set as %v.", includeDir)
-			}
-			log.Infof("Done.")
-			return nil
+		if err != nil || !isExecOwner || util.IsDir(binaryPath) {
+			checkedBinaryPaths = append(checkedBinaryPaths, binaryPath)
+			continue
 		}
-		checkedBinaryPaths = append(checkedBinaryPaths, binaryPath)
+
+		// Check that tt directories exist.
+		if err = util.CreateDirectory(ttBinDir, defaultDirPermissions); err != nil {
+			return err
+		}
+		if err = util.CreateDirectory(ttIncludeDir, defaultDirPermissions); err != nil {
+			return err
+		}
+
+		log.Infof("Changing symlinks...")
+		err = util.CreateSymlink(binaryPath, filepath.Join(ttBinDir, "tarantool"), true)
+		if err != nil {
+			return err
+		}
+
+		includeDir, err = searchTarantoolHeaders(buildDir, includeDir)
+		if err != nil {
+			return err
+		}
+		tarantoolIncludeSymlink := filepath.Join(ttIncludeDir, "tarantool")
+		// Remove old symlink to the tarantool headers.
+		// RemoveAll is used to perform deletion even if the file is not a symlink.
+		err = os.RemoveAll(tarantoolIncludeSymlink)
+		if err != nil {
+			return err
+		}
+		if includeDir == "" {
+			log.Warn("Tarantool headers location was not specified. " +
+				"`tt package build`, `tt rocks` may not work properly.\n" +
+				"  To specify include files location use --include-dir option.")
+		} else {
+			err = util.CreateSymlink(includeDir, tarantoolIncludeSymlink, true)
+			if err != nil {
+				return err
+			}
+			log.Infof("tarantool headers directory set as %v.", includeDir)
+		}
+		log.Infof("Done.")
+		return nil
 	}
 
 	return fmt.Errorf("tarantool binary was not found in the paths:\n%s",

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -247,7 +247,8 @@ func programDependenciesInstalled(program search.Program) error {
 	case search.ProgramTt:
 		programs = []Package{{"mage", "mage"}, {"git", "git"}}
 	case search.ProgramCe:
-		if osName == "darwin" {
+		switch {
+		case osName == "darwin":
 			programs = []Package{
 				{"cmake", "cmake"},
 				{"git", "git"},
@@ -255,7 +256,7 @@ func programDependenciesInstalled(program search.Program) error {
 				{"clang", "clang"},
 				{"openssl", "openssl"},
 			}
-		} else if strings.Contains(osName, "Ubuntu") || strings.Contains(osName, "Debian") {
+		case strings.Contains(osName, "Ubuntu") || strings.Contains(osName, "Debian"):
 			programs = []Package{
 				{"cmake", "cmake"},
 				{"git", "git"},
@@ -263,7 +264,7 @@ func programDependenciesInstalled(program search.Program) error {
 				{"gcc", " build-essential"},
 			}
 			packages = []string{"coreutils", "sed"} // spell-checker:disable-line
-		} else if strings.Contains(osName, "CentOs") {
+		case strings.Contains(osName, "CentOs"):
 			programs = []Package{
 				{"cmake", "cmake"},
 				{"git", "git"},
@@ -272,7 +273,7 @@ func programDependenciesInstalled(program search.Program) error {
 				{"g++", "gcc-c++ "},
 			}
 			packages = []string{"libstdc++-static", "perl"}
-		} else {
+		default:
 			answer, err := util.AskConfirm(os.Stdin,
 				"Unknown OS, can't check if dependencies"+
 					" are installed.\n"+
@@ -313,7 +314,8 @@ func programDependenciesInstalled(program search.Program) error {
 		var errMsg strings.Builder
 		errMsg.WriteString("Missing packages: " + strings.Join(missing_pack, " ") + " " +
 			strings.Join(missing_pack_src, " ") + "\n")
-		if osName == "darwin" {
+		switch {
+		case osName == "darwin":
 			errMsg.WriteString(
 				"You can install them by running commands:\nbrew install " + strings.Join(
 					missing_pack,
@@ -324,7 +326,7 @@ func programDependenciesInstalled(program search.Program) error {
 						" ",
 					) + "\n",
 			)
-		} else if strings.Contains(osName, "CentOs") {
+		case strings.Contains(osName, "CentOs"):
 			errMsg.WriteString("You can install them by running command:\n")
 			if len(missing_pack) != 0 {
 				errMsg.WriteString(" sudo yum install " + strings.Join(missing_pack, " ") + "\n")
@@ -333,7 +335,7 @@ func programDependenciesInstalled(program search.Program) error {
 				errMsg.WriteString("install from sources: " +
 					strings.Join(missing_pack_src, " ") + "\n")
 			}
-		} else if strings.Contains(osName, "Ubuntu") || strings.Contains(osName, "Debian") {
+		case strings.Contains(osName, "Ubuntu") || strings.Contains(osName, "Debian"):
 			errMsg.WriteString("You can install them by running command:\n")
 			if len(missing_pack) != 0 {
 				errMsg.WriteString(" sudo apt install " + strings.Join(missing_pack, " ") + "\n")
@@ -368,9 +370,7 @@ func downloadRepo(repoLink, tag, dst string, logFile *os.File, verbose bool) err
 }
 
 // copyBuildedTT copies tt binary.
-func copyBuildedTT(binDir, path, version string, installCtx InstallCtx,
-	logFile *os.File,
-) error {
+func copyBuildedTT(binDir, path, version string, installCtx InstallCtx) error {
 	var err error
 	if _, err := os.Stat(binDir); os.IsNotExist(err) {
 		err = os.MkdirAll(binDir, defaultDirPermissions)
@@ -644,7 +644,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 
 	// Copy binary.
 	log.Infof("Copying executable...")
-	err = copyBuildedTT(binDir, path, versionStr, installCtx, logFile)
+	err = copyBuildedTT(binDir, path, versionStr, installCtx)
 	if err != nil {
 		printLog(logFile.Name())
 		return err
@@ -670,7 +670,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 // prepareCmakeOpts prepares cmake command line options for tarantool building.
 func prepareCmakeOpts(buildPath string,
 	installCtx InstallCtx,
-) ([]string, error) {
+) []string {
 	cmakeOpts := []string{".."}
 
 	cmakeOpts = append(cmakeOpts, `-DCMAKE_TARANTOOL_ARGS=-DCMAKE_BUILD_TYPE=RelWithDebInfo;`+
@@ -683,7 +683,7 @@ func prepareCmakeOpts(buildPath string,
 		cmakeOpts = append(cmakeOpts, "-DCMAKE_INSTALL_PREFIX="+buildPath)
 	}
 
-	return cmakeOpts, nil
+	return cmakeOpts
 }
 
 // prepareMakeOpts prepares make command line options for tarantool building.
@@ -712,10 +712,7 @@ func buildTarantool(srcPath string,
 		return "", err
 	}
 
-	cmakeOpts, err := prepareCmakeOpts(buildPath, installCtx)
-	if err != nil {
-		return "", err
-	}
+	cmakeOpts := prepareCmakeOpts(buildPath, installCtx)
 
 	err = util.ExecuteCommand("cmake", installCtx.verbose, logFile, buildPath, cmakeOpts...)
 	if err != nil {

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -445,80 +445,180 @@ func gitCheckout(repoDir, checkout string, verbose bool, logWriter io.Writer) er
 	return nil
 }
 
-// installTt installs selected version of tt.
-func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
-	versionFound := false
-	pullRequestHash := ""
-	isPullRequest := false
-	pullRequestID := ""
+type resolvedInstallVersion struct {
+	version         string
+	versionStr      string
+	versionFound    bool
+	isPullRequest   bool
+	pullRequestID   string
+	pullRequestHash string
+}
+
+func resolveTtInstallVersion(installCtx InstallCtx, distfiles string) (
+	resolvedInstallVersion,
+	error,
+) {
+	result := resolvedInstallVersion{version: installCtx.version}
 
 	// Get latest version if it was not specified.
-	ttVersion := installCtx.version
-	if ttVersion == "" {
+	if result.version == "" {
 		log.Infof("Getting latest tt version...")
 		versions, err := getVersionsFromRepo(installCtx.Local, distfiles, "tt", search.GitRepoTT)
 		if err != nil {
-			return err
+			return resolvedInstallVersion{}, err
 		}
 		if len(versions) == 0 {
-			return fmt.Errorf("no versions were fetched")
-		} else {
-			ttVersion = versions[len(versions)-1].Str
+			return resolvedInstallVersion{}, fmt.Errorf("no versions were fetched")
 		}
+		result.version = versions[len(versions)-1].Str
 	}
 
-	// Check that the version exists.
-	// The tag format in tt is vX.Y.Z, but the user can use the X.Y.Z format
-	// and this option needs to be supported.
-	if ttVersion != "master" {
-		if version.IsVersion(ttVersion, false) {
+	// The tag format in tt is vX.Y.Z, but the user can use X.Y.Z.
+	if result.version != "master" {
+		if version.IsVersion(result.version, false) {
 			log.Infof("Searching in versions...")
-			versions, err := getVersionsFromRepo(installCtx.Local, distfiles,
-				"tt", search.GitRepoTT)
+			versions, err := getVersionsFromRepo(
+				installCtx.Local, distfiles, "tt", search.GitRepoTT)
 			if err != nil {
-				return err
+				return resolvedInstallVersion{}, err
 			}
-			match, err := version.MatchVersion(ttVersion, versions)
+			match, err := version.MatchVersion(result.version, versions)
 			if err != nil {
 				var errNotFound version.NotFoundError
 				if !errors.As(err, &errNotFound) {
-					return err
+					return resolvedInstallVersion{}, err
 				}
 			} else {
-				versionFound = true
-				ttVersion = match
+				result.versionFound = true
+				result.version = match
 			}
 		}
-		if !versionFound {
-			isPullRequest, pullRequestID = util.IsPullRequest(ttVersion)
-
-			if isPullRequest {
+		if !result.versionFound {
+			result.isPullRequest, result.pullRequestID = util.IsPullRequest(result.version)
+			if result.isPullRequest {
 				log.Infof("Searching in pull-requests...")
 			} else {
 				log.Infof("Searching in commits...")
 			}
 
 			var err error
-			ttVersion, pullRequestHash, err = checkCommit(
-				ttVersion, "tt", installCtx, distfiles)
+			result.version, result.pullRequestHash, err = checkCommit(
+				result.version, "tt", installCtx, distfiles)
 			if err != nil {
-				return err
+				return resolvedInstallVersion{}, err
 			}
 		}
 	}
 
-	var versionStr string
+	switch {
+	case result.versionFound:
+		result.versionStr = search.ProgramTt.Exec() + version.FsSeparator + result.version
+	case result.isPullRequest:
+		result.versionStr = search.ProgramTt.Exec() + version.FsSeparator + result.pullRequestHash
+	default:
+		result.versionStr = search.ProgramTt.Exec() + version.FsSeparator +
+			result.version[0:util.Min(len(result.version), util.MinCommitHashLength)]
+	}
 
-	if versionFound {
-		versionStr = search.ProgramTt.Exec() + version.FsSeparator + ttVersion
-	} else {
-		if isPullRequest {
-			versionStr = search.ProgramTt.Exec() + version.FsSeparator + pullRequestHash
-		} else {
-			versionStr = search.ProgramTt.Exec() + version.FsSeparator +
-				ttVersion[0:util.Min(len(ttVersion), util.MinCommitHashLength)]
+	return result, nil
+}
+
+func resolveTarantoolInstallVersion(installCtx InstallCtx, distfiles string) (
+	resolvedInstallVersion,
+	error,
+) {
+	result := resolvedInstallVersion{version: installCtx.version}
+
+	// Get latest release if it was not specified.
+	if result.version == "" {
+		log.Infof("Getting latest tarantool version...")
+		versions, err := getVersionsFromRepo(
+			installCtx.Local, distfiles, "tarantool", search.GitRepoTarantool)
+		if err != nil {
+			return resolvedInstallVersion{}, err
+		}
+		result.version = getLatestRelease(versions)
+		if result.version == "" {
+			return resolvedInstallVersion{}, fmt.Errorf("no version found")
 		}
 	}
+
+	if result.version != "master" {
+		if version.IsVersion(result.version, false) {
+			log.Infof("Searching in versions...")
+			versions, err := getVersionsFromRepo(
+				installCtx.Local, distfiles, "tarantool", search.GitRepoTarantool)
+			if err != nil {
+				return resolvedInstallVersion{}, err
+			}
+			match, err := version.MatchVersion(result.version, versions)
+			if err != nil {
+				var errNotFound version.NotFoundError
+				if !errors.As(err, &errNotFound) {
+					return resolvedInstallVersion{}, err
+				}
+			} else {
+				result.versionFound = true
+				result.version = match
+			}
+		}
+		if !result.versionFound {
+			result.isPullRequest, result.pullRequestID = util.IsPullRequest(result.version)
+			if result.isPullRequest {
+				log.Infof("Searching in pull-requests...")
+			} else {
+				log.Infof("Searching in commits...")
+			}
+
+			var err error
+			result.version, result.pullRequestHash, err = checkCommit(
+				result.version, "tarantool", installCtx, distfiles)
+			if err != nil {
+				return resolvedInstallVersion{}, err
+			}
+		}
+	}
+
+	switch {
+	case result.versionFound:
+		result.versionStr = search.ProgramCe.String() + version.FsSeparator + result.version
+	case result.isPullRequest:
+		result.versionStr = search.ProgramCe.String() + version.FsSeparator + result.pullRequestHash
+	default:
+		result.versionStr = search.ProgramCe.String() + version.FsSeparator +
+			result.version[0:util.Min(len(result.version), util.MinCommitHashLength)]
+	}
+
+	return result, nil
+}
+
+func prepareTarantoolInstall(binDir, incDir string, installCtx InstallCtx, distfiles string) (
+	resolvedInstallVersion,
+	error,
+) {
+	if binDir == "" {
+		return resolvedInstallVersion{},
+			fmt.Errorf("bin_dir is not set, check %s", configure.ConfigName)
+	}
+	if incDir == "" {
+		return resolvedInstallVersion{},
+			fmt.Errorf("inc_dir is not set, check %s", configure.ConfigName)
+	}
+	return resolveTarantoolInstallVersion(installCtx, distfiles)
+}
+
+// installTt installs selected version of tt.
+func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
+	resolved, err := resolveTtInstallVersion(installCtx, distfiles)
+	if err != nil {
+		return err
+	}
+	ttVersion := resolved.version
+	versionStr := resolved.versionStr
+	versionFound := resolved.versionFound
+	isPullRequest := resolved.isPullRequest
+	pullRequestID := resolved.pullRequestID
+	pullRequestHash := resolved.pullRequestHash
 
 	// Check if that version is already installed.
 	// If it is installed, check if the newest version exists.
@@ -899,87 +999,17 @@ func changeActiveTarantoolVersion(versionStr, binDir, incDir string) error {
 
 // installTarantool installs selected version of tarantool.
 func installTarantool(binDir string, installCtx InstallCtx, distfiles string) error {
-	// Check bin and header dirs.
-	if binDir == "" {
-		return fmt.Errorf("bin_dir is not set, check %s", configure.ConfigName)
-	}
 	incDir := installCtx.IncDir
-	if incDir == "" {
-		return fmt.Errorf("inc_dir is not set, check %s", configure.ConfigName)
+	resolved, err := prepareTarantoolInstall(binDir, incDir, installCtx, distfiles)
+	if err != nil {
+		return err
 	}
-
-	versionFound := false
-	pullRequestHash := ""
-	isPullRequest := false
-	pullRequestID := ""
-
-	// Get latest version if it was not specified.
-	tarVersion := installCtx.version
-	if tarVersion == "" {
-		log.Infof("Getting latest tarantool version...")
-
-		versions, err := getVersionsFromRepo(installCtx.Local, distfiles, "tarantool",
-			search.GitRepoTarantool)
-		if err != nil {
-			return err
-		}
-
-		tarVersion = getLatestRelease(versions)
-		if tarVersion == "" {
-			return fmt.Errorf("no version found")
-		}
-	}
-
-	// Check that the version exists.
-	if tarVersion != "master" {
-		if version.IsVersion(tarVersion, false) {
-			log.Infof("Searching in versions...")
-			versions, err := getVersionsFromRepo(installCtx.Local, distfiles, "tarantool",
-				search.GitRepoTarantool)
-			if err != nil {
-				return err
-			}
-			match, err := version.MatchVersion(tarVersion, versions)
-			if err != nil {
-				var errNotFound version.NotFoundError
-				if !errors.As(err, &errNotFound) {
-					return err
-				}
-			} else {
-				versionFound = true
-				tarVersion = match
-			}
-		}
-		if !versionFound {
-			isPullRequest, pullRequestID = util.IsPullRequest(tarVersion)
-
-			if isPullRequest {
-				log.Infof("Searching in pull-requests...")
-			} else {
-				log.Infof("Searching in commits...")
-			}
-
-			var err error
-			tarVersion, pullRequestHash, err = checkCommit(
-				tarVersion, "tarantool", installCtx, distfiles)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	var versionStr string
-
-	if versionFound {
-		versionStr = search.ProgramCe.String() + version.FsSeparator + tarVersion
-	} else {
-		if isPullRequest {
-			versionStr = search.ProgramCe.String() + version.FsSeparator + pullRequestHash
-		} else {
-			versionStr = search.ProgramCe.String() + version.FsSeparator +
-				tarVersion[0:util.Min(len(tarVersion), util.MinCommitHashLength)]
-		}
-	}
+	tarVersion := resolved.version
+	versionStr := resolved.versionStr
+	versionFound := resolved.versionFound
+	isPullRequest := resolved.isPullRequest
+	pullRequestID := resolved.pullRequestID
+	pullRequestHash := resolved.pullRequestHash
 
 	// Check if program is already installed.
 	// If it is installed, check if newest version exists.

--- a/cli/install/install_bundle.go
+++ b/cli/install/install_bundle.go
@@ -64,7 +64,7 @@ func checkInstallDirs(binDir, includeDir string) error {
 
 // checkExistingInstallation checks if the specific version of the program is already installed.
 // Returns true if the installation exists, false otherwise.
-func checkExistingInstallation(bp *bundleParams) (bool, error) {
+func checkExistingInstallation(bp *bundleParams) bool {
 	binPath := filepath.Join(bp.opts.Env.BinDir, bp.prgVersion)
 	incPath := filepath.Join(bp.inst.IncDir, bp.prgVersion)
 
@@ -72,13 +72,13 @@ func checkExistingInstallation(bp *bundleParams) (bool, error) {
 
 	if !bp.inst.Program.IsTarantool() {
 		log.Debugf("Checking existence: bin=%s (%t)", binPath, binExists)
-		return binExists, nil
+		return binExists
 	}
 	incExists := util.IsDir(incPath)
 
 	log.Debugf("Checking existence: bin=%s (%t), inc=%s (%t)",
 		binPath, binExists, incPath, incExists)
-	return binExists && incExists, nil
+	return binExists && incExists
 }
 
 // prepareTemporaryDirs creates temporary directories for installation and logging.
@@ -244,12 +244,10 @@ func prepareForReinstall(bp *bundleParams) error {
 
 		log.Debugf("Existing files removed to reinstall version %q for program %q",
 			bp.prgVersion, bp.inst.Program)
-	} else {
+	} else if util.IsRegularFile(destBinPath) || util.IsDir(destIncPath) {
 		// If no Reinstall option, ensure that we don't have already installed version.
-		if util.IsRegularFile(destBinPath) || util.IsDir(destIncPath) {
-			return fmt.Errorf("installation path %s or %s already exists",
-				destBinPath, destIncPath)
-		}
+		return fmt.Errorf("installation path %s or %s already exists",
+			destBinPath, destIncPath)
 	}
 
 	return nil
@@ -454,10 +452,7 @@ func installBundleProgram(installCtx *InstallCtx, cliOpts *config.CliOpts) error
 
 	if !bp.inst.Reinstall {
 		log.Infof("Checking existing installation...")
-		exists, err := checkExistingInstallation(&bp)
-		if err != nil {
-			return fmt.Errorf("failed to check existing installation: %w", err)
-		}
+		exists := checkExistingInstallation(&bp)
 
 		if exists {
 			log.Infof("%s version %s already exists.", bp.inst.Program, bp.prgVersion)

--- a/cli/install/install_bundle.go
+++ b/cli/install/install_bundle.go
@@ -221,35 +221,36 @@ func prepareForReinstall(bp *bundleParams) error {
 	destBinPath := filepath.Join(bp.opts.Env.BinDir, bp.prgVersion)
 	destIncPath := filepath.Join(bp.inst.IncDir, bp.prgVersion)
 
-	if bp.inst.Reinstall {
-		if util.IsRegularFile(destBinPath) {
-			log.Infof("%s version of %q already exists, removing...",
-				bp.prgVersion, bp.inst.Program)
-
-			if err := os.RemoveAll(destBinPath); err != nil {
-				fmt.Fprintf(bp.logFile, "Error removing binary: %v\n", err)
-				return fmt.Errorf("failed to remove binary %s: %w", destBinPath, err)
-			}
+	if !bp.inst.Reinstall {
+		if util.IsRegularFile(destBinPath) || util.IsDir(destIncPath) {
+			return fmt.Errorf("installation path %s or %s already exists",
+				destBinPath, destIncPath)
 		}
-
-		if util.IsDir(destIncPath) {
-			log.Infof("Include directory for %s version already exists, removing...",
-				bp.prgVersion)
-			if err := os.RemoveAll(destIncPath); err != nil {
-				fmt.Fprintf(bp.logFile, "Error removing include dir: %v\n", err)
-				return fmt.Errorf("failed to remove include directory %s: %w",
-					destIncPath, err)
-			}
-		}
-
-		log.Debugf("Existing files removed to reinstall version %q for program %q",
-			bp.prgVersion, bp.inst.Program)
-	} else if util.IsRegularFile(destBinPath) || util.IsDir(destIncPath) {
-		// If no Reinstall option, ensure that we don't have already installed version.
-		return fmt.Errorf("installation path %s or %s already exists",
-			destBinPath, destIncPath)
+		return nil
 	}
 
+	if util.IsRegularFile(destBinPath) {
+		log.Infof("%s version of %q already exists, removing...",
+			bp.prgVersion, bp.inst.Program)
+
+		if err := os.RemoveAll(destBinPath); err != nil {
+			fmt.Fprintf(bp.logFile, "Error removing binary: %v\n", err)
+			return fmt.Errorf("failed to remove binary %s: %w", destBinPath, err)
+		}
+	}
+
+	if util.IsDir(destIncPath) {
+		log.Infof("Include directory for %s version already exists, removing...",
+			bp.prgVersion)
+		if err := os.RemoveAll(destIncPath); err != nil {
+			fmt.Fprintf(bp.logFile, "Error removing include dir: %v\n", err)
+			return fmt.Errorf("failed to remove include directory %s: %w",
+				destIncPath, err)
+		}
+	}
+
+	log.Debugf("Existing files removed to reinstall version %q for program %q",
+		bp.prgVersion, bp.inst.Program)
 	return nil
 }
 

--- a/cli/install/install_test.go
+++ b/cli/install/install_test.go
@@ -124,7 +124,8 @@ func Test_installTarantoolDev(t *testing.T) {
 	ttBinDir := "binDir"
 	ttIncDir := "incDir"
 
-	setupEnv := func() string {
+	setupEnv := func(t *testing.T) string {
+		t.Helper()
 		//	├── ttBinDir
 		//	├── build_ce
 		//	│   └── src
@@ -135,8 +136,7 @@ func Test_installTarantoolDev(t *testing.T) {
 		//	│           └── tarantool
 		//	└── ttIncDir
 
-		tempDir := os.TempDir()
-		tempsDir, _ := os.MkdirTemp(tempDir, "install_tarantool_dev_test")
+		tempsDir := t.TempDir()
 
 		ttBinDir := filepath.Join(tempsDir, ttBinDir)
 		os.Mkdir(ttBinDir, os.ModePerm)
@@ -160,8 +160,7 @@ func Test_installTarantoolDev(t *testing.T) {
 	}
 
 	t.Run("no include-dir", func(t *testing.T) {
-		tempDirectory := setupEnv()
-		defer os.RemoveAll(tempDirectory)
+		tempDirectory := setupEnv(t)
 
 		ttBinPath := filepath.Join(tempDirectory, ttBinDir)
 		ttIncPath := filepath.Join(tempDirectory, ttIncDir)
@@ -188,8 +187,7 @@ func Test_installTarantoolDev(t *testing.T) {
 	})
 
 	t.Run("with include-dir", func(t *testing.T) {
-		tempDirectory := setupEnv()
-		defer os.RemoveAll(tempDirectory)
+		tempDirectory := setupEnv(t)
 
 		ttBinPath := filepath.Join(tempDirectory, ttBinDir)
 		ttIncPath := filepath.Join(tempDirectory, ttIncDir)
@@ -237,8 +235,7 @@ func Test_installTarantoolDev(t *testing.T) {
 	})
 
 	t.Run("no executable", func(t *testing.T) {
-		tempDirectory := setupEnv()
-		defer os.RemoveAll(tempDirectory)
+		tempDirectory := setupEnv(t)
 
 		ttBinPath := filepath.Join(tempDirectory, ttBinDir)
 		ttIncPath := filepath.Join(tempDirectory, ttIncDir)
@@ -251,9 +248,7 @@ func Test_installTarantoolDev(t *testing.T) {
 }
 
 func TestSearchTarantoolHeaders(t *testing.T) {
-	tempDir := os.TempDir()
-	tempsDir, _ := os.MkdirTemp(tempDir, "search_tarantool_headers_test")
-	defer os.RemoveAll(tempsDir)
+	tempsDir := t.TempDir()
 
 	buildEmptyPath := filepath.Join(tempsDir, "build_empty")
 	os.MkdirAll(buildEmptyPath, os.ModePerm)

--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -18,6 +18,21 @@ type httpDoer struct {
 	token  string
 }
 
+// NewTntIoDownloader configures and returns an HTTP client suitable for downloading bundles.
+func NewTntIoDownloader(token string) *httpDoer {
+	return &httpDoer{
+		client: &http.Client{
+			Timeout: 0,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				req.Host = req.URL.Hostname()
+				addSessionIdCookie(req, token)
+				return nil
+			},
+		},
+		token: token,
+	}
+}
+
 // Do implement TntIoDoer interface.
 // It sends an HTTP request and returns Body data from HTTP response.
 func (d *httpDoer) Do(req *http.Request) ([]byte, error) {
@@ -64,21 +79,6 @@ func addSessionIdCookie(req *http.Request, token string) {
 			Value: token,
 		}
 		req.AddCookie(cookie)
-	}
-}
-
-// NewTntIoDownloader configures and returns an HTTP client suitable for downloading bundles.
-func NewTntIoDownloader(token string) *httpDoer {
-	return &httpDoer{
-		client: &http.Client{
-			Timeout: 0,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				req.Host = req.URL.Hostname()
-				addSessionIdCookie(req, token)
-				return nil
-			},
-		},
-		token: token,
 	}
 }
 

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -214,7 +214,7 @@ func TestGetModulesInfo(t *testing.T) {
 				},
 			}
 			if tt.env_modules != "" {
-				os.Setenv("TT_CLI_MODULES_PATH", tt.env_modules)
+				t.Setenv("TT_CLI_MODULES_PATH", tt.env_modules)
 			}
 			var buf bytes.Buffer
 			log.SetOutput(&buf)

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/cmdcontext"
-	"github.com/tarantool/tt/cli/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -49,7 +49,7 @@ func RunCmd(cmdCtx *cmdcontext.CmdCtx, cmdPath string, modulesInfo *ModulesInfo,
 // GetDefaultCmdArgs returns all arguments from the command line
 // to external module that come after the command name.
 func GetDefaultCmdArgs(cmdName string) []string {
-	cmdNameIndexInArgs := util.Find(os.Args, cmdName)
+	cmdNameIndexInArgs := slices.Index(os.Args, cmdName)
 	return os.Args[cmdNameIndexInArgs+1:]
 }
 

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -85,29 +85,6 @@ func NewCConfigInstance(evaler connector.Evaler) *CConfigInstance {
 	return inst
 }
 
-// discovery returns a replicasets topology for a single instance with
-// the centralized config orchestrator.
-func (c *CConfigInstance) discovery() (Replicasets, error) {
-	topology, err := getCConfigInstanceTopology(c.evaler)
-	if err != nil {
-		return Replicasets{}, err
-	}
-
-	return recalculateMasters(Replicasets{
-		State:        StateBootstrapped,
-		Orchestrator: OrchestratorCentralizedConfig,
-		Replicasets: []Replicaset{
-			{
-				UUID:       topology.UUID,
-				LeaderUUID: topology.LeaderUUID,
-				Alias:      topology.Alias,
-				Failover:   ParseFailover(topology.Failover),
-				Instances:  topology.Instances,
-			},
-		},
-	}), nil
-}
-
 // Promote promotes an instance.
 func (c *CConfigInstance) Promote(ctx PromoteCtx) error {
 	return cconfigPromoteElection(c.evaler, ctx.Timeout)
@@ -149,6 +126,29 @@ func (c *CConfigInstance) RolesChange(ctx RolesChangeCtx,
 	return newErrRolesChangeByInstanceNotSupported(OrchestratorCentralizedConfig, changeRoleAction)
 }
 
+// discovery returns a replicasets topology for a single instance with
+// the centralized config orchestrator.
+func (c *CConfigInstance) discovery() (Replicasets, error) {
+	topology, err := getCConfigInstanceTopology(c.evaler)
+	if err != nil {
+		return Replicasets{}, err
+	}
+
+	return recalculateMasters(Replicasets{
+		State:        StateBootstrapped,
+		Orchestrator: OrchestratorCentralizedConfig,
+		Replicasets: []Replicaset{
+			{
+				UUID:       topology.UUID,
+				LeaderUUID: topology.LeaderUUID,
+				Alias:      topology.Alias,
+				Failover:   ParseFailover(topology.Failover),
+				Instances:  topology.Instances,
+			},
+		},
+	}), nil
+}
+
 // CConfigApplication is an application with the centralized config
 // orchestrator.
 type CConfigApplication struct {
@@ -175,38 +175,6 @@ func NewCConfigApplication(
 	}
 	app.discoverer = app
 	return app
-}
-
-// discovery returns a replicasets topology for an application with
-// the centralized config orchestrator.
-func (c *CConfigApplication) discovery() (Replicasets, error) {
-	var topologies []cconfigTopology
-
-	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(
-		func(ictx running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-			topology, err := getCConfigInstanceTopology(evaler)
-			if err != nil {
-				return true, err
-			}
-			for i := range topology.Instances {
-				if topology.Instances[i].UUID == topology.InstanceUUID {
-					topology.Instances[i].InstanceCtx = ictx
-					topology.Instances[i].InstanceCtxFound = true
-				}
-			}
-
-			topologies = append(topologies, topology)
-			return false, nil
-		}))
-	if err != nil {
-		return Replicasets{}, err
-	}
-
-	if len(topologies) == 0 {
-		return Replicasets{}, fmt.Errorf("no instance found in the application")
-	}
-
-	return mergeCConfigTopologies(topologies)
 }
 
 // Expel expels an instance from the centralized config's replicasets.
@@ -539,6 +507,38 @@ func (c *CConfigApplication) RolesChange(ctx RolesChangeCtx,
 		err = errors.Join(err, reloadCConfig(instances))
 	}
 	return err
+}
+
+// discovery returns a replicasets topology for an application with
+// the centralized config orchestrator.
+func (c *CConfigApplication) discovery() (Replicasets, error) {
+	var topologies []cconfigTopology
+
+	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(
+		func(ictx running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+			topology, err := getCConfigInstanceTopology(evaler)
+			if err != nil {
+				return true, err
+			}
+			for i := range topology.Instances {
+				if topology.Instances[i].UUID == topology.InstanceUUID {
+					topology.Instances[i].InstanceCtx = ictx
+					topology.Instances[i].InstanceCtxFound = true
+				}
+			}
+
+			topologies = append(topologies, topology)
+			return false, nil
+		}))
+	if err != nil {
+		return Replicasets{}, err
+	}
+
+	if len(topologies) == 0 {
+		return Replicasets{}, fmt.Errorf("no instance found in the application")
+	}
+
+	return mergeCConfigTopologies(topologies)
 }
 
 // cconfigPromoteElection tries to promote an instance via `box.ctl.promote()`.

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -467,6 +467,17 @@ func (c *CConfigApplication) RolesChange(ctx RolesChangeCtx,
 		unavailable []string
 	)
 
+	if ctx.InstName == "" {
+		for _, r := range c.replicasets.Replicasets {
+			for _, i := range r.Instances {
+				if !i.InstanceCtxFound {
+					unavailable = append(unavailable, i.Alias)
+					continue
+				}
+				instances = append(instances, i.InstanceCtx)
+			}
+		}
+	}
 	if ctx.InstName != "" {
 		targetReplicaset, targetInstance, found :=
 			findInstanceByAlias(replicasets, ctx.InstName)
@@ -482,16 +493,6 @@ func (c *CConfigApplication) RolesChange(ctx RolesChangeCtx,
 				continue
 			}
 			instances = append(instances, inst.InstanceCtx)
-		}
-	} else {
-		for _, r := range c.replicasets.Replicasets {
-			for _, i := range r.Instances {
-				if !i.InstanceCtxFound {
-					unavailable = append(unavailable, i.Alias)
-					continue
-				}
-				instances = append(instances, i.InstanceCtx)
-			}
 		}
 	}
 	if len(unavailable) > 0 {
@@ -873,28 +874,30 @@ func cconfigGetFailover(cfg goconfig.Config, instName string) (Failover, error) 
 	}
 
 	var raw any
-	if _, err = instCfg.Get(goconfig.NewKeyPath("replication/failover"), &raw); err != nil {
-		if errors.Is(err, goconfig.ErrKeyNotFound) {
-			// Path not found. Check whether "replication" exists but is not a
-			// map (e.g. replication: 42), to preserve the original error message.
-			if repVal, ok := instCfg.Lookup(goconfig.NewKeyPath("replication")); ok {
-				var repMap map[string]any
-				if innerErr := repVal.Get(&repMap); innerErr != nil {
-					return FailoverOff,
-						fmt.Errorf(`path ["replication"] is not a map`)
-				}
-			}
-			// https://github.com/tarantool/tt/issues/791
-			return FailoverOff, nil
+	if _, err = instCfg.Get(goconfig.NewKeyPath("replication/failover"), &raw); err == nil {
+		failoverStr, ok := raw.(string)
+		if !ok {
+			return FailoverOff,
+				fmt.Errorf("unexpected failover type: %T, string expected", raw)
 		}
+		return ParseFailover(failoverStr), nil
+	}
+	if !errors.Is(err, goconfig.ErrKeyNotFound) {
 		return FailoverOff, fmt.Errorf("failed to get failover: %w", err)
 	}
-	failoverStr, ok := raw.(string)
+
+	// Path not found. Check whether "replication" exists but is not a
+	// map (e.g. replication: 42), to preserve the original error message.
+	repVal, ok := instCfg.Lookup(goconfig.NewKeyPath("replication"))
 	if !ok {
-		return FailoverOff,
-			fmt.Errorf("unexpected failover type: %T, string expected", raw)
+		// https://github.com/tarantool/tt/issues/791
+		return FailoverOff, nil
 	}
-	return ParseFailover(failoverStr), nil
+	var repMap map[string]any
+	if innerErr := repVal.Get(&repMap); innerErr != nil {
+		return FailoverOff, fmt.Errorf(`path ["replication"] is not a map`)
+	}
+	return FailoverOff, nil
 }
 
 // cconfigGetElectionMode extracts election_mode from the cluster config.

--- a/cli/replicaset/cmd/upgrade.go
+++ b/cli/replicaset/cmd/upgrade.go
@@ -177,13 +177,14 @@ func collectRwRoInfo(rs replicaset.Replicaset,
 			isRW = instance.Mode.String() == "rw"
 		}
 
-		if isRW && master != nil {
+		switch {
+		case isRW && master != nil:
 			closeConnectors(master, replicas)
 			return nil, nil, fmt.Errorf("%s and %s are both masters",
-				running.GetAppInstanceName((*master).run), fullInstanceName)
-		} else if isRW {
+				running.GetAppInstanceName(master.run), fullInstanceName)
+		case isRW:
 			master = &instanceMeta{run, conn}
-		} else {
+		default:
 			replicas = append(replicas, instanceMeta{run, conn})
 		}
 	}
@@ -197,11 +198,12 @@ func waitLSN(conn connector.Connector, masterIID uint32, masterLSN uint64, lsnTi
 	deadline := time.Now().Add(time.Duration(lsnTimeout) * time.Second)
 	for {
 		res, err := conn.Eval(query, []any{}, connector.RequestOpts{})
-		if err != nil {
+		switch {
+		case err != nil:
 			lastError = fmt.Errorf("failed to evaluate LSN query: %w", err)
-		} else if len(res) == 0 {
+		case len(res) == 0:
 			lastError = errors.New("empty result from LSN query")
-		} else {
+		default:
 			var lsn uint64
 			if err := mapstructure.Decode(res[0], &lsn); err != nil {
 				lastError = fmt.Errorf("failed to decode LSN: %w", err)

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -88,6 +88,41 @@ func collectCConfig(
 	return configData, merged, nil
 }
 
+// Promote patches a config to promote an instance.
+func (c *CConfigSource) Promote(ctx PromoteCtx) error {
+	return c.patchInstanceConfig(
+		ctx.InstName,
+		ctx.Force,
+		getCConfigPromotePath,
+		patchCConfigPromote,
+	)
+}
+
+// Demote patches a config to demote an instance.
+func (c *CConfigSource) Demote(ctx DemoteCtx) error {
+	return c.patchInstanceConfig(
+		ctx.InstName,
+		ctx.Force,
+		getCConfigDemotePath,
+		patchCConfigDemote,
+	)
+}
+
+// Expel patches a config to expel an instance.
+func (c *CConfigSource) Expel(ctx ExpelCtx) error {
+	return c.patchInstanceConfig(
+		ctx.InstName,
+		ctx.Force,
+		getCConfigExpelPath,
+		patchCConfigExpel,
+	)
+}
+
+// ChangeRole patches a config with addition/removing role.
+func (c *CConfigSource) ChangeRole(ctx RolesChangeCtx, action RolesChangerAction) error {
+	return c.patchConfigWithRoles(ctx, getCConfigRolesPath, action.Change, patchCConfigEditRole)
+}
+
 // pickTarget applies keyPicker to the targets slice and returns picked target.
 func (c *CConfigSource) pickTarget(targets []patchTarget, force bool,
 	pathMsg string,
@@ -215,41 +250,6 @@ func (c *CConfigSource) patchConfigWithRoles(ctx RolesChangeCtx,
 		return fmt.Errorf("failed to publish the config: %w", err)
 	}
 	return nil
-}
-
-// Promote patches a config to promote an instance.
-func (c *CConfigSource) Promote(ctx PromoteCtx) error {
-	return c.patchInstanceConfig(
-		ctx.InstName,
-		ctx.Force,
-		getCConfigPromotePath,
-		patchCConfigPromote,
-	)
-}
-
-// Demote patches a config to demote an instance.
-func (c *CConfigSource) Demote(ctx DemoteCtx) error {
-	return c.patchInstanceConfig(
-		ctx.InstName,
-		ctx.Force,
-		getCConfigDemotePath,
-		patchCConfigDemote,
-	)
-}
-
-// Expel patches a config to expel an instance.
-func (c *CConfigSource) Expel(ctx ExpelCtx) error {
-	return c.patchInstanceConfig(
-		ctx.InstName,
-		ctx.Force,
-		getCConfigExpelPath,
-		patchCConfigExpel,
-	)
-}
-
-// ChangeRole patches a config with addition/removing role.
-func (c *CConfigSource) ChangeRole(ctx RolesChangeCtx, action RolesChangerAction) error {
-	return c.patchConfigWithRoles(ctx, getCConfigRolesPath, action.Change, patchCConfigEditRole)
 }
 
 // getCConfigRolesPath returns a path and it's minimum interesting depth

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -223,12 +223,7 @@ func (c *CConfigSource) Promote(ctx PromoteCtx) error {
 		ctx.InstName,
 		ctx.Force,
 		getCConfigPromotePath,
-		func(config *goconfig.MutableConfig, inst cconfigInstance) (
-			*goconfig.MutableConfig,
-			error,
-		) {
-			return patchCConfigPromote(config, inst)
-		},
+		patchCConfigPromote,
 	)
 }
 
@@ -238,12 +233,7 @@ func (c *CConfigSource) Demote(ctx DemoteCtx) error {
 		ctx.InstName,
 		ctx.Force,
 		getCConfigDemotePath,
-		func(config *goconfig.MutableConfig, inst cconfigInstance) (
-			*goconfig.MutableConfig,
-			error,
-		) {
-			return patchCConfigDemote(config, inst)
-		},
+		patchCConfigDemote,
 	)
 }
 
@@ -253,12 +243,7 @@ func (c *CConfigSource) Expel(ctx ExpelCtx) error {
 		ctx.InstName,
 		ctx.Force,
 		getCConfigExpelPath,
-		func(config *goconfig.MutableConfig, inst cconfigInstance) (
-			*goconfig.MutableConfig,
-			error,
-		) {
-			return patchCConfigExpel(config, inst)
-		},
+		patchCConfigExpel,
 	)
 }
 
@@ -424,10 +409,7 @@ func getCConfigPatchTargets(data []libcluster.Data,
 				fmt.Errorf("failed to decode config from %q: %w", item.Source, err)
 		}
 		snap := mut.Snapshot()
-		depth, err := getCConfigPathDepth(snap, path, depth)
-		if err != nil {
-			return nil, err
-		}
+		depth := getCConfigPathDepth(snap, path, depth)
 		if depth != noDepth {
 			targets = append(targets, patchTarget{
 				key:      item.Source,
@@ -449,11 +431,11 @@ const noDepth = -1
 // If it is less than lowerDepth, it returns noDepth.
 func getCConfigPathDepth(config goconfig.Config,
 	path goconfig.KeyPath, lowerDepth int,
-) (int, error) {
+) int {
 	for i := len(path); i >= lowerDepth; i-- {
 		if _, ok := config.Lookup(path[:i]); ok {
-			return i, nil
+			return i
 		}
 	}
-	return noDepth, nil
+	return noDepth
 }

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -98,12 +98,12 @@ func newOnceMockDataPublisher(err error) *mockDataPublisher {
 	}
 }
 
-func assertPublished(t *testing.T, p *mockDataPublisher, key string, revision int64, data []byte) {
+func assertPublished(t *testing.T, p *mockDataPublisher, key string, data []byte) {
 	t.Helper()
 
 	require.Equal(t, 1, p.Called)
 	require.Equal(t, []string{key}, p.Keys)
-	require.Equal(t, []int64{revision}, p.Revisions)
+	require.Equal(t, []int64{42}, p.Revisions)
 	require.Equal(t, [][]byte{data}, p.Data)
 }
 
@@ -255,7 +255,7 @@ func TestCConfigSource_Promote_single_key(t *testing.T) {
 			source := replicaset.NewCConfigSource(collector, publisher, keyPicker)
 			err := source.Promote(replicaset.PromoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
-			assertPublished(t, publisher, "all", revision, expected)
+			assertPublished(t, publisher, "all", expected)
 		})
 	}
 }
@@ -482,7 +482,7 @@ func TestCConfigSource_Promote_many_keys(t *testing.T) {
 			source := replicaset.NewCConfigSource(collector, publisher, picker)
 			err := source.Promote(replicaset.PromoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
-			assertPublished(t, publisher, tc.keys[0], revision, expected)
+			assertPublished(t, publisher, tc.keys[0], expected)
 		})
 	}
 }
@@ -519,7 +519,7 @@ func TestCConfigSource_Promote_many_keys_choose_affects(t *testing.T) {
 	err := source.Promote(replicaset.PromoteCtx{InstName: "instance-002"})
 	require.NoError(t, err)
 	fmt.Println(string(publisher.Data[0]))
-	assertPublished(t, publisher, "b", revision, expected)
+	assertPublished(t, publisher, "b", expected)
 }
 
 func TestCConfigSource_Promote_mix_failovers(t *testing.T) {
@@ -647,7 +647,7 @@ func TestCConfigSource_Demote_single_key(t *testing.T) {
 			source := replicaset.NewCConfigSource(collector, publisher, keyPicker)
 			err := source.Demote(replicaset.DemoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
-			assertPublished(t, publisher, "all", revision, expected)
+			assertPublished(t, publisher, "all", expected)
 		})
 	}
 }
@@ -687,7 +687,7 @@ func TestCConfigSource_Demote_many_keys(t *testing.T) {
 			err := source.Demote(replicaset.DemoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
 			fmt.Println(string(publisher.Data[0]))
-			assertPublished(t, publisher, tc.keys[0], revision, expected)
+			assertPublished(t, publisher, tc.keys[0], expected)
 		})
 	}
 }
@@ -734,7 +734,7 @@ func TestCConfigSource_Demote_many_keys_choose_affects(t *testing.T) {
 	source := replicaset.NewCConfigSource(collector, publisher, picker)
 	err := source.Demote(replicaset.DemoteCtx{InstName: "instance-002"})
 	require.NoError(t, err)
-	assertPublished(t, publisher, "b", revision, expected)
+	assertPublished(t, publisher, "b", expected)
 }
 
 func TestCConfigSource_Expel_single_key(t *testing.T) {
@@ -767,7 +767,7 @@ func TestCConfigSource_Expel_single_key(t *testing.T) {
             iproto:
               listen: {}
 `)
-	assertPublished(t, publisher, "a", revision, expected)
+	assertPublished(t, publisher, "a", expected)
 }
 
 func TestCConfigSource_AddRole(t *testing.T) {
@@ -949,7 +949,7 @@ roles:
 				require.EqualError(t, err, tc.errMsg)
 			} else {
 				require.NoError(t, err)
-				assertPublished(t, publisher, "a", revision, tc.expectedCfg)
+				assertPublished(t, publisher, "a", tc.expectedCfg)
 			}
 		})
 	}
@@ -1135,7 +1135,7 @@ roles: []
 				require.EqualError(t, err, tc.errMsg)
 			} else {
 				require.NoError(t, err)
-				assertPublished(t, publisher, "a", revision, tc.expectedCfg)
+				assertPublished(t, publisher, "a", tc.expectedCfg)
 			}
 		})
 	}

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -47,28 +47,6 @@ func NewCustomInstance(evaler connector.Evaler) *CustomInstance {
 	return inst
 }
 
-// discovery returns a replicasets topology for a single
-// instance with a custom type of orchestrator.
-func (c *CustomInstance) discovery() (Replicasets, error) {
-	topology, err := getCustomInstanceTopology("", c.evaler)
-	if err != nil {
-		return Replicasets{}, err
-	}
-
-	return recalculateMasters(Replicasets{
-		State:        StateBootstrapped,
-		Orchestrator: OrchestratorCustom,
-		Replicasets: []Replicaset{
-			{
-				UUID:       topology.UUID,
-				LeaderUUID: topology.LeaderUUID,
-				Alias:      topology.Alias,
-				Instances:  topology.Instances,
-			},
-		},
-	}), nil
-}
-
 // Promote is not supported for a single instance by the Custom orchestrator.
 func (c *CustomInstance) Promote(ctx PromoteCtx) error {
 	return newErrPromoteByInstanceNotSupported(OrchestratorCustom)
@@ -99,6 +77,28 @@ func (c *CustomInstance) RolesChange(_ RolesChangeCtx, action RolesChangerAction
 	return newErrRolesChangeByInstanceNotSupported(OrchestratorCustom, action)
 }
 
+// discovery returns a replicasets topology for a single
+// instance with a custom type of orchestrator.
+func (c *CustomInstance) discovery() (Replicasets, error) {
+	topology, err := getCustomInstanceTopology("", c.evaler)
+	if err != nil {
+		return Replicasets{}, err
+	}
+
+	return recalculateMasters(Replicasets{
+		State:        StateBootstrapped,
+		Orchestrator: OrchestratorCustom,
+		Replicasets: []Replicaset{
+			{
+				UUID:       topology.UUID,
+				LeaderUUID: topology.LeaderUUID,
+				Alias:      topology.Alias,
+				Instances:  topology.Instances,
+			},
+		},
+	}), nil
+}
+
 // CustomApplication is an application with a custom orchestrator.
 type CustomApplication struct {
 	cachedDiscoverer
@@ -113,34 +113,6 @@ func NewCustomApplication(runningCtx running.RunningCtx) *CustomApplication {
 	}
 	app.discoverer = app
 	return app
-}
-
-// discovery returns a replicasets configuration for an application with
-// a custom orchestrator.
-func (c *CustomApplication) discovery() (Replicasets, error) {
-	var topologies []customTopology
-
-	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(
-		func(ictx running.InstanceCtx, evaler connector.Evaler) (bool, error) {
-			topology, err := getCustomInstanceTopology(ictx.InstName, evaler)
-			if err != nil {
-				return true, err
-			}
-			for i := range topology.Instances {
-				if topology.Instances[i].UUID == topology.InstanceUUID {
-					topology.Instances[i].InstanceCtx = ictx
-					topology.Instances[i].InstanceCtxFound = true
-				}
-			}
-
-			topologies = append(topologies, topology)
-			return false, nil
-		}))
-	if err != nil {
-		return Replicasets{}, err
-	}
-
-	return mergeCustomTopologies(topologies)
 }
 
 // Promote is not supported for an application by the Custom orchestrator.
@@ -173,6 +145,34 @@ func (c *CustomApplication) RolesChange(_ RolesChangeCtx,
 	action RolesChangerAction,
 ) error {
 	return newErrRolesChangeByAppNotSupported(OrchestratorCustom, action)
+}
+
+// discovery returns a replicasets configuration for an application with
+// a custom orchestrator.
+func (c *CustomApplication) discovery() (Replicasets, error) {
+	var topologies []customTopology
+
+	err := EvalForeachAlive(c.runningCtx.Instances, InstanceEvalFunc(
+		func(ictx running.InstanceCtx, evaler connector.Evaler) (bool, error) {
+			topology, err := getCustomInstanceTopology(ictx.InstName, evaler)
+			if err != nil {
+				return true, err
+			}
+			for i := range topology.Instances {
+				if topology.Instances[i].UUID == topology.InstanceUUID {
+					topology.Instances[i].InstanceCtx = ictx
+					topology.Instances[i].InstanceCtxFound = true
+				}
+			}
+
+			topologies = append(topologies, topology)
+			return false, nil
+		}))
+	if err != nil {
+		return Replicasets{}, err
+	}
+
+	return mergeCustomTopologies(topologies)
 }
 
 // getCustomInstanceTopology returns a topology for an instance.

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -254,22 +254,22 @@ func updateCustomInstances(replicaset *Replicaset, topology customTopology) {
 				instance = &replicaset.Instances[i]
 			}
 		}
-		if instance != nil {
-			if instance.Alias == "" {
-				instance.Alias = tinstance.Alias
-			}
-			if instance.URI == "" {
-				instance.URI = tinstance.URI
-			}
-			if instance.Mode == ModeUnknown {
-				instance.Mode = tinstance.Mode
-			}
-			if !instance.InstanceCtxFound {
-				instance.InstanceCtx = tinstance.InstanceCtx
-				instance.InstanceCtxFound = tinstance.InstanceCtxFound
-			}
-		} else {
+		if instance == nil {
 			replicaset.Instances = append(replicaset.Instances, tinstance)
+			continue
+		}
+		if instance.Alias == "" {
+			instance.Alias = tinstance.Alias
+		}
+		if instance.URI == "" {
+			instance.URI = tinstance.URI
+		}
+		if instance.Mode == ModeUnknown {
+			instance.Mode = tinstance.Mode
+		}
+		if !instance.InstanceCtxFound {
+			instance.InstanceCtx = tinstance.InstanceCtx
+			instance.InstanceCtxFound = tinstance.InstanceCtxFound
 		}
 	}
 }

--- a/cli/replicaset/replicaset.go
+++ b/cli/replicaset/replicaset.go
@@ -47,17 +47,18 @@ func recalculateMaster(replicaset *Replicaset) {
 		}
 	}
 
-	if masters > 1 {
+	switch {
+	case masters > 1:
 		replicaset.Master = MasterMulti
-	} else if masters == 1 {
+	case masters == 1:
 		if unknown == 0 {
 			replicaset.Master = MasterSingle
 		} else {
 			replicaset.Master = MasterUnknown
 		}
-	} else if unknown == 0 {
+	case unknown == 0:
 		replicaset.Master = MasterNo
-	} else {
+	default:
 		replicaset.Master = MasterUnknown
 	}
 }

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -30,11 +30,11 @@ const (
 
 // addLuarocksRepoOpts adds --server option to luarocks command line if rocks repository
 // info is specified in tt config. Return updated args slice.
-func addLuarocksRepoOpts(cliOpts *config.CliOpts, args []string) ([]string, error) {
+func addLuarocksRepoOpts(cliOpts *config.CliOpts, args []string) []string {
 	// Make sure there is no --only-server option is specified.
 	for _, opt := range args {
 		if opt == "--only-server" || strings.HasPrefix(opt, "--only-server=") {
-			return args, nil // If --only-server is specified, no need to add --server option.
+			return args // If --only-server is specified, no need to add --server option.
 		}
 	}
 
@@ -55,7 +55,7 @@ func addLuarocksRepoOpts(cliOpts *config.CliOpts, args []string) ([]string, erro
 		}
 	}
 
-	return args, nil
+	return args
 }
 
 // getRocksRepoPath returns actual rocks repo path: either from passed path argument or
@@ -124,10 +124,7 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) error {
 	cliOpts.Repo.Rocks = getRocksRepoPath(cliOpts.Repo.Rocks)
 
-	var err error
-	if args, err = addLuarocksRepoOpts(cliOpts, args); err != nil {
-		return err
-	}
+	args = addLuarocksRepoOpts(cliOpts, args)
 
 	version, err := cmdCtx.Cli.TarantoolCli.GetVersion()
 	if err != nil {

--- a/cli/rocks/rocks_test.go
+++ b/cli/rocks/rocks_test.go
@@ -19,10 +19,9 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 		args    []string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
+		name string
+		args args
+		want []string
 	}{
 		{
 			"Rocks repo is not specified",
@@ -35,7 +34,6 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{},
 			},
 			[]string{},
-			false,
 		},
 		{
 			"Nil repo config",
@@ -46,7 +44,6 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{},
 			},
 			[]string{},
-			false,
 		},
 		{
 			"Rock repo is specified",
@@ -59,7 +56,6 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{},
 			},
 			[]string{"--server", "local_path"},
-			false,
 		},
 		{
 			"Rock repo is specified and --only-server opt is provided",
@@ -72,7 +68,6 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{"--only-server", "/other/repo"},
 			},
 			[]string{"--only-server", "/other/repo"}, // No --server option is added.
-			false,
 		},
 		{
 			"Rock repo is specified and --server is passed",
@@ -85,7 +80,6 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{"--server", "/other/repo"},
 			},
 			[]string{"--server", "/other/repo local_path"},
-			false,
 		},
 		{
 			"Rock repo is specified and --server= is passed",
@@ -98,18 +92,12 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 				[]string{"--server=/other/repo"},
 			},
 			[]string{"--server=/other/repo local_path"},
-			false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := addLuarocksRepoOpts(tt.args.cliOpts, tt.args.args)
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			got := addLuarocksRepoOpts(tt.args.cliOpts, tt.args.args)
 			require.EqualValues(t, got, tt.want)
 		})
 	}
@@ -120,7 +108,7 @@ func TestGetRocksRepoPath(t *testing.T) {
 	assert.EqualValues(t, "./testdata/repo", getRocksRepoPath("./testdata/repo"))
 	assert.EqualValues(t, "./testdata/emptyrepo", getRocksRepoPath("./testdata/emptyrepo"))
 
-	os.Setenv(repoRocksPathEnvVarName, "./other_repo")
+	t.Setenv(repoRocksPathEnvVarName, "./other_repo")
 	// If env var is set, return it if manifests is missing in passed repo.
 	assert.EqualValues(t, "./other_repo", getRocksRepoPath("./testdata/emptyrepo"))
 	// Return passed repo path, since manifest exists. Env var is ignored.
@@ -230,7 +218,7 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 		require.NoError(t, err)
 
 		if input.tntPrefixEnv != "" {
-			os.Setenv(tarantoolPrefixEnvVarName, input.tntPrefixEnv)
+			t.Setenv(tarantoolPrefixEnvVarName, input.tntPrefixEnv)
 		}
 		tarantoolPrefix, err := GetTarantoolPrefix(&input.cli, input.cliOpts)
 		os.Unsetenv(tarantoolPrefixEnvVarName)

--- a/cli/running/internal/layout/multi_inst_layout.go
+++ b/cli/running/internal/layout/multi_inst_layout.go
@@ -33,17 +33,6 @@ func NewMultiInstLayout(baseDir, appName, instanceName string) (*MultiInstLayout
 	}, nil
 }
 
-// genFilePath generate file path.
-func (layout MultiInstLayout) genFilePath(subdir, fileName string) string {
-	var dstDir string
-	if filepath.IsAbs(subdir) {
-		dstDir = util.JoinPaths(layout.baseDir, subdir, layout.appName, layout.instanceName)
-	} else {
-		dstDir = util.JoinPaths(layout.baseDir, subdir, layout.instanceName)
-	}
-	return filepath.Join(dstDir, fileName)
-}
-
 // PidFile returns pid file path.
 func (layout MultiInstLayout) PidFile(dir string) string {
 	return layout.genFilePath(dir, "tt.pid")
@@ -67,4 +56,15 @@ func (layout MultiInstLayout) BinaryPort(dir string) string {
 // DataDir returns data directory path.
 func (layout MultiInstLayout) DataDir(dir string) string {
 	return filepath.Dir(layout.genFilePath(dir, "0"))
+}
+
+// genFilePath generate file path.
+func (layout MultiInstLayout) genFilePath(subdir, fileName string) string {
+	var dstDir string
+	if filepath.IsAbs(subdir) {
+		dstDir = util.JoinPaths(layout.baseDir, subdir, layout.appName, layout.instanceName)
+	} else {
+		dstDir = util.JoinPaths(layout.baseDir, subdir, layout.instanceName)
+	}
+	return filepath.Join(dstDir, fileName)
 }

--- a/cli/running/process_controller.go
+++ b/cli/running/process_controller.go
@@ -31,16 +31,6 @@ type processController struct {
 	done bool
 }
 
-// start starts the process.
-func (pc *processController) start() error {
-	// Start an Instance.
-	if err := pc.Start(); err != nil {
-		return err
-	}
-	pc.done = false
-	return nil
-}
-
 // Wait waits for the process to complete.
 func (pc *processController) Wait() error {
 	if pc.done {
@@ -128,4 +118,14 @@ func (pc *processController) GetPid() int {
 // ProcessState returns completed process state.
 func (pc *processController) ProcessState() *os.ProcessState {
 	return pc.Cmd.ProcessState
+}
+
+// start starts the process.
+func (pc *processController) start() error {
+	// Start an Instance.
+	if err := pc.Start(); err != nil {
+		return err
+	}
+	pc.done = false
+	return nil
 }

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -897,11 +897,12 @@ func StartWatchdog(cmdCtx *cmdcontext.CmdCtx, ttExecutable string, instance Inst
 	}
 	newArgs = append(newArgs, args...)
 
-	if cmdCtx.Cli.IsSystem {
+	switch {
+	case cmdCtx.Cli.IsSystem:
 		newArgs = append(newArgs, "-S")
-	} else if cmdCtx.Cli.LocalLaunchDir != "" {
+	case cmdCtx.Cli.LocalLaunchDir != "":
 		newArgs = append(newArgs, "-L", cmdCtx.Cli.LocalLaunchDir)
-	} else {
+	default:
 		newArgs = append(newArgs, "--cfg", cmdCtx.Cli.ConfigPath)
 	}
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -330,10 +330,6 @@ func findInstanceScriptInAppDir(appDir, instName, clusterCfgPath, defaultScript 
 func loadInstanceConfig(configPath, instName string,
 	integrityCtx integrity.IntegrityCtx,
 ) (*goconfig.Config, error) {
-	if configPath == "" {
-		return nil, nil
-	}
-
 	cfg, err := cluster.GetClusterConfig(context.Background(), configPath, integrityCtx)
 	if err != nil {
 		return nil, err
@@ -409,11 +405,13 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 		}
 		log.Debugf("Instance %q", instance.InstName)
 
-		instance.Configuration, err = loadInstanceConfig(instance.ClusterConfigPath,
-			instance.InstName, integrityCtx)
-		if err != nil && (loadConfig == ConfigLoadAll || loadConfig == ConfigLoadCluster) {
-			return instances, fmt.Errorf("error loading instance %q configuration from "+
-				"config %q: %w", instance.InstName, instance.ClusterConfigPath, err)
+		if instance.ClusterConfigPath != "" {
+			instance.Configuration, err = loadInstanceConfig(instance.ClusterConfigPath,
+				instance.InstName, integrityCtx)
+			if err != nil && (loadConfig == ConfigLoadAll || loadConfig == ConfigLoadCluster) {
+				return instances, fmt.Errorf("error loading instance %q configuration from "+
+					"config %q: %w", instance.InstName, instance.ClusterConfigPath, err)
+			}
 		}
 
 		instance.SingleApp = false

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -363,20 +363,20 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 			return nil, fmt.Errorf(
 				"cluster config %q is found, but instances config (instances.yml) is missing",
 				appDirFiles.clusterCfgPath)
-		} else {
-			if appDirFiles.defaultLuaPath != "" {
-				return []InstanceCtx{{
-					InstanceScript: appDirFiles.defaultLuaPath,
-					AppName:        filepath.Base(appDir),
-					InstName:       filepath.Base(appDir),
-					AppDir:         appDir,
-					SingleApp:      true,
-				}}, nil
-			} else if loadConfig == ConfigLoadAll || loadConfig == ConfigLoadScripts {
-				return nil, fmt.Errorf("require files are missing in application directory %q: "+
-					"there must be instances config or the default instance script (%q)",
-					appDir, "init.lua")
-			}
+		}
+		if appDirFiles.defaultLuaPath != "" {
+			return []InstanceCtx{{
+				InstanceScript: appDirFiles.defaultLuaPath,
+				AppName:        filepath.Base(appDir),
+				InstName:       filepath.Base(appDir),
+				AppDir:         appDir,
+				SingleApp:      true,
+			}}, nil
+		}
+		if loadConfig == ConfigLoadAll || loadConfig == ConfigLoadScripts {
+			return nil, fmt.Errorf("require files are missing in application directory %q: "+
+				"there must be instances config or the default instance script (%q)",
+				appDir, "init.lua")
 		}
 	}
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -146,31 +146,6 @@ func GetAppPath(instance InstanceCtx) string {
 	return instance.AppDir
 }
 
-// updateCtx updates cmdCtx according to the current contents of the cfg file.
-func (provider *providerImpl) updateCtx() error {
-	cliOpts, _, err := configure.GetCliOpts(provider.cmdCtx.Cli.ConfigPath,
-		provider.cmdCtx.Integrity.Repository)
-	if err != nil {
-		return err
-	}
-
-	var args []string
-	if provider.instanceCtx.SingleApp {
-		args = []string{provider.instanceCtx.AppName}
-	} else {
-		args = []string{provider.instanceCtx.AppName + string(InstanceDelimiter) +
-			provider.instanceCtx.InstName}
-	}
-
-	var runningCtx RunningCtx
-	if err = FillCtx(
-		cliOpts, provider.cmdCtx, &runningCtx, args, ConfigLoadSkip); err != nil {
-		return err
-	}
-	provider.instanceCtx = &runningCtx.Instances[0]
-	return nil
-}
-
 // createInstance creates an Instance.
 func createInstance(cmdCtx cmdcontext.CmdCtx, instanceCtx InstanceCtx,
 	opts ...InstanceOption,
@@ -238,6 +213,31 @@ func (provider *providerImpl) IsRestartable() (bool, error) {
 	}
 
 	return provider.instanceCtx.Restartable, nil
+}
+
+// updateCtx updates cmdCtx according to the current contents of the cfg file.
+func (provider *providerImpl) updateCtx() error {
+	cliOpts, _, err := configure.GetCliOpts(provider.cmdCtx.Cli.ConfigPath,
+		provider.cmdCtx.Integrity.Repository)
+	if err != nil {
+		return err
+	}
+
+	var args []string
+	if provider.instanceCtx.SingleApp {
+		args = []string{provider.instanceCtx.AppName}
+	} else {
+		args = []string{provider.instanceCtx.AppName + string(InstanceDelimiter) +
+			provider.instanceCtx.InstName}
+	}
+
+	var runningCtx RunningCtx
+	if err = FillCtx(
+		cliOpts, provider.cmdCtx, &runningCtx, args, ConfigLoadSkip); err != nil {
+		return err
+	}
+	provider.instanceCtx = &runningCtx.Instances[0]
+	return nil
 }
 
 // searchApplicationScript searches for application script in a directory.

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -80,13 +80,6 @@ func shortenSocketPath(socketPath, basePath string) (string, error) {
 	return "", err
 }
 
-// setTarantoolLog sets tarantool log file path env var.
-func (inst *scriptInstance) setTarantoolLog(cmd *exec.Cmd) {
-	if inst.logDir != "" {
-		cmd.Env = append(cmd.Env, "TARANTOOL_LOG=")
-	}
-}
-
 // Start starts the Instance with the specified parameters.
 func (inst *scriptInstance) Start(ctx context.Context) error {
 	if inst.integrityChecks {
@@ -168,4 +161,11 @@ func (inst *scriptInstance) Start(ctx context.Context) error {
 	StdinPipe.Close()
 
 	return nil
+}
+
+// setTarantoolLog sets tarantool log file path env var.
+func (inst *scriptInstance) setTarantoolLog(cmd *exec.Cmd) {
+	if inst.logDir != "" {
+		cmd.Env = append(cmd.Env, "TARANTOOL_LOG=")
+	}
 }

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -52,7 +52,7 @@ func startTestInstance(t *testing.T, ctx context.Context, app, consoleSock strin
 	assert.Nilf(err, `Can't create an instance. Error: "%v".`, err)
 
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
-	os.Setenv("started_flag_file", filepath.Join(binDir, app))
+	t.Setenv("started_flag_file", filepath.Join(binDir, app))
 	defer os.Remove(os.Getenv("started_flag_file"))
 	err = inst.Start(ctx)
 	assert.Nilf(err, `Can't start the instance. Error: "%v".`, err)
@@ -238,7 +238,7 @@ func TestInstanceLogs(t *testing.T) {
 	t.Cleanup(func() { cleanupTestInstance(t, inst) })
 
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
-	os.Setenv("started_flag_file", filepath.Join(binDir, app))
+	t.Setenv("started_flag_file", filepath.Join(binDir, app))
 	defer os.Remove(os.Getenv("started_flag_file"))
 	err = inst.Start(context.Background())
 	require.NoError(t, err)

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -116,7 +116,7 @@ func TestWatchdogBase(t *testing.T) {
 
 	binPath, err := os.Executable()
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
-	os.Setenv("started_flag_file", filepath.Join(filepath.Dir(binPath), t.Name()))
+	t.Setenv("started_flag_file", filepath.Join(filepath.Dir(binPath), t.Name()))
 
 	wd := createTestWatchdog(t, true)
 	t.Cleanup(func() { cleanupWatchdog(t, wd) })
@@ -149,7 +149,7 @@ func TestWatchdogNotRestartable(t *testing.T) {
 
 	binPath, err := os.Executable()
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
-	os.Setenv("started_flag_file", filepath.Join(filepath.Dir(binPath), t.Name()))
+	t.Setenv("started_flag_file", filepath.Join(filepath.Dir(binPath), t.Name()))
 
 	wd := createTestWatchdog(t, false)
 	t.Cleanup(func() { cleanupWatchdog(t, wd) })

--- a/cli/search/bundle_test.go
+++ b/cli/search/bundle_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestFetchBundlesInfo(t *testing.T) {
-	os.Setenv("TT_CLI_EE_USERNAME", testingUsername)
-	os.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
+	t.Setenv("TT_CLI_EE_USERNAME", testingUsername)
+	t.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
 	defer os.Unsetenv("TT_CLI_EE_USERNAME")
 	defer os.Unsetenv("TT_CLI_EE_PASSWORD")
 

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -75,9 +75,9 @@ func SearchVersions(searchCtx SearchCtx, cliOpts *config.CliOpts) error {
 	var vers version.VersionSlice
 	switch prg {
 	case ProgramCe:
-		vers, err = searchVersionsGit(cliOpts, GitRepoTarantool)
+		vers, err = searchVersionsGit(GitRepoTarantool)
 	case ProgramTt:
-		vers, err = searchVersionsGit(cliOpts, GitRepoTT)
+		vers, err = searchVersionsGit(GitRepoTT)
 	case ProgramEe, ProgramTcm: // Group of API-based searches.
 		vers, err = searchVersionsTntIo(cliOpts, &searchCtx)
 	default:

--- a/cli/search/search_git.go
+++ b/cli/search/search_git.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 )
@@ -162,7 +161,7 @@ func GetVersionsFromGitLocal(repo string) (version.VersionSlice, error) {
 }
 
 // searchVersionsGit handles searching versions from a remote Git repository.
-func searchVersionsGit(cliOpts *config.CliOpts, repo string) (
+func searchVersionsGit(repo string) (
 	version.VersionSlice, error,
 ) {
 	versions, err := GetVersionsFromGitRemote(repo)

--- a/cli/search/search_local_test.go
+++ b/cli/search/search_local_test.go
@@ -20,10 +20,12 @@ type mockDirEntry struct {
 	isDir bool
 }
 
-func (m mockDirEntry) Name() string               { return m.name }
-func (m mockDirEntry) IsDir() bool                { return m.isDir }
-func (m mockDirEntry) Type() fs.FileMode          { return 0 }
-func (m mockDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+func (m mockDirEntry) Name() string      { return m.name }
+func (m mockDirEntry) IsDir() bool       { return m.isDir }
+func (m mockDirEntry) Type() fs.FileMode { return 0 }
+func (m mockDirEntry) Info() (fs.FileInfo, error) {
+	return nil, errors.New("not implemented")
+}
 
 // mockFS is a mock implementation of fs.FS for testing.
 type mockFS struct {

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -155,7 +155,7 @@ func getBuildType(isDev bool) string {
 }
 
 // TntIoMakePkgURI generates a URI for downloading a package.
-func TntIoMakePkgURI(searchCtx *SearchCtx, Tarball string) (string, error) {
+func TntIoMakePkgURI(searchCtx *SearchCtx, tarball string) (string, error) {
 	var uri string
 
 	if searchCtx.platformInformer == nil || reflect.ValueOf(searchCtx.platformInformer).IsNil() {
@@ -179,7 +179,7 @@ func TntIoMakePkgURI(searchCtx *SearchCtx, Tarball string) (string, error) {
 		osType,
 		arch,
 		searchCtx.ReleaseVersion,
-		Tarball,
+		tarball,
 	)
 
 	return uri, nil

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -36,6 +36,10 @@ type PlatformInformer interface {
 
 type realInfo struct{}
 
+func NewPlatformInformer() *realInfo {
+	return &realInfo{}
+}
+
 // GetOs implement PlatformInformer interface.
 func (*realInfo) GetOs() (util.OsType, error) {
 	return util.GetOs()
@@ -44,10 +48,6 @@ func (*realInfo) GetOs() (util.OsType, error) {
 // GetArch implement PlatformInformer interface.
 func (*realInfo) GetArch() (string, error) {
 	return util.GetArch()
-}
-
-func NewPlatformInformer() *realInfo {
-	return &realInfo{}
 }
 
 // TntIoDoer is an interface that wraps the Do method.

--- a/cli/search/tntio_api_test.go
+++ b/cli/search/tntio_api_test.go
@@ -144,8 +144,8 @@ func checkOutputVersionOrder(t *testing.T, got string, expected []string) {
 }
 
 func TestSearchVersions_TntIo(t *testing.T) {
-	os.Setenv("TT_CLI_EE_USERNAME", testingUsername)
-	os.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
+	t.Setenv("TT_CLI_EE_USERNAME", testingUsername)
+	t.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
 	defer os.Unsetenv("TT_CLI_EE_USERNAME")
 	defer os.Unsetenv("TT_CLI_EE_PASSWORD")
 

--- a/cli/search/tntio_api_test.go
+++ b/cli/search/tntio_api_test.go
@@ -431,7 +431,7 @@ func TestSearchVersions_TntIo(t *testing.T) {
 
 			var logBuilder strings.Builder
 			for _, entry := range handler.Entries {
-				logBuilder.WriteString(fmt.Sprintf("%s %s\n", entry.Level, entry.Message))
+				fmt.Fprintf(&logBuilder, "%s %s\n", entry.Level, entry.Message)
 			}
 			gotLog := logBuilder.String()
 			t.Logf("Log:\n%s", gotLog)

--- a/cli/status/table_printer.go
+++ b/cli/status/table_printer.go
@@ -62,18 +62,6 @@ func formatAlert(alert instanceAlert) string {
 	}
 }
 
-// printInstanceAlerts prints alerts for a specific instance.
-func (t TablePrinter) printInstanceAlerts(instanceName string, instStatus *instanceStatus) {
-	if len(instStatus.Alerts) == 0 {
-		return
-	}
-	fmt.Printf("Alerts for %s:\n", instanceName)
-	for _, alert := range instStatus.Alerts {
-		fmt.Printf("  • %s\n", formatAlert(alert))
-	}
-	fmt.Println()
-}
-
 // hasAlerts checks if any instance has alerts.
 func hasAlerts(instances map[string]*instanceStatus) bool {
 	for _, instStatus := range instances {
@@ -136,4 +124,16 @@ func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
 	}
 
 	return nil
+}
+
+// printInstanceAlerts prints alerts for a specific instance.
+func (t TablePrinter) printInstanceAlerts(instanceName string, instStatus *instanceStatus) {
+	if len(instStatus.Alerts) == 0 {
+		return
+	}
+	fmt.Printf("Alerts for %s:\n", instanceName)
+	for _, alert := range instStatus.Alerts {
+		fmt.Printf("  • %s\n", formatAlert(alert))
+	}
+	fmt.Println()
 }

--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -32,21 +32,18 @@ func readWithTimeout(t *testing.T, ch <-chan string, timeout time.Duration) (str
 	}
 }
 
-func writeLogLines(t *testing.T, f *os.File, count int, line_fmt string) error {
+func writeLogLines(t *testing.T, f *os.File, count int, line_fmt string) {
 	t.Helper()
 
 	for i := range count {
 		_, err := fmt.Fprintln(f, fmt.Sprintf(line_fmt, i+1))
 		if err != nil {
 			t.Fatalf("Failed to write line %d: %v", i+1, err)
-			return err
 		}
 	}
-
-	return nil
 }
 
-func createTmpLogFile(t *testing.T, count int, line_fmt string) string {
+func createTmpLogFile(t *testing.T) string {
 	t.Helper()
 
 	f, err := os.CreateTemp(t.TempDir(), "follow-test-*.log")
@@ -55,17 +52,15 @@ func createTmpLogFile(t *testing.T, count int, line_fmt string) string {
 	}
 	defer f.Close()
 
-	if err = writeLogLines(t, f, count, line_fmt); err != nil {
-		t.Fatalf("Failed to write initial log lines: %v", err)
-	}
+	writeLogLines(t, f, linesPerStep, logLineFormat)
 
 	return f.Name()
 }
 
-func checksLinesInFile(t *testing.T, lines int, ch <-chan string, exp_fmt string) error {
+func checksLinesInFile(t *testing.T, ch <-chan string, exp_fmt string) error {
 	t.Helper()
 
-	for i := range lines {
+	for i := range linesPerStep {
 		n := i + 1
 
 		line, err := readWithTimeout(t, ch, time.Second)
@@ -83,7 +78,7 @@ func checksLinesInFile(t *testing.T, lines int, ch <-chan string, exp_fmt string
 }
 
 func TestFollow2_ReadExistingContent(t *testing.T) {
-	lf := createTmpLogFile(t, linesPerStep, logLineFormat)
+	lf := createTmpLogFile(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -95,7 +90,7 @@ func TestFollow2_ReadExistingContent(t *testing.T) {
 		t.Fatalf("Failed to follow: %v", err)
 	}
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logLineFormat)
+	err = checksLinesInFile(t, outCh, logLineFormat)
 	if err != nil {
 		t.Fatalf("Failed to check lines in file: %v", err)
 	}
@@ -109,7 +104,7 @@ func TestFollow2_FollowNewContent(t *testing.T) {
 		t.Skip("Skipping flaky test on CI until issue #TNTP-3131 is fixed")
 	}
 
-	lf := createTmpLogFile(t, linesPerStep, logLineFormat)
+	lf := createTmpLogFile(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -121,7 +116,7 @@ func TestFollow2_FollowNewContent(t *testing.T) {
 		t.Fatalf("Failed to follow: %v", err)
 	}
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logLineFormat)
+	err = checksLinesInFile(t, outCh, logLineFormat)
 	if err != nil {
 		t.Fatalf("Failed to check lines in file: %v", err)
 	}
@@ -132,14 +127,11 @@ func TestFollow2_FollowNewContent(t *testing.T) {
 		t.Fatalf("Failed to open file for append: %v", err)
 	}
 
-	err = writeLogLines(t, appendFile, linesPerStep, logNewLineFormat)
-	if err != nil {
-		t.Fatalf("Failed to write new log lines: %v", err)
-	}
+	writeLogLines(t, appendFile, linesPerStep, logNewLineFormat)
 
 	appendFile.Close()
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logNewLineFormat)
+	err = checksLinesInFile(t, outCh, logNewLineFormat)
 	if err != nil {
 		t.Fatalf("Failed to check lines in file: %v", err)
 	}
@@ -149,7 +141,7 @@ func TestFollow2_FollowNewContent(t *testing.T) {
 }
 
 func TestFollow2_ContextCancellation(t *testing.T) {
-	lf := createTmpLogFile(t, linesPerStep, logLineFormat)
+	lf := createTmpLogFile(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -161,7 +153,7 @@ func TestFollow2_ContextCancellation(t *testing.T) {
 		t.Fatalf("Failed to follow: %v", err)
 	}
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logLineFormat)
+	err = checksLinesInFile(t, outCh, logLineFormat)
 	if err != nil {
 		t.Fatalf("Failed to check lines in file: %v", err)
 	}
@@ -200,7 +192,7 @@ func TestFollow2_NonExistentFile(t *testing.T) {
 func rotationTest(t *testing.T, use_delay bool) {
 	t.Helper()
 
-	lf := createTmpLogFile(t, linesPerStep, logLineFormat)
+	lf := createTmpLogFile(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -212,7 +204,7 @@ func rotationTest(t *testing.T, use_delay bool) {
 		t.Skipf("Failed to follow: %v", err)
 	}
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logLineFormat)
+	err = checksLinesInFile(t, outCh, logLineFormat)
 	if err != nil {
 		t.Skipf("Failed to check initial lines in file: %v", err)
 		return
@@ -232,18 +224,13 @@ func rotationTest(t *testing.T, use_delay bool) {
 		t.Fatalf("Failed to create new log file: %v", err)
 	}
 
-	err = writeLogLines(t, newFile, linesPerStep, logNewLineFormat)
+	writeLogLines(t, newFile, linesPerStep, logNewLineFormat)
 
 	newFile.Close()
 
-	if err != nil {
-		t.Skipf("Failed to write new log lines after rotation: %v", err)
-		return
-	}
-
 	newFile.Close()
 
-	err = checksLinesInFile(t, linesPerStep, outCh, logNewLineFormat)
+	err = checksLinesInFile(t, outCh, logNewLineFormat)
 	if err != nil {
 		t.Skipf("Failed to check appended lines in file: %v", err)
 		return

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -41,6 +41,9 @@ func (t *tailer) Read(ctx context.Context, lines int) (<-chan string, error) {
 	return TailN(ctx, fmt, t.name, lines)
 }
 
+// LogFormatter is a function used to format log string before output.
+type LogFormatter func(str string) string
+
 // NewLogFormatter creates a function to make log prefix colored.
 func NewLogFormatter(prefix string, color color.Color) LogFormatter {
 	buf := strings.Builder{}
@@ -52,9 +55,6 @@ func NewLogFormatter(prefix string, color color.Color) LogFormatter {
 		return buf.String()
 	}
 }
-
-// LogFormatter is a function used to format log string before output.
-type LogFormatter func(str string) string
 
 // newTailReader returns a reader for last count lines.
 func newTailReader(ctx context.Context, reader io.ReadSeeker, count int) (io.Reader, int64, error) {

--- a/cli/tcm/log_printer.go
+++ b/cli/tcm/log_printer.go
@@ -62,6 +62,26 @@ type logPrinter struct {
 	sync     func() error
 }
 
+// Print reads lines from the input channel and prints them to the output writer.
+func (l *logPrinter) Print(ctx context.Context, in <-chan string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case line, ok := <-in:
+			if !ok {
+				return nil
+			}
+
+			fmt.Fprintln(l.out, l.format(line))
+
+			if l.sync != nil {
+				l.sync()
+			}
+		}
+	}
+}
+
 // format formats a log string, applying colors and indentation if necessary.
 // If noFormat is true or the string is not a valid JSON object, it returns
 // the string as is without any formatting.
@@ -97,26 +117,6 @@ func (l *logPrinter) format(str string) string {
 	resultLines = append(resultLines, color.Sprint("}"))
 
 	return strings.Join(resultLines, "\n")
-}
-
-// Print reads lines from the input channel and prints them to the output writer.
-func (l *logPrinter) Print(ctx context.Context, in <-chan string) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case line, ok := <-in:
-			if !ok {
-				return nil
-			}
-
-			fmt.Fprintln(l.out, l.format(line))
-
-			if l.sync != nil {
-				l.sync()
-			}
-		}
-	}
 }
 
 func colorizeJsonLines(lines []string, cKey, cVal color.Color) []string {

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -31,9 +31,7 @@ var errNotInstalled = errors.New("program is not installed")
 
 // remove removes binary/directory and symlinks from directory.
 // It returns true if symlink was removed, error.
-func remove(program search.Program, programVersion, directory string,
-	cmdCtx *cmdcontext.CmdCtx,
-) (bool, error) {
+func remove(program search.Program, programVersion, directory string) (bool, error) {
 	var linkPath string
 	var err error
 
@@ -133,7 +131,7 @@ func UninstallProgram(
 
 	var isSymlinkRemoved bool
 	for _, verToDel := range versionsToDelete {
-		isSymlinkRemoved, err = remove(program, verToDel, binDst, cmdCtx)
+		isSymlinkRemoved, err = remove(program, verToDel, binDst)
 		if err != nil && !errors.Is(err, errNotInstalled) {
 			return err
 		}
@@ -147,7 +145,7 @@ func UninstallProgram(
 
 	if program.IsTarantool() {
 		log.Infof("Removing headers...")
-		_, err = remove(program, programVersion, headerDst, cmdCtx)
+		_, err = remove(program, programVersion, headerDst)
 		if err != nil {
 			return err
 		}

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -57,12 +57,10 @@ func remove(program search.Program, programVersion, directory string) (bool, err
 	var isSymlinkRemoved bool
 
 	_, err = os.Lstat(linkPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return false, fmt.Errorf("failed to access %q: %w", linkPath, err)
-		}
-		isSymlinkRemoved = false
-	} else {
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("failed to access %q: %w", linkPath, err)
+	}
+	if err == nil {
 		// Get path where symlink point.
 		resolvedPath, err := util.ResolveSymlink(linkPath)
 		if err != nil {
@@ -274,18 +272,10 @@ func searchLatestVersion(program search.Program, binDst, headerDst string) (stri
 		if !slices.Contains(programsToSearch, programName) {
 			continue
 		}
-		if latestHash == "" {
-			isHash, _ := util.IsValidCommitHash(matches["ver"])
-			if isHash {
-				if program.IsTarantool() {
-					// Same version of headers is required to activate the Tarantool binary.
-					if _, err := os.Stat(filepath.Join(headerDst, binaryName)); os.IsNotExist(err) {
-						continue
-					}
-				}
-				latestHash = binaryName
-				continue
-			}
+		if latestHash == "" && isUsableCommitBinary(program, headerDst, binaryName,
+			matches["ver"]) {
+			latestHash = binaryName
+			continue
 		}
 
 		ver, err := version.Parse(matches["ver"])
@@ -309,6 +299,19 @@ func searchLatestVersion(program search.Program, binDst, headerDst string) (stri
 		return latestVersion, nil
 	}
 	return latestHash, nil
+}
+
+func isUsableCommitBinary(program search.Program, headerDst, binaryName, versionStr string) bool {
+	isHash, _ := util.IsValidCommitHash(versionStr)
+	if !isHash {
+		return false
+	}
+	if !program.IsTarantool() {
+		return true
+	}
+	// Same version of headers is required to activate the Tarantool binary.
+	_, err := os.Stat(filepath.Join(headerDst, binaryName))
+	return !os.IsNotExist(err)
 }
 
 // switchProgramToLatestVersion switches the active version of the program to the latest installed.

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -681,17 +681,19 @@ func ExecuteCommandStdin(program string, isVerbose bool, logFile *os.File, workD
 // CreateSymlink creates newName as a symbolic link to oldName. Overwrites existing if overwrite
 // flag is set.
 func CreateSymlink(oldName, newName string, overwrite bool) error {
-	if _, err := os.Stat(newName); err == nil {
-		if !overwrite {
-			return fmt.Errorf("symbolic link cannot be created: '%s' already exists", newName)
-		} else {
-			log.Debugf("Replace existing '%s' with new symlink.", newName)
-			if err := os.Remove(newName); err != nil {
-				return err
-			}
-		}
-	} else if !os.IsNotExist(err) {
+	_, err := os.Stat(newName)
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("symbolic link cannot be created: %s", err)
+	}
+	if os.IsNotExist(err) {
+		return os.Symlink(oldName, newName)
+	}
+	if !overwrite {
+		return fmt.Errorf("symbolic link cannot be created: '%s' already exists", newName)
+	}
+	log.Debugf("Replace existing '%s' with new symlink.", newName)
+	if err := os.Remove(newName); err != nil {
+		return err
 	}
 
 	return os.Symlink(oldName, newName)

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -713,10 +713,8 @@ func IsApp(path string) bool {
 				}
 			}
 		}
-	} else {
-		if filepath.Ext(entry.Name()) == ".lua" {
-			return true
-		}
+	} else if filepath.Ext(entry.Name()) == ".lua" {
+		return true
 	}
 
 	return false
@@ -837,12 +835,13 @@ func GetYamlFileName(fileName string, mustExist bool) (string, error) {
 		return "", err
 	}
 	yamlFilesCount := len(foundYamlFiles)
-	if yamlFilesCount > 1 {
+	switch {
+	case yamlFilesCount > 1:
 		return "", fmt.Errorf("more than one YAML files are found:\n%s\nAmbiguous selection",
 			strings.Join(foundYamlFiles, ", "))
-	} else if yamlFilesCount == 1 {
+	case yamlFilesCount == 1:
 		return foundYamlFiles[0], nil
-	} else if !mustExist {
+	case !mustExist:
 		return "", nil
 	}
 

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -61,11 +61,9 @@ func TestIsDir(t *testing.T) {
 
 	workDir := t.TempDir()
 
-	defer os.RemoveAll(workDir)
-
 	require.True(t, IsDir(workDir))
 
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 
@@ -76,7 +74,7 @@ func TestIsDir(t *testing.T) {
 func TestIsRegularFile(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpFile, err := os.CreateTemp("", "")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 

--- a/cli/util/wal.go
+++ b/cli/util/wal.go
@@ -70,26 +70,7 @@ func collectWALsFromSinglePath(path string, isRecursive bool) ([]string, error) 
 	}
 
 	// Handle the case where path is a directory.
-	if isRecursive {
-		err := filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-			if err != nil {
-				log.Warnf("Skipping %q due to error during walk: %s", p, err)
-				if d != nil && d.IsDir() && errors.Is(err, fs.ErrPermission) {
-					// Skip directory if permission denied, but continue walking other parts.
-					return fs.SkipDir
-				}
-				return nil
-			}
-
-			if !d.IsDir() && isWal(d.Name()) {
-				collected = append(collected, p)
-			}
-			return nil
-		})
-		if err != nil {
-			log.Warnf("Error encountered during recursive walk of %q: %s", path, err)
-		}
-	} else {
+	if !isRecursive {
 		dirEntries, readErr := os.ReadDir(path)
 		if readErr != nil {
 			log.Warnf("Failed to read directory %q: %s", path, readErr)
@@ -100,6 +81,26 @@ func collectWALsFromSinglePath(path string, isRecursive bool) ([]string, error) 
 				collected = append(collected, filepath.Join(path, entry.Name()))
 			}
 		}
+		return collected, nil
+	}
+
+	err = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Warnf("Skipping %q due to error during walk: %s", p, err)
+			if d != nil && d.IsDir() && errors.Is(err, fs.ErrPermission) {
+				// Skip directory if permission denied, but continue walking other parts.
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if !d.IsDir() && isWal(d.Name()) {
+			collected = append(collected, p)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Warnf("Error encountered during recursive walk of %q: %s", path, err)
 	}
 
 	return collected, nil

--- a/cli/util/wal_test.go
+++ b/cli/util/wal_test.go
@@ -249,17 +249,18 @@ func TestCollectWalFiles_recursive(t *testing.T) {
 
 			if test.errMsg != "" {
 				assert.ErrorContains(t, err, test.errMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.output, result)
+			if buf.Len() == 0 {
+				return
+			}
+			logStr := buf.String()
+			if test.logMsg != "" {
+				assert.Contains(t, logStr, test.logMsg)
 			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.output, result)
-				if buf.Len() > 0 {
-					logStr := buf.String()
-					if test.logMsg != "" {
-						assert.Contains(t, logStr, test.logMsg)
-					} else {
-						t.Log(logStr)
-					}
-				}
+				t.Log(logStr)
 			}
 		})
 	}

--- a/cli/util/wal_test.go
+++ b/cli/util/wal_test.go
@@ -227,20 +227,16 @@ func TestCollectWalFiles_recursive(t *testing.T) {
 
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.Chdir(wd))
-	}()
-
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if len(test.input) == 0 || test.input[0][0] != '/' {
 				// If the first element of input is relative path,
 				// we need to change the working directory to the test directory.
-				require.NoError(t, os.Chdir(tstDir))
+				t.Chdir(tstDir)
 			} else {
 				// If the first element of input is absolute path,
 				// run test from current directory, not in temp.
-				require.NoError(t, os.Chdir(wd))
+				t.Chdir(wd)
 			}
 
 			var buf bytes.Buffer

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/tarantool/tt
 go 1.25.7
 
 require (
-	github.com/adam-hanna/arrayOperations v0.2.6
 	github.com/apex/log v1.9.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/briandowns/spinner v1.23.2
@@ -42,7 +41,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.2
 	go.etcd.io/etcd/client/pkg/v3 v3.6.11
 	go.etcd.io/etcd/client/v3 v3.6.11
-	golang.org/x/crypto v0.50.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	google.golang.org/grpc v1.80.0
@@ -154,6 +152,7 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adam-hanna/arrayOperations v0.2.6 h1:QZC99xC8MgUawXnav7bFMejs/dm7YySnDpMx3oZzz2Y=
-github.com/adam-hanna/arrayOperations v0.2.6/go.mod h1:iIzkSjP91FnE66cUFNAjjUJVmjyAwCH0SXnWsx2nbdk=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=

--- a/lib/cluster/file_test.go
+++ b/lib/cluster/file_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,9 +20,7 @@ const (
 )
 
 func TestNewFileCollector(t *testing.T) {
-	var collector cluster.DataCollector
-
-	collector = cluster.NewFileCollector(testYamlPath)
+	var collector cluster.DataCollector = cluster.NewFileCollector(testYamlPath)
 
 	assert.NotNil(t, collector)
 }
@@ -31,7 +30,7 @@ func TestNewFileCollector_fileReadFunc_error(t *testing.T) {
 
 	factory := cluster.NewFactory(
 		cluster.WithFileReadFunc(func(path string) (io.ReadCloser, error) {
-			return nil, fmt.Errorf(errMsg)
+			return nil, errors.New(errMsg)
 		}),
 	)
 	collector := factory.NewFileCollector("foo")
@@ -123,9 +122,7 @@ func TestNewFileCollector_not_exist(t *testing.T) {
 }
 
 func TestNewFilePublisher(t *testing.T) {
-	var publisher cluster.DataPublisher
-
-	publisher = cluster.NewFilePublisher("")
+	var publisher cluster.DataPublisher = cluster.NewFilePublisher("")
 	assert.NotNil(t, publisher)
 }
 

--- a/lib/cluster/integration_test.go
+++ b/lib/cluster/integration_test.go
@@ -75,8 +75,9 @@ func doWithCtx(action func(context.Context) error) error {
 	return action(ctx)
 }
 
-func startEtcd(t *testing.T, opts etcdOpts) *etcdtest.LazyCluster {
+func startEtcd(t *testing.T) *etcdtest.LazyCluster {
 	t.Helper()
+	opts := etcdOpts{}
 
 	myDir, err := os.Getwd()
 	if err != nil {
@@ -190,18 +191,18 @@ func etcdGet(t *testing.T, etcd *clientv3.Client, key string) ([]byte, int64) {
 }
 
 func newEtcdCollector(t *testing.T, stor pkgstorage.Storage,
-	prefix, key string, timeout time.Duration,
+	key string,
 ) cluster.DataCollector {
 	t.Helper()
 
-	collector, err := cluster.NewFactory().NewRemoteStorage(stor, prefix, key, timeout, "etcd")
+	collector, err := cluster.NewFactory().NewRemoteStorage(stor, "/foo/", key, timeout, "etcd")
 	require.NoError(t, err)
 
 	return collector
 }
 
 func newEtcdPublisher(t *testing.T, stor pkgstorage.Storage,
-	prefix, key string, timeout time.Duration,
+	prefix, key string,
 ) cluster.DataPublisher {
 	t.Helper()
 
@@ -212,7 +213,7 @@ func newEtcdPublisher(t *testing.T, stor pkgstorage.Storage,
 }
 
 func TestEtcdCollectors_single(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -228,8 +229,8 @@ func TestEtcdCollectors_single(t *testing.T) {
 		Name      string
 		Collector cluster.DataCollector
 	}{
-		{"all", newEtcdCollector(t, stor, "/foo/", "", timeout)},
-		{"key", newEtcdCollector(t, stor, "/foo/", "bar", timeout)},
+		{"all", newEtcdCollector(t, stor, "")},
+		{"key", newEtcdCollector(t, stor, "bar")},
 	}
 
 	for _, tc := range cases {
@@ -245,7 +246,7 @@ func TestEtcdCollectors_single(t *testing.T) {
 }
 
 func TestEtcdAllCollector_merge(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -258,7 +259,7 @@ func TestEtcdAllCollector_merge(t *testing.T) {
 	etcdPut(t, etcd, "/foo/config/a", "foo: bar")
 	etcdPut(t, etcd, "/foo/config/b", "foo: car\nzoo: car")
 
-	data, err := newEtcdCollector(t, stor, "/foo/", "", timeout).Collect()
+	data, err := newEtcdCollector(t, stor, "").Collect()
 	require.NoError(t, err)
 	// Two separate etcd keys → two Data entries.
 	require.Len(t, data, 2)
@@ -275,7 +276,7 @@ func TestEtcdAllCollector_merge(t *testing.T) {
 }
 
 func TestEtcdCollectors_empty(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -289,8 +290,8 @@ func TestEtcdCollectors_empty(t *testing.T) {
 		Name      string
 		Collector cluster.DataCollector
 	}{
-		{"all", newEtcdCollector(t, stor, "/foo/", "", timeout)},
-		{"key", newEtcdCollector(t, stor, "/foo/", "bar", timeout)},
+		{"all", newEtcdCollector(t, stor, "")},
+		{"key", newEtcdCollector(t, stor, "bar")},
 	}
 
 	for _, tc := range cases {
@@ -303,7 +304,7 @@ func TestEtcdCollectors_empty(t *testing.T) {
 }
 
 func TestEtcdDataPublishers_Publish_single(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -319,8 +320,8 @@ func TestEtcdDataPublishers_Publish_single(t *testing.T) {
 		Key       string
 		Publisher cluster.DataPublisher
 	}{
-		{"all", "all", newEtcdPublisher(t, stor, "/foo/", "", timeout)},
-		{"key", "key", newEtcdPublisher(t, stor, "/foo/", "key", timeout)},
+		{"all", "all", newEtcdPublisher(t, stor, "/foo/", "")},
+		{"key", "key", newEtcdPublisher(t, stor, "/foo/", "key")},
 	}
 
 	for _, tc := range cases {
@@ -335,7 +336,7 @@ func TestEtcdDataPublishers_Publish_single(t *testing.T) {
 }
 
 func TestEtcdDataPublishers_Publish_rewrite(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -352,8 +353,8 @@ func TestEtcdDataPublishers_Publish_rewrite(t *testing.T) {
 		Key       string
 		Publisher cluster.DataPublisher
 	}{
-		{"all", "all", newEtcdPublisher(t, stor, "/foo/", "", timeout)},
-		{"key", "key", newEtcdPublisher(t, stor, "/foo/", "key", timeout)},
+		{"all", "all", newEtcdPublisher(t, stor, "/foo/", "")},
+		{"key", "key", newEtcdPublisher(t, stor, "/foo/", "key")},
 	}
 
 	for _, tc := range cases {
@@ -369,7 +370,7 @@ func TestEtcdDataPublishers_Publish_rewrite(t *testing.T) {
 }
 
 func TestEtcdAllDataPublisher_Publish_rewrite_prefix(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -383,7 +384,7 @@ func TestEtcdAllDataPublisher_Publish_rewrite_prefix(t *testing.T) {
 	etcdPut(t, etcd, "/foo/config/zoo", "zoo")
 
 	data := []byte("zoo bar foo")
-	err = newEtcdPublisher(t, stor, "/foo/", "", timeout).Publish(0, data)
+	err = newEtcdPublisher(t, stor, "/foo/", "").Publish(0, data)
 	require.NoError(t, err)
 
 	actual, _ := etcdGet(t, etcd, "/foo/config/zoo")
@@ -397,7 +398,7 @@ func TestEtcdAllDataPublisher_Publish_rewrite_prefix(t *testing.T) {
 }
 
 func TestEtcdKeyDataPublisher_Publish_modRevision_specified(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -412,7 +413,7 @@ func TestEtcdKeyDataPublisher_Publish_modRevision_specified(t *testing.T) {
 
 	data := []byte("baz")
 
-	publisher := newEtcdPublisher(t, stor, "/foo", "key", timeout)
+	publisher := newEtcdPublisher(t, stor, "/foo", "key")
 	// Use wrong revision.
 	err = publisher.Publish(modRevision-1, data)
 	assert.Errorf(t, err, "failed to put data into etcd: wrong revision")
@@ -427,7 +428,7 @@ func TestEtcdKeyDataPublisher_Publish_modRevision_specified(t *testing.T) {
 }
 
 func TestEtcdAllDataPublisher_Publish_ignore_prefix(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -441,7 +442,7 @@ func TestEtcdAllDataPublisher_Publish_ignore_prefix(t *testing.T) {
 	etcdPut(t, etcd, "/foo/config/foo", "zoo")
 
 	data := []byte("zoo bar foo")
-	err = newEtcdPublisher(t, stor, "/foo/", "all", timeout).Publish(0, data)
+	err = newEtcdPublisher(t, stor, "/foo/", "all").Publish(0, data)
 
 	assert.NoError(t, err)
 
@@ -456,7 +457,7 @@ func TestEtcdAllDataPublisher_Publish_ignore_prefix(t *testing.T) {
 }
 
 func TestEtcdAllDataPublisher_collect_publish_collect(t *testing.T) {
-	inst := startEtcd(t, etcdOpts{})
+	inst := startEtcd(t)
 	defer inst.Terminate()
 
 	endpoints := inst.EndpointsGRPC()
@@ -469,8 +470,8 @@ func TestEtcdAllDataPublisher_collect_publish_collect(t *testing.T) {
 	etcdPut(t, etcd, "/foo/config/foo", "zoo: bar")
 
 	prefix := "/foo/"
-	publisher := newEtcdPublisher(t, stor, prefix, "", timeout)
-	collector := newEtcdCollector(t, stor, prefix, "", timeout)
+	publisher := newEtcdPublisher(t, stor, prefix, "")
+	collector := newEtcdCollector(t, stor, "")
 
 	// Collect and verify initial data.
 	data, err := collector.Collect()
@@ -620,7 +621,7 @@ var testsIntegrity = []struct {
 		Setup: func(t *testing.T) interface{} {
 			t.Helper()
 
-			inst := startEtcd(t, etcdOpts{})
+			inst := startEtcd(t)
 			return inst
 		},
 		Shutdown: func(t *testing.T, inst interface{}) {

--- a/lib/cluster/integration_test.go
+++ b/lib/cluster/integration_test.go
@@ -103,55 +103,57 @@ func startEtcd(t *testing.T) *etcdtest.LazyCluster {
 	config := etcdtest.ClusterConfig{Size: 1, PeerTLS: tls}
 	inst := etcdtest.NewLazyCluster(config)
 
-	if opts.Username != "" {
-		etcd, err := clientv3.New(clientv3.Config{
-			Endpoints: inst.EndpointsGRPC(),
-		})
-		require.NoError(t, err)
-		defer etcd.Close()
+	if opts.Username == "" {
+		return inst
+	}
 
+	etcd, err := clientv3.New(clientv3.Config{
+		Endpoints: inst.EndpointsGRPC(),
+	})
+	require.NoError(t, err)
+	defer etcd.Close()
+
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to create user in etcd: %s", err)
+	}
+
+	if opts.Username != "root" {
+		// We need the root user for auth enable anyway.
 		if err := doWithCtx(func(ctx context.Context) error {
-			_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
+			_, err := etcd.UserAdd(ctx, "root", "")
 			return err
 		}); err != nil {
 			inst.Terminate()
-			t.Fatalf("Failed to create user in etcd: %s", err)
-		}
-
-		if opts.Username != "root" {
-			// We need the root user for auth enable anyway.
-			if err := doWithCtx(func(ctx context.Context) error {
-				_, err := etcd.UserAdd(ctx, "root", "")
-				return err
-			}); err != nil {
-				inst.Terminate()
-				t.Fatalf("Failed to create root in etcd: %s", err)
-			}
-
-			if err := doWithCtx(func(ctx context.Context) error {
-				_, err := etcd.UserGrantRole(ctx, "root", "root")
-				return err
-			}); err != nil {
-				inst.Terminate()
-				t.Fatalf("Failed to grant root in etcd: %s", err)
-			}
+			t.Fatalf("Failed to create root in etcd: %s", err)
 		}
 
 		if err := doWithCtx(func(ctx context.Context) error {
-			_, err := etcd.UserGrantRole(ctx, opts.Username, "root")
+			_, err := etcd.UserGrantRole(ctx, "root", "root")
 			return err
 		}); err != nil {
 			inst.Terminate()
-			t.Fatalf("Failed to grant user in etcd: %s", err)
+			t.Fatalf("Failed to grant root in etcd: %s", err)
 		}
+	}
 
-		if err := doWithCtx(func(ctx context.Context) error {
-			_, err = etcd.AuthEnable(ctx)
-			return err
-		}); err != nil {
-			inst.Terminate()
-			t.Fatalf("Failed to enable auth in etcd: %s", err)
-		}
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err := etcd.UserGrantRole(ctx, opts.Username, "root")
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to grant user in etcd: %s", err)
+	}
+
+	if err := doWithCtx(func(ctx context.Context) error {
+		_, err = etcd.AuthEnable(ctx)
+		return err
+	}); err != nil {
+		inst.Terminate()
+		t.Fatalf("Failed to enable auth in etcd: %s", err)
 	}
 
 	return inst

--- a/lib/cluster/storage.go
+++ b/lib/cluster/storage.go
@@ -57,69 +57,68 @@ type RawStorage struct {
 	timeout        time.Duration
 }
 
+// NewStorage returns a *RawStorage bound to the given backend.
+//
+// Most callers should use Factory.NewRemoteStorage, which fills objectLocation
+// with the default configLocation. Use this directly only when a different
+// objectLocation (or none) is required, such as for the failover command
+// namespace.
+func NewStorage(
+	storage gstorage.Storage,
+	prefix string,
+	timeout time.Duration,
+	key string,
+	storageType string,
+	integrityOpts *IntegrityOptions,
+	objectLocation string,
+) (*RawStorage, error) {
+	prefix = strings.TrimRight(prefix, "/")
+
+	codec := integrity.NewCodecBuilder[StorageDataType]().
+		WithMarshaller(marshaller.NewTypedBytesMarshaller())
+	if objectLocation != "" {
+		codec = codec.WithObjectLocation(objectLocation)
+	}
+	if integrityOpts != nil {
+		for _, h := range integrityOpts.Hashers {
+			codec = codec.WithHasher(h)
+		}
+		for _, sv := range integrityOpts.SignerVerifiers {
+			codec = codec.WithSignerVerifier(sv)
+		}
+		for _, signer := range integrityOpts.Signers {
+			codec = codec.WithSigner(signer)
+		}
+		for _, verifier := range integrityOpts.Verifiers {
+			codec = codec.WithVerifier(verifier)
+		}
+	}
+
+	codecBuild, err := codec.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	storage, err = gstorage.Prefixed(prefix, storage)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RawStorage{
+		storage:        codecBuild.Bind(storage),
+		codec:          codecBuild,
+		key:            key,
+		storageType:    storageType,
+		timeout:        timeout,
+		prefix:         prefix,
+		objectLocation: objectLocation,
+	}, nil
+}
+
 // SetCleanup attaches a cleanup callback that Close will invoke. Used when the
 // caller wants Close to also release an underlying connection.
 func (r *RawStorage) SetCleanup(cleanup func()) {
 	r.cleanup = cleanup
-}
-
-// normalizeName normalizes a name by removing the prefix and object location from it.
-// It trims leading slashes and strips the configured prefix and object location,
-// returning the relative name within the storage.
-func (r *RawStorage) normalizeName(name string) string {
-	if name == "" {
-		return ""
-	}
-
-	trimObjectLocation := func(name string) string {
-		name = strings.TrimPrefix(name, "/")
-		if r.objectLocation == "" {
-			return name
-		}
-		if trimmed, ok := strings.CutPrefix(name, r.objectLocation); ok {
-			return strings.TrimPrefix(trimmed, "/")
-		}
-		return name
-	}
-
-	if r.prefix == "" {
-		return trimObjectLocation(name)
-	}
-
-	configPrefix := r.prefix
-	if trimmed, ok := strings.CutPrefix(name, configPrefix); ok {
-		return trimObjectLocation(trimmed)
-	}
-
-	configPrefix = strings.TrimSuffix(configPrefix, "/")
-	if trimmed, ok := strings.CutPrefix(name, configPrefix); ok {
-		return trimObjectLocation(trimmed)
-	}
-
-	return trimObjectLocation(name)
-}
-
-// sourceName constructs the full source path for a name by combining
-// the prefix, object location and the normalized name.
-func (r *RawStorage) sourceName(name string) string {
-	name = r.normalizeName(name)
-	if name == "" {
-		return r.prefix
-	}
-
-	result := r.prefix
-	if r.objectLocation != "" {
-		result += "/" + r.objectLocation
-	}
-	return result + "/" + name
-}
-
-// withTimeout returns a context bounded by r.timeout (background context if 0).
-func (r *RawStorage) withTimeout() (context.Context, context.CancelFunc) {
-	if r.timeout == 0 {
-		return context.Background(), func() {}
-	}
-	return context.WithTimeout(context.Background(), r.timeout)
 }
 
 // Collect collects values from storage by prefix (if no key bound) or by key.
@@ -211,21 +210,6 @@ func (r *RawStorage) Put(ctx context.Context, key, value string) error {
 	return r.put(ctx, key, []byte(value), 0) //nolint:wrapcheck // put already wraps.
 }
 
-func (r *RawStorage) put(ctx context.Context, key string, data []byte, revision int64) error {
-	if data == nil {
-		return fmt.Errorf("failed to publish data into %s: %w", r.storageType, errDataMissing)
-	}
-	var predicates []integrity.Predicate
-	if revision != 0 {
-		predicates = append(predicates, r.codec.VersionEqual(revision))
-	}
-	if err := r.storage.Put(ctx, r.normalizeName(key), data,
-		integrity.WithPutPredicates(predicates...)); err != nil {
-		return fmt.Errorf("failed to publish data into %s: %w", r.storageType, err)
-	}
-	return nil
-}
-
 // Watch watches on a key and return watched events through the returned channel.
 func (r *RawStorage) Watch(ctx context.Context, key string) (<-chan WatchEvent, error) {
 	ch := make(chan WatchEvent)
@@ -248,62 +232,78 @@ func (r *RawStorage) Watch(ctx context.Context, key string) (<-chan WatchEvent, 
 	return ch, nil
 }
 
-// NewStorage returns a *RawStorage bound to the given backend.
-//
-// Most callers should use Factory.NewRemoteStorage, which fills objectLocation
-// with the default configLocation. Use this directly only when a different
-// objectLocation (or none) is required, such as for the failover command
-// namespace.
-func NewStorage(
-	storage gstorage.Storage,
-	prefix string,
-	timeout time.Duration,
-	key string,
-	storageType string,
-	integrityOpts *IntegrityOptions,
-	objectLocation string,
-) (*RawStorage, error) {
-	prefix = strings.TrimRight(prefix, "/")
-
-	codec := integrity.NewCodecBuilder[StorageDataType]().
-		WithMarshaller(marshaller.NewTypedBytesMarshaller())
-	if objectLocation != "" {
-		codec = codec.WithObjectLocation(objectLocation)
-	}
-	if integrityOpts != nil {
-		for _, h := range integrityOpts.Hashers {
-			codec = codec.WithHasher(h)
-		}
-		for _, sv := range integrityOpts.SignerVerifiers {
-			codec = codec.WithSignerVerifier(sv)
-		}
-		for _, signer := range integrityOpts.Signers {
-			codec = codec.WithSigner(signer)
-		}
-		for _, verifier := range integrityOpts.Verifiers {
-			codec = codec.WithVerifier(verifier)
-		}
+// normalizeName normalizes a name by removing the prefix and object location from it.
+// It trims leading slashes and strips the configured prefix and object location,
+// returning the relative name within the storage.
+func (r *RawStorage) normalizeName(name string) string {
+	if name == "" {
+		return ""
 	}
 
-	codecBuild, err := codec.Build()
-	if err != nil {
-		return nil, err
+	trimObjectLocation := func(name string) string {
+		name = strings.TrimPrefix(name, "/")
+		if r.objectLocation == "" {
+			return name
+		}
+		if trimmed, ok := strings.CutPrefix(name, r.objectLocation); ok {
+			return strings.TrimPrefix(trimmed, "/")
+		}
+		return name
 	}
 
-	storage, err = gstorage.Prefixed(prefix, storage)
-	if err != nil {
-		return nil, err
+	if r.prefix == "" {
+		return trimObjectLocation(name)
 	}
 
-	return &RawStorage{
-		storage:        codecBuild.Bind(storage),
-		codec:          codecBuild,
-		key:            key,
-		storageType:    storageType,
-		timeout:        timeout,
-		prefix:         prefix,
-		objectLocation: objectLocation,
-	}, nil
+	configPrefix := r.prefix
+	if trimmed, ok := strings.CutPrefix(name, configPrefix); ok {
+		return trimObjectLocation(trimmed)
+	}
+
+	configPrefix = strings.TrimSuffix(configPrefix, "/")
+	if trimmed, ok := strings.CutPrefix(name, configPrefix); ok {
+		return trimObjectLocation(trimmed)
+	}
+
+	return trimObjectLocation(name)
+}
+
+// sourceName constructs the full source path for a name by combining
+// the prefix, object location and the normalized name.
+func (r *RawStorage) sourceName(name string) string {
+	name = r.normalizeName(name)
+	if name == "" {
+		return r.prefix
+	}
+
+	result := r.prefix
+	if r.objectLocation != "" {
+		result += "/" + r.objectLocation
+	}
+	return result + "/" + name
+}
+
+// withTimeout returns a context bounded by r.timeout (background context if 0).
+func (r *RawStorage) withTimeout() (context.Context, context.CancelFunc) {
+	if r.timeout == 0 {
+		return context.Background(), func() {}
+	}
+	return context.WithTimeout(context.Background(), r.timeout)
+}
+
+func (r *RawStorage) put(ctx context.Context, key string, data []byte, revision int64) error {
+	if data == nil {
+		return fmt.Errorf("failed to publish data into %s: %w", r.storageType, errDataMissing)
+	}
+	var predicates []integrity.Predicate
+	if revision != 0 {
+		predicates = append(predicates, r.codec.VersionEqual(revision))
+	}
+	if err := r.storage.Put(ctx, r.normalizeName(key), data,
+		integrity.WithPutPredicates(predicates...)); err != nil {
+		return fmt.Errorf("failed to publish data into %s: %w", r.storageType, err)
+	}
+	return nil
 }
 
 // connectEtcdClient creates and returns a new etcd client connection

--- a/lib/cluster/storage.go
+++ b/lib/cluster/storage.go
@@ -310,30 +310,11 @@ func (r *RawStorage) put(ctx context.Context, key string, data []byte, revision 
 // configured with the provided connection parameters, including TLS settings.
 func connectEtcdClient(cfg gsconnect.Config) (*clientv3.Client, error) {
 	var tlsConfig *tls.Config
-	if cfg.SSL.KeyFile != "" || cfg.SSL.CertFile != "" || cfg.SSL.CaFile != "" ||
-		cfg.SSL.CaPath != "" || !cfg.SSL.VerifyHost || !cfg.SSL.VerifyPeer {
-		tlsInfo := transport.TLSInfo{
-			CertFile:      cfg.SSL.CertFile,
-			KeyFile:       cfg.SSL.KeyFile,
-			TrustedCAFile: cfg.SSL.CaFile,
-		}
-
+	if needsEtcdTLSConfig(cfg.SSL) {
 		var err error
-		tlsConfig, err = tlsInfo.ClientConfig()
+		tlsConfig, err = makeEtcdTLSConfig(cfg.SSL)
 		if err != nil {
-			return nil, fmt.Errorf("fail to create tls client config: %w", err)
-		}
-
-		if cfg.SSL.CaPath != "" {
-			roots, err := loadRootCA(cfg.SSL.CaPath)
-			if err != nil {
-				return nil, fmt.Errorf("fail to load CA directory: %w", err)
-			}
-			tlsConfig.RootCAs = roots
-		}
-
-		if !cfg.SSL.VerifyHost || !cfg.SSL.VerifyPeer {
-			tlsConfig.InsecureSkipVerify = true
+			return nil, err
 		}
 	}
 
@@ -346,6 +327,34 @@ func connectEtcdClient(cfg gsconnect.Config) (*clientv3.Client, error) {
 		Logger:      zap.NewNop(),
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
+}
+
+func needsEtcdTLSConfig(sslCfg gsconnect.SSLConfig) bool {
+	return sslCfg.KeyFile != "" || sslCfg.CertFile != "" || sslCfg.CaFile != "" ||
+		sslCfg.CaPath != "" || !sslCfg.VerifyHost || !sslCfg.VerifyPeer
+}
+
+func makeEtcdTLSConfig(sslCfg gsconnect.SSLConfig) (*tls.Config, error) {
+	tlsInfo := transport.TLSInfo{
+		CertFile:      sslCfg.CertFile,
+		KeyFile:       sslCfg.KeyFile,
+		TrustedCAFile: sslCfg.CaFile,
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("fail to create tls client config: %w", err)
+	}
+	if sslCfg.CaPath != "" {
+		roots, err := loadRootCA(sslCfg.CaPath)
+		if err != nil {
+			return nil, fmt.Errorf("fail to load CA directory: %w", err)
+		}
+		tlsConfig.RootCAs = roots
+	}
+	if !sslCfg.VerifyHost || !sslCfg.VerifyPeer {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	return tlsConfig, nil
 }
 
 // connectTarantoolConnector creates and returns a new tarantool connection

--- a/lib/connect/credentials_test.go
+++ b/lib/connect/credentials_test.go
@@ -86,10 +86,7 @@ func Test_getCredsFromEnvVars(t *testing.T) {
 			prepare: func() {},
 			want:    UserCredentials{Username: "", Password: ""},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				if err.Error() == "no credentials in environment variables were found" {
-					return true
-				}
-				return false
+				return err.Error() == "no credentials in environment variables were found"
 			},
 		},
 		{
@@ -110,7 +107,7 @@ func Test_getCredsFromEnvVars(t *testing.T) {
 			t.Setenv(EnvSdkPassword, "")
 			tt.prepare()
 			got, err := getCredsFromEnvVars()
-			if !tt.wantErr(t, err, fmt.Sprintf("getCredsFromEnvVars()")) {
+			if !tt.wantErr(t, err, "getCredsFromEnvVars()") {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "getCredsFromEnvVars()")

--- a/magefile.go
+++ b/magefile.go
@@ -363,19 +363,8 @@ func (Unit) Coverage() error {
 		return err
 	}
 	coverDir := filepath.Join(cwd, "coverage", "unit")
-	coverageDirInfo, err := os.Stat(coverDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			if err := os.MkdirAll(coverDir, 0o750); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	} else {
-		if !coverageDirInfo.IsDir() {
-			return fmt.Errorf("%q is not a directory", coverDir)
-		}
+	if err := ensureCoverageDir(coverDir); err != nil {
+		return err
 	}
 
 	err = runUnitTests([]string{
@@ -395,6 +384,20 @@ func (Unit) Coverage() error {
 	go tool covdata func -i %q
 `, relCoverDir)
 
+	return nil
+}
+
+func ensureCoverageDir(coverDir string) error {
+	coverageDirInfo, err := os.Stat(coverDir)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(coverDir, 0o750)
+	}
+	if err != nil {
+		return err
+	}
+	if !coverageDirInfo.IsDir() {
+		return fmt.Errorf("%q is not a directory", coverDir)
+	}
 	return nil
 }
 

--- a/test/integration/aeon/server/service/server.go
+++ b/test/integration/aeon/server/service/server.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/tarantool/tt/cli/aeon/pb"
@@ -17,8 +18,11 @@ type Server struct {
 func (s *Server) SQLCheck(ctx context.Context,
 	request *pb.SQLRequest,
 ) (*pb.SQLCheckResponse, error) {
+	if request == nil {
+		return nil, errors.New("sql check request is nil")
+	}
 	status := pb.SQLCheckStatus_SQL_QUERY_INCOMPLETE
-	switch strings.ToLower(request.Query) {
+	switch strings.ToLower(request.GetQuery()) {
 	case "ok":
 		status = pb.SQLCheckStatus_SQL_QUERY_VALID
 	case "error":
@@ -28,12 +32,18 @@ func (s *Server) SQLCheck(ctx context.Context,
 }
 
 func (s *Server) SQL(ctx context.Context, in *pb.SQLRequest) (*pb.SQLResponse, error) {
-	res := makeSQLResponse(in.Query)
+	if in == nil {
+		return nil, errors.New("sql request is nil")
+	}
+	res := makeSQLResponse(in.GetQuery())
 	return &res, nil
 }
 
 func (s *Server) SQLStream(in *pb.SQLRequest, stream pb.SQLService_SQLStreamServer) error {
-	res := makeSQLResponse(in.Query)
+	if in == nil {
+		return errors.New("sql stream request is nil")
+	}
+	res := makeSQLResponse(in.GetQuery())
 	stream.Send(&res)
 	return nil
 }


### PR DESCRIPTION
- Enable: gocritic, unparam, usetesting, gocyclo, nilnil, protogetter, staticcheck, funcorder, nestif
- Simplify nested control flow and extract focused version-resolution helpers.
- Remove unused private parameters and always-nil error results.
- Use testing.T helpers for environment and temporary filesystem state.
- Read protobuf fields through generated getters and validate nested messages.
- Replace deprecated helpers while retaining intentional compatibility paths.
- Normalize constructor and method ordering.

Part of TNTP-9993