### PR TITLE
lint: enable noctx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - gosec
     - ireturn # Ireturn is disabled, since it's not needed.
     - maintidx # Maintidx is disabled, purpose of this metric is unknown.
-    - modernize
     - nlreturn # Nlreturn is disabled, since it's duplicated by wsl_v5.return check.
     - noinlineerr
     - paralleltest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,36 +22,40 @@ linters:
   default: all
 
   disable:
-    - cyclop
+    - cyclop # Cyclop is disabled, since cyclomatic complexity is a very abstract metric
+      # that sometimes leads to strange linter behavior.
     - depguard
-    - dupl
+    - dupl # Dupl is disabled, since we're generating a lot of boilerplate code.
     - err113
     - errcheck
     - errorlint
     - exhaustruct
     - exhaustruct_v5
-    - forbidigo
-    - funlen
+    - forbidigo # Forbidigo is disabled because direct stdout output is intentional
+      # in the CLI and Mage targets.
+    - funlen # Funlen is disabled, function length limits are too restrictive.
     - gochecknoglobals
-    - gocognit
+    - gocognit # Gocognit is disabled, cognitive complexity is too restrictive.
     - goconst
-    - godox
+    - godox # Godox is disabled to allow TODO comments for unimplemented functionality.
     - gomodguard
     - gosec
-    - ireturn
-    - maintidx
-    - mnd
+    - ireturn # Ireturn is disabled, since it's not needed.
+    - maintidx # Maintidx is disabled, purpose of this metric is unknown.
     - modernize
-    - nlreturn
+    - nlreturn # Nlreturn is disabled, since it's duplicated by wsl_v5.return check.
     - noinlineerr
     - paralleltest
     - perfsprint
     - testifylint
+    # TODO: Enable after internal tests are converted to external test packages
+    # without exporting production internals solely to satisfy the linter.
     - testpackage
     - tparallel
     - varnamelen
     - wrapcheck
-    - wsl
+    - wsl # WSL is disabled, since it's obsolete; its replacement is disabled
+      # separately below.
     - wsl_v5
 
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,8 +31,6 @@ linters:
     - errorlint
     - exhaustruct
     - exhaustruct_v5
-    - forbidigo # Forbidigo is disabled because direct stdout output is intentional
-      # in the CLI and Mage targets.
     - funlen # Funlen is disabled, function length limits are too restrictive.
     - gochecknoglobals
     - gocognit # Gocognit is disabled, cognitive complexity is too restrictive.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
     - dupl # Dupl is disabled, since we're generating a lot of boilerplate code.
     - err113
     - errcheck
-    - errorlint
     - exhaustruct
     - exhaustruct_v5
     - funlen # Funlen is disabled, function length limits are too restrictive.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
     - mnd
     - modernize
     - nlreturn
-    - noctx
     - noinlineerr
     - paralleltest
     - perfsprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - noinlineerr
     - paralleltest
     - perfsprint
-    - revive
     - testifylint
     - testpackage
     - tparallel

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -29,6 +29,8 @@ type Client struct {
 	client pb.SQLServiceClient
 }
 
+const requestTimeout = 10 * time.Second
+
 func makeAddress(ctx cmd.ConnectCtx) string {
 	if ctx.Network == connector.UnixNetwork {
 		if strings.HasPrefix(ctx.Address, "@") {
@@ -121,7 +123,7 @@ func (c *Client) Title() string {
 
 // Validate implements console.Handler interface.
 func (c *Client) Validate(input string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
 	check, err := c.client.SQLCheck(ctx, &pb.SQLRequest{Query: input})
@@ -139,7 +141,7 @@ func (c *Client) Validate(input string) bool {
 
 // Execute implements console.Handler interface.
 func (c *Client) Execute(input string) any {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
 	resp, err := c.client.SQL(ctx, &pb.SQLRequest{Query: input})
@@ -162,7 +164,7 @@ func (c *Client) Complete(input prompt.Document) []prompt.Suggest {
 
 func (c *Client) ping() error {
 	log.Infof("Start ping aeon server")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 
 	diag := pb.NewDiagServiceClient(c.conn)

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -43,14 +43,14 @@ func getCertificate(args cmd.Ssl) (tls.Certificate, error) {
 	if args.CertFile == "" && args.KeyFile == "" {
 		return tls.Certificate{}, nil
 	}
-	tls_cert, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
+	tlsCert, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
 	if err != nil {
-		return tls_cert, fmt.Errorf("could not load client key pair: %w", err)
+		return tlsCert, fmt.Errorf("could not load client key pair: %w", err)
 	}
-	return tls_cert, nil
+	return tlsCert, nil
 }
 
-func getTlsConfig(args cmd.Ssl) (*tls.Config, error) {
+func getTLSConfig(args cmd.Ssl) (*tls.Config, error) {
 	var pool *x509.CertPool
 
 	if args.CaFile != "" {
@@ -80,7 +80,7 @@ func getTlsConfig(args cmd.Ssl) (*tls.Config, error) {
 func getDialOpts(ctx cmd.ConnectCtx) (grpc.DialOption, error) {
 	var creds credentials.TransportCredentials
 	if ctx.Transport == cmd.TransportSsl {
-		config, err := getTlsConfig(ctx.Ssl)
+		config, err := getTLSConfig(ctx.Ssl)
 		if err != nil {
 			return nil, fmt.Errorf("not tls config: %w", err)
 		}

--- a/cli/aeon/cmd/connect.go
+++ b/cli/aeon/cmd/connect.go
@@ -28,8 +28,8 @@ type ConnectCtx struct {
 
 // Advertise structure groups connection parameters.
 type Advertise struct {
-	// Uri is a connection URL, unix socket address and etc.
-	Uri string `mapstructure:"uri"`
+	// URI is a connection URL, unix socket address and etc.
+	URI string `mapstructure:"uri"`
 	// Group of connection parameters.
 	Params AdvertiseParams `mapstructure:"params"`
 }

--- a/cli/aeon/cmd/connection.go
+++ b/cli/aeon/cmd/connection.go
@@ -17,7 +17,7 @@ import (
 // collected configuration by given instanceName and libconnect.UriOpts.
 // It returns an error if fails to collect a configuration,
 // instantiate a cluster config or find an instance in the cluster.
-func FillConnectCtx(connectCtx *ConnectCtx, uriOpts libconnect.UriOpts,
+func FillConnectCtx(connectCtx *ConnectCtx, uriOpts libconnect.URIOpts,
 	instanceName string, factory libcluster.Factory,
 ) error {
 	connOpts := libcluster.ConnectOpts{
@@ -62,11 +62,11 @@ func FillConnectCtx(connectCtx *ConnectCtx, uriOpts libconnect.UriOpts,
 		return fmt.Errorf("failed to decode aeon advertise: %w", err)
 	}
 
-	if advertise.Uri == "" {
+	if advertise.URI == "" {
 		return errors.New("invalid connection url")
 	}
 
-	cleanedURL, err := util.RemoveScheme(advertise.Uri)
+	cleanedURL, err := util.RemoveScheme(advertise.URI)
 	if err != nil {
 		return err
 	}

--- a/cli/aeon/results.go
+++ b/cli/aeon/results.go
@@ -2,6 +2,7 @@ package aeon
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/tarantool/tt/cli/aeon/pb"
 	"github.com/tarantool/tt/cli/console"
@@ -36,16 +37,17 @@ func (r resultType) Format(f console.Format) (string, error) {
 
 // asYaml prepare results for formatter.MakeOutput.
 func (r resultType) asYaml() string {
-	yaml := "---\n"
+	var yaml strings.Builder
+	yaml.WriteString("---\n")
 	for _, row := range r.rows {
 		mark := "-"
 		for i, v := range row {
 			n := r.names[i]
-			yaml += fmt.Sprintf("%s %s: %v\n", mark, n, v)
+			fmt.Fprintf(&yaml, "%s %s: %v\n", mark, n, v)
 			mark = " "
 		}
 	}
-	return yaml
+	return yaml.String()
 }
 
 // Format produce formatted string according required console.Format settings.

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -24,9 +24,9 @@ import (
 // printBinaries outputs installed versions of the program.
 func printVersion(versionString string) {
 	if strings.HasSuffix(versionString, "[active]") {
-		fmt.Printf("	%s\n", util.Bold(color.GreenString(versionString)))
+		fmt.Fprintf(os.Stdout, "	%s\n", util.Bold(color.GreenString(versionString)))
 	} else {
-		fmt.Printf("	%s\n", color.YellowString(versionString))
+		fmt.Fprintf(os.Stdout, "	%s\n", color.YellowString(versionString))
 	}
 }
 
@@ -118,7 +118,7 @@ func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) error {
 		search.ProgramEe,
 		search.ProgramTcm,
 	}
-	fmt.Println("List of installed binaries:")
+	fmt.Fprintln(os.Stdout, "List of installed binaries:")
 	for _, program := range programs {
 		binaryVersions, err := ParseBinaries(binDirFilesList, program, binDir)
 		if err != nil {

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -108,7 +108,7 @@ func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) error {
 	if len(binDirFilesList) == 0 || errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("there are no binaries installed in this environment of 'tt'")
 	} else if err != nil {
-		return fmt.Errorf("error reading directory %q: %s", binDir, err)
+		return fmt.Errorf("error reading directory %q: %w", binDir, err)
 	}
 
 	programs := [...]search.Program{

--- a/cli/binary/switch.go
+++ b/cli/binary/switch.go
@@ -65,7 +65,7 @@ func ChooseVersion(binDir string, program search.Program) (string, error) {
 	if len(binDirFilesList) == 0 || errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("there are no binaries installed in this environment of 'tt'")
 	} else if err != nil {
-		return "", fmt.Errorf("error reading directory %q: %s", binDir, err)
+		return "", fmt.Errorf("error reading directory %q: %w", binDir, err)
 	}
 	versions, err := ParseBinaries(binDirFilesList, program, binDir)
 	if err != nil {
@@ -106,7 +106,7 @@ func switchHeaders(switchCtx *SwitchCtx, versionStr string) error {
 		filepath.Join(includeDir, switchCtx.Program.Exec()),
 		true)
 	if err != nil {
-		return fmt.Errorf("failed create symlink: %s", err)
+		return fmt.Errorf("failed create symlink: %w", err)
 	}
 	return nil
 }
@@ -122,7 +122,7 @@ func switchBinary(switchCtx *SwitchCtx, versionStr string) error {
 		filepath.Join(switchCtx.BinDir, switchCtx.Program.Exec()),
 		true)
 	if err != nil {
-		return fmt.Errorf("failed create symlink: %s", err)
+		return fmt.Errorf("failed create symlink: %w", err)
 	}
 	return nil
 }
@@ -146,13 +146,13 @@ func Switch(switchCtx *SwitchCtx) error {
 
 	err := switchBinary(switchCtx, versionStr)
 	if err != nil {
-		return fmt.Errorf("failed to switch binary: %s", err)
+		return fmt.Errorf("failed to switch binary: %w", err)
 	}
 
 	if switchCtx.Program.IsTarantool() {
 		err = switchHeaders(switchCtx, versionStr)
 		if err != nil {
-			return fmt.Errorf("failed to switch headers: %s", err)
+			return fmt.Errorf("failed to switch headers: %w", err)
 		}
 	}
 

--- a/cli/checkpoint/checkpoint.go
+++ b/cli/checkpoint/checkpoint.go
@@ -70,7 +70,7 @@ func Play(tntCli cmdcontext.TarantoolCli) error {
 	scanner := bufio.NewScanner(stdoutPipe)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		fmt.Println(scanner.Text())
+		fmt.Fprintln(os.Stdout, scanner.Text())
 	}
 	cmd.Wait()
 

--- a/cli/checkpoint/checkpoint.go
+++ b/cli/checkpoint/checkpoint.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,7 +27,7 @@ type Opts struct {
 // Cat print the contents of .snap/.xlog files.
 // Returns an error if such occur during reading files.
 func Cat(tntCli cmdcontext.TarantoolCli) error {
-	cmd := exec.Command(tntCli.Executable, "-")
+	cmd := exec.CommandContext(context.Background(), tntCli.Executable, "-")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
@@ -48,7 +49,7 @@ func Cat(tntCli cmdcontext.TarantoolCli) error {
 // Returns an error if such occur during playing.
 func Play(tntCli cmdcontext.TarantoolCli) error {
 	var errBuff bytes.Buffer
-	cmd := exec.Command(tntCli.Executable, "-")
+	cmd := exec.CommandContext(context.Background(), tntCli.Executable, "-")
 	cmd.Stderr = &errBuff
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/cli/cluster/cluster_test.go
+++ b/cli/cluster/cluster_test.go
@@ -25,7 +25,7 @@ func clearAmbientTTEnv(t *testing.T) {
 		if !strings.HasPrefix(kv, "TT_") {
 			continue
 		}
-		k := strings.SplitN(kv, "=", 2)[0]
+		k, _, _ := strings.Cut(kv, "=")
 		saved := os.Getenv(k)
 		t.Setenv(k, saved)
 		require.NoError(t, os.Unsetenv(k))

--- a/cli/cluster/cmd/common.go
+++ b/cli/cluster/cmd/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	goconfig "github.com/tarantool/go-config"
 
@@ -18,7 +19,7 @@ func printGoConfig(cfg goconfig.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-	fmt.Print(string(b))
+	fmt.Fprint(os.Stdout, string(b))
 	return nil
 }
 

--- a/cli/cluster/cmd/common.go
+++ b/cli/cluster/cmd/common.go
@@ -99,7 +99,7 @@ func validateRawClusterConfig(yamlBytes []byte) error {
 func validateGoConfig(view goconfig.Config, _ bool) error {
 	var errs []error
 	if err := cluster.Validate(view); err != nil {
-		errs = append(errs, fmt.Errorf("an invalid cluster configuration: %s", err))
+		errs = append(errs, fmt.Errorf("an invalid cluster configuration: %w", err))
 	}
 
 	names, err := cluster.Instances(view)

--- a/cli/cluster/cmd/common.go
+++ b/cli/cluster/cmd/common.go
@@ -133,7 +133,7 @@ func validateInstanceConfig(instCfg goconfig.Config, name string) error {
 // collector-flavored *RawStorage using the given factory's integrity options.
 // The returned cleanup releases the connection.
 func openRemoteCollector(factory libcluster.Factory,
-	connOpts libcluster.ConnectOpts, opts libconnect.UriOpts,
+	connOpts libcluster.ConnectOpts, opts libconnect.URIOpts,
 ) (libcluster.DataCollector, func(), error) {
 	stor, cleanup, storageType, err := libcluster.NewStorageConnection(connOpts, opts)
 	if err != nil {
@@ -155,7 +155,7 @@ func openRemoteCollector(factory libcluster.Factory,
 func openCollectorAndPublisher(
 	collectors, publishers libcluster.Factory,
 	connOpts libcluster.ConnectOpts,
-	opts libconnect.UriOpts,
+	opts libconnect.URIOpts,
 ) (libcluster.DataCollector, libcluster.DataPublisher, func(), error) {
 	prefix, key, timeout := opts.Prefix, opts.Params["key"], opts.Timeout
 

--- a/cli/cluster/cmd/failover.go
+++ b/cli/cluster/cmd/failover.go
@@ -65,7 +65,7 @@ type SwitchStatusCtx struct {
 // RawStorage scoped to the configured prefix. Used by the failover commands
 // which talk to the storage directly via Get/Put/Watch. Close on the returned
 // storage releases the underlying connection.
-func connectFailoverStorage(uriOpts connect.UriOpts,
+func connectFailoverStorage(uriOpts connect.URIOpts,
 	connOpts libcluster.ConnectOpts,
 ) (*libcluster.RawStorage, error) {
 	stor, cleanup, storageType, err := libcluster.NewStorageConnection(connOpts, uriOpts)
@@ -88,7 +88,7 @@ func connectFailoverStorage(uriOpts connect.UriOpts,
 
 // Switch master instance.
 func Switch(url string, switchCtx SwitchCtx) error {
-	uriOpts, err := connect.CreateUriOpts(url)
+	uriOpts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}
@@ -175,7 +175,7 @@ func waitForSwitch(conn *libcluster.RawStorage, key string, yamlCmd []byte, time
 
 // SwitchStatus shows master switching status.
 func SwitchStatus(url string, switchCtx SwitchStatusCtx) error {
-	uriOpts, err := connect.CreateUriOpts(url)
+	uriOpts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}

--- a/cli/cluster/cmd/failover.go
+++ b/cli/cluster/cmd/failover.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/apex/log"
@@ -129,7 +130,7 @@ func Switch(url string, switchCtx SwitchCtx) error {
 		return err
 	}
 
-	fmt.Printf("%s\n%s '%s' %s\n",
+	fmt.Fprintf(os.Stdout, "%s\n%s '%s' %s\n",
 		"To check the switching status, run:",
 		"tt cluster failover switch-status",
 		url, uuid)
@@ -160,7 +161,7 @@ func waitForSwitch(conn *libcluster.RawStorage, key string, yamlCmd []byte, time
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s", ev.Value)
+		fmt.Fprintf(os.Stdout, "%s", ev.Value)
 		if result.Status == "success" || result.Status == "failed" {
 			return nil
 		}
@@ -200,7 +201,7 @@ func SwitchStatus(url string, switchCtx SwitchStatusCtx) error {
 		return fmt.Errorf("task with id `%s` is not found", switchCtx.TaskID)
 	}
 
-	fmt.Print(string(result[0].Value))
+	fmt.Fprint(os.Stdout, string(result[0].Value))
 
 	return nil
 }

--- a/cli/cluster/cmd/publish.go
+++ b/cli/cluster/cmd/publish.go
@@ -36,8 +36,8 @@ type PublishCtx struct {
 	Replicaset string
 }
 
-// PublishUri publishes a configuration to URI.
-func PublishUri(publishCtx PublishCtx, opts connect.UriOpts) error {
+// PublishURI publishes a configuration to URI.
+func PublishURI(publishCtx PublishCtx, opts connect.URIOpts) error {
 	instance := opts.Params["name"]
 	if err := publishCtxValidateConfig(publishCtx, instance); err != nil {
 		return err

--- a/cli/cluster/cmd/replicaset.go
+++ b/cli/cluster/cmd/replicaset.go
@@ -87,7 +87,7 @@ func pickPatchKey(keys []string, force bool, pathMsg string) (int, error) {
 func createDataCollectorAndKeyPublisher(
 	collectors libcluster.Factory,
 	publishers libcluster.Factory,
-	opts connect.UriOpts, connOpts libcluster.ConnectOpts,
+	opts connect.URIOpts, connOpts libcluster.ConnectOpts,
 ) (libcluster.DataCollector, replicaset.DataPublisher, func(), error) {
 	prefix, key, timeout := opts.Prefix, opts.Params["key"], opts.Timeout
 	stor, closeFunc, storageType, err := libcluster.NewStorageConnection(connOpts, opts)
@@ -108,7 +108,7 @@ func createDataCollectorAndKeyPublisher(
 
 // Promote promotes an instance by patching the cluster config.
 func Promote(url string, ctx PromoteCtx) error {
-	opts, err := connect.CreateUriOpts(url)
+	opts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}
@@ -155,7 +155,7 @@ type DemoteCtx struct {
 
 // Demote demotes an instance by patching the cluster config.
 func Demote(url string, ctx DemoteCtx) error {
-	opts, err := connect.CreateUriOpts(url)
+	opts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}
@@ -202,7 +202,7 @@ type ExpelCtx struct {
 
 // Expel expels an instance by patching the cluster config.
 func Expel(url string, ctx ExpelCtx) error {
-	opts, err := connect.CreateUriOpts(url)
+	opts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}
@@ -256,7 +256,7 @@ type RolesChangeCtx struct {
 
 // ChangeRole adds/removes a role by patching the cluster config.
 func ChangeRole(url string, ctx RolesChangeCtx, action replicaset.RolesChangerAction) error {
-	opts, err := connect.CreateUriOpts(url)
+	opts, err := connect.CreateURIOpts(url)
 	if err != nil {
 		return fmt.Errorf("invalid URL %q: %w", url, err)
 	}

--- a/cli/cluster/cmd/show.go
+++ b/cli/cluster/cmd/show.go
@@ -26,8 +26,8 @@ type ShowCtx struct {
 	Validate bool
 }
 
-// ShowUri shows a configuration from URI.
-func ShowUri(showCtx ShowCtx, opts connect.UriOpts) error {
+// ShowURI shows a configuration from URI.
+func ShowURI(showCtx ShowCtx, opts connect.URIOpts) error {
 	connOpts := libcluster.ConnectOpts{
 		Username: showCtx.Username,
 		Password: showCtx.Password,

--- a/cli/cluster/scope.go
+++ b/cli/cluster/scope.go
@@ -7,6 +7,8 @@ import (
 	goconfig "github.com/tarantool/go-config"
 )
 
+const instancePathSegments = 6
+
 // splitInstancePath parses a full structural path of the form
 // "groups/<g>/replicasets/<r>/instances/<i>" and returns the group,
 // replicaset, and instance name segments.
@@ -16,7 +18,7 @@ import (
 // 4=="instances").
 func splitInstancePath(path string) (string, string, string) {
 	kp := goconfig.NewKeyPath(path)
-	if len(kp) != 6 {
+	if len(kp) != instancePathSegments {
 		return "", "", ""
 	}
 	if kp[0] != "groups" || kp[2] != "replicasets" || kp[4] != "instances" {

--- a/cli/cmd/aeon.go
+++ b/cli/cmd/aeon.go
@@ -108,7 +108,7 @@ func aeonConnectValidateArgs(cmd *cobra.Command, args []string) error {
 		}
 		connectCtx.Network, connectCtx.Address = libconnect.ParseBaseURI(url)
 	case len(args) == 2 && libconnect.IsCredentialsURI(args[0]):
-		err := getConfigUri(&cmdCtx, args[0], args[1])
+		err := getConfigURI(&cmdCtx, args[0], args[1])
 		if err != nil {
 			return err
 		}
@@ -227,11 +227,11 @@ func readConfigFilePath(configPath, instance string) error {
 		return err
 	}
 
-	if advertise.Uri == "" {
+	if advertise.URI == "" {
 		return errors.New("invalid connection url")
 	}
 
-	cleanedURL, err := util.RemoveScheme(advertise.Uri)
+	cleanedURL, err := util.RemoveScheme(advertise.URI)
 	if err != nil {
 		return err
 	}
@@ -262,13 +262,13 @@ func readConfigFilePath(configPath, instance string) error {
 	return nil
 }
 
-func getConfigUri(cmdCtx *cmdcontext.CmdCtx, url, instanceName string) error {
+func getConfigURI(cmdCtx *cmdcontext.CmdCtx, url, instanceName string) error {
 	factory, err := cluster.NewCollectorFactory(cmdCtx.Integrity)
 	if err != nil {
 		return err
 	}
 
-	if uri, err := libconnect.CreateUriOpts(url); err == nil {
+	if uri, err := libconnect.CreateURIOpts(url); err == nil {
 		aeoncmd.FillConnectCtx(&connectCtx, uri, instanceName, factory)
 	}
 

--- a/cli/cmd/aeon.go
+++ b/cli/cmd/aeon.go
@@ -23,6 +23,7 @@ import (
 const (
 	aeonHistoryFileName = ".aeon_history"
 	aeonHistoryLines    = console.DefaultHistoryLines
+	aeonConnectMaxArgs  = 2
 )
 
 var aeonHelp = libconnect.MakeURLHelp(map[string]any{
@@ -58,7 +59,7 @@ func newAeonConnectCmd() *cobra.Command {
 				internalAeonConnect, args)
 			util.HandleCmdErr(cmd, err)
 		},
-		Args: cobra.MatchAll(cobra.RangeArgs(1, 2), aeonConnectValidateArgs),
+		Args: cobra.MatchAll(cobra.RangeArgs(1, aeonConnectMaxArgs), aeonConnectValidateArgs),
 	}
 	aeonCmd.Flags().StringVarP(&connectCtx.Username, "username", "u", "",
 		"username (used as etcd credentials only)")

--- a/cli/cmd/binaries.go
+++ b/cli/cmd/binaries.go
@@ -17,6 +17,8 @@ var binariesSupportedPrograms = []string{
 	search.ProgramTcm.String(),
 }
 
+const binariesSwitchMaxArgs = 2
+
 // NewBinariesCmd creates binaries command.
 func NewBinariesCmd() *cobra.Command {
 	binariesCmd := &cobra.Command{
@@ -43,8 +45,9 @@ You will need to choose version using arrow keys in your console.
 # Switch with program and version.
 
 	$ tt binaries switch tarantool 3.0.0`,
-		Run:       RunModuleFunc(internalSwitchModule),
-		Args:      cobra.MatchAll(cobra.MaximumNArgs(2), binariesSwitchValidateArgs),
+		Run: RunModuleFunc(internalSwitchModule),
+		Args: cobra.MatchAll(
+			cobra.MaximumNArgs(binariesSwitchMaxArgs), binariesSwitchValidateArgs),
 		ValidArgs: binariesSupportedPrograms,
 	}
 	listCmd := &cobra.Command{

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -106,7 +106,7 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	timestamp, err := util.StringToTimestamp(catFlags.Timestamp)
 	if err != nil {
-		return fmt.Errorf("failed to parse a timestamp: %s", err)
+		return fmt.Errorf("failed to parse a timestamp: %w", err)
 	}
 	os.Setenv("TT_CLI_CAT_TIMESTAMP", timestamp)
 

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -79,26 +79,26 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	}
 
 	// List of files is passed to lua cat script via environment variable in json format.
-	filesJson, err := json.Marshal(walFiles)
+	filesJSON, err := json.Marshal(walFiles)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with files: %s",
 			version.GetVersion, err)
 	}
 
-	os.Setenv("TT_CLI_CAT_FILES", string(filesJson))
+	os.Setenv("TT_CLI_CAT_FILES", string(filesJSON))
 	os.Setenv("TT_CLI_CAT_SHOW_SYS", strconv.FormatBool(catFlags.ShowSystem))
 	os.Setenv("TT_CLI_CAT_FORMAT", catFlags.Format)
 
 	// List of spaces is passed to lua cat script via environment variable in json format.
-	spacesJson, err := json.Marshal(catFlags.Space)
+	spacesJSON, err := json.Marshal(catFlags.Space)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with spaces: %s",
 			version.GetVersion, err)
 	}
-	if string(spacesJson) != "null" {
-		os.Setenv("TT_CLI_CAT_SPACES", string(spacesJson))
+	if string(spacesJSON) != "null" {
+		os.Setenv("TT_CLI_CAT_SPACES", string(spacesJSON))
 	}
 
 	os.Setenv("TT_CLI_CAT_FROM", strconv.FormatUint(catFlags.From, 10))
@@ -111,14 +111,14 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	os.Setenv("TT_CLI_CAT_TIMESTAMP", timestamp)
 
 	// List of replicas is passed to lua cat script via environment variable in json format.
-	replicasJson, err := json.Marshal(catFlags.Replica)
+	replicasJSON, err := json.Marshal(catFlags.Replica)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with replicas: %s",
 			version.GetVersion, err)
 	}
-	if string(replicasJson) != "null" {
-		os.Setenv("TT_CLI_CAT_REPLICAS", string(replicasJson))
+	if string(replicasJSON) != "null" {
+		os.Setenv("TT_CLI_CAT_REPLICAS", string(replicasJSON))
 	}
 
 	log.Infof("Running cat with files: %s\n", args)

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -516,12 +516,12 @@ func internalClusterFailoverSwitchStatusModule(cmdCtx *cmdcontext.CmdCtx, args [
 func readSourceFile(path string) ([]byte, map[string]any, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read path %q: %s", path, err)
+		return nil, nil, fmt.Errorf("failed to read path %q: %w", path, err)
 	}
 
 	var decoded map[string]any
 	if err := yaml.Unmarshal(data, &decoded); err != nil {
-		return nil, nil, fmt.Errorf("failed to read a configuration from path %q: %s", path, err)
+		return nil, nil, fmt.Errorf("failed to read a configuration from path %q: %w", path, err)
 	}
 
 	return data, decoded, nil

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -93,6 +93,11 @@ environment variables < command flags < URL credentials.`,
 )
 
 func newClusterReplicasetCmd() *cobra.Command {
+	const (
+		targetArgs = 2
+		roleArgs   = 2
+	)
+
 	cmd := &cobra.Command{
 		Use:     "replicaset",
 		Short:   "manage replicaset via 3.0 cluster config source",
@@ -105,7 +110,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Short:                 "Promote an instance",
 		Long:                  "Promote an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetPromoteModule),
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.ExactArgs(targetArgs),
 	}
 	promoteCmd.Flags().StringVarP(&promoteCtx.Username, "username", "u", "",
 		"username (used as etcd/tarantool config storage credentials)")
@@ -121,7 +126,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Short:                 "Demote an instance",
 		Long:                  "Demote an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetDemoteModule),
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.ExactArgs(targetArgs),
 	}
 
 	demoteCmd.Flags().StringVarP(&demoteCtx.Username, "username", "u", "",
@@ -138,7 +143,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Short:                 "Expel an instance",
 		Long:                  "Expel an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetExpelModule),
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.ExactArgs(targetArgs),
 	}
 
 	expelCmd.Flags().StringVarP(&expelCtx.Username, "username", "u", "",
@@ -161,7 +166,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Run:   RunModuleFunc(internalClusterReplicasetRolesAddModule),
 		Example: "tt cluster replicaset roles add http://user:pass@localhost:3301" +
 			" roles.metrics-export --instance_name master",
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(roleArgs),
 	}
 
 	addRolesCmd.Flags().StringVarP(&rolesChangeCtx.ReplicasetName, "replicaset", "r", "",
@@ -188,7 +193,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Run:   RunModuleFunc(internalClusterReplicasetRolesRemoveModule),
 		Example: "tt cluster replicaset roles remove http://user:pass@localhost:3301" +
 			" roles.metrics-export --instance_name master",
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(roleArgs),
 	}
 
 	removeRolesCmd.Flags().StringVarP(&rolesChangeCtx.ReplicasetName, "replicaset", "r", "",
@@ -220,6 +225,8 @@ func newClusterReplicasetCmd() *cobra.Command {
 }
 
 func newClusterFailoverCmd() *cobra.Command {
+	const commandArgs = 2
+
 	cmd := &cobra.Command{
 		Use:     "failover",
 		Short:   "Manage supervised failover",
@@ -233,7 +240,7 @@ func newClusterFailoverCmd() *cobra.Command {
 		Long:                  "Switch master instance\n\n" + failoverURIHelp,
 		Example:               "tt cluster failover switch http://localhost:2379/app instance_name",
 		Run:                   RunModuleFunc(internalClusterFailoverSwitchModule),
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.ExactArgs(commandArgs),
 	}
 
 	switchCmd.Flags().StringVarP(&switchCtx.Username, "username", "u", "",
@@ -251,7 +258,7 @@ func newClusterFailoverCmd() *cobra.Command {
 		Short:                 "Show master switching status",
 		Long:                  "Show master switching status\n\n" + failoverURIHelp,
 		Run:                   RunModuleFunc(internalClusterFailoverSwitchStatusModule),
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.ExactArgs(commandArgs),
 	}
 
 	cmd.AddCommand(switchCmd)
@@ -261,6 +268,8 @@ func newClusterFailoverCmd() *cobra.Command {
 }
 
 func NewClusterCmd() *cobra.Command {
+	const publishArgs = 2
+
 	clusterCmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manage cluster configuration",
@@ -319,7 +328,7 @@ func NewClusterCmd() *cobra.Command {
 			"https://user:pass@localhost:2379/tt?name=instance " +
 			"instance.yaml",
 		Run:  RunModuleFunc(internalClusterPublishModule),
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(publishArgs),
 		ValidArgsFunction: func(
 			cmd *cobra.Command,
 			args []string,

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -69,7 +69,7 @@ var rolesChangeCtx = clustercmd.RolesChangeCtx{}
 var (
 	defaultSwitchTimeout       uint64 = 30
 	clusterIntegrityPrivateKey string
-	clusterUriHelp             = libconnect.MakeURLHelp(map[string]any{
+	clusterURIHelp             = libconnect.MakeURLHelp(map[string]any{
 		"service": "etcd or tarantool config storage",
 		"prefix": "a base path to Tarantool configuration in" +
 			" etcd or tarantool config storage",
@@ -81,7 +81,7 @@ var (
 environment variables < command flags < URL credentials.`,
 	})
 
-	failoverUriHelp = libconnect.MakeURLHelp(map[string]any{
+	failoverURIHelp = libconnect.MakeURLHelp(map[string]any{
 		"service": "etcd or tarantool config storage",
 		"prefix": "a base path to Tarantool configuration in" +
 			" etcd or tarantool config storage",
@@ -103,7 +103,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Use:                   "promote [-f] [flags] <URI> <INSTANCE_NAME>",
 		DisableFlagsInUseLine: true,
 		Short:                 "Promote an instance",
-		Long:                  "Promote an instance\n\n" + clusterUriHelp,
+		Long:                  "Promote an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetPromoteModule),
 		Args:                  cobra.ExactArgs(2),
 	}
@@ -119,7 +119,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Use:                   "demote [-f] [flags] <URI> <INSTANCE_NAME>",
 		DisableFlagsInUseLine: true,
 		Short:                 "Demote an instance",
-		Long:                  "Demote an instance\n\n" + clusterUriHelp,
+		Long:                  "Demote an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetDemoteModule),
 		Args:                  cobra.ExactArgs(2),
 	}
@@ -136,7 +136,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 		Use:                   "expel [-f] [flags] <URI> <INSTANCE_NAME>",
 		DisableFlagsInUseLine: true,
 		Short:                 "Expel an instance",
-		Long:                  "Expel an instance\n\n" + clusterUriHelp,
+		Long:                  "Expel an instance\n\n" + clusterURIHelp,
 		Run:                   RunModuleFunc(internalClusterReplicasetExpelModule),
 		Args:                  cobra.ExactArgs(2),
 	}
@@ -157,7 +157,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 	addRolesCmd := &cobra.Command{
 		Use:   "add <URI> <ROLE_NAME> [flags]",
 		Short: "Add role to an instance, group or instance",
-		Long:  "Add role to an instance, group or instance\n\n" + clusterUriHelp,
+		Long:  "Add role to an instance, group or instance\n\n" + clusterURIHelp,
 		Run:   RunModuleFunc(internalClusterReplicasetRolesAddModule),
 		Example: "tt cluster replicaset roles add http://user:pass@localhost:3301" +
 			" roles.metrics-export --instance_name master",
@@ -184,7 +184,7 @@ func newClusterReplicasetCmd() *cobra.Command {
 	removeRolesCmd := &cobra.Command{
 		Use:   "remove <URI> <ROLE_NAME> [flags]",
 		Short: "Remove role from instance, group, instance or globally",
-		Long:  "Remove role from instance, group, instance or globally\n\n" + clusterUriHelp,
+		Long:  "Remove role from instance, group, instance or globally\n\n" + clusterURIHelp,
 		Run:   RunModuleFunc(internalClusterReplicasetRolesRemoveModule),
 		Example: "tt cluster replicaset roles remove http://user:pass@localhost:3301" +
 			" roles.metrics-export --instance_name master",
@@ -230,7 +230,7 @@ func newClusterFailoverCmd() *cobra.Command {
 		Use:                   "switch <URI> <INSTANCE_NAME> [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Switch master instance",
-		Long:                  "Switch master instance\n\n" + failoverUriHelp,
+		Long:                  "Switch master instance\n\n" + failoverURIHelp,
 		Example:               "tt cluster failover switch http://localhost:2379/app instance_name",
 		Run:                   RunModuleFunc(internalClusterFailoverSwitchModule),
 		Args:                  cobra.ExactArgs(2),
@@ -249,7 +249,7 @@ func newClusterFailoverCmd() *cobra.Command {
 		Use:                   "switch-status <URI> <TASK_ID>",
 		DisableFlagsInUseLine: true,
 		Short:                 "Show master switching status",
-		Long:                  "Show master switching status\n\n" + failoverUriHelp,
+		Long:                  "Show master switching status\n\n" + failoverURIHelp,
 		Run:                   RunModuleFunc(internalClusterFailoverSwitchStatusModule),
 		Args:                  cobra.ExactArgs(2),
 	}
@@ -270,7 +270,7 @@ func NewClusterCmd() *cobra.Command {
 		Use:   "show (<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)",
 		Short: "Show a cluster configuration",
 		Long: "Show a cluster configuration for an application, instance," +
-			" from etcd URI or from tarantool config storage URI.\n\n" + clusterUriHelp,
+			" from etcd URI or from tarantool config storage URI.\n\n" + clusterURIHelp,
 		Example: "tt cluster show application_name\n" +
 			"  tt cluster show application_name:instance_name\n" +
 			"  tt cluster show https://user:pass@localhost:2379/tt\n" +
@@ -304,7 +304,7 @@ func NewClusterCmd() *cobra.Command {
 		Short: "Publish a cluster configuration",
 		Long: "Publish an application or an instance configuration to a cluster " +
 			"configuration file, to a etcd URI or to a tarantool config storage URI.\n\n" +
-			clusterUriHelp + "\n" +
+			clusterURIHelp + "\n" +
 			"By default, the command removes all keys in etcd with prefix " +
 			"'/prefix/config/' and writes the result to '/prefix/config/all'. " +
 			"You could work and update a target key with the 'key' argument.",
@@ -351,13 +351,13 @@ func NewClusterCmd() *cobra.Command {
 
 // internalClusterShowModule is an entrypoint for `cluster show` command.
 func internalClusterShowModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	if opts, err := libconnect.CreateUriOpts(args[0]); err == nil {
+	if opts, err := libconnect.CreateURIOpts(args[0]); err == nil {
 		factory, cerr := cluster.NewCollectorFactory(cmdCtx.Integrity)
 		if cerr != nil {
 			return cerr
 		}
 		showCtx.Collectors = factory
-		return clustercmd.ShowUri(showCtx, opts)
+		return clustercmd.ShowURI(showCtx, opts)
 	}
 
 	// It looks like an application or an application:instance.
@@ -390,8 +390,8 @@ func internalClusterPublishModule(cmdCtx *cmdcontext.CmdCtx, args []string) erro
 	publishCtx.Src = data
 	publishCtx.Config = config
 
-	if opts, err := libconnect.CreateUriOpts(args[0]); err == nil {
-		return clustercmd.PublishUri(publishCtx, opts)
+	if opts, err := libconnect.CreateURIOpts(args[0]); err == nil {
+		return clustercmd.PublishURI(publishCtx, opts)
 	}
 
 	// It looks like an application or an application:instance.

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -100,7 +101,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(res))
+		fmt.Fprint(os.Stdout, string(res))
 
 	case shellZsh:
 		if err := rootCmd.GenZshCompletion(&buf); err != nil {
@@ -110,7 +111,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(res))
+		fmt.Fprint(os.Stdout, string(res))
 
 	case shellFish:
 		if err := rootCmd.GenFishCompletion(&buf, true); err != nil {
@@ -120,7 +121,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(res))
+		fmt.Fprint(os.Stdout, string(res))
 
 	default:
 		return fmt.Errorf("specified shell type is not supported. Available: %s", listShells())

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -224,7 +224,7 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		}
 		// "Println" is used instead of "log..." to print the result without
 		// any decoration.
-		fmt.Println(string(res))
+		fmt.Fprintln(os.Stdout, string(res))
 		if !connectInteractive || !terminal.IsTerminal(syscall.Stdin) {
 			return nil
 		}

--- a/cli/cmd/env.go
+++ b/cli/cmd/env.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
@@ -24,6 +25,6 @@ func NewEnvCmd() *cobra.Command {
 // internalEnvModule is a default env module.
 func internalEnvModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	var err error
-	_, err = fmt.Print(env.CreateEnvString(cliOpts))
+	_, err = fmt.Fprint(os.Stdout, env.CreateEnvString(cliOpts))
 	return err
 }

--- a/cli/cmd/kill.go
+++ b/cli/cmd/kill.go
@@ -66,7 +66,7 @@ func internalKillModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	confirm, err := askConfirmation(args)
 	if err != nil {
-		return fmt.Errorf("error asking for confirmation: %s", err)
+		return fmt.Errorf("error asking for confirmation: %w", err)
 	}
 
 	if !confirm {

--- a/cli/cmd/log.go
+++ b/cli/cmd/log.go
@@ -20,6 +20,8 @@ var logOpts struct {
 	follow bool // Follow logs output.
 }
 
+const defaultLogLines = 10
+
 // NewLogCmd creates log command.
 func NewLogCmd() *cobra.Command {
 	logCmd := &cobra.Command{
@@ -38,7 +40,7 @@ func NewLogCmd() *cobra.Command {
 		},
 	}
 
-	logCmd.Flags().IntVarP(&logOpts.nLines, "lines", "n", 10,
+	logCmd.Flags().IntVarP(&logOpts.nLines, "lines", "n", defaultLogLines,
 		"Count of last lines to output")
 	logCmd.Flags().BoolVarP(&logOpts.follow, "follow", "f", false,
 		"Output appended data as the log file grows")

--- a/cli/cmd/log.go
+++ b/cli/cmd/log.go
@@ -57,7 +57,7 @@ func printLines(ctx context.Context, in <-chan string) error {
 			if !ok {
 				return nil
 			}
-			fmt.Println(line)
+			fmt.Fprintln(os.Stdout, line)
 		}
 	}
 }

--- a/cli/cmd/log.go
+++ b/cli/cmd/log.go
@@ -81,7 +81,7 @@ func follow(instances []running.InstanceCtx, n int) error {
 				continue
 			}
 			stop()
-			return fmt.Errorf("cannot read log file %q: %s", inst.Log, err)
+			return fmt.Errorf("cannot read log file %q: %w", inst.Log, err)
 		}
 		tailRoutinesStarted++
 		color = nextColor()
@@ -111,7 +111,7 @@ func printLastN(instances []running.InstanceCtx, n int) error {
 				continue
 			}
 			stop()
-			return fmt.Errorf("cannot read log file %q: %s", inst.Log, err)
+			return fmt.Errorf("cannot read log file %q: %w", inst.Log, err)
 		}
 		if err := printLines(ctx, logLines); err != nil {
 			return err

--- a/cli/cmd/modules.go
+++ b/cli/cmd/modules.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -62,17 +63,17 @@ func internalModulesList(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		m := modulesInfo[path]
 
 		if showVersion {
-			fmt.Printf("%-5s\t", m.Version)
+			fmt.Fprintf(os.Stdout, "%-5s\t", m.Version)
 		}
-		fmt.Printf("%s - ", m.Name)
+		fmt.Fprintf(os.Stdout, "%s - ", m.Name)
 
 		if showPath {
-			fmt.Print(m.Main)
+			fmt.Fprint(os.Stdout, m.Main)
 		} else {
-			fmt.Print(m.Help)
+			fmt.Fprint(os.Stdout, m.Help)
 		}
 
-		fmt.Print("\n")
+		fmt.Fprint(os.Stdout, "\n")
 	}
 	return nil
 }

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -53,6 +53,8 @@ var (
 // Flags specific to `tt package add`.
 var packageDev bool
 
+const packageAddMaxArgs = 2
+
 // NewPackageCmd creates the `tt package` command group: the manifest build
 // pipeline (build, fetch and pack), the dependency-changing commands (add,
 // remove and update), installation, and the inventory over what is installed
@@ -98,10 +100,10 @@ func newPackageAddCmd() *cobra.Command {
 			"the others — that is what tt package update is for. Nothing is " +
 			"fetched into .rocks/; the next tt package build picks the new lock " +
 			"up.",
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(1, packageAddMaxArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			constraint := ""
-			if len(args) == 2 {
+			if len(args) == packageAddMaxArgs {
 				constraint = args[1]
 			}
 

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -143,10 +143,10 @@ func runPackageAdd(name, constraint string) error {
 	}
 
 	if result.Change.Existed {
-		fmt.Printf("changed %s in [%s]: %s -> %s\n",
+		fmt.Fprintf(os.Stdout, "changed %s in [%s]: %s -> %s\n",
 			name, table, result.Change.Previous, declared)
 	} else {
-		fmt.Printf("added %s %s to [%s]\n", name, declared, table)
+		fmt.Fprintf(os.Stdout, "added %s %s to [%s]\n", name, declared, table)
 	}
 
 	printMoves(result.Moves)
@@ -191,7 +191,7 @@ func runPackageRemove(name string) error {
 		return err
 	}
 
-	fmt.Printf("removed %s %s\n", name, result.Change.Previous)
+	fmt.Fprintf(os.Stdout, "removed %s %s\n", name, result.Change.Previous)
 	printMoves(result.Moves)
 
 	return nil
@@ -240,7 +240,7 @@ func runPackageUpdate(name string) error {
 	}
 
 	if len(result.Moves) == 0 {
-		fmt.Println("everything is already up to date")
+		fmt.Fprintln(os.Stdout, "everything is already up to date")
 
 		return nil
 	}
@@ -281,11 +281,11 @@ func printMoves(moves []deps.Move) {
 	for _, move := range moves {
 		switch {
 		case move.From == "":
-			fmt.Printf("  %s %s\n", move.Name, move.To)
+			fmt.Fprintf(os.Stdout, "  %s %s\n", move.Name, move.To)
 		case move.To == "":
-			fmt.Printf("  %s %s -> (dropped)\n", move.Name, move.From)
+			fmt.Fprintf(os.Stdout, "  %s %s -> (dropped)\n", move.Name, move.From)
 		default:
-			fmt.Printf("  %s %s -> %s\n", move.Name, move.From, move.To)
+			fmt.Fprintf(os.Stdout, "  %s %s -> %s\n", move.Name, move.From, move.To)
 		}
 	}
 }
@@ -401,14 +401,15 @@ func runPackageUninstall(name string) error {
 		return err
 	}
 
-	fmt.Printf("removed %s %s from %s scope\n", result.Package, result.Version, result.Scope)
+	fmt.Fprintf(os.Stdout, "removed %s %s from %s scope\n",
+		result.Package, result.Version, result.Scope)
 
 	for _, dep := range result.RemovedDependencies {
-		fmt.Printf("  removed unused dependency %s\n", dep)
+		fmt.Fprintf(os.Stdout, "  removed unused dependency %s\n", dep)
 	}
 
 	for _, dep := range result.KeptDependencies {
-		fmt.Printf("  kept %s (%s)\n", dep.Name, keptReason(dep))
+		fmt.Fprintf(os.Stdout, "  kept %s (%s)\n", dep.Name, keptReason(dep))
 	}
 
 	return nil
@@ -514,7 +515,8 @@ func runPackageInstall(archives []string) error {
 			continue
 		}
 
-		fmt.Printf("installed %s %s into %s scope\n", one.Package, one.Version, one.Scope)
+		fmt.Fprintf(os.Stdout, "installed %s %s into %s scope\n",
+			one.Package, one.Version, one.Scope)
 	}
 
 	return nil
@@ -624,7 +626,7 @@ func runPackagePack() error {
 		return err
 	}
 
-	fmt.Println(result.Path)
+	fmt.Fprintln(os.Stdout, result.Path)
 
 	return nil
 }

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -202,7 +202,7 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	timestamp, err := util.StringToTimestamp(playFlags.Timestamp)
 	if err != nil {
-		return fmt.Errorf("failed to parse a timestamp: %s", err)
+		return fmt.Errorf("failed to parse a timestamp: %w", err)
 	}
 	os.Setenv("TT_CLI_PLAY_TIMESTAMP", timestamp)
 

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -150,14 +150,14 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	uriAndWalFiles := append([]string{args[0]}, walFiles...)
 
 	// List of files and URI is passed to lua play script via environment variable in json format.
-	filesAndUriJson, err := json.Marshal(uriAndWalFiles)
+	filesAndURIJSON, err := json.Marshal(uriAndWalFiles)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with files and uri: %s",
 			version.GetVersion, err)
 	}
 
-	os.Setenv("TT_CLI_PLAY_FILES_AND_URI", string(filesAndUriJson))
+	os.Setenv("TT_CLI_PLAY_FILES_AND_URI", string(filesAndURIJSON))
 	if playUsername != "" {
 		os.Setenv("TT_CLI_PLAY_USERNAME", playUsername)
 	}
@@ -185,14 +185,14 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	os.Setenv("TT_CLI_PLAY_SHOW_SYS", strconv.FormatBool(playFlags.ShowSystem))
 
 	// List of spaces is passed to lua play script via environment variable in json format.
-	spacesJson, err := json.Marshal(playFlags.Space)
+	spacesJSON, err := json.Marshal(playFlags.Space)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with spaces: %s",
 			version.GetVersion, err)
 	}
-	if string(spacesJson) != "null" {
-		os.Setenv("TT_CLI_PLAY_SPACES", string(spacesJson))
+	if string(spacesJSON) != "null" {
+		os.Setenv("TT_CLI_PLAY_SPACES", string(spacesJSON))
 	}
 
 	os.Setenv("TT_CLI_PLAY_FROM", strconv.FormatUint(playFlags.From, 10))
@@ -205,14 +205,14 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	os.Setenv("TT_CLI_PLAY_TIMESTAMP", timestamp)
 
 	// List of replicas is passed to lua play script via environment variable in json format.
-	replicasJson, err := json.Marshal(playFlags.Replica)
+	replicasJSON, err := json.Marshal(playFlags.Replica)
 	if err != nil {
 		return util.InternalError(
 			"Internal error: problem with creating json params with replicas: %s",
 			version.GetVersion, err)
 	}
-	if string(replicasJson) != "null" {
-		os.Setenv("TT_CLI_PLAY_REPLICAS", string(replicasJson))
+	if string(replicasJSON) != "null" {
+		os.Setenv("TT_CLI_PLAY_REPLICAS", string(replicasJSON))
 	}
 
 	log.Infof("Running play with URI=%s and files: %s\n", args[0], args[1:])

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -30,6 +30,8 @@ var playFlags = checkpoint.Opts{
 	Recursive:  false,
 }
 
+const playMinArgs = 2
+
 var (
 	// playUsername contains username flag.
 	playUsername string
@@ -90,7 +92,7 @@ func NewPlayCmd() *cobra.Command {
 
 // playValidateArgs validates non-flag arguments 'play' command.
 func playValidateArgs(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
+	if len(args) < playMinArgs {
 		return errors.New("it is required to specify an URI and at least one .xlog/.snap file " +
 			"or directory")
 	}

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -47,7 +47,7 @@ var (
 	chosenReplicasetAliases []string
 	lsnTimeout              int
 
-	replicasetUriHelp = "  The URI can be specified in the following formats:\n" +
+	replicasetURIHelp = "  The URI can be specified in the following formats:\n" +
 		"  * [tcp://][username:password@][host:port]\n" +
 		"  * [unix://][username:password@]socketpath\n" +
 		"  To specify relative path without `unix://` use `./`."
@@ -57,7 +57,7 @@ var (
 func newUpgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "upgrade (<APP_NAME> | <URI>) [flags]\n\n" +
-			replicasetUriHelp,
+			replicasetURIHelp,
 		DisableFlagsInUseLine: true,
 		Short:                 "Upgrade tarantool cluster",
 		Long: "Upgrade tarantool cluster.\n\n" +
@@ -94,7 +94,7 @@ func newDowngradeCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "downgrade (<APP_NAME> | <URI>) VERSION [flags]\n\n" +
-			replicasetUriHelp,
+			replicasetURIHelp,
 		DisableFlagsInUseLine: true,
 		Short:                 "Downgrade tarantool cluster",
 		Long: "Downgrade tarantool cluster.\n\n" +
@@ -119,7 +119,7 @@ func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "status [--config|--custom] [flags] " +
 			"(<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)\n\n" +
-			replicasetUriHelp,
+			replicasetURIHelp,
 		DisableFlagsInUseLine: true,
 		Short:                 "Show a replicaset status",
 		Long: "Show a replicaset status.\n\n" +
@@ -138,7 +138,7 @@ func newPromoteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "promote [--config|--custom] [-f] [--timeout secs] [flags] " +
 			"(<APP_NAME:INSTANCE_NAME> | <URI>)\n\n" +
-			replicasetUriHelp,
+			replicasetURIHelp,
 		DisableFlagsInUseLine: true,
 		Short:                 "Promote an instance",
 		Long: "Promote an instance.\n\n" +
@@ -224,7 +224,7 @@ func newBootstrapVShardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "bootstrap [--config|--custom] [--timeout secs] [flags] " +
 			"(<APP_NAME> | <APP_NAME:INSTANCE_NAME> | <URI>)\n\n" +
-			replicasetUriHelp,
+			replicasetURIHelp,
 		DisableFlagsInUseLine: true,
 		Short:                 "Bootstrap vshard in the cluster",
 		Long: "Bootstrap vshard in the cluster.\n\n" +

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -456,7 +456,7 @@ func replicasetFillCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target str
 		var err error
 		ctx.Conn, err = connector.Connect(connOpts)
 		if err != nil {
-			return fmt.Errorf("unable to establish connection: %s", err)
+			return fmt.Errorf("unable to establish connection: %w", err)
 		}
 	}
 

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -53,6 +53,8 @@ var (
 		"  To specify relative path without `unix://` use `./`."
 )
 
+const defaultLSNSyncTimeout = 5
+
 // newUpgradeCmd creates a "replicaset upgrade" command.
 func newUpgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -69,7 +71,7 @@ func newUpgradeCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&chosenReplicasetAliases, "replicaset", "r",
 		[]string{}, "specify the replicaset name(s) to upgrade")
 
-	cmd.Flags().IntVarP(&lsnTimeout, "timeout", "t", 5,
+	cmd.Flags().IntVarP(&lsnTimeout, "timeout", "t", defaultLSNSyncTimeout,
 		"timeout for waiting the LSN synchronization (in seconds)")
 
 	addOrchestratorFlags(cmd)
@@ -79,6 +81,8 @@ func newUpgradeCmd() *cobra.Command {
 
 // newDowngradeCmd creates a "replicaset downgrade" command.
 func newDowngradeCmd() *cobra.Command {
+	const commandArgs = 2
+
 	validateVersion := func(i int) cobra.PositionalArgs {
 		return func(cmd *cobra.Command, args []string) error {
 			versionPattern := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
@@ -100,13 +104,13 @@ func newDowngradeCmd() *cobra.Command {
 		Long: "Downgrade tarantool cluster.\n\n" +
 			libconnect.EnvTarantoolCredentialsHelp + "\n\n",
 		Run:  RunModuleFunc(internalReplicasetDowngradeModule),
-		Args: cobra.MatchAll(cobra.ExactArgs(2), validateVersion(1)),
+		Args: cobra.MatchAll(cobra.ExactArgs(commandArgs), validateVersion(1)),
 	}
 
 	cmd.Flags().StringArrayVarP(&chosenReplicasetAliases, "replicaset", "r",
 		[]string{}, "specify the replicaset name(s) to downgrade")
 
-	cmd.Flags().IntVarP(&lsnTimeout, "timeout", "t", 5,
+	cmd.Flags().IntVarP(&lsnTimeout, "timeout", "t", defaultLSNSyncTimeout,
 		"timeout for waiting the LSN synchronization (in seconds)")
 
 	addOrchestratorFlags(cmd)
@@ -283,13 +287,15 @@ func newRolesCmd() *cobra.Command {
 
 // newRolesAddCmd creates a "replicaset roles add" command.
 func newRolesAddCmd() *cobra.Command {
+	const commandArgs = 2
+
 	cmd := &cobra.Command{
 		Use: "add [--config|--custom] [-f] [--timeout secs]" +
 			"<APP_NAME:INSTANCE_NAME> <ROLE_NAME> [flags]",
 		Short: "Adds a role for Tarantool 3 orchestrator",
 		Long:  "Adds a role for Tarantool 3 orchestrator",
 		Run:   RunModuleFunc(internalReplicasetRolesAddModule),
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(commandArgs),
 	}
 
 	cmd.Flags().StringVarP(&replicasetReplicasetName, "replicaset", "r", "",
@@ -315,13 +321,15 @@ func newRolesAddCmd() *cobra.Command {
 
 // newRolesRemoveCmd creates a "replicaset roles remove" command.
 func newRolesRemoveCmd() *cobra.Command {
+	const commandArgs = 2
+
 	cmd := &cobra.Command{
 		Use: "remove [--config|--custom] [-f] [--timeout secs]" +
 			"<APP_NAME:INSTANCE_NAME> <ROLE_NAME> [flags]",
 		Short: "Removes a role for Tarantool 3 orchestrator",
 		Long:  "Removes a role for Tarantool 3 orchestrator",
 		Run:   RunModuleFunc(internalReplicasetRolesRemoveModule),
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(commandArgs),
 	}
 
 	cmd.Flags().StringVarP(&replicasetReplicasetName, "replicaset", "r", "",

--- a/cli/cmd/tcm.go
+++ b/cli/cmd/tcm.go
@@ -175,7 +175,7 @@ func internalTcmStatus(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	}
 
 	if _, err := os.Stat(pidAbsPath); err != nil {
-		return fmt.Errorf("path does not exist: %v", err)
+		return fmt.Errorf("path does not exist: %w", err)
 	}
 
 	ts := table.NewWriter()

--- a/cli/cmd/tcm.go
+++ b/cli/cmd/tcm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -105,7 +106,7 @@ func NewTcmCmd() *cobra.Command {
 }
 
 func startTcmInteractive(logLevel string) error {
-	tcmApp := exec.Command(tcmCtx.Executable,
+	tcmApp := exec.CommandContext(context.Background(), tcmCtx.Executable,
 		"--log.default.add-source",
 		"--log.default.output=file",
 		"--log.default.format=json",

--- a/cli/cmd/tcm.go
+++ b/cli/cmd/tcm.go
@@ -24,9 +24,14 @@ import (
 var tcmCtx = tcmCmd.TcmCtx{}
 
 const (
-	tcmPidFile      = "tcm.pid"
-	watchdogPidFile = "watchdog.pid"
-	logFileName     = "tcm.log"
+	tcmPidFile             = "tcm.pid"
+	watchdogPidFile        = "watchdog.pid"
+	logFileName            = "tcm.log"
+	tcmDefaultLogLines     = 10
+	watchdogRestartDelay   = 5 * time.Second
+	statusPIDColumn        = 2
+	statusExecutableColumn = 3
+	statusStateColumn      = 4
 )
 
 func newTcmStartCmd() *cobra.Command {
@@ -75,7 +80,7 @@ func newTcmLogCmd() *cobra.Command {
 		Run:   RunModuleFunc(internalTcmLog),
 	}
 
-	cmd.Flags().IntVarP(&tcmCtx.Log.Lines, "lines", "n", 10,
+	cmd.Flags().IntVarP(&tcmCtx.Log.Lines, "lines", "n", tcmDefaultLogLines,
 		"Count of last lines to output")
 	cmd.Flags().BoolVarP(&tcmCtx.Log.IsFollow, "follow", "f", false,
 		"Output appended data as the log file grows")
@@ -132,7 +137,7 @@ func startTcmInteractive(logLevel string) error {
 }
 
 func startTcmUnderWatchDog() error {
-	wd := libwatchdog.NewWatchdog(tcmPidFile, watchdogPidFile, 5*time.Second)
+	wd := libwatchdog.NewWatchdog(tcmPidFile, watchdogPidFile, watchdogRestartDelay)
 	if err := wd.Start(tcmCtx.Executable); err != nil {
 		return err
 	}
@@ -181,9 +186,9 @@ func internalTcmStatus(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	ts.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 2, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 3, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 4, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: statusPIDColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: statusExecutableColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: statusStateColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
 	})
 
 	status := process_utils.ProcessStatus(pidAbsPath)

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
@@ -29,6 +30,6 @@ func NewVersionCmd() *cobra.Command {
 
 // internalVersionModule is a default (internal) version module function.
 func internalVersionModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	fmt.Println(version.GetVersion(showShort, needCommit))
+	fmt.Fprintln(os.Stdout, version.GetVersion(showShort, needCommit))
 	return nil
 }

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -39,6 +39,8 @@ type TcmCli struct {
 	ConfigPath string
 }
 
+const minVersionFields = 2
+
 // GetVersion returns and caches the tarantool version.
 func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	if tntCli.version.Str != "" {
@@ -58,7 +60,7 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	versionOut := strings.Split(string(output), "\n")
 	versionLine := strings.Split(versionOut[0], " ")
 
-	if len(versionLine) < 2 {
+	if len(versionLine) < minVersionFields {
 		return tntCli.version, fmt.Errorf("failed to get tarantool version: corrupted data")
 	}
 

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -1,6 +1,7 @@
 package cmdcontext
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -48,7 +49,8 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 		return tntCli.version, fmt.Errorf(
 			"tarantool executable is not set, unable to get tarantool version")
 	}
-	output, err := exec.Command(tntCli.Executable, "--version").Output()
+	output, err := exec.CommandContext(
+		context.Background(), tntCli.Executable, "--version").Output()
 	if err != nil {
 		return tntCli.version, fmt.Errorf("failed to get tarantool version: %s", err)
 	}
@@ -76,7 +78,7 @@ func GetTtVersion(pathToBin string) (version.Version, error) {
 		return version.Version{}, fmt.Errorf("file %q not found", pathToBin)
 	}
 
-	output, err := exec.Command(pathToBin, "--self", "version",
+	output, err := exec.CommandContext(context.Background(), pathToBin, "--self", "version",
 		"--commit").Output()
 	if err != nil {
 		return version.Version{}, fmt.Errorf("failed to get tt version: %s", err)

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -54,7 +54,7 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	output, err := exec.CommandContext(
 		context.Background(), tntCli.Executable, "--version").Output()
 	if err != nil {
-		return tntCli.version, fmt.Errorf("failed to get tarantool version: %s", err)
+		return tntCli.version, fmt.Errorf("failed to get tarantool version: %w", err)
 	}
 
 	versionOut := strings.Split(string(output), "\n")
@@ -83,7 +83,7 @@ func GetTtVersion(pathToBin string) (version.Version, error) {
 	output, err := exec.CommandContext(context.Background(), pathToBin, "--self", "version",
 		"--commit").Output()
 	if err != nil {
-		return version.Version{}, fmt.Errorf("failed to get tt version: %s", err)
+		return version.Version{}, fmt.Errorf("failed to get tt version: %w", err)
 	}
 
 	ttVersion, err := version.ParseTt(string(output))

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -227,10 +227,10 @@ func updateCliOpts(cliOpts *config.CliOpts, configDir string) error {
 	return nil
 }
 
-func decodeStringAsArrayField(from, to reflect.Type, value interface{}) (
-	interface{}, error,
+func decodeStringAsArrayField(from, to reflect.Type, value any) (
+	any, error,
 ) {
-	if to != reflect.TypeOf(config.FieldStringArrayType{}) || from.Kind() != reflect.String {
+	if to != reflect.TypeFor[config.FieldStringArrayType]() || from.Kind() != reflect.String {
 		return value, nil
 	}
 	str, ok := value.(string)

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -241,11 +241,11 @@ func decodeStringAsArrayField(from, to reflect.Type, value interface{}) (
 }
 
 func decodeConfig(input map[string]any, cfg *config.CliOpts) error {
-	decoder_config := mapstructure.DecoderConfig{
+	decoderConfig := mapstructure.DecoderConfig{
 		Result:     cfg,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(decodeStringAsArrayField),
 	}
-	decoder, err := mapstructure.NewDecoder(&decoder_config)
+	decoder, err := mapstructure.NewDecoder(&decoderConfig)
 	if err != nil {
 		return err
 	}

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -264,7 +264,7 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 	switch {
 	case err == nil:
 		if configPath, err = filepath.Abs(configPath); err != nil {
-			return nil, "", fmt.Errorf("cannot determine config file path: %s", err)
+			return nil, "", fmt.Errorf("cannot determine config file path: %w", err)
 		}
 		// Config file is found, load it.
 		if repository != nil {
@@ -277,11 +277,11 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 		}
 		rawConfigOpts, err := util.ParseYAML(configPath)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to parse Tarantool CLI configuration: %s", err)
+			return nil, "", fmt.Errorf("failed to parse Tarantool CLI configuration: %w", err)
 		}
 
 		if err := decodeConfig(rawConfigOpts, cfg); err != nil {
-			return nil, "", fmt.Errorf("failed to parse Tarantool CLI configuration: %s", err)
+			return nil, "", fmt.Errorf("failed to parse Tarantool CLI configuration: %w", err)
 		}
 
 		if cfg == nil {
@@ -291,7 +291,7 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 	case err != nil && !os.IsNotExist(err):
 		// TODO: Add warning in next patches, discussion
 		// what if the file exists, but access is denied, etc.
-		return nil, "", fmt.Errorf("failed to get access to configuration file: %s", err)
+		return nil, "", fmt.Errorf("failed to get access to configuration file: %w", err)
 	case os.IsNotExist(err):
 		configPath = ""
 	}
@@ -326,16 +326,16 @@ func GetDaemonOpts(configurePath string) (*config.DaemonOpts, error) {
 
 	// Config could not be processed.
 	if _, err := os.Stat(configurePath); err != nil {
-		return nil, fmt.Errorf("failed to get access to daemon configuration file: %s", err)
+		return nil, fmt.Errorf("failed to get access to daemon configuration file: %w", err)
 	}
 
 	rawConfigOpts, err := util.ParseYAML(configurePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse daemon configuration: %s", err)
+		return nil, fmt.Errorf("failed to parse daemon configuration: %w", err)
 	}
 
 	if err := mapstructure.Decode(rawConfigOpts, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse daemon configuration: %s", err)
+		return nil, fmt.Errorf("failed to parse daemon configuration: %w", err)
 	}
 
 	if cfg.DaemonConfig == nil {
@@ -398,14 +398,14 @@ func Cli(cmdCtx *cmdcontext.CmdCtx) error {
 
 	if cmdCtx.Cli.ConfigPath != "" {
 		if _, err := os.Stat(cmdCtx.Cli.ConfigPath); err != nil {
-			return fmt.Errorf("specified path to the configuration file is invalid: %s", err)
+			return fmt.Errorf("specified path to the configuration file is invalid: %w", err)
 		}
 	}
 
 	var err error
 	cmdCtx.Cli.DaemonCfgPath, err = getDaemonCfgPath(daemonCfgPath)
 	if err != nil {
-		return fmt.Errorf("failed to get tt daemon config: %s", err)
+		return fmt.Errorf("failed to get tt daemon config: %w", err)
 	}
 
 	// Set default (system) tarantool binary, can be replaced by "local" or "system" later.
@@ -434,14 +434,14 @@ func detectLocalTarantool(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) er
 
 	if _, err := os.Stat(localTarantool); err == nil {
 		if _, err := exec.LookPath(localTarantool); err != nil {
-			return fmt.Errorf(`found Tarantool binary '%s' isn't executable: %s`,
+			return fmt.Errorf(`found Tarantool binary '%s' isn't executable: %w`,
 				localTarantool, err)
 		}
 
 		cmdCtx.Cli.TarantoolCli.Executable = localTarantool
 		cmdCtx.Cli.IsTarantoolBinFromRepo = true
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to get access to Tarantool binary file: %s", err)
+		return fmt.Errorf("failed to get access to Tarantool binary file: %w", err)
 	}
 
 	log.Debugf("Tarantool executable found: '%s'", cmdCtx.Cli.TarantoolCli.Executable)
@@ -558,11 +558,11 @@ func ensureCliConfigPath(cmdCtx *cmdcontext.CmdCtx, launchDir string) error {
 	// TODO: Add warning messages, discussion what if the file
 	// exists, but access is denied, etc.
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to get access to configuration file: %s", err)
+		return fmt.Errorf("failed to get access to configuration file: %w", err)
 	}
 	configPath, err = getConfigPath()
 	if err != nil {
-		return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
+		return fmt.Errorf("failed to get Tarantool CLI config: %w", err)
 	}
 	if configPath != "" {
 		cmdCtx.Cli.ConfigPath = configPath
@@ -585,11 +585,11 @@ func switchToLocalCli(cmdCtx *cmdcontext.CmdCtx, localCli, currentCli, launchDir
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get access to tt binary file: %s", err)
+		return fmt.Errorf("failed to get access to tt binary file: %w", err)
 	}
 	if _, err := exec.LookPath(localCli); err != nil {
 		return fmt.Errorf(
-			`found tt binary in local directory "%s" isn't executable: %s`, launchDir, err)
+			`found tt binary in local directory "%s" isn't executable: %w`, launchDir, err)
 	}
 
 	// Before switching to local cli, we shall check its integrity.
@@ -612,13 +612,13 @@ func configureLocalLaunch(cmdCtx *cmdcontext.CmdCtx) error {
 	var launchDir string
 	if cmdCtx.Cli.LocalLaunchDir != "" {
 		if launchDir, err = filepath.Abs(cmdCtx.Cli.LocalLaunchDir); err != nil {
-			return fmt.Errorf(`failed to get absolute path to local directory: %s`, err)
+			return fmt.Errorf(`failed to get absolute path to local directory: %w`, err)
 		}
 
 		log.Debugf("Local launch directory: %s", launchDir)
 
 		if _, err = util.Chdir(launchDir); err != nil {
-			return fmt.Errorf(`failed to change working directory: %s`, err)
+			return fmt.Errorf(`failed to change working directory: %w`, err)
 		}
 	}
 
@@ -682,7 +682,7 @@ func configureDefaultCli(cmdCtx *cmdcontext.CmdCtx) error {
 		// If the config is not found, then we take it from the standard place (/etc/tarantool).
 
 		if cmdCtx.Cli.ConfigPath, err = getConfigPath(); err != nil {
-			return fmt.Errorf("failed to get Tarantool CLI config: %s", err)
+			return fmt.Errorf("failed to get Tarantool CLI config: %w", err)
 		}
 	}
 
@@ -699,7 +699,7 @@ func configureDefaultCli(cmdCtx *cmdcontext.CmdCtx) error {
 func getConfigPath() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to detect current directory: %s", err)
+		return "", fmt.Errorf("failed to detect current directory: %w", err)
 	}
 
 	for curDir != "/" {
@@ -750,7 +750,7 @@ func getDaemonCfgPath(configName string) (string, error) {
 	// Config in current dir.
 	curDir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to detect current directory: %s", err)
+		return "", fmt.Errorf("failed to detect current directory: %w", err)
 	}
 
 	configPath = fmt.Sprintf("%s/%s", curDir, configName)

--- a/cli/configure/configure_test.go
+++ b/cli/configure/configure_test.go
@@ -338,61 +338,61 @@ func TestUpdateCliOpts(t *testing.T) {
 }
 
 func TestGetCliOpts_modules_directory(t *testing.T) {
-	work_dir, err := os.Getwd()
+	workDir, err := os.Getwd()
 	require.NoError(t, err)
-	work_dir = filepath.Join(work_dir, "testdata/modules_cfg")
+	workDir = filepath.Join(workDir, "testdata/modules_cfg")
 
 	tests := []struct {
-		name        string
-		config      string
-		modules_dir config.FieldStringArrayType
-		cfg_path    string
+		name       string
+		config     string
+		modulesDir config.FieldStringArrayType
+		cfgPath    string
 	}{
 		{
-			name:        "Single string relative path",
-			config:      "tt-modules1",
-			modules_dir: []string{filepath.Join(work_dir, "modules-dir")},
-			cfg_path:    "tt-modules1.yaml",
+			name:       "Single string relative path",
+			config:     "tt-modules1",
+			modulesDir: []string{filepath.Join(workDir, "modules-dir")},
+			cfgPath:    "tt-modules1.yaml",
 		},
 		{
-			name:        "Single entry list",
-			config:      "tt-modules2",
-			modules_dir: []string{filepath.Join(work_dir, "modules-dir")},
-			cfg_path:    "tt-modules2.yml",
+			name:       "Single entry list",
+			config:     "tt-modules2",
+			modulesDir: []string{filepath.Join(workDir, "modules-dir")},
+			cfgPath:    "tt-modules2.yml",
 		},
 		{
 			name:   "Multiple entries list",
 			config: "tt-modules3.",
-			modules_dir: []string{
-				filepath.Join(work_dir, "modules-dir"),
+			modulesDir: []string{
+				filepath.Join(workDir, "modules-dir"),
 				"/ext/path/modules",
-				filepath.Join(work_dir, "local_modules"),
+				filepath.Join(workDir, "local_modules"),
 			},
-			cfg_path: "tt-modules3.yaml",
+			cfgPath: "tt-modules3.yaml",
 		},
 		{
-			name:        "Empty list = default value",
-			config:      "tt-modules4.yaml",
-			modules_dir: []string{filepath.Join(work_dir, "modules")},
-			cfg_path:    "tt-modules4.yml",
+			name:       "Empty list = default value",
+			config:     "tt-modules4.yaml",
+			modulesDir: []string{filepath.Join(workDir, "modules")},
+			cfgPath:    "tt-modules4.yml",
 		},
 		{
-			name:        "Single string absolute path",
-			config:      "tt-modules5.yml",
-			modules_dir: []string{"/ext/path/modules"},
-			cfg_path:    "tt-modules5.yaml",
+			name:       "Single string absolute path",
+			config:     "tt-modules5.yml",
+			modulesDir: []string{"/ext/path/modules"},
+			cfgPath:    "tt-modules5.yaml",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockRepo := newMockRepository()
-			config := filepath.Join(work_dir, tt.config)
+			config := filepath.Join(workDir, tt.config)
 			opts, cfg, err := GetCliOpts(config, &mockRepo)
 			require.NoError(t, err)
 			require.NotNil(t, opts.Modules)
-			require.Equal(t, tt.modules_dir, opts.Modules.Directories)
-			require.Equal(t, filepath.Join(work_dir, tt.cfg_path), cfg)
+			require.Equal(t, tt.modulesDir, opts.Modules.Directories)
+			require.Equal(t, filepath.Join(workDir, tt.cfgPath), cfg)
 		})
 	}
 }

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -315,7 +315,7 @@ func (command helpCmd) Run(console *Console,
 func setLanguageFunc(console *Console, cmd string, args []string) (string, error) {
 	if lang, ok := ParseLanguage(args[0]); ok {
 		if err := ChangeLanguage(console.conn, lang); err != nil {
-			return "", fmt.Errorf("failed to change language: %s", err)
+			return "", fmt.Errorf("failed to change language: %w", err)
 		} else {
 			console.language = lang
 		}

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -261,7 +261,8 @@ func newHelpCmd(infos []cmdInfo) helpCmd {
 	shorts = append(shorts, strings.Join(getHelp, ", "))
 	longs := make([]string, 0, 1+len(infos))
 	longs = append(longs, "show this screen")
-	msg := `
+	var msg strings.Builder
+	msg.WriteString(`
   To get help, see the Tarantool manual at https://tarantool.io/en/doc/
   To start the interactive Tarantool tutorial, type 'tutorial()' here.
 
@@ -270,7 +271,7 @@ func newHelpCmd(infos []cmdInfo) helpCmd {
 
   Available backslash commands:
 
-`
+`)
 
 	shortMaxLen := len(shorts[0])
 	for _, info := range infos {
@@ -282,15 +283,18 @@ func newHelpCmd(infos []cmdInfo) helpCmd {
 	}
 
 	for i := range shorts {
-		msg += "  " + shorts[i]
+		msg.WriteString("  ")
+		msg.WriteString(shorts[i])
 		for j := len(shorts[i]); j < shortMaxLen; j++ {
-			msg += " "
+			msg.WriteByte(' ')
 		}
-		msg += " -- " + longs[i] + "\n"
+		msg.WriteString(" -- ")
+		msg.WriteString(longs[i])
+		msg.WriteByte('\n')
 	}
 
 	return helpCmd{
-		help: msg,
+		help: msg.String(),
 	}
 }
 

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -625,7 +626,7 @@ func (executor cmdExecutor) Execute(console *Console, in string) bool {
 			if err != nil {
 				log.Errorf("%s\n", err)
 			} else if msg != "" {
-				fmt.Printf("%s\n", msg)
+				fmt.Fprintf(os.Stdout, "%s\n", msg)
 			}
 			return true
 		}

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -97,7 +97,7 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 	}
 	defer conn.Close()
 
-	evalArgs := []interface{}{command, connectCtx.Language == SQLLanguage}
+	evalArgs := []any{command, connectCtx.Language == SQLLanguage}
 	if connectCtx.Language != DefaultLanguage {
 		// Change a language.
 		if err := ChangeLanguage(conn, connectCtx.Language); err != nil {
@@ -134,7 +134,7 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 			return nil, fmt.Errorf("unexpected response type: %T", response[0])
 		}
 	}
-	var checkMock interface{}
+	var checkMock any
 	if err = yaml.Unmarshal([]byte(resYAML), &checkMock); err != nil {
 		return nil, err
 	}

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -78,7 +78,7 @@ func getEvalCmd(connectCtx ConnectCtx) (string, error) {
 // Connect establishes a connection to the instance and starts the console.
 func Connect(connectCtx ConnectCtx, connOpts connector.ConnectOpts) error {
 	if err := runConsole(connOpts, connectCtx, ""); err != nil {
-		return fmt.Errorf("failed to run interactive console: %s", err)
+		return fmt.Errorf("failed to run interactive console: %w", err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 	// Connecting to the instance.
 	conn, err := connector.Connect(connOpts)
 	if err != nil {
-		return nil, fmt.Errorf("unable to establish connection: %s", err)
+		return nil, fmt.Errorf("unable to establish connection: %w", err)
 	}
 	defer conn.Close()
 
@@ -101,7 +101,7 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 	if connectCtx.Language != DefaultLanguage {
 		// Change a language.
 		if err := ChangeLanguage(conn, connectCtx.Language); err != nil {
-			return nil, fmt.Errorf("unable to change a language: %s", err)
+			return nil, fmt.Errorf("unable to change a language: %w", err)
 		}
 		evalArgs = append(evalArgs, false)
 	} else {
@@ -146,12 +146,12 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 func runConsole(connOpts connector.ConnectOpts, connectCtx ConnectCtx, title string) error {
 	console, err := NewConsole(connOpts, connectCtx, title)
 	if err != nil {
-		return fmt.Errorf("failed to create new console: %s", err)
+		return fmt.Errorf("failed to create new console: %w", err)
 	}
 	defer console.Close()
 
 	if err := console.Run(); err != nil {
-		return fmt.Errorf("failed to start new console: %s", err)
+		return fmt.Errorf("failed to start new console: %w", err)
 	}
 
 	return nil

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -240,7 +240,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 					return
 				}
 
-				fmt.Printf("%s\n", encodedData)
+				fmt.Fprintf(os.Stdout, "%s\n", encodedData)
 			},
 			ResData: &results,
 		}
@@ -268,7 +268,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 			log.Errorf("Unable to format output: %s", err)
 			log.Infof("Source YAML:\n%s", data)
 		} else {
-			fmt.Print(output)
+			fmt.Fprint(os.Stdout, output)
 		}
 
 		console.input = ""
@@ -403,7 +403,7 @@ func getPromptOptions(console *Console) []prompt.Option {
 				Fn: func(buf *prompt.Buffer) {
 					console.input = ""
 					console.livePrefixEnabled = false
-					fmt.Println("^C")
+					fmt.Fprintln(os.Stdout, "^C")
 				},
 			},
 		),

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -274,7 +274,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 		console.livePrefixEnabled = false
 	}
 
-	signaller_executor := func(in string) {
+	signallerExecutor := func(in string) {
 		// Signal handler.
 		handleSignals := func(console *Console, stop chan struct{}) {
 			sig := make(chan os.Signal, 1)
@@ -294,7 +294,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 		stop <- struct{}{}
 	}
 
-	return signaller_executor, nil
+	return signallerExecutor, nil
 }
 
 func getCompleter(console *Console, connectCtx ConnectCtx) prompt.Completer {

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -22,7 +22,7 @@ import (
 )
 
 // EvalFunc defines a function type for evaluating an expression via connection.
-type EvalFunc func(console *Console, funcBodyFmt string, args ...interface{}) (interface{}, error)
+type EvalFunc func(console *Console, funcBodyFmt string, args ...any) (any, error)
 
 const (
 	HistoryFileName       = ".tarantool_history"
@@ -228,12 +228,12 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 		var results []string
 		needMetaInfo := console.format == formatter.TableFormat ||
 			console.format == formatter.TTableFormat
-		args := []interface{}{
+		args := []any{
 			console.input, console.language == SQLLanguage,
 			needMetaInfo,
 		}
 		opts := connector.RequestOpts{
-			PushCallback: func(pushedData interface{}) {
+			PushCallback: func(pushedData any) {
 				encodedData, err := yaml.Marshal(pushedData)
 				if err != nil {
 					log.Warnf("Failed to encode pushed data: %s", err)
@@ -324,7 +324,7 @@ func getCompleter(console *Console, connectCtx ConnectCtx) prompt.Completer {
 		}
 
 		var suggestionsTexts []string
-		args := []interface{}{lastWord, len(lastWord)}
+		args := []any{lastWord, len(lastWord)}
 		opts := connector.RequestOpts{
 			ReadTimeout: suggestionReadTimeout,
 			ResData:     &suggestionsTexts,
@@ -364,10 +364,7 @@ func setTitle(console *Console, title string) {
 func setPrefix(console *Console) {
 	console.prefix = fmt.Sprintf("%s> ", console.title)
 
-	livePrefixIndent := len(console.title)
-	if livePrefixIndent > MaxLivePrefixIndent {
-		livePrefixIndent = MaxLivePrefixIndent
-	}
+	livePrefixIndent := min(len(console.title), MaxLivePrefixIndent)
 
 	console.livePrefix = fmt.Sprintf("%s> ", strings.Repeat(" ", livePrefixIndent))
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -25,7 +25,8 @@ import (
 type EvalFunc func(console *Console, funcBodyFmt string, args ...interface{}) (interface{}, error)
 
 const (
-	HistoryFileName = ".tarantool_history"
+	HistoryFileName       = ".tarantool_history"
+	suggestionReadTimeout = 3 * time.Second
 
 	MaxLivePrefixIndent = 15
 	MaxHistoryLines     = 10000
@@ -325,7 +326,7 @@ func getCompleter(console *Console, connectCtx ConnectCtx) prompt.Completer {
 		var suggestionsTexts []string
 		args := []interface{}{lastWord, len(lastWord)}
 		opts := connector.RequestOpts{
-			ReadTimeout: 3 * time.Second,
+			ReadTimeout: suggestionReadTimeout,
 			ResData:     &suggestionsTexts,
 		}
 

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -108,20 +109,20 @@ func NewConsole(connOpts connector.ConnectOpts, connectCtx ConnectCtx, title str
 	// Connect to specified address.
 	console.conn, err = connector.Connect(connOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect: %s", err)
+		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 
 	// Change a language.
 	if connectCtx.Language != DefaultLanguage {
 		if err := ChangeLanguage(console.conn, connectCtx.Language); err != nil {
-			return nil, fmt.Errorf("unable to change a language: %s", err)
+			return nil, fmt.Errorf("unable to change a language: %w", err)
 		}
 	}
 
 	// Initialize user commands executor.
 	console.executor, err = getExecutor(console, connectCtx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init prompt: %s", err)
+		return nil, fmt.Errorf("failed to init prompt: %w", err)
 	}
 
 	// Initialize commands completer.
@@ -247,7 +248,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 
 		var data string
 		if _, err := console.conn.Eval(evalBody, args, opts); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// We need to call 'console.Close()' here because in some cases (e.g 'os.exit()')
 				// it won't be called from 'defer console.Close' in 'connect.runConsole()'.
 				console.Close()

--- a/cli/connect/history.go
+++ b/cli/connect/history.go
@@ -103,7 +103,7 @@ func (history *commandHistory) writeToFile() error {
 		fmt.Fprintf(&historyContent, "#%d\n%s\n", history.timestamps[i], command)
 	}
 	if err := os.WriteFile(history.filepath, historyContent.Bytes(), historyFileMode); err != nil {
-		return fmt.Errorf("failed to write to history file: %s", err)
+		return fmt.Errorf("failed to write to history file: %w", err)
 	}
 
 	return nil
@@ -113,7 +113,7 @@ func (history *commandHistory) writeToFile() error {
 func newCommandHistory(historyFileName string, maxCommands int) (*commandHistory, error) {
 	homeDir, err := util.GetHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %s", err)
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	history := commandHistory{

--- a/cli/connect/history.go
+++ b/cli/connect/history.go
@@ -13,6 +13,8 @@ import (
 	"github.com/tarantool/tt/cli/util"
 )
 
+const historyFileMode = 0o640
+
 // commandHistory stores console command history.
 type commandHistory struct {
 	filepath    string
@@ -100,7 +102,7 @@ func (history *commandHistory) writeToFile() error {
 	for i, command := range history.commands {
 		fmt.Fprintf(&historyContent, "#%d\n%s\n", history.timestamps[i], command)
 	}
-	if err := os.WriteFile(history.filepath, historyContent.Bytes(), 0o640); err != nil {
+	if err := os.WriteFile(history.filepath, historyContent.Bytes(), historyFileMode); err != nil {
 		return fmt.Errorf("failed to write to history file: %s", err)
 	}
 

--- a/cli/connect/input.go
+++ b/cli/connect/input.go
@@ -93,10 +93,10 @@ func cleanupDelimiter(stmt, delim string) (string, bool) {
 	if delim == "" {
 		return stmt, true
 	}
-	no_space := strings.TrimRightFunc(stmt, unicode.IsSpace)
-	no_delim := strings.TrimSuffix(no_space, delim)
-	if len(no_space) > len(no_delim) {
-		return no_delim, true
+	noSpace := strings.TrimRightFunc(stmt, unicode.IsSpace)
+	noDelim := strings.TrimSuffix(noSpace, delim)
+	if len(noSpace) > len(noDelim) {
+		return noDelim, true
 	}
 	return stmt, false
 }

--- a/cli/connect/internal/luabody/eval.go
+++ b/cli/connect/internal/luabody/eval.go
@@ -39,7 +39,7 @@ func GetEvalFuncBody(evaler string) (string, error) {
 		if evalerPath, isFile := strings.CutPrefix(evaler, "@"); isFile {
 			evalerFileBytes, err := os.ReadFile(evalerPath)
 			if err != nil {
-				return "", fmt.Errorf("failed to read the evaler file: %s", err)
+				return "", fmt.Errorf("failed to read the evaler file: %w", err)
 			}
 			mapping["evaler"] = string(evalerFileBytes)
 		} else {

--- a/cli/connect/internal/luabody/eval.go
+++ b/cli/connect/internal/luabody/eval.go
@@ -16,7 +16,7 @@ var evalFuncBody string
 var getSuggestionsFuncBody string
 
 // GetTemplatedStr returns a templated string.
-func GetTemplatedStr(text string, obj interface{}) (string, error) {
+func GetTemplatedStr(text string, obj any) (string, error) {
 	tmpl, err := template.New("s").Parse(text)
 	if err != nil {
 		return "", err
@@ -36,8 +36,8 @@ func GetTemplatedStr(text string, obj interface{}) (string, error) {
 func GetEvalFuncBody(evaler string) (string, error) {
 	mapping := map[string]string{}
 	if len(evaler) != 0 {
-		if strings.HasPrefix(evaler, "@") {
-			evalerFileBytes, err := os.ReadFile(strings.TrimPrefix(evaler, "@"))
+		if evalerPath, isFile := strings.CutPrefix(evaler, "@"); isFile {
+			evalerFileBytes, err := os.ReadFile(evalerPath)
 			if err != nil {
 				return "", fmt.Errorf("failed to read the evaler file: %s", err)
 			}

--- a/cli/connect/language.go
+++ b/cli/connect/language.go
@@ -66,7 +66,7 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 		return err
 	}
 	response, err := evaler.Eval(evalBody,
-		[]interface{}{languageCmd},
+		[]any{languageCmd},
 		connector.RequestOpts{},
 	)
 	if err != nil {
@@ -85,13 +85,13 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 		return fmt.Errorf("unexpected response: %v", response)
 	}
 
-	var decoded interface{}
+	var decoded any
 	if err = yaml.Unmarshal([]byte(ret), &decoded); err != nil {
 		return fmt.Errorf("unable to decode response: %w", err)
 	}
 
-	var decodedArray []interface{}
-	if decodedArray, ok = decoded.([]interface{}); !ok || len(decodedArray) != 1 {
+	var decodedArray []any
+	if decodedArray, ok = decoded.([]any); !ok || len(decodedArray) != 1 {
 		return fmt.Errorf("unexpected response: %s", ret)
 	}
 

--- a/cli/connect/language_test.go
+++ b/cli/connect/language_test.go
@@ -70,13 +70,13 @@ func TestLanguage_String(t *testing.T) {
 
 type inputEvaler struct {
 	fun  string
-	args []interface{}
+	args []any
 	opts connector.RequestOpts
 }
 
 func (evaler *inputEvaler) Eval(fun string,
-	args []interface{}, opts connector.RequestOpts,
-) ([]interface{}, error) {
+	args []any, opts connector.RequestOpts,
+) ([]any, error) {
 	evaler.fun = fun
 	evaler.args = args
 	evaler.opts = opts
@@ -113,37 +113,37 @@ func TestChangeLanguage_requestInputs(t *testing.T) {
 }
 
 type outputEvaler struct {
-	ret []interface{}
+	ret []any
 	err error
 }
 
-func (evaler outputEvaler) Eval(f string, a []interface{},
+func (evaler outputEvaler) Eval(f string, a []any,
 	o connector.RequestOpts,
-) ([]interface{}, error) {
+) ([]any, error) {
 	return evaler.ret, evaler.err
 }
 
 func TestChangeLanguage_requestOutputsValid(t *testing.T) {
-	evaler := outputEvaler{ret: []interface{}{"- true"}}
+	evaler := outputEvaler{ret: []any{"- true"}}
 	assert.NoError(t, ChangeLanguage(evaler, LuaLanguage))
 }
 
 func TestChangeLanguage_requestOutputsInvalid(t *testing.T) {
 	cases := []struct {
-		ret      []interface{}
+		ret      []any
 		err      error
 		expected string
 	}{
 		{nil, nil, "unexpected response: empty"},
 		{nil, errors.New("any error"), "any error"},
-		{[]interface{}{true}, nil, "unexpected response: [true]"},
-		{[]interface{}{",,,"}, nil, "unable to decode response: yaml:" +
+		{[]any{true}, nil, "unexpected response: [true]"},
+		{[]any{",,,"}, nil, "unable to decode response: yaml:" +
 			" did not find expected node content"},
-		{[]interface{}{"true"}, nil, "unexpected response: true"},
-		{[]interface{}{"- true", "- true"}, nil, "unexpected response: [- true - true]"},
-		{[]interface{}{"- true\n  true"}, nil, "unexpected response: - true\n  true"},
-		{[]interface{}{"- 123"}, nil, "unexpected response: - 123"},
-		{[]interface{}{"- false"}, nil, "\\set language lua returns false"},
+		{[]any{"true"}, nil, "unexpected response: true"},
+		{[]any{"- true", "- true"}, nil, "unexpected response: [- true - true]"},
+		{[]any{"- true\n  true"}, nil, "unexpected response: - true\n  true"},
+		{[]any{"- 123"}, nil, "unexpected response: - 123"},
+		{[]any{"- false"}, nil, "\\set language lua returns false"},
 	}
 
 	for _, c := range cases {

--- a/cli/connector/binary.go
+++ b/cli/connector/binary.go
@@ -28,9 +28,9 @@ func NewBinaryConnector(conn tarantool.Connector) *BinaryConnector {
 }
 
 // Eval sends an eval request.
-func (conn *BinaryConnector) Eval(expr string, args []interface{},
+func (conn *BinaryConnector) Eval(expr string, args []any,
 	opts RequestOpts,
-) ([]interface{}, error) {
+) ([]any, error) {
 	// Create a request.
 	evalReq := tarantool.NewEvalRequest(expr).Args(args)
 	if opts.ReadTimeout != 0 {
@@ -43,7 +43,7 @@ func (conn *BinaryConnector) Eval(expr string, args []interface{},
 
 	// Execute the request.
 	var err error
-	var data []interface{}
+	var data []any
 	future := conn.conn.Do(evalReq)
 	if opts.PushCallback != nil {
 		if err := processPushes(future, opts); err != nil {

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -69,7 +69,8 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		defer os.Chdir(workDir)
 	}
 	// Connect to specified address.
-	greetingConn, err := net.Dial(opts.Network, opts.Address)
+	greetingConn, err := (&net.Dialer{}).DialContext(
+		context.Background(), opts.Network, opts.Address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %s", err)
 	}

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -73,7 +73,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 	greetingConn, err := (&net.Dialer{}).DialContext(
 		context.Background(), opts.Network, opts.Address)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial: %s", err)
+		return nil, fmt.Errorf("failed to dial: %w", err)
 	}
 
 	// Set a deadline for the greeting.
@@ -87,7 +87,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		if ssl {
 			protocol = BinaryProtocol
 		} else {
-			return nil, fmt.Errorf("failed to get protocol: %s", err)
+			return nil, fmt.Errorf("failed to get protocol: %w", err)
 		}
 	} else if ssl {
 		greetingConn.Close()

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -18,6 +18,7 @@ const (
 	greetingOperationTimeout = 3 * time.Second
 	maxSocketPathLinux       = 108
 	maxSocketPathMac         = 106
+	socketPathPrefixLength   = 3
 )
 
 // RequestOpts describes the parameters of a request to be executed.
@@ -64,7 +65,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		opts.Address = "./" + filepath.Base(opts.Address)
 		if len(opts.Address)+1 > maxSocketPath {
 			return nil, fmt.Errorf("socket name is longer than %d symbols: %s",
-				maxSocketPath-3, filepath.Base(opts.Address))
+				maxSocketPath-socketPathPrefixLength, filepath.Base(opts.Address))
 		}
 		defer os.Chdir(workDir)
 	}

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -24,17 +24,17 @@ const (
 // RequestOpts describes the parameters of a request to be executed.
 type RequestOpts struct {
 	// PushCallback is the cb that will be called when a "push" message is received.
-	PushCallback func(interface{})
+	PushCallback func(any)
 	// ReadTimeout timeout for the operation.
 	ReadTimeout time.Duration
 	// ResData describes the typed result of the operation executed.
-	ResData interface{}
+	ResData any
 }
 
 // Evaler is an interface that wraps Eval method.
 type Evaler interface {
 	// Eval passes Lua expression for evaluation.
-	Eval(expr string, args []interface{}, opts RequestOpts) ([]interface{}, error)
+	Eval(expr string, args []any, opts RequestOpts) ([]any, error)
 }
 
 // Connector is an interface that wraps all method required for a

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -26,6 +26,9 @@ const (
 
 	tagPushPrefixYAML = `%TAG`
 	tagPushPrefixLua  = `-- Push`
+
+	decodeBufferSize = 256
+	pushLineParts    = 2
 )
 
 type EvalPlainTextOpts struct {
@@ -195,7 +198,7 @@ func readFromPlainTextConn(conn net.Conn, opts EvalPlainTextOpts) ([]byte, error
 func readDataPortionFromPlainTextConn(conn net.Conn, buffer *bytes.Buffer,
 	readTimeout time.Duration,
 ) ([]byte, error) {
-	tmp := make([]byte, 256)
+	tmp := make([]byte, decodeBufferSize)
 	data := make([]byte, 0)
 
 	if readTimeout > 0 {
@@ -290,7 +293,7 @@ func getPushedData(pushedDataBytes []byte) (interface{}, error) {
 		// Lua.
 
 		// remove first line (-- Push).
-		pushedDataString = strings.SplitN(pushedDataString, "\n", 2)[1]
+		pushedDataString = strings.SplitN(pushedDataString, "\n", pushLineParts)[1]
 		// remove ";".
 		pushedDataString = strings.TrimRight(pushedDataString, ";")
 

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -53,12 +53,12 @@ func evalPlainTextConn(conn net.Conn, funcBody string, args []any,
 
 	// recv from socket.
 	resBytes, err := readFromPlainTextConn(conn, opts)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to check returned data: %s", err)
+		return nil, fmt.Errorf("failed to check returned data: %w", err)
 	}
 
 	data, err := processEvalTarantoolRes(resBytes, opts.ResData)
@@ -78,7 +78,7 @@ func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 
 	argsEncoded, err := msgpack.Marshal(args)
 	if err != nil {
-		return fmt.Errorf("failed to encode args: %s", err)
+		return fmt.Errorf("failed to encode args: %w", err)
 	}
 
 	evalFunc, err := util.GetTextTemplatedStr(&evalFuncTmpl, map[string]string{
@@ -86,7 +86,7 @@ func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 		"ArgsEncoded":  fmt.Sprintf("%x", argsEncoded),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to instantiate eval function template: %s", err)
+		return fmt.Errorf("failed to instantiate eval function template: %w", err)
 	}
 
 	evalFuncFormatted := strings.Join(
@@ -96,7 +96,7 @@ func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 
 	// write to socket.
 	if err := writeToPlainTextConn(conn, evalFuncFormatted); err != nil {
-		return fmt.Errorf("failed to send eval function to socket: %s", err)
+		return fmt.Errorf("failed to send eval function to socket: %w", err)
 	}
 
 	return nil
@@ -105,11 +105,11 @@ func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 func writeToPlainTextConn(conn net.Conn, data string) error {
 	writer := bufio.NewWriter(conn)
 	if _, err := writer.WriteString(data); err != nil {
-		return fmt.Errorf("failed to send to socket: %s", err)
+		return fmt.Errorf("failed to send to socket: %w", err)
 	}
 
 	if err := writer.Flush(); err != nil {
-		return fmt.Errorf("failed to flush: %s", err)
+		return fmt.Errorf("failed to flush: %w", err)
 	}
 
 	return nil
@@ -165,12 +165,12 @@ func readFromPlainTextConn(conn net.Conn, opts EvalPlainTextOpts) ([]byte, error
 		// received tag string can be handled via pushCallback function.
 		//
 		dataPortionBytes, err := readDataPortionFromPlainTextConn(conn, &buffer, opts.ReadTimeout)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, err
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to read from instance socket: %s", err)
+			return nil, fmt.Errorf("failed to read from instance socket: %w", err)
 		}
 
 		dataPortion := string(dataPortionBytes)
@@ -223,9 +223,9 @@ func readDataPortionFromPlainTextConn(conn net.Conn, buffer *bytes.Buffer,
 		//
 
 		if buffer.Len() == 0 {
-			if n, err := conn.Read(tmp); err != nil && err != io.EOF {
-				return nil, fmt.Errorf("failed to read: %s", err)
-			} else if n == 0 || err == io.EOF {
+			if n, err := conn.Read(tmp); err != nil && !errors.Is(err, io.EOF) {
+				return nil, fmt.Errorf("failed to read: %w", err)
+			} else if n == 0 || errors.Is(err, io.EOF) {
 				return nil, io.EOF
 			} else {
 				buffer.Write(tmp[:n])
@@ -234,7 +234,7 @@ func readDataPortionFromPlainTextConn(conn net.Conn, buffer *bytes.Buffer,
 
 		nextByte, err := buffer.ReadByte()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get byte from buffer: %s", err)
+			return nil, fmt.Errorf("failed to get byte from buffer: %w", err)
 		}
 
 		data = append(data, nextByte)
@@ -287,7 +287,7 @@ func getPushedData(pushedDataBytes []byte) (any, error) {
 	if strings.HasPrefix(pushedDataString, tagPushPrefixYAML) {
 		// YAML - just decode tag.
 		if err := yaml.Unmarshal(pushedDataBytes, &pushedData); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal pushed data: %s", err)
+			return nil, fmt.Errorf("failed to unmarshal pushed data: %w", err)
 		}
 	} else {
 		// Lua.
@@ -344,12 +344,12 @@ func processEvalTarantoolRes(resBytes []byte, result any) ([]any, error) {
 
 	dataEnc, err := base64.StdEncoding.DecodeString(evalResultEncBase64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode hex value: %s", err)
+		return nil, fmt.Errorf("failed to decode hex value: %w", err)
 	}
 
 	if result != nil {
 		if err := msgpack.Unmarshal(dataEnc, result); err != nil {
-			return nil, fmt.Errorf("failed to parse eval result: %s", err)
+			return nil, fmt.Errorf("failed to parse eval result: %w", err)
 		}
 
 		return nil, nil
@@ -357,7 +357,7 @@ func processEvalTarantoolRes(resBytes []byte, result any) ([]any, error) {
 
 	var data []any
 	if err := msgpack.Unmarshal(dataEnc, &data); err != nil {
-		return nil, fmt.Errorf("failed to parse eval result: %s", err)
+		return nil, fmt.Errorf("failed to parse eval result: %w", err)
 	}
 
 	return data, nil
@@ -380,14 +380,14 @@ func getPlainTextEvalResYaml(resBytes []byte) (string, error) {
 func getPlainTextEvalError(resBytes []byte, parseErr error) error {
 	errorStrings := make([]map[string]string, 0)
 	if err := yaml.UnmarshalStrict(resBytes, &errorStrings); err != nil {
-		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+		return fmt.Errorf("failed to parse eval result: %w", parseErr)
 	}
 	if len(errorStrings) == 0 {
-		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+		return fmt.Errorf("failed to parse eval result: %w", parseErr)
 	}
 	errStr, found := errorStrings[0]["error"]
 	if !found {
-		return fmt.Errorf("failed to parse eval result: %s", parseErr)
+		return fmt.Errorf("failed to parse eval result: %w", parseErr)
 	}
 	return errors.New(errStr)
 }

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -33,8 +33,8 @@ const (
 
 type EvalPlainTextOpts struct {
 	ReadTimeout  time.Duration
-	PushCallback func(interface{})
-	ResData      interface{}
+	PushCallback func(any)
+	ResData      any
 }
 
 type PlainTextEvalRes struct {
@@ -44,9 +44,9 @@ type PlainTextEvalRes struct {
 // evalPlainTextConnYAML calls function on Tarantool instance
 // Function should return `interface{}`, `string` (res, err)
 // to be correctly processed.
-func evalPlainTextConn(conn net.Conn, funcBody string, args []interface{},
+func evalPlainTextConn(conn net.Conn, funcBody string, args []any,
 	opts EvalPlainTextOpts,
-) ([]interface{}, error) {
+) ([]any, error) {
 	if err := formatAndSendEvalFunc(conn, funcBody, args, evalFuncTmpl); err != nil {
 		return nil, err
 	}
@@ -69,11 +69,11 @@ func evalPlainTextConn(conn net.Conn, funcBody string, args []interface{},
 	return data, nil
 }
 
-func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []interface{},
+func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 	evalFuncTmpl string,
 ) error {
 	if args == nil {
-		args = []interface{}{}
+		args = []any{}
 	}
 
 	argsEncoded, err := msgpack.Marshal(args)
@@ -181,7 +181,7 @@ func readFromPlainTextConn(conn net.Conn, opts EvalPlainTextOpts) ([]byte, error
 		}
 
 		if opts.PushCallback != nil {
-			var pushedData interface{}
+			var pushedData any
 
 			pushedData, err := getPushedData(dataPortionBytes)
 			if err != nil {
@@ -280,8 +280,8 @@ func pushTagIsReceived(dataPortion string) bool {
 	return false
 }
 
-func getPushedData(pushedDataBytes []byte) (interface{}, error) {
-	var pushedData interface{}
+func getPushedData(pushedDataBytes []byte) (any, error) {
+	var pushedData any
 	pushedDataString := string(pushedDataBytes)
 
 	if strings.HasPrefix(pushedDataString, tagPushPrefixYAML) {
@@ -303,7 +303,7 @@ func getPushedData(pushedDataBytes []byte) (interface{}, error) {
 	return pushedData, nil
 }
 
-func processEvalTarantoolRes(resBytes []byte, result interface{}) ([]interface{}, error) {
+func processEvalTarantoolRes(resBytes []byte, result any) ([]any, error) {
 	var err error
 	var evalResultEncBase64 string
 
@@ -355,7 +355,7 @@ func processEvalTarantoolRes(resBytes []byte, result interface{}) ([]interface{}
 		return nil, nil
 	}
 
-	var data []interface{}
+	var data []any
 	if err := msgpack.Unmarshal(dataEnc, &data); err != nil {
 		return nil, fmt.Errorf("failed to parse eval result: %s", err)
 	}

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -91,10 +91,10 @@ func TestConnect_Eval(t *testing.T) {
 			eval := "local val = 'testtest'\n return val"
 			opts := RequestOpts{}
 
-			ret, err := c.connect.Eval(eval, []interface{}{}, opts)
+			ret, err := c.connect.Eval(eval, []any{}, opts)
 
 			assert.NoError(t, err)
-			assert.Equal(t, []interface{}{"testtest"}, ret)
+			assert.Equal(t, []any{"testtest"}, ret)
 		})
 	}
 }
@@ -110,10 +110,10 @@ func TestBinaryConnector_Eval_args(t *testing.T) {
 			eval := "return ..."
 			opts := RequestOpts{}
 
-			ret, err := c.connect.Eval(eval, []interface{}{"test1", "test2"}, opts)
+			ret, err := c.connect.Eval(eval, []any{"test1", "test2"}, opts)
 
 			assert.NoError(t, err)
-			assert.Equal(t, []interface{}{"test1", "test2"}, ret)
+			assert.Equal(t, []any{"test1", "test2"}, ret)
 		})
 	}
 }
@@ -131,7 +131,7 @@ func TestBinaryConnector_Eval_readTimeout(t *testing.T) {
 				ReadTimeout: 10 * time.Millisecond,
 			}
 
-			_, err := c.connect.Eval(eval, []interface{}{}, opts)
+			_, err := c.connect.Eval(eval, []any{}, opts)
 
 			assert.ErrorContains(t, err, "i/o timeout")
 		})
@@ -153,7 +153,7 @@ func TestBinaryConnector_Eval_resData(t *testing.T) {
 			opts := RequestOpts{
 				ResData: &result,
 			}
-			ret, err := c.connect.Eval(eval, []interface{}{}, opts)
+			ret, err := c.connect.Eval(eval, []any{}, opts)
 
 			assert.NoError(t, err)
 			assert.Nil(t, ret)
@@ -170,21 +170,21 @@ func TestBinaryConnector_Eval_pushCallback(t *testing.T) {
 
 	for _, c := range connects {
 		t.Run(c.protocol.String(), func(t *testing.T) {
-			var pushes []interface{}
+			var pushes []any
 
 			eval := "box.session.push('hello')\n" +
 				"box.session.push('world')\n" +
 				"return 'return'"
 			opts := RequestOpts{
-				PushCallback: func(push interface{}) {
+				PushCallback: func(push any) {
 					pushes = append(pushes, push)
 				},
 			}
-			ret, err := c.connect.Eval(eval, []interface{}{}, opts)
+			ret, err := c.connect.Eval(eval, []any{}, opts)
 
 			assert.NoError(t, err)
-			assert.Equal(t, []interface{}{"return"}, ret)
-			assert.Equal(t, []interface{}{"hello", "world"}, pushes)
+			assert.Equal(t, []any{"return"}, ret)
+			assert.Equal(t, []any{"hello", "world"}, pushes)
 		})
 	}
 }
@@ -200,9 +200,9 @@ func TestConnect_binary(t *testing.T) {
 	defer conn.Close()
 
 	eval := "return 'hello', 'world'"
-	ret, err := conn.Eval(eval, []interface{}{}, RequestOpts{})
+	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
 	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{"hello", "world"}, ret)
+	assert.Equal(t, []any{"hello", "world"}, ret)
 }
 
 func TestConnect_binaryTlsToNoTls(t *testing.T) {
@@ -232,9 +232,9 @@ func TestConnect_binaryTlsToTls(t *testing.T) {
 	defer conn.Close()
 
 	eval := "return 'hello', 'world'"
-	ret, err := conn.Eval(eval, []interface{}{}, RequestOpts{})
+	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
 	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{"hello", "world"}, ret)
+	assert.Equal(t, []any{"hello", "world"}, ret)
 }
 
 func TestConnect_text(t *testing.T) {
@@ -246,9 +246,9 @@ func TestConnect_text(t *testing.T) {
 	defer conn.Close()
 
 	eval := "return 'hello', 'world'"
-	ret, err := conn.Eval(eval, []interface{}{}, RequestOpts{})
+	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
 	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{"hello", "world"}, ret)
+	assert.Equal(t, []any{"hello", "world"}, ret)
 }
 
 func TestConnect_textTls(t *testing.T) {

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -340,7 +340,7 @@ func TestPoolEval_error(t *testing.T) {
 func runTestMain(m *testing.M) int {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
-		fmt.Println("Failed to prepare test work dir:", err)
+		fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
 		return 1
 	}
 
@@ -354,7 +354,7 @@ func runTestMain(m *testing.M) int {
 		Dialer:       dialer,
 	})
 	if err != nil {
-		fmt.Println("Failed to prepare test tarantool:", err)
+		fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
 		return 1
 	}
 	defer test_helpers.StopTarantoolWithCleanup(inst)
@@ -363,7 +363,7 @@ func runTestMain(m *testing.M) int {
 	defer cancel()
 	conn, err := tarantool.Connect(ctx, dialer, opts)
 	if err != nil {
-		fmt.Println("Failed to check tarantool version:", err)
+		fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
 		return 1
 	}
 	req := tarantool.NewEvalRequest("return box.info.package")
@@ -371,7 +371,7 @@ func runTestMain(m *testing.M) int {
 	conn.Close()
 
 	if err != nil {
-		fmt.Println("Failed to get box.info.package:", err)
+		fmt.Fprintln(os.Stdout, "Failed to get box.info.package:", err)
 		return 1
 	}
 
@@ -384,7 +384,7 @@ func runTestMain(m *testing.M) int {
 	if tarantoolEe {
 		absTLSWorkDir, err := filepath.Abs(workDir + "_tls")
 		if err != nil {
-			fmt.Println("Failed to prepare TLS test work dir:", err)
+			fmt.Fprintln(os.Stdout, "Failed to prepare TLS test work dir:", err)
 			return 1
 		}
 
@@ -413,7 +413,7 @@ func runTestMain(m *testing.M) int {
 			Dialer:       tlsDialer,
 		})
 		if err != nil {
-			fmt.Println("Failed to prepare test tarantool with TLS:", err)
+			fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool with TLS:", err)
 			return 1
 		}
 		defer test_helpers.StopTarantoolWithCleanup(inst)

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -23,7 +23,7 @@ import (
 const (
 	workDir   = "work_dir"
 	server    = "127.0.0.1:3013"
-	serverTls = "127.0.0.1:3014"
+	serverTLS = "127.0.0.1:3014"
 	console   = workDir + "/" + "console.control"
 )
 
@@ -223,7 +223,7 @@ func TestConnect_binaryTlsToTls(t *testing.T) {
 	}
 	conn, err := Connect(ConnectOpts{
 		Network:  "tcp",
-		Address:  serverTls,
+		Address:  serverTLS,
 		Username: "test",
 		Password: "password",
 		Ssl:      sslOpts,
@@ -389,13 +389,13 @@ func runTestMain(m *testing.M) int {
 		}
 
 		// Try to start Tarantool instance with TLS.
-		listen := serverTls + "?transport=ssl&" +
+		listen := serverTLS + "?transport=ssl&" +
 			"ssl_key_file=testdata/localhost.key&" +
 			"ssl_cert_file=testdata/localhost.crt&" +
 			"ssl_ca_file=testdata/ca.crt"
 
 		tlsDialer := tlsdialer.OpenSSLDialer{
-			Address:     serverTls,
+			Address:     serverTLS,
 			User:        dialer.User,
 			Password:    dialer.Password,
 			SslKeyFile:  sslOpts.KeyFile,

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -49,7 +49,7 @@ var sslOpts = SslOpts{
 func textConnectWithValidation(t *testing.T) *TextConnector {
 	t.Helper()
 
-	conn, err := net.Dial("unix", console)
+	conn, err := (&net.Dialer{}).DialContext(t.Context(), "unix", console)
 	require.NoError(t, err)
 
 	protocol, err := GetProtocol(conn)

--- a/cli/connector/text.go
+++ b/cli/connector/text.go
@@ -19,9 +19,9 @@ func NewTextConnector(conn net.Conn) *TextConnector {
 }
 
 // Eval sends an eval request.
-func (conn *TextConnector) Eval(expr string, args []interface{},
+func (conn *TextConnector) Eval(expr string, args []any,
 	opts RequestOpts,
-) ([]interface{}, error) {
+) ([]any, error) {
 	evalOpts := EvalPlainTextOpts{
 		PushCallback: opts.PushCallback,
 		ReadTimeout:  opts.ReadTimeout,

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -179,10 +179,10 @@ func (c *Console) execute(in string) {
 		os.Exit(0)
 	}
 
-	fmt.Println("---")
+	fmt.Fprintln(os.Stdout, "---")
 	output, err := c.impl.Format.Sprint(results)
 	if err == nil {
-		fmt.Println(output)
+		fmt.Fprintln(os.Stdout, output)
 	} else {
 		log.Errorf("Unable to format output: %s", err)
 		log.Infof("Source results:\n%v", results)
@@ -247,7 +247,7 @@ func (c *Console) getPromptOptions() []prompt.Option {
 				Fn: func(buf *prompt.Buffer) {
 					c.input = ""
 					c.livePrefixEnabled = false
-					fmt.Println("^C")
+					fmt.Fprintln(os.Stdout, "^C")
 				},
 			},
 		),

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -209,10 +209,7 @@ func (c *Console) complete(input prompt.Document) []prompt.Suggest {
 func (c *Console) setPrefix() {
 	c.prefix = fmt.Sprintf("%s> ", c.title())
 
-	livePrefixIndent := len(c.title())
-	if livePrefixIndent > maxLivePrefixIndent {
-		livePrefixIndent = maxLivePrefixIndent
-	}
+	livePrefixIndent := min(len(c.title()), maxLivePrefixIndent)
 
 	c.livePrefix = fmt.Sprintf("%s> ", strings.Repeat(" ", livePrefixIndent))
 }

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -129,10 +129,10 @@ func (c *Console) cleanupDelimiter() bool {
 	if c.delimiter == "" {
 		return true
 	}
-	no_space := strings.TrimRightFunc(c.input, unicode.IsSpace)
-	no_delim := strings.TrimSuffix(no_space, c.delimiter)
-	if len(no_space) > len(no_delim) {
-		c.input = no_delim
+	noSpace := strings.TrimRightFunc(c.input, unicode.IsSpace)
+	noDelim := strings.TrimSuffix(noSpace, c.delimiter)
+	if len(noSpace) > len(noDelim) {
+		c.input = noDelim
 		return true
 	}
 	return false
@@ -150,8 +150,8 @@ func (c *Console) addStmt(part string) bool {
 		c.input += "\n" + part
 	}
 
-	has_delim := c.cleanupDelimiter()
-	c.livePrefixEnabled = !has_delim || !c.impl.Handler.Validate(c.input)
+	hasDelim := c.cleanupDelimiter()
+	c.livePrefixEnabled = !hasDelim || !c.impl.Handler.Validate(c.input)
 	return !c.livePrefixEnabled
 }
 

--- a/cli/console/history.go
+++ b/cli/console/history.go
@@ -18,6 +18,7 @@ const (
 	DefaultHistoryFileName = ".tarantool_history"
 	// DefaultHistoryLines is used for the DefaultHistoryFile() helping method.
 	DefaultHistoryLines = 10000
+	historyFileMode     = 0o640
 )
 
 // History implementation of active history handler.
@@ -131,7 +132,7 @@ func (h *History) writeToFile() error {
 	for i, c := range h.commands {
 		fmt.Fprintf(&buff, "#%d\n%s\n", h.timestamps[i], c)
 	}
-	if err := os.WriteFile(h.filepath, buff.Bytes(), 0o640); err != nil {
+	if err := os.WriteFile(h.filepath, buff.Bytes(), historyFileMode); err != nil {
 		return fmt.Errorf("failed to write to history file: %s", err)
 	}
 

--- a/cli/console/history.go
+++ b/cli/console/history.go
@@ -133,7 +133,7 @@ func (h *History) writeToFile() error {
 		fmt.Fprintf(&buff, "#%d\n%s\n", h.timestamps[i], c)
 	}
 	if err := os.WriteFile(h.filepath, buff.Bytes(), historyFileMode); err != nil {
-		return fmt.Errorf("failed to write to history file: %s", err)
+		return fmt.Errorf("failed to write to history file: %w", err)
 	}
 
 	return nil

--- a/cli/console/history_test.go
+++ b/cli/console/history_test.go
@@ -47,7 +47,7 @@ func TestNewHistory(t *testing.T) {
 			}
 			cmds := hist.Commands()
 			if !reflect.DeepEqual(cmds, tt.want) {
-				fmt.Print(cmds)
+				fmt.Fprint(os.Stdout, cmds)
 				t.Errorf("NewHistory() = %v, want %v", cmds, tt.want)
 			}
 		})

--- a/cli/coredump/coredump.go
+++ b/cli/coredump/coredump.go
@@ -23,8 +23,11 @@ var coreScripts embed.FS
 var extensions embed.FS
 
 const (
-	packEmbedPath    = "scripts/tarabrt.sh" // spell-checker:disable-line
-	inspectEmbedPath = "scripts/gdb.sh"
+	packEmbedPath       = "scripts/tarabrt.sh" // spell-checker:disable-line
+	inspectEmbedPath    = "scripts/gdb.sh"
+	scriptFileMode      = 0o755
+	extensionFileMode   = 0o644
+	commandArgsCapacity = 2
 )
 
 // Pack packs coredump into a tar.gz archive.
@@ -48,7 +51,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 
 	// Prepare gdb wrapper for packing.
 	inspectPath := filepath.Join(tmpDir, filepath.Base(inspectEmbedPath))
-	err = util.FsCopyFileChangePerms(coreScripts, inspectEmbedPath, inspectPath, 0o755)
+	err = util.FsCopyFileChangePerms(coreScripts, inspectEmbedPath, inspectPath, scriptFileMode)
 	if err != nil {
 		return fmt.Errorf("failed to put the inspecting script into the archive: %v", err)
 	}
@@ -63,7 +66,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	for _, extEntry := range extEntries {
 		extSrc := filepath.Join(extDirName, extEntry.Name())
 		extDst := filepath.Join(tmpDir, extEntry.Name())
-		err = util.FsCopyFileChangePerms(extensions, extSrc, extDst, 0o644)
+		err = util.FsCopyFileChangePerms(extensions, extSrc, extDst, extensionFileMode)
 		if err != nil {
 			return fmt.Errorf("failed to put GDB-extension into the archive: %v", err)
 		}
@@ -74,7 +77,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open pack script: %v", err)
 	}
-	cmdArgs := make([]string, 0, 2+len(scriptArgs))
+	cmdArgs := make([]string, 0, commandArgsCapacity+len(scriptArgs))
 	cmdArgs = append(cmdArgs, "-s", "--")
 	cmd := exec.CommandContext(context.Background(), "bash", append(cmdArgs, scriptArgs...)...)
 	cmd.Stdin = script
@@ -133,7 +136,7 @@ func Inspect(archiveOrDir, sourceDir string) error {
 	_, err = os.Stat(scriptPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		// If the wrapper is missing in archive, then use the embedded one.
-		err = util.FsCopyFileChangePerms(coreScripts, inspectEmbedPath, scriptPath, 0o755)
+		err = util.FsCopyFileChangePerms(coreScripts, inspectEmbedPath, scriptPath, scriptFileMode)
 	}
 
 	if err != nil {

--- a/cli/coredump/coredump.go
+++ b/cli/coredump/coredump.go
@@ -1,6 +1,7 @@
 package coredump
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	}
 	cmdArgs := make([]string, 0, 2+len(scriptArgs))
 	cmdArgs = append(cmdArgs, "-s", "--")
-	cmd := exec.Command("bash", append(cmdArgs, scriptArgs...)...)
+	cmd := exec.CommandContext(context.Background(), "bash", append(cmdArgs, scriptArgs...)...)
 	cmd.Stdin = script
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -146,7 +147,7 @@ func Inspect(archiveOrDir, sourceDir string) error {
 
 	// GDB-wrapper use standard input, so we need to launch it directly
 	// rather than pass it over standard input to bash -s.
-	cmd := exec.Command(scriptPath, scriptArgs...)
+	cmd := exec.CommandContext(context.Background(), scriptPath, scriptArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cli/coredump/coredump.go
+++ b/cli/coredump/coredump.go
@@ -34,7 +34,7 @@ const (
 func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	tmpDir, err := os.MkdirTemp(os.TempDir(), "tt-coredump-*")
 	if err != nil {
-		return fmt.Errorf("cannot create a temporary directory for archiving: %v", err)
+		return fmt.Errorf("cannot create a temporary directory for archiving: %w", err)
 	}
 	defer os.RemoveAll(tmpDir) // Clean up on function return.
 
@@ -53,7 +53,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	inspectPath := filepath.Join(tmpDir, filepath.Base(inspectEmbedPath))
 	err = util.FsCopyFileChangePerms(coreScripts, inspectEmbedPath, inspectPath, scriptFileMode)
 	if err != nil {
-		return fmt.Errorf("failed to put the inspecting script into the archive: %v", err)
+		return fmt.Errorf("failed to put the inspecting script into the archive: %w", err)
 	}
 	scriptArgs = append(scriptArgs, "-g", inspectPath)
 
@@ -61,21 +61,21 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	const extDirName = "extensions"
 	extEntries, err := extensions.ReadDir(extDirName)
 	if err != nil {
-		return fmt.Errorf("failed to find embedded GDB-extensions: %v", err)
+		return fmt.Errorf("failed to find embedded GDB-extensions: %w", err)
 	}
 	for _, extEntry := range extEntries {
 		extSrc := filepath.Join(extDirName, extEntry.Name())
 		extDst := filepath.Join(tmpDir, extEntry.Name())
 		err = util.FsCopyFileChangePerms(extensions, extSrc, extDst, extensionFileMode)
 		if err != nil {
-			return fmt.Errorf("failed to put GDB-extension into the archive: %v", err)
+			return fmt.Errorf("failed to put GDB-extension into the archive: %w", err)
 		}
 		scriptArgs = append(scriptArgs, "-x", extDst)
 	}
 
 	script, err := coreScripts.Open(packEmbedPath)
 	if err != nil {
-		return fmt.Errorf("failed to open pack script: %v", err)
+		return fmt.Errorf("failed to open pack script: %w", err)
 	}
 	cmdArgs := make([]string, 0, commandArgsCapacity+len(scriptArgs))
 	cmdArgs = append(cmdArgs, "-s", "--")
@@ -85,7 +85,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("pack script execution failed: %v", err)
+		return fmt.Errorf("pack script execution failed: %w", err)
 	}
 	log.Info("Core was successfully packed.")
 	return nil
@@ -95,7 +95,7 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 func Unpack(archivePath string) error {
 	err := util.ExtractTarGz(archivePath, ".")
 	if err != nil {
-		return fmt.Errorf("failed to unpack: %v", err)
+		return fmt.Errorf("failed to unpack: %w", err)
 	}
 	log.Info("Archive was successfully unpacked.")
 	return nil
@@ -105,7 +105,7 @@ func Unpack(archivePath string) error {
 func Inspect(archiveOrDir, sourceDir string) error {
 	stat, err := os.Stat(archiveOrDir)
 	if err != nil {
-		return fmt.Errorf("failed to inspect: %v", err)
+		return fmt.Errorf("failed to inspect: %w", err)
 	}
 
 	var dir string
@@ -116,13 +116,13 @@ func Inspect(archiveOrDir, sourceDir string) error {
 		// temporary directory.
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "tt-coredump-*")
 		if err != nil {
-			return fmt.Errorf("cannot create a temporary directory for unpacking: %v", err)
+			return fmt.Errorf("cannot create a temporary directory for unpacking: %w", err)
 		}
 		defer os.RemoveAll(tmpDir) // Clean up on function return.
 
 		err = util.ExtractTarGz(archiveOrDir, tmpDir)
 		if err != nil {
-			return fmt.Errorf("failed to unpack: %v", err)
+			return fmt.Errorf("failed to unpack: %w", err)
 		}
 
 		// Directory name is archive basename w/o extensions.
@@ -140,7 +140,7 @@ func Inspect(archiveOrDir, sourceDir string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to find inspect script: %v", err)
+		return fmt.Errorf("failed to find inspect script: %w", err)
 	}
 
 	scriptArgs := []string{}
@@ -156,7 +156,7 @@ func Inspect(archiveOrDir, sourceDir string) error {
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return fmt.Errorf("inspect script execution failed: %v", err)
+		return fmt.Errorf("inspect script execution failed: %w", err)
 	}
 	return nil
 }

--- a/cli/create/internal/app_template/manifest.go
+++ b/cli/create/internal/app_template/manifest.go
@@ -59,7 +59,7 @@ func validateManifest(manifest *TemplateManifest) error {
 func LoadManifest(manifestPath string) (TemplateManifest, error) {
 	var templateManifest TemplateManifest
 	if _, err := os.Stat(manifestPath); err != nil {
-		return templateManifest, fmt.Errorf("failed to get access to manifest file: %s", err)
+		return templateManifest, fmt.Errorf("failed to get access to manifest file: %w", err)
 	}
 
 	rawConfigOpts, err := util.ParseYAML(manifestPath)
@@ -68,11 +68,11 @@ func LoadManifest(manifestPath string) (TemplateManifest, error) {
 	}
 
 	if err := mapstructure.Decode(rawConfigOpts, &templateManifest); err != nil {
-		return templateManifest, fmt.Errorf("failed to decode template manifest: %s", err)
+		return templateManifest, fmt.Errorf("failed to decode template manifest: %w", err)
 	}
 
 	if err := validateManifest(&templateManifest); err != nil {
-		return templateManifest, fmt.Errorf("invalid manifest format: %s", err)
+		return templateManifest, fmt.Errorf("invalid manifest format: %w", err)
 	}
 
 	return templateManifest, nil

--- a/cli/create/internal/steps/cleanup.go
+++ b/cli/create/internal/steps/cleanup.go
@@ -32,7 +32,7 @@ func (hook Cleanup) Run(createCtx *create_ctx.CreateCtx,
 	for _, fileName := range templateCtx.Manifest.Include {
 		// File name may contain template vars.
 		if fileName, err = templateCtx.Engine.RenderText(fileName, templateCtx.Vars); err != nil {
-			return fmt.Errorf("file name rendering error: %s", err)
+			return fmt.Errorf("file name rendering error: %w", err)
 		}
 		fullPath := filepath.Join(templateCtx.AppPath, fileName)
 		filesToKeep[fullPath] = true
@@ -62,7 +62,7 @@ func (hook Cleanup) Run(createCtx *create_ctx.CreateCtx,
 			return nil
 		})
 	if err != nil {
-		return fmt.Errorf("cleanup failed: %s", err)
+		return fmt.Errorf("cleanup failed: %w", err)
 	}
 
 	// Remove empty directories.

--- a/cli/create/internal/steps/collect_template_vars.go
+++ b/cli/create/internal/steps/collect_template_vars.go
@@ -30,7 +30,7 @@ func validateExistingValue(createCtx *create_ctx.CreateCtx, varInfo app_template
 
 	matched, err := regexp.MatchString(varInfo.Re, existingValue)
 	if err != nil {
-		return false, fmt.Errorf("failed to validate user input: %s", err)
+		return false, fmt.Errorf("failed to validate user input: %w", err)
 	}
 	if matched {
 		return true, nil
@@ -80,7 +80,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 			// User input.
 			if !createCtx.SilentMode {
 				if input, err = collectTemplateVarsFromUser.Reader.ReadString('\n'); err != nil {
-					return fmt.Errorf("error reading user input: %s", err)
+					return fmt.Errorf("error reading user input: %w", err)
 				}
 				input = strings.TrimSuffix(input, "\n")
 			}
@@ -101,7 +101,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 			}
 			matched, err = regexp.MatchString(varInfo.Re, input)
 			if err != nil {
-				return fmt.Errorf("failed to validate user input: %s", err)
+				return fmt.Errorf("failed to validate user input: %w", err)
 			}
 			if !matched {
 				if createCtx.SilentMode {

--- a/cli/create/internal/steps/collect_template_vars.go
+++ b/cli/create/internal/steps/collect_template_vars.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -37,7 +38,7 @@ func validateExistingValue(createCtx *create_ctx.CreateCtx, varInfo app_template
 	if createCtx.SilentMode {
 		return false, fmt.Errorf("invalid format of %s variable", varInfo.Name)
 	}
-	fmt.Printf("Invalid format of %s variable.\n", varInfo.Name)
+	fmt.Fprintf(os.Stdout, "Invalid format of %s variable.\n", varInfo.Name)
 	return false, nil
 }
 
@@ -67,12 +68,12 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 				if createCtx.SilentMode {
 					return fmt.Errorf("%s variable value is not set", varInfo.Name)
 				}
-				fmt.Printf("%s: ", varInfo.Prompt)
+				fmt.Fprintf(os.Stdout, "%s: ", varInfo.Prompt)
 			} else {
 				if createCtx.SilentMode {
 					input = varInfo.Default
 				} else {
-					fmt.Printf("%s (default: %s): ", varInfo.Prompt, varInfo.Default)
+					fmt.Fprintf(os.Stdout, "%s (default: %s): ", varInfo.Prompt, varInfo.Default)
 				}
 			}
 
@@ -86,7 +87,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 
 			if input == "" {
 				if varInfo.Default == "" {
-					fmt.Println("Please enter a value.")
+					fmt.Fprintln(os.Stdout, "Please enter a value.")
 				} else {
 					input = varInfo.Default
 				}
@@ -106,7 +107,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 				if createCtx.SilentMode {
 					return fmt.Errorf("invalid format of %s variable", varInfo.Name)
 				}
-				fmt.Println("Invalid format. Try again.")
+				fmt.Fprintln(os.Stdout, "Invalid format. Try again.")
 			}
 		}
 		templateCtx.Vars[varInfo.Name] = input

--- a/cli/create/internal/steps/copy_app_template.go
+++ b/cli/create/internal/steps/copy_app_template.go
@@ -70,7 +70,7 @@ func (CopyAppTemplate) Run(createCtx *create_ctx.CreateCtx,
 		if util.IsDir(templatePath) {
 			log.Infof("Using template from %s", templatePath)
 			if err := copy.Copy(templatePath, templateCtx.AppPath); err != nil {
-				return fmt.Errorf("template copying failed: %s", err)
+				return fmt.Errorf("template copying failed: %w", err)
 			}
 			return nil
 		}

--- a/cli/create/internal/steps/copy_app_template_test.go
+++ b/cli/create/internal/steps/copy_app_template_test.go
@@ -29,7 +29,7 @@ func createArchive(buf io.Writer, files ...string) error {
 	for _, fileName := range files {
 		err := addToArchive(tarWriter, fileName)
 		if err != nil {
-			return fmt.Errorf("error adding %s to archive: %s", fileName, err)
+			return fmt.Errorf("error adding %s to archive: %w", fileName, err)
 		}
 	}
 

--- a/cli/create/internal/steps/create_temporary_app_dir.go
+++ b/cli/create/internal/steps/create_temporary_app_dir.go
@@ -47,7 +47,7 @@ func (CreateTemporaryAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 
 	templateCtx.AppPath, err = os.MkdirTemp("", createCtx.AppName+"*")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary application directory: %s", err)
+		return fmt.Errorf("failed to create temporary application directory: %w", err)
 	}
 
 	return nil

--- a/cli/create/internal/steps/load_manifest.go
+++ b/cli/create/internal/steps/load_manifest.go
@@ -28,14 +28,14 @@ func (LoadManifest) Run(ctx *create_ctx.CreateCtx, templateCtx *app_template.Tem
 
 	manifest, err := app_template.LoadManifest(manifestPath)
 	if err != nil {
-		return fmt.Errorf("failed to load manifest file: %s", err)
+		return fmt.Errorf("failed to load manifest file: %w", err)
 	}
 
 	templateCtx.Manifest = manifest
 	templateCtx.IsManifestPresent = true
 
 	if err = os.Remove(manifestPath); err != nil {
-		return fmt.Errorf("failed to remove manifest %s: %s", manifestPath, err)
+		return fmt.Errorf("failed to remove manifest %s: %w", manifestPath, err)
 	}
 
 	return nil

--- a/cli/create/internal/steps/load_vars_file.go
+++ b/cli/create/internal/steps/load_vars_file.go
@@ -25,12 +25,12 @@ func (LoadVarsFile) Run(ctx *create_ctx.CreateCtx,
 	varsDefFileFullPath := filepath.Join(templateCtx.AppPath, ctx.VarsFile)
 	_, err := os.Stat(varsDefFileFullPath)
 	if err != nil {
-		return fmt.Errorf("vars file loading error: %s", err)
+		return fmt.Errorf("vars file loading error: %w", err)
 	}
 
 	varsFile, err := os.Open(varsDefFileFullPath)
 	if err != nil {
-		return fmt.Errorf("vars file loading error: %s", err)
+		return fmt.Errorf("vars file loading error: %w", err)
 	}
 	defer varsFile.Close()
 
@@ -38,7 +38,7 @@ func (LoadVarsFile) Run(ctx *create_ctx.CreateCtx,
 	for scanner.Scan() {
 		varDef, err := parseVarDefinition(scanner.Text())
 		if err != nil {
-			return fmt.Errorf("failed to load vars from %s: %s", varsDefFileFullPath, err)
+			return fmt.Errorf("failed to load vars from %s: %w", varsDefFileFullPath, err)
 		}
 		log.Debugf("Setting var from vars file: %s = %s", varDef.name, varDef.value)
 		templateCtx.Vars[varDef.name] = varDef.value

--- a/cli/create/internal/steps/move_app_dir.go
+++ b/cli/create/internal/steps/move_app_dir.go
@@ -26,7 +26,7 @@ func (MoveAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 			return fmt.Errorf("'%s' already exists", templateCtx.TargetAppPath)
 		}
 		if err = os.RemoveAll(templateCtx.TargetAppPath); err != nil {
-			return fmt.Errorf("failed to remove %s: %s", templateCtx.TargetAppPath, err)
+			return fmt.Errorf("failed to remove %s: %w", templateCtx.TargetAppPath, err)
 		}
 	}
 

--- a/cli/create/internal/steps/render_template.go
+++ b/cli/create/internal/steps/render_template.go
@@ -30,18 +30,18 @@ func render(templateCtx *app_template.TemplateCtx, templateFileNamePattern *rege
 		}
 		// Remove original template file.
 		if err := os.Remove(filePath); err != nil {
-			return fmt.Errorf("error removing %s: %s", filePath, err)
+			return fmt.Errorf("error removing %s: %w", filePath, err)
 		}
 		filePath = resultFilePath
 	}
 	// Render file name.
 	newFileName, err := templateCtx.Engine.RenderText(filePath, templateCtx.Vars)
 	if err != nil {
-		return fmt.Errorf("failed file name processing %s: %s", filePath, err)
+		return fmt.Errorf("failed file name processing %s: %w", filePath, err)
 	}
 	if newFileName != filePath {
 		if err = os.Rename(filePath, newFileName); err != nil {
-			return fmt.Errorf("error renaming %s to %s: %s", filePath, newFileName, err)
+			return fmt.Errorf("error renaming %s to %s: %w", filePath, newFileName, err)
 		}
 	}
 	return nil
@@ -58,7 +58,7 @@ func (RenderTemplate) Run(ctx *create_ctx.CreateCtx, templateCtx *app_template.T
 			return render(templateCtx, templateFileNamePattern, filePath, fileInfo)
 		})
 	if err != nil {
-		return fmt.Errorf("template instantiation error: %s", err)
+		return fmt.Errorf("template instantiation error: %w", err)
 	}
 	return nil
 }

--- a/cli/create/internal/steps/run_hook.go
+++ b/cli/create/internal/steps/run_hook.go
@@ -42,12 +42,12 @@ func (hook RunHook) Run(ctx *create_ctx.CreateCtx, templateCtx *app_template.Tem
 	executablePath := filepath.Join(templateCtx.AppPath, hookPath)
 	_, err := os.Stat(executablePath)
 	if err != nil {
-		return fmt.Errorf("error access to %s: %s", executablePath, err)
+		return fmt.Errorf("error access to %s: %w", executablePath, err)
 	}
 	log.Infof("Executing %s-hook %s", hook.HookType, hookPath)
 	if err = exec.CommandContext(
 		context.Background(), executablePath, templateCtx.AppPath).Run(); err != nil {
-		return fmt.Errorf("error executing %s: %s", executablePath, err)
+		return fmt.Errorf("error executing %s: %w", executablePath, err)
 	}
 	// Remove pre/post executable.
 	if err = os.Remove(executablePath); err != nil {

--- a/cli/create/internal/steps/run_hook.go
+++ b/cli/create/internal/steps/run_hook.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -44,7 +45,8 @@ func (hook RunHook) Run(ctx *create_ctx.CreateCtx, templateCtx *app_template.Tem
 		return fmt.Errorf("error access to %s: %s", executablePath, err)
 	}
 	log.Infof("Executing %s-hook %s", hook.HookType, hookPath)
-	if err = exec.Command(executablePath, templateCtx.AppPath).Run(); err != nil {
+	if err = exec.CommandContext(
+		context.Background(), executablePath, templateCtx.AppPath).Run(); err != nil {
 		return fmt.Errorf("error executing %s: %s", executablePath, err)
 	}
 	// Remove pre/post executable.

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -53,11 +53,11 @@ func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Reques
 	var cmd command
 
 	// Construct client IP msg.
-	var clientIpMsg string
+	var clientIPMsg string
 	if ip, err := handler.getClientIP(req); err != nil {
-		clientIpMsg = err.Error()
+		clientIPMsg = err.Error()
 	} else {
-		clientIpMsg = ip
+		clientIPMsg = ip
 	}
 
 	rawBody, err := parseCommand(req.Body, &cmd)
@@ -86,7 +86,7 @@ func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Reques
 
 	// Log client IP, raw json request body, raw json response body.
 	handler.logger.Printf("Client IP: %s; Request body: %s; Response body: %s",
-		clientIpMsg, rawBody, jsonResMsg)
+		clientIPMsg, rawBody, jsonResMsg)
 
 	// Write the result.
 	wr.Header().Set("Content-Type", "application/json")

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -23,7 +23,7 @@ type DaemonHandler struct {
 
 // resResult describes a failure during the command execution.
 type resResult struct {
-	Res interface{} `json:"res"`
+	Res any `json:"res"`
 }
 
 // errorResult describes a failure during the command execution.
@@ -48,7 +48,7 @@ func (handler *DaemonHandler) Logger(logger ttlog.Logger) *DaemonHandler {
 // ServeHTTP handles requests to the tt daemon.
 func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	// Parse, check and call the command.
-	var res interface{}
+	var res any
 	var status int
 	var cmd command
 
@@ -135,8 +135,7 @@ func (handler *DaemonHandler) getClientIP(req *http.Request) (string, error) {
 	// Note: it can also be easily spoofed
 	// by the client.
 	ips := req.Header.Get("X-Forwarded-For")
-	splitIps := strings.Split(ips, ",")
-	for _, ip := range splitIps {
+	for ip := range strings.SplitSeq(ips, ",") {
 		// Check IP is correct.
 		netIP := net.ParseIP(ip)
 		if netIP != nil {

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,7 +66,9 @@ func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Reques
 		res = &errorResult{err.Error()}
 	} else {
 		status = http.StatusOK
-		commandRes, err := handler.callCommand(&cmd)
+		// A daemon command must continue running if the HTTP client disconnects.
+		commandCtx := context.WithoutCancel(req.Context())
+		commandRes, err := handler.callCommand(commandCtx, &cmd)
 		if err != nil {
 			res = &errorResult{err.Error()}
 		} else {
@@ -94,10 +97,10 @@ func (handler *DaemonHandler) ServeHTTP(wr http.ResponseWriter, req *http.Reques
 }
 
 // callCommand invokes the command and returns the execution result.
-func (handler *DaemonHandler) callCommand(ttCmd *command) (string, error) {
+func (handler *DaemonHandler) callCommand(ctx context.Context, ttCmd *command) (string, error) {
 	newArgs := append([]string{ttCmd.Name}, ttCmd.Params...)
 
-	cmd := exec.Command(handler.cmdPath, newArgs...)
+	cmd := exec.CommandContext(ctx, handler.cmdPath, newArgs...)
 
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer

--- a/cli/daemon/httpserver.go
+++ b/cli/daemon/httpserver.go
@@ -70,7 +70,8 @@ func (httpServer *HTTPServer) Start(ttPath string) {
 	http.Handle("/tarantool", daemonHandler)
 
 	// Start HTTP server.
-	socket, err := net.Listen("tcp4", httpServer.srv.Addr)
+	socket, err := (&net.ListenConfig{}).Listen(
+		context.Background(), "tcp4", httpServer.srv.Addr)
 	if err != nil {
 		httpServer.logger.Fatal(err)
 	}

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -83,7 +83,7 @@ func (process *Process) Start() error {
 	if process.IsChild() {
 		var err error
 		if process.logger, err = ttlog.NewFileLogger(process.logOpts); err != nil {
-			return fmt.Errorf("failed to create log: %s", err)
+			return fmt.Errorf("failed to create log: %w", err)
 		}
 
 		if err := process_utils.CreatePIDFile(process.pidFileName, os.Getpid()); err != nil {

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -101,7 +102,7 @@ func (process *Process) Start() error {
 		return err
 	}
 
-	cmd := exec.Command(process.cmdPath, process.cmdArgs...)
+	cmd := exec.CommandContext(context.Background(), process.cmdPath, process.cmdArgs...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=true", process.DaemonTag))
 
 	if err := cmd.Start(); err != nil {

--- a/cli/daemon/process_test.go
+++ b/cli/daemon/process_test.go
@@ -16,7 +16,7 @@ func TestProcessBase(t *testing.T) {
 	t.Cleanup(func() { cleanupDaemonFiles(TestProcessLogPath, TestProcessPidFile) })
 
 	// Start daemon.
-	cmd := exec.Command("go", "run", "test_process/test_process.go")
+	cmd := exec.CommandContext(t.Context(), "go", "run", "test_process/test_process.go")
 	err := cmd.Run()
 	require.Nilf(t, err, `Can't start daemon. Error: "%v".`, err)
 

--- a/cli/daemon/process_test_helpers.go
+++ b/cli/daemon/process_test_helpers.go
@@ -18,13 +18,14 @@ const (
 const (
 	TestProcessLogPath = "test_process.log"
 	TestProcessPidFile = "test_process.pid"
+	processStartDelay  = 500 * time.Millisecond
 )
 
 // waitProcessChanges waits for the new process to set signal handlers.
 func waitProcessChanges() {
 	// We need to wait for the new process (tarantool instance) to set handlers.
 	// It is necessary to update for more correct synchronization.
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(processStartDelay)
 }
 
 // cleanupDaemonFiles cleans up daemon artifacts.

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -154,15 +154,15 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 	}
 	log.Info("Docker image is built.")
 
-	containerId, err := createContainer(dockerClient, runOptions)
+	containerID, err := createContainer(dockerClient, runOptions)
 	if err != nil {
 		return fmt.Errorf("failed to create container: %w", err)
 	}
 	defer func() {
-		log.Debugf("Removing container %s", containerId[:12])
-		if _, err := dockerClient.ContainerRemove(context.Background(), containerId,
+		log.Debugf("Removing container %s", containerID[:12])
+		if _, err := dockerClient.ContainerRemove(context.Background(), containerID,
 			mobyclient.ContainerRemoveOptions{}); err != nil {
-			log.Warnf("Failed to remove container %s", containerId[:12])
+			log.Warnf("Failed to remove container %s", containerID[:12])
 		}
 	}()
 
@@ -170,14 +170,14 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	log.Debugf("The following command is going to be invoked in the container: %s.",
 		strings.Join(runOptions.Command, " "))
-	if _, err := dockerClient.ContainerStart(ctx, containerId,
+	if _, err := dockerClient.ContainerStart(ctx, containerID,
 		mobyclient.ContainerStartOptions{}); err != nil {
 		cancelFunc()
 		return err
 	}
 	defer interruptHandler(cancelFunc)()
 
-	out, err := dockerClient.ContainerLogs(ctx, containerId, mobyclient.ContainerLogsOptions{
+	out, err := dockerClient.ContainerLogs(ctx, containerID, mobyclient.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     true,
@@ -188,14 +188,14 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 	stdcopy.StdCopy(writer, writer, out)
 	out.Close()
 
-	waitResult := dockerClient.ContainerWait(ctx, containerId,
+	waitResult := dockerClient.ContainerWait(ctx, containerID,
 		mobyclient.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})
 	select {
 	case err := <-waitResult.Error:
 		if ctx.Err() == context.Canceled {
-			if _, err = dockerClient.ContainerStop(context.Background(), containerId,
+			if _, err = dockerClient.ContainerStop(context.Background(), containerID,
 				mobyclient.ContainerStopOptions{}); err != nil {
-				log.Warnf("Failed to stop the container %s", containerId[:12])
+				log.Warnf("Failed to stop the container %s", containerID[:12])
 			}
 			return fmt.Errorf("the operation is interrupted")
 		}

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -50,7 +50,7 @@ func interruptHandler(cancelFunc context.CancelFunc) func() {
 	go func() {
 		_, ok := <-signals
 		if ok {
-			fmt.Println("Canceling operation...")
+			fmt.Fprintln(os.Stdout, "Canceling operation...")
 			cancelFunc()
 		}
 	}()

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -81,7 +81,7 @@ func buildDockerImage(dockerClient *mobyclient.Client, imageTag, buildContextDir
 	defer interruptHandler(cancelFunc)()
 	buildResult, err := dockerClient.ImageBuild(ctx, buildCtx, opts)
 	if err != nil {
-		return fmt.Errorf("docker image build failed: %s", err)
+		return fmt.Errorf("docker image build failed: %w", err)
 	}
 	if buildResult.Body == nil {
 		return nil

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -36,7 +36,7 @@ func searchSDKVersionToDownload(downloadCtx DownloadCtx, cliOpts *config.CliOpts
 
 	bundles, err := search.FetchBundlesInfo(&searchCtx, cliOpts)
 	if err != nil {
-		return search.BundleInfo{}, fmt.Errorf("cannot get SDK bundles list: %s", err)
+		return search.BundleInfo{}, fmt.Errorf("cannot get SDK bundles list: %w", err)
 	}
 	return search.SelectVersion(bundles, downloadCtx.Version)
 }
@@ -55,12 +55,12 @@ func DownloadSDK(cmdCtx *cmdcontext.CmdCtx, downloadCtx DownloadCtx,
 	}
 
 	if err = unix.Access(downloadCtx.DirectoryPrefix, unix.W_OK); err != nil {
-		return fmt.Errorf("bad directory prefix: %s", err)
+		return fmt.Errorf("bad directory prefix: %w", err)
 	}
 
 	ver, err := searchSDKVersionToDownload(downloadCtx, cliOpts)
 	if err != nil {
-		return fmt.Errorf("no version for download: %s", err)
+		return fmt.Errorf("no version for download: %w", err)
 	}
 
 	bundleName := ver.Version.Tarball
@@ -88,13 +88,13 @@ func DownloadSDK(cmdCtx *cmdcontext.CmdCtx, downloadCtx DownloadCtx,
 
 	bundleSource, err := search.TntIoMakePkgURI(&searchCtx, bundleName)
 	if err != nil {
-		return fmt.Errorf("failed to make URI for downloading: %s", err)
+		return fmt.Errorf("failed to make URI for downloading: %w", err)
 	}
 
 	err = install_ee.DownloadBundle(searchCtx.TntIoDoer,
 		bundleName, bundleSource, downloadCtx.DirectoryPrefix)
 	if err != nil {
-		return fmt.Errorf("download error: %s", err)
+		return fmt.Errorf("download error: %w", err)
 	}
 
 	log.Infof("Downloaded to: %q", bundlePath)

--- a/cli/formatter/lua.go
+++ b/cli/formatter/lua.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -10,29 +11,33 @@ import (
 func luaEncodeElement(elem any) string {
 	switch t := elem.(type) {
 	case map[any]any:
-		res := "{"
+		var res strings.Builder
+		res.WriteByte('{')
 		first := true
 		for k, v := range t {
 			if !first {
-				res += ", "
+				res.WriteString(", ")
 			}
 			if str, ok := k.(string); ok {
-				res += fmt.Sprintf("%s = %s", str, luaEncodeElement(v))
+				fmt.Fprintf(&res, "%s = %s", str, luaEncodeElement(v))
 			} else {
-				res += fmt.Sprintf("[%v] = %s", k, luaEncodeElement(v))
+				fmt.Fprintf(&res, "[%v] = %s", k, luaEncodeElement(v))
 			}
 			first = false
 		}
-		return res + "}"
+		res.WriteByte('}')
+		return res.String()
 	case []any:
-		res := "{"
+		var res strings.Builder
+		res.WriteByte('{')
 		for k, v := range t {
-			res += luaEncodeElement(v)
+			res.WriteString(luaEncodeElement(v))
 			if k < len(t)-1 {
-				res += ", "
+				res.WriteString(", ")
 			}
 		}
-		return res + "}"
+		res.WriteByte('}')
+		return res.String()
 	default:
 		if elem == nil {
 			return "nil"
@@ -53,15 +58,15 @@ func makeLuaOutput(input string) (string, error) {
 
 	var decoded []any
 	if err := yaml.Unmarshal([]byte(input), &decoded); err == nil {
-		var res string
+		var res strings.Builder
 		for i, unpackedVal := range decoded {
+			res.WriteString(luaEncodeElement(unpackedVal))
 			if i < len(decoded)-1 {
-				res += luaEncodeElement(unpackedVal) + ", "
-			} else {
-				res += luaEncodeElement(unpackedVal)
+				res.WriteString(", ")
 			}
 		}
-		return res + ";\n", nil
+		res.WriteString(";\n")
+		return res.String(), nil
 	} else {
 		return "", fmt.Errorf("cannot render lua: %w", err)
 	}

--- a/cli/formatter/table.go
+++ b/cli/formatter/table.go
@@ -54,7 +54,7 @@ func castMapToUMap(src map[any]any) unorderedMap[any] {
 }
 
 // deepCastAnyMapToStringMap casts all map[any]any to map[string]any deeply.
-func deepCastAnyMapToStringMap(v any) interface{} {
+func deepCastAnyMapToStringMap(v any) any {
 	switch x := v.(type) {
 	case []any:
 		for i, v2 := range x {
@@ -210,7 +210,7 @@ func newTableWriter(opts Opts) table.Writer {
 
 // handleColumnWidth handles width max value for tables columns.
 func handleColumnWidth(t table.Writer, columns int, opts Opts) {
-	colWidthTransformer := text.Transformer(func(val interface{}) string {
+	colWidthTransformer := text.Transformer(func(val any) string {
 		str := fmt.Sprintf("%v", val)
 		widthMax := opts.ColumnWidthMax
 		if utf8.RuneCountInString(str) > widthMax {
@@ -275,23 +275,25 @@ func transposeRows(rowsRaw []table.Row) []table.Row {
 
 // createMarkdownTable creates a table in markdown notation.
 func createMarkdownTable(table []string, columns int) string {
-	empty := "| "
-	separator := "|-"
+	var empty, separator strings.Builder
+	empty.WriteString("| ")
+	separator.WriteString("|-")
 	for i := 1; i < columns; i++ {
-		empty += "| "
-		separator += "|-"
+		empty.WriteString("| ")
+		separator.WriteString("|-")
 	}
-	empty += "|"
-	separator += "|"
+	empty.WriteByte('|')
+	separator.WriteByte('|')
 
-	var result string
-	for _, rows := range [][]string{{empty, separator}, table} {
+	var result strings.Builder
+	for _, rows := range [][]string{{empty.String(), separator.String()}, table} {
 		for _, row := range rows {
-			result += row + "\n"
+			result.WriteString(row)
+			result.WriteByte('\n')
 		}
 	}
 
-	return result
+	return result.String()
 }
 
 // renderEqualMaps returns maps with equal keys as single table string.
@@ -428,21 +430,21 @@ func renderBatch(batch []any, transpose bool, opts Opts) (string, error) {
 
 // renderBatches combines multiple batches into one string.
 func renderBatches(batches [][]any, transpose bool, opts Opts) (string, error) {
-	var result string
+	var result strings.Builder
 	for _, batch := range batches {
 		if len(batch) != 0 {
 			batchStr, err := renderBatch(batch, transpose, opts)
 			if err != nil {
 				return "", fmt.Errorf("cannot render tables: %w", err)
 			}
-			result += batchStr
+			result.WriteString(batchStr)
 			if !opts.Graphics {
-				result += "\n"
+				result.WriteByte('\n')
 			}
 		}
 	}
 
-	return result, nil
+	return result.String(), nil
 }
 
 type metadataField struct {

--- a/cli/formatter/table.go
+++ b/cli/formatter/table.go
@@ -92,7 +92,7 @@ func encodeScalar(val any) string {
 }
 
 // encodeJson encodes a value into json.
-func encodeJson(val any) (string, error) {
+func encodeJSON(val any) (string, error) {
 	jsonData, err := json.Marshal(deepCastAnyMapToStringMap(val))
 	if err != nil {
 		return "", err
@@ -106,7 +106,7 @@ func encodeCell(val any) (string, error) {
 	if getNodeType(val) == scalarNodeType {
 		return encodeScalar(val), nil
 	}
-	return encodeJson(val)
+	return encodeJSON(val)
 }
 
 // isSingleType returns true if all elements of the batch belongs to

--- a/cli/formatter/table.go
+++ b/cli/formatter/table.go
@@ -516,7 +516,7 @@ func makeTableOutput(input string, transpose bool, opts Opts) (string, error) {
 	// convert any value to metadataRows type.
 	lazyNodes, err := lazyDecodeYaml(input)
 	if err != nil {
-		return "", fmt.Errorf("not yaml array, cannot render tables: %s", err)
+		return "", fmt.Errorf("not yaml array, cannot render tables: %w", err)
 	}
 
 	var metaFields metadataRows
@@ -542,7 +542,7 @@ func makeTableOutput(input string, transpose bool, opts Opts) (string, error) {
 			var node any
 			err = lazyNode.Unmarshal(&node)
 			if err != nil {
-				return "", fmt.Errorf("not yaml any: %s", err)
+				return "", fmt.Errorf("not yaml any: %w", err)
 			}
 			nodes = append(nodes, node)
 		}

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/apex/log"
@@ -995,9 +996,9 @@ func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx Inst
 func getLatestRelease(versions []version.Version) string {
 	latestRelease := ""
 
-	for n := len(versions) - 1; n >= 0; n-- {
-		if versions[n].Release.Type == version.TypeRelease {
-			latestRelease = versions[n].Str
+	for _, candidate := range slices.Backward(versions) {
+		if candidate.Release.Type == version.TypeRelease {
+			latestRelease = candidate.Str
 			break
 		}
 	}

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -202,7 +203,7 @@ func isProgramInstalled(program string) bool {
 
 // isPackageInstalledDebian checks if package is installed on Debian/Ubuntu.
 func isPackageInstalledDebian(packageName string) bool {
-	cmd := exec.Command("dpkg", "-L", packageName)
+	cmd := exec.CommandContext(context.Background(), "dpkg", "-L", packageName)
 	cmd.Start()
 	if cmd.Wait() == nil {
 		return true

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -290,60 +290,60 @@ func programDependenciesInstalled(program search.Program) error {
 	case search.ProgramUnknown, search.ProgramEe, search.ProgramDev, search.ProgramTcm:
 		// These programs have no source-build dependency checks.
 	}
-	missing_pack := []string{}
+	missingPack := []string{}
 	// Programs that are installed from source.
-	missing_pack_src := []string{}
+	missingPackSrc := []string{}
 	for _, program := range programs {
 		if !isProgramInstalled(program.sysName) {
 			// Mage is installed from source instead of package manager.
 			if program.sysName == "mage" {
-				missing_pack_src = append(missing_pack_src, program.installName)
+				missingPackSrc = append(missingPackSrc, program.installName)
 			} else {
-				missing_pack = append(missing_pack, program.installName)
+				missingPack = append(missingPack, program.installName)
 			}
 		}
 	}
 
 	for _, packageName := range packages {
 		if !isPackageInstalled(packageName) {
-			missing_pack = append(missing_pack, packageName)
+			missingPack = append(missingPack, packageName)
 		}
 	}
 
-	if len(missing_pack) != 0 || len(missing_pack_src) != 0 {
+	if len(missingPack) != 0 || len(missingPackSrc) != 0 {
 		log.Error("The operation requires some dependencies.")
 		var errMsg strings.Builder
-		errMsg.WriteString("Missing packages: " + strings.Join(missing_pack, " ") + " " +
-			strings.Join(missing_pack_src, " ") + "\n")
+		errMsg.WriteString("Missing packages: " + strings.Join(missingPack, " ") + " " +
+			strings.Join(missingPackSrc, " ") + "\n")
 		switch {
 		case osName == "darwin":
 			errMsg.WriteString(
 				"You can install them by running commands:\nbrew install " + strings.Join(
-					missing_pack,
+					missingPack,
 					" ",
 				) +
 					strings.Join(
-						missing_pack_src,
+						missingPackSrc,
 						" ",
 					) + "\n",
 			)
 		case strings.Contains(osName, "CentOs"):
 			errMsg.WriteString("You can install them by running command:\n")
-			if len(missing_pack) != 0 {
-				errMsg.WriteString(" sudo yum install " + strings.Join(missing_pack, " ") + "\n")
+			if len(missingPack) != 0 {
+				errMsg.WriteString(" sudo yum install " + strings.Join(missingPack, " ") + "\n")
 			}
-			if len(missing_pack_src) != 0 {
+			if len(missingPackSrc) != 0 {
 				errMsg.WriteString("install from sources: " +
-					strings.Join(missing_pack_src, " ") + "\n")
+					strings.Join(missingPackSrc, " ") + "\n")
 			}
 		case strings.Contains(osName, "Ubuntu") || strings.Contains(osName, "Debian"):
 			errMsg.WriteString("You can install them by running command:\n")
-			if len(missing_pack) != 0 {
-				errMsg.WriteString(" sudo apt install " + strings.Join(missing_pack, " ") + "\n")
+			if len(missingPack) != 0 {
+				errMsg.WriteString(" sudo apt install " + strings.Join(missingPack, " ") + "\n")
 			}
-			if len(missing_pack_src) != 0 {
+			if len(missingPackSrc) != 0 {
 				errMsg.WriteString("install from sources: " +
-					strings.Join(missing_pack_src, " ") + "\n")
+					strings.Join(missingPackSrc, " ") + "\n")
 			}
 		}
 		errMsg.WriteString("Usage: tt install -f if you already have those packages installed")

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -379,10 +379,10 @@ func copyBuildedTT(binDir, path, version string, installCtx InstallCtx) error {
 	if _, err := os.Stat(binDir); os.IsNotExist(err) {
 		err = os.MkdirAll(binDir, defaultDirPermissions)
 		if err != nil {
-			return fmt.Errorf("unable to create %s\n Error: %s", binDir, err)
+			return fmt.Errorf("unable to create %s\n Error: %w", binDir, err)
 		}
 	} else if err != nil {
-		return fmt.Errorf("unable to create %s\n Error: %s", binDir, err)
+		return fmt.Errorf("unable to create %s\n Error: %w", binDir, err)
 	}
 	if installCtx.Reinstall {
 		err = os.Remove(filepath.Join(binDir, version))
@@ -439,12 +439,12 @@ func checkCommit(input, programName string, installCtx InstallCtx,
 func gitCheckout(repoDir, checkout string, verbose bool, logWriter io.Writer) error {
 	err := util.ExecuteCommand("git", verbose, logWriter, repoDir, "checkout", checkout)
 	if err != nil {
-		return fmt.Errorf("failed to checkout: %s", err)
+		return fmt.Errorf("failed to checkout: %w", err)
 	}
 	err = util.ExecuteCommand("git", verbose, logWriter, repoDir, "submodule", "update",
 		"--init", "--recursive")
 	if err != nil {
-		return fmt.Errorf("failed to update submodules: %s", err)
+		return fmt.Errorf("failed to update submodules: %w", err)
 	}
 	return nil
 }
@@ -870,10 +870,10 @@ func copyBuildedTarantool(binPath, incPath, binDir, includeDir, version string) 
 	if _, err := os.Stat(binDir); os.IsNotExist(err) {
 		err = os.MkdirAll(binDir, defaultDirPermissions)
 		if err != nil {
-			return fmt.Errorf("unable to create %s\n Error: %s", binDir, err)
+			return fmt.Errorf("unable to create %s\n Error: %w", binDir, err)
 		}
 	} else if err != nil {
-		return fmt.Errorf("unable to create %s\n Error: %s", binDir, err)
+		return fmt.Errorf("unable to create %s\n Error: %w", binDir, err)
 	}
 
 	execPath := filepath.Join(binDir, version)
@@ -886,10 +886,10 @@ func copyBuildedTarantool(binPath, incPath, binDir, includeDir, version string) 
 	if _, err := os.Stat(includeDir); os.IsNotExist(err) {
 		err = os.MkdirAll(includeDir, defaultDirPermissions)
 		if err != nil {
-			return fmt.Errorf("unable to create %s\n Error: %s", includeDir, err)
+			return fmt.Errorf("unable to create %s\n Error: %w", includeDir, err)
 		}
 	} else if err != nil {
-		return fmt.Errorf("unable to create %s\n Error: %s", includeDir, err)
+		return fmt.Errorf("unable to create %s\n Error: %w", includeDir, err)
 	}
 
 	if incPath != "" {
@@ -1290,7 +1290,7 @@ func installTarantoolDev(ttBinDir, ttIncludeDir, buildDir,
 
 	// Validate build directory.
 	if buildDir, err = filepath.Abs(buildDir); err != nil {
-		return fmt.Errorf("failed to get absolute path: %v", err)
+		return fmt.Errorf("failed to get absolute path: %w", err)
 	}
 	if !util.IsDir(buildDir) {
 		return fmt.Errorf("directory %v doesn't exist, or isn't directory", buildDir)

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -34,6 +34,8 @@ const (
 	// We need to give permission for all to execute
 	// read,write for user and only read for others.
 	defaultDirPermissions = 0o755
+	gitCloneArgsCapacity  = 10
+	dockerfileMode        = 0o664
 )
 
 // programGitRepoUrls contains URLs of programs git repositories.
@@ -354,7 +356,7 @@ func programDependenciesInstalled(program search.Program) error {
 
 // downloadRepo downloads git repository.
 func downloadRepo(repoLink, tag, dst string, logFile *os.File, verbose bool) error {
-	gitCloneArgs := make([]string, 0, 10)
+	gitCloneArgs := make([]string, 0, gitCloneArgsCapacity)
 	if tag == "master" {
 		gitCloneArgs = append(gitCloneArgs, "clone", repoLink,
 			"--recursive", dst)
@@ -931,7 +933,7 @@ func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx Inst
 
 	// Write docker file (rw-rw-r-- permissions).
 	if err = os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfileText),
-		0o664); err != nil {
+		dockerfileMode); err != nil {
 		return err
 	}
 

--- a/cli/install/install_bundle.go
+++ b/cli/install/install_bundle.go
@@ -348,7 +348,7 @@ func acquireBundleInfoToInstall(bp *bundleParams) error {
 		searchCtx := search.NewSearchCtx(search.NewPlatformInformer(), search.NewTntIoDoer())
 		searchCtx.Program = bp.inst.Program
 		searchCtx.Filter = search.SearchAll
-		searchCtx.Package = search.GetApiPackage(bp.inst.Program)
+		searchCtx.Package = search.GetAPIPackage(bp.inst.Program)
 		searchCtx.DevBuilds = bp.inst.DevBuild
 
 		bundles, err = search.FetchBundlesInfo(&searchCtx, bp.opts)

--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -1,6 +1,7 @@
 package install_ee
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -84,7 +85,8 @@ func addSessionIdCookie(req *http.Request, token string) {
 
 // createHttpRequest creates a new GET HTTP request with the necessary headers and cookies.
 func createHttpRequest(bundleSource, token string) (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, bundleSource, http.NoBody)
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, bundleSource, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -26,7 +26,7 @@ func NewTntIoDownloader(token string) *httpDoer {
 			Timeout: 0,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				req.Host = req.URL.Hostname()
-				addSessionIdCookie(req, token)
+				addSessionIDCookie(req, token)
 				return nil
 			},
 		},
@@ -73,7 +73,7 @@ func validateDestination(dst string) error {
 }
 
 // addSessionIdCookie adds a session ID cookie to the request if the token is not empty.
-func addSessionIdCookie(req *http.Request, token string) {
+func addSessionIDCookie(req *http.Request, token string) {
 	if token != "" {
 		cookie := &http.Cookie{
 			Name:  "sessionid",
@@ -84,14 +84,14 @@ func addSessionIdCookie(req *http.Request, token string) {
 }
 
 // createHttpRequest creates a new GET HTTP request with the necessary headers and cookies.
-func createHttpRequest(bundleSource, token string) (*http.Request, error) {
+func createHTTPRequest(bundleSource, token string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(
 		context.Background(), http.MethodGet, bundleSource, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	addSessionIdCookie(req, token)
+	addSessionIDCookie(req, token)
 	req.Header.Set("User-Agent", "tt")
 	return req, nil
 }
@@ -131,7 +131,7 @@ func DownloadBundle(doer search.TntIoDoer, bundleName, bundleSource, dst string)
 		return err
 	}
 
-	req, err := createHttpRequest(bundleSource, doer.Token())
+	req, err := createHTTPRequest(bundleSource, doer.Token())
 	if err != nil {
 		return err
 	}

--- a/cli/install_ee/install_ee_test.go
+++ b/cli/install_ee/install_ee_test.go
@@ -23,7 +23,7 @@ type mockBundleDoer struct {
 	token       string
 	resBody     []byte
 	resErr      error
-	expectedUrl string
+	expectedURL string
 }
 
 // Do mocks the Do method of search.TntIoDoer.
@@ -31,7 +31,7 @@ type mockBundleDoer struct {
 func (m *mockBundleDoer) Do(req *http.Request) ([]byte, error) {
 	m.t.Helper()
 
-	require.Equal(m.t, m.expectedUrl, req.URL.String(), "Request URL mismatch")
+	require.Equal(m.t, m.expectedURL, req.URL.String(), "Request URL mismatch")
 	require.Equal(m.t, http.MethodGet, req.Method, "Request method mismatch")
 	require.Equal(m.t, "tt", req.Header.Get("User-Agent"), "User-Agent header mismatch")
 
@@ -177,7 +177,7 @@ func TestDownloadBundle(t *testing.T) {
 
 			if tc.doer != nil {
 				tc.doer.t = t
-				tc.doer.expectedUrl = tc.bundleSource
+				tc.doer.expectedURL = tc.bundleSource
 			}
 			err := DownloadBundle(tc.doer, tc.bundleName, tc.bundleSource, dst)
 

--- a/cli/install_ee/install_ee_test.go
+++ b/cli/install_ee/install_ee_test.go
@@ -236,7 +236,8 @@ func TestNewTntIoDownloader(t *testing.T) {
 
 			// Using a dummy request to test the CheckRedirect behavior.
 			requestURL := fmt.Sprintf("http://%s/testpath", tc.requestHost)
-			dummyReq, err := http.NewRequest(http.MethodGet, requestURL, nil)
+			dummyReq, err := http.NewRequestWithContext(
+				t.Context(), http.MethodGet, requestURL, nil)
 			require.NoError(t, err, "Failed to create dummy HTTP request")
 
 			// Call the CheckRedirect to add cookies to dummyReq and set Host.

--- a/cli/modules/modules.go
+++ b/cli/modules/modules.go
@@ -168,31 +168,31 @@ func getConfigModulesDirs(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) ([
 
 // getEnvironmentModulesDirs returns the list of modules directory based on environment info.
 func getEnvironmentModulesDirs() ([]string, error) {
-	env_var := os.Getenv("TT_CLI_MODULES_PATH")
-	if env_var == "" {
+	envVar := os.Getenv("TT_CLI_MODULES_PATH")
+	if envVar == "" {
 		return []string{}, nil
 	}
 
-	paths := strings.Split(env_var, ":")
+	paths := strings.Split(envVar, ":")
 	return collectDirectoriesList(paths)
 }
 
 // isPossibleModule checks is exists any manifest or executable `main` file inside dir.
 func isPossibleModule(dir string) (modulesEntry, bool) {
-	is_module := false
+	isModule := false
 	entries := modulesEntry{Directory: dir}
 	manifest, _ := util.GetYamlFileName(filepath.Join(dir, manifestFileName), false)
 	if manifest != "" {
 		entries.Manifest = manifest
-		is_module = true
+		isModule = true
 	}
 
 	if main, err := exec.LookPath(filepath.Join(dir, mainEntryPoint)); err == nil {
 		entries.Main = main
-		is_module = true
+		isModule = true
 	}
 
-	return entries, is_module
+	return entries, isModule
 }
 
 // readSubDirectories returns sorted list of subdirectories in the specified path.
@@ -229,11 +229,11 @@ func getExternalModules(paths []string) (possibleModules, error) {
 		}
 
 		for _, d := range dirs {
-			mod_path := filepath.Join(path, d)
+			modPath := filepath.Join(path, d)
 
 			e, exists := modules[d]
 			if exists {
-				log.Warnf("Ignore duplicate module %q overlap with %q", mod_path, e.Directory)
+				log.Warnf("Ignore duplicate module %q overlap with %q", modPath, e.Directory)
 				continue
 			}
 
@@ -241,8 +241,8 @@ func getExternalModules(paths []string) (possibleModules, error) {
 				return modules, fmt.Errorf("module %q is disabled to override", d)
 			}
 
-			if mod_entry, is_module := isPossibleModule(mod_path); is_module {
-				modules[d] = mod_entry
+			if modEntry, isModule := isPossibleModule(modPath); isModule {
+				modules[d] = modEntry
 			}
 		}
 	}

--- a/cli/modules/modules.go
+++ b/cli/modules/modules.go
@@ -63,16 +63,16 @@ func readManifest(dir, manifest string) (Manifest, error) {
 	mf := Manifest{}
 	data, err := os.ReadFile(manifest)
 	if err != nil {
-		return mf, fmt.Errorf("failed to read manifest: %s", err)
+		return mf, fmt.Errorf("failed to read manifest: %w", err)
 	}
 
 	if err := yaml.Unmarshal(data, &mf); err != nil {
-		return mf, fmt.Errorf("failed to parse manifest: %s", err)
+		return mf, fmt.Errorf("failed to parse manifest: %w", err)
 	}
 
 	mf.Main, err = exec.LookPath(filepath.Join(dir, mf.Main))
 	if err != nil {
-		return mf, fmt.Errorf("failed to find module executable: %s", err)
+		return mf, fmt.Errorf("failed to find module executable: %w", err)
 	}
 
 	if mf.Version == "" {
@@ -113,7 +113,7 @@ func GetModulesInfo(
 	externalModules, err := getExternalModules(modulesDirs)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to get available external modules information: %s", err)
+			"failed to get available external modules information: %w", err)
 	}
 
 	modulesInfo := ModulesInfo{}
@@ -199,7 +199,7 @@ func isPossibleModule(dir string) (modulesEntry, bool) {
 func readSubDirectories(path string) ([]string, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf(`failed to read "%s" directory: %s`, path, err)
+		return nil, fmt.Errorf(`failed to read "%s" directory: %w`, path, err)
 	}
 
 	entries = slices.DeleteFunc(entries, func(e os.DirEntry) bool {

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestGetModulesInfo(t *testing.T) {
 	tests := map[string]struct {
-		config      string
-		modules     []string
-		env_modules string
-		want        modules.ModulesInfo
-		err         string
-		log         []string
+		config     string
+		modules    []string
+		envModules string
+		want       modules.ModulesInfo
+		err        string
+		log        []string
 	}{
 		"no config": {
 			config: "",
@@ -58,8 +58,8 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 
 		"env modules": {
-			config:      "some/config/tt.yaml",
-			env_modules: "testdata/modules1:testdata/modules2",
+			config:     "some/config/tt.yaml",
+			envModules: "testdata/modules1:testdata/modules2",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
 					Name:    "ext_mod",
@@ -83,8 +83,8 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 
 		"no config but env modules": {
-			config:      "",
-			env_modules: "testdata/modules1",
+			config:     "",
+			envModules: "testdata/modules1",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
 					Name:    "ext_mod",
@@ -102,9 +102,9 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 
 		"config and env modules": {
-			config:      "some/config/tt.yaml",
-			modules:     []string{"testdata/modules1"},
-			env_modules: "testdata/modules2",
+			config:     "some/config/tt.yaml",
+			modules:    []string{"testdata/modules1"},
+			envModules: "testdata/modules2",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
 					Name:    "ext_mod",
@@ -128,9 +128,9 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 
 		"config duplicate env modules": {
-			config:      "some/config/tt.yaml",
-			modules:     []string{"testdata/modules1"},
-			env_modules: "testdata/modules1",
+			config:     "some/config/tt.yaml",
+			modules:    []string{"testdata/modules1"},
+			envModules: "testdata/modules1",
 			want: modules.ModulesInfo{
 				"root ext_mod": modules.Manifest{
 					Name:    "ext_mod",
@@ -174,10 +174,10 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 
 		"not a directory in env ": {
-			config:      "some/config/tt.yaml",
-			env_modules: "testdata/modules1/simple/main",
-			want:        modules.ModulesInfo{},
-			err:         "specified path in configuration file is not a directory",
+			config:     "some/config/tt.yaml",
+			envModules: "testdata/modules1/simple/main",
+			want:       modules.ModulesInfo{},
+			err:        "specified path in configuration file is not a directory",
 		},
 
 		"override internal": {
@@ -193,10 +193,10 @@ func TestGetModulesInfo(t *testing.T) {
 			},
 		},
 		"disabled override ": {
-			config:      "some/config/tt.yaml",
-			env_modules: "testdata/disabled_override",
-			want:        modules.ModulesInfo{},
-			err:         `module "modules" is disabled to override`,
+			config:     "some/config/tt.yaml",
+			envModules: "testdata/disabled_override",
+			want:       modules.ModulesInfo{},
+			err:        `module "modules" is disabled to override`,
 		},
 	}
 
@@ -213,8 +213,8 @@ func TestGetModulesInfo(t *testing.T) {
 					Directories: tt.modules,
 				},
 			}
-			if tt.env_modules != "" {
-				t.Setenv("TT_CLI_MODULES_PATH", tt.env_modules)
+			if tt.envModules != "" {
+				t.Setenv("TT_CLI_MODULES_PATH", tt.envModules)
 			}
 			var buf bytes.Buffer
 			log.SetOutput(&buf)

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -56,7 +57,7 @@ func GetDefaultCmdArgs(cmdName string) []string {
 // RunExec exec command with the supplied arguments.
 // returns an error code from exec command.
 func RunExec(command string, args []string) int {
-	cmd := exec.Command(command, args...)
+	cmd := exec.CommandContext(context.Background(), command, args...)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -77,14 +78,15 @@ func RunExec(command string, args []string) int {
 // GetExternalModuleHelp calls external module with
 // the --help flag and returns an output.
 func GetExternalModuleHelp(module string) (string, error) {
-	out, err := exec.Command(module, "--help").Output()
+	out, err := exec.CommandContext(context.Background(), module, "--help").Output()
 	return string(out), err
 }
 
 // fillManifest update Manifest required fields, by calls external module `main`
 // with both `description` and `version` flags and parse reply.
 func fillManifest(mf Manifest) (Manifest, error) {
-	out, err := exec.Command(mf.Main, "--description", "--version").Output()
+	out, err := exec.CommandContext(
+		context.Background(), mf.Main, "--description", "--version").Output()
 	if err != nil {
 		return mf, fmt.Errorf("failed to get module info: %w", err)
 	}

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -64,7 +65,8 @@ func RunExec(command string, args []string) int {
 	cmd.Stdin = os.Stdin
 
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			return exitError.ExitCode()
 		}
 

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -18,7 +18,12 @@ import (
 // user:   read/write/execute
 // group:  read/write/execute
 // others: nil
-const defaultDirPerms = 0o770
+const (
+	defaultDirPerms           = 0o770
+	pidFileMode               = 0o644
+	processTerminationTimeout = 30 * time.Second
+	processPollInterval       = 100 * time.Millisecond
+)
 
 type ProcessState struct {
 	Code        int
@@ -159,7 +164,7 @@ func CreatePIDFile(pidFileName string, pid int) error {
 	//    group:  read
 	//    others: read
 	pidFile, err := os.OpenFile(pidFileName,
-		syscall.O_EXCL|syscall.O_CREAT|syscall.O_RDWR, 0o644)
+		syscall.O_EXCL|syscall.O_CREAT|syscall.O_RDWR, pidFileMode)
 	if err != nil {
 		return fmt.Errorf(`can't create a new PID file. Error: "%v"`, err)
 	}
@@ -199,7 +204,7 @@ func StopProcess(pidFile string) (int, error) {
 		return 0, fmt.Errorf(`can't terminate the process. Error: "%v"`, err)
 	}
 
-	if res := waitProcessTermination(pid, 30*time.Second, 100*time.Millisecond); !res {
+	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
 		return 0, fmt.Errorf("can't terminate the process")
 	}
 
@@ -217,7 +222,7 @@ func QuitProcess(pidFile string) (int, error) {
 		return 0, fmt.Errorf("can't terminate the process with SIGQUIT: %s", err)
 	}
 
-	if res := waitProcessTermination(pid, 30*time.Second, 100*time.Millisecond); !res {
+	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
 		return 0, fmt.Errorf("can't terminate the process with SIGQUIT")
 	}
 

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -77,19 +77,19 @@ func GetPIDFromFile(pidFileName string) (int, error) {
 
 	pidFile, err := os.Open(pidFileName)
 	if err != nil {
-		return 0, fmt.Errorf(`can't open the PID file. Error: "%v"`, err)
+		return 0, fmt.Errorf(`can't open the PID file. Error: "%w"`, err)
 	}
 	defer pidFile.Close()
 
 	pidBytes, err := io.ReadAll(pidFile)
 	if err != nil {
-		return 0, fmt.Errorf(`can't read the PID file. Error: "%v"`, err)
+		return 0, fmt.Errorf(`can't read the PID file. Error: "%w"`, err)
 	}
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
 	if err != nil {
 		return 0,
-			fmt.Errorf(`pID file exists with unknown format. Error: "%s"`, err)
+			fmt.Errorf(`pID file exists with unknown format. Error: "%w"`, err)
 	}
 
 	return pid, nil
@@ -103,7 +103,7 @@ func CheckPIDFile(pidFileName string) error {
 		// The PID file already exists. We have to check if the process is alive.
 		pid, err := GetPIDFromFile(pidFileName)
 		if err != nil {
-			return fmt.Errorf(`pID file exists, but PID can't be read. Error: "%v"`, err)
+			return fmt.Errorf(`pID file exists, but PID can't be read. Error: "%w"`, err)
 		}
 		if res, _ := IsProcessAlive(pid); res {
 			return fmt.Errorf("the process already exists. PID: %d", pid)
@@ -111,7 +111,7 @@ func CheckPIDFile(pidFileName string) error {
 			os.Remove(pidFileName)
 		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf(`something went wrong while trying to read the PID file. Error: "%v"`,
+		return fmt.Errorf(`something went wrong while trying to read the PID file. Error: "%w"`,
 			err)
 	}
 
@@ -126,7 +126,7 @@ func ExistsAndRecord(pidFileName string) (bool, error) {
 		// The PID file already exists. We have to check if the process is alive.
 		pid, err := GetPIDFromFile(pidFileName)
 		if err != nil {
-			return false, fmt.Errorf(`PID file exists, but PID can't be read. Error: "%v"`, err)
+			return false, fmt.Errorf(`PID file exists, but PID can't be read. Error: "%w"`, err)
 		}
 		if res, _ := IsProcessAlive(pid); res {
 			return true, nil
@@ -151,10 +151,10 @@ func CreatePIDFile(pidFileName string, pid int) error {
 		if os.IsNotExist(err) {
 			err = os.MkdirAll(pidAbsDir, defaultDirPerms)
 			if err != nil {
-				return fmt.Errorf(`can't crete PID file directory. Error: "%v"`, err)
+				return fmt.Errorf(`can't crete PID file directory. Error: "%w"`, err)
 			}
 		} else {
-			return fmt.Errorf(`can't stat PID file directory. Error: "%v"`, err)
+			return fmt.Errorf(`can't stat PID file directory. Error: "%w"`, err)
 		}
 	}
 
@@ -166,7 +166,7 @@ func CreatePIDFile(pidFileName string, pid int) error {
 	pidFile, err := os.OpenFile(pidFileName,
 		syscall.O_EXCL|syscall.O_CREAT|syscall.O_RDWR, pidFileMode)
 	if err != nil {
-		return fmt.Errorf(`can't create a new PID file. Error: "%v"`, err)
+		return fmt.Errorf(`can't create a new PID file. Error: "%w"`, err)
 	}
 	defer pidFile.Close()
 
@@ -185,7 +185,7 @@ func getRunningPid(pidFile string) (int, error) {
 	}
 
 	if alive, err := IsProcessAlive(pid); err != nil {
-		return 0, fmt.Errorf("failed to check if the process %v is running: %s", pid, err)
+		return 0, fmt.Errorf("failed to check if the process %v is running: %w", pid, err)
 	} else if !alive {
 		return 0, fmt.Errorf("the process %v is not running", pid)
 	}
@@ -201,7 +201,7 @@ func StopProcess(pidFile string) (int, error) {
 	}
 
 	if err = syscall.Kill(pid, syscall.SIGINT); err != nil {
-		return 0, fmt.Errorf(`can't terminate the process. Error: "%v"`, err)
+		return 0, fmt.Errorf(`can't terminate the process. Error: "%w"`, err)
 	}
 
 	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
@@ -215,11 +215,11 @@ func StopProcess(pidFile string) (int, error) {
 func QuitProcess(pidFile string) (int, error) {
 	pid, err := getRunningPid(pidFile)
 	if err != nil {
-		return 0, fmt.Errorf("can't get pid of running process: %s", err)
+		return 0, fmt.Errorf("can't get pid of running process: %w", err)
 	}
 
 	if err = syscall.Kill(pid, syscall.SIGQUIT); err != nil {
-		return 0, fmt.Errorf("can't terminate the process with SIGQUIT: %s", err)
+		return 0, fmt.Errorf("can't terminate the process with SIGQUIT: %w", err)
 	}
 
 	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
@@ -233,16 +233,16 @@ func QuitProcess(pidFile string) (int, error) {
 func KillProcessGroup(pidFile string) (int, error) {
 	pid, err := getRunningPid(pidFile)
 	if err != nil {
-		return 0, fmt.Errorf("can't get pid of running process: %s", err)
+		return 0, fmt.Errorf("can't get pid of running process: %w", err)
 	}
 
 	pgid, err := syscall.Getpgid(pid)
 	if err != nil {
-		return 0, fmt.Errorf("can't get a process group of the %d process: %s", pid, err)
+		return 0, fmt.Errorf("can't get a process group of the %d process: %w", pid, err)
 	}
 
 	if err = syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
-		return 0, fmt.Errorf("can't kill the process: %s", err)
+		return 0, fmt.Errorf("can't kill the process: %w", err)
 	}
 
 	return pid, nil

--- a/cli/process_utils/process_utils_test.go
+++ b/cli/process_utils/process_utils_test.go
@@ -11,7 +11,7 @@ import (
 func Test_ExistsAndRecord(t *testing.T) {
 	testFile := "test.pid"
 	invalid := "invalid.pid"
-	cmd := exec.Command("sleep", "10")
+	cmd := exec.CommandContext(t.Context(), "sleep", "10")
 
 	t.Cleanup(func() {
 		os.Remove(testFile)
@@ -29,6 +29,7 @@ func Test_ExistsAndRecord(t *testing.T) {
 
 	err = cmd.Process.Kill()
 	require.NoError(t, err)
+	require.Error(t, cmd.Wait())
 
 	statusInvalid, err := ExistsAndRecord(invalid)
 	require.False(t, statusInvalid)

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -182,7 +182,7 @@ func NewCConfigApplication(
 func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
 	replicasets, err := c.Discovery(UseCache)
 	if err != nil {
-		return fmt.Errorf("failed to get replicasets: %s", err)
+		return fmt.Errorf("failed to get replicasets: %w", err)
 	}
 
 	targetReplicaset, targetInstance, found := findInstanceByAlias(replicasets, ctx.InstName)

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -591,7 +591,7 @@ func reloadCConfig(instances []running.InstanceCtx) error {
 		opts := connector.RequestOpts{}
 		_, err := evaler.Eval("require('config'):reload()", args, opts)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stdout, err)
 			errored = append(errored, instance.InstName)
 		}
 		return false, nil

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/apex/log"
@@ -420,13 +421,7 @@ func (c *CConfigApplication) BootstrapVShard(ctx VShardBootstrapCtx) error {
 			// Try again with another instance.
 			return false, nil
 		}
-		isRouter := false
-		for _, role := range roles {
-			if role == "router" {
-				isRouter = true
-				break
-			}
-		}
+		isRouter := slices.Contains(roles, "router")
 		if !isRouter {
 			// Try again with another instance.
 			return false, nil

--- a/cli/replicaset/cmd/bootstrap.go
+++ b/cli/replicaset/cmd/bootstrap.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/replicaset"
@@ -65,7 +66,7 @@ func Bootstrap(ctx BootstrapCtx) error {
 			return err
 		}
 		statusReplicasets(replicasets)
-		fmt.Println()
+		fmt.Fprintln(os.Stdout)
 		log.Info("Done.")
 	}
 	return err

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/connector"
@@ -48,7 +49,7 @@ func Demote(ctx DemoteCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
@@ -56,7 +57,7 @@ func Demote(ctx DemoteCtx) error {
 		return err
 	}
 	statusReplicasets(replicasets)
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	if ctx.InstName != "" {
 		log.Infof("Demote instance: %s", ctx.InstName)

--- a/cli/replicaset/cmd/downgrade.go
+++ b/cli/replicaset/cmd/downgrade.go
@@ -27,8 +27,7 @@ var downgradeMasterLua string
 
 func filterComments(script string) string {
 	var filteredLines []string
-	lines := strings.Split(script, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(script, "\n") {
 		trimmedLine := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmedLine, "--") {
 			filteredLines = append(filteredLines, line)
@@ -75,7 +74,7 @@ func downgradeMaster(master *instanceMeta, version string) (syncInfo, error) {
 	var downgradeInfo syncInfo
 	fullMasterName := running.GetAppInstanceName(master.run)
 	res, err := master.conn.Eval(filterComments(downgradeMasterLua),
-		[]interface{}{version}, connector.RequestOpts{})
+		[]any{version}, connector.RequestOpts{})
 	if err != nil {
 		return downgradeInfo, fmt.Errorf(
 			"failed to execute downgrade script on master instance - %s: %w",

--- a/cli/replicaset/cmd/downgrade.go
+++ b/cli/replicaset/cmd/downgrade.go
@@ -3,6 +3,7 @@ package replicasetcmd
 import (
 	_ "embed"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -62,10 +63,10 @@ func internalDowngrade(replicasets []replicaset.Replicaset, lsnTimeout int, vers
 	for _, replicaset := range replicasets {
 		err := downgradeReplicaset(replicaset, lsnTimeout, version, connOpts)
 		if err != nil {
-			fmt.Printf("• %s: error\n", replicaset.Alias)
+			fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
 			return fmt.Errorf("replicaset %s: %w", replicaset.Alias, err)
 		}
-		fmt.Printf("• %s: ok\n", replicaset.Alias)
+		fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
 	}
 	return nil
 }

--- a/cli/replicaset/cmd/expel.go
+++ b/cli/replicaset/cmd/expel.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 
@@ -48,7 +49,7 @@ func Expel(expelCtx ExpelCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Println("")
+	fmt.Fprintln(os.Stdout, "")
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
@@ -57,7 +58,7 @@ func Expel(expelCtx ExpelCtx) error {
 	}
 	statusReplicasets(replicasets)
 
-	fmt.Println("")
+	fmt.Fprintln(os.Stdout, "")
 	log.Infof("Expel instance: %s", expelCtx.Instance)
 
 	// Try to expel the instance.

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/connector"
@@ -59,7 +60,7 @@ func Promote(ctx PromoteCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
@@ -67,7 +68,7 @@ func Promote(ctx PromoteCtx) error {
 		return err
 	}
 	statusReplicasets(replicasets)
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	if ctx.InstName != "" {
 		log.Infof("Promote instance: %s", ctx.InstName)

--- a/cli/replicaset/cmd/roles.go
+++ b/cli/replicaset/cmd/roles.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/connector"
@@ -66,7 +67,7 @@ func RolesChange(ctx RolesChangeCtx, changeRoleAction replicaset.RolesChangerAct
 	}
 
 	log.Info("Discovery application...")
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
@@ -74,7 +75,7 @@ func RolesChange(ctx RolesChangeCtx, changeRoleAction replicaset.RolesChangerAct
 		return err
 	}
 	statusReplicasets(replicasets)
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 
 	action := []string{"Add", "to"}
 	if changeRoleAction.Action() == replicaset.RemoveAction {

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -62,17 +63,17 @@ func statusReplicasets(replicasets replicaset.Replicasets) error {
 		return fmt.Errorf("unknown or empty replicasets configuration")
 	}
 
-	fmt.Println("Orchestrator:     ", replicasets.Orchestrator)
-	fmt.Println("Replicasets state:", replicasets.State)
+	fmt.Fprintln(os.Stdout, "Orchestrator:     ", replicasets.Orchestrator)
+	fmt.Fprintln(os.Stdout, "Replicasets state:", replicasets.State)
 
 	replicasets = fillAliases(replicasets)
 	replicasets = sortAliases(replicasets)
 
 	if len(replicasets.Replicasets) > 0 {
-		fmt.Println()
+		fmt.Fprintln(os.Stdout)
 	}
 	for _, replicaset := range replicasets.Replicasets {
-		fmt.Print(replicasetToString(replicaset))
+		fmt.Fprint(os.Stdout, replicasetToString(replicaset))
 	}
 	return nil
 }

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -111,26 +111,38 @@ func sortAliases(replicasets replicaset.Replicasets) replicaset.Replicasets {
 
 // replicasetToString returns a string representation of a replicaset.
 func replicasetToString(replicas replicaset.Replicaset) string {
-	ret := "• " + replicas.Alias + "\n"
-	ret += "  Failover: " + replicas.Failover.String() + "\n"
+	var result strings.Builder
+	result.WriteString("• ")
+	result.WriteString(replicas.Alias)
+	result.WriteByte('\n')
+	result.WriteString("  Failover: ")
+	result.WriteString(replicas.Failover.String())
+	result.WriteByte('\n')
 	if replicas.StateProvider != replicaset.StateProviderUnknown {
-		ret += "  Provider: " + replicas.StateProvider.String() + "\n"
+		result.WriteString("  Provider: ")
+		result.WriteString(replicas.StateProvider.String())
+		result.WriteByte('\n')
 	}
 	if replicas.Master != replicaset.MasterUnknown {
-		ret += "  Master:   " + replicas.Master.String() + "\n"
+		result.WriteString("  Master:   ")
+		result.WriteString(replicas.Master.String())
+		result.WriteByte('\n')
 	}
 	if len(replicas.Roles) > 0 {
-		ret += "  Roles:    " + strings.Join(replicas.Roles, ", ") + "\n"
+		result.WriteString("  Roles:    ")
+		result.WriteString(strings.Join(replicas.Roles, ", "))
+		result.WriteByte('\n')
 	}
 	for _, instance := range replicas.Instances {
 		if replicas.LeaderUUID != "" && replicas.LeaderUUID == instance.UUID {
-			ret += "    ★ "
+			result.WriteString("    ★ ")
 		} else {
-			ret += "    • "
+			result.WriteString("    • ")
 		}
-		ret += instanceToString(instance) + "\n"
+		result.WriteString(instanceToString(instance))
+		result.WriteByte('\n')
 	}
-	return ret
+	return result.String()
 }
 
 // instanceToString returns a string representation of an instance.

--- a/cli/replicaset/cmd/upgrade.go
+++ b/cli/replicaset/cmd/upgrade.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -85,10 +86,10 @@ func internalUpgrade(replicasets []replicaset.Replicaset, lsnTimeout int,
 	for _, replicaset := range replicasets {
 		err := upgradeReplicaset(replicaset, lsnTimeout, connOpts)
 		if err != nil {
-			fmt.Printf("• %s: error\n", replicaset.Alias)
+			fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
 			return fmt.Errorf("replicaset %s: %w", replicaset.Alias, err)
 		}
-		fmt.Printf("• %s: ok\n", replicaset.Alias)
+		fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
 	}
 	return nil
 }

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -85,7 +85,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 		return discoverApp(orchestrator)
 	}
 	if err := retry.Do(discoverAppFunc, retryOpts...); err != nil {
-		return fmt.Errorf("failed to bootstrap vshard: %s", err)
+		return fmt.Errorf("failed to bootstrap vshard: %w", err)
 	}
 
 	fmt.Fprintln(os.Stdout, "")

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/apex/log"
@@ -73,7 +74,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Println("")
+	fmt.Fprintln(os.Stdout, "")
 
 	retryOpts := []retry.Option{
 		retry.Delay(1 * time.Second),
@@ -87,7 +88,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 		return fmt.Errorf("failed to bootstrap vshard: %s", err)
 	}
 
-	fmt.Println("")
+	fmt.Fprintln(os.Stdout, "")
 	log.Info("Bootstrapping vshard")
 
 	err = orchestrator.BootstrapVShard(replicaset.VShardBootstrapCtx{Timeout: ctx.Timeout})

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -13,6 +13,8 @@ import (
 	libcluster "github.com/tarantool/tt/lib/cluster"
 )
 
+const configPathSuffixSegments = 2
+
 // KeyPicker picks a key to patch.
 type KeyPicker func(keys []string, force bool, pathMsg string) (int, error)
 
@@ -324,7 +326,7 @@ func getCConfigPromotePath(inst cconfigInstance) (goconfig.KeyPath, int, error) 
 		path = goconfig.NewKeyPath(fmt.Sprintf(
 			"groups/%s/replicasets/%s/instances/%s/database/mode",
 			groupName, replicasetName, instName))
-		depth = len(path) - 2
+		depth = len(path) - configPathSuffixSegments
 	case FailoverManual:
 		path = goconfig.NewKeyPath(fmt.Sprintf(
 			"groups/%s/replicasets/%s/leader",
@@ -355,7 +357,7 @@ func getCConfigDemotePath(inst cconfigInstance) (goconfig.KeyPath, int, error) {
 		path = goconfig.NewKeyPath(fmt.Sprintf(
 			"groups/%s/replicasets/%s/instances/%s/database/mode",
 			groupName, replicasetName, instName))
-		depth = len(path) - 2
+		depth = len(path) - configPathSuffixSegments
 	case FailoverManual, FailoverElection:
 		err = fmt.Errorf(`unsupported failover: %q, supported: "off"`, failover)
 	default:
@@ -375,7 +377,7 @@ func getCConfigExpelPath(inst cconfigInstance) (goconfig.KeyPath, int, error) {
 	path := goconfig.NewKeyPath(fmt.Sprintf(
 		"groups/%s/replicasets/%s/instances/%s/iproto/listen",
 		groupName, replicasetName, instName))
-	depth := len(path) - 2
+	depth := len(path) - configPathSuffixSegments
 	return path, depth, nil
 }
 

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -220,7 +220,7 @@ func (c *CConfigSource) patchConfigWithRoles(ctx RolesChangeCtx,
 		}
 
 		if updatedRoles, err = updateRolesFunc(updatedRoles, ctx.RoleName); err != nil {
-			return fmt.Errorf("cannot update roles by path %s: %s", path.path, err)
+			return fmt.Errorf("cannot update roles by path %s: %w", path.path, err)
 		}
 
 		targets, err := getCConfigPatchTargets(configData, path.path, path.depth)

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -3,6 +3,7 @@ package replicaset_test
 import (
 	"embed"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -518,7 +519,7 @@ func TestCConfigSource_Promote_many_keys_choose_affects(t *testing.T) {
 	source := replicaset.NewCConfigSource(collector, publisher, picker)
 	err := source.Promote(replicaset.PromoteCtx{InstName: "instance-002"})
 	require.NoError(t, err)
-	fmt.Println(string(publisher.Data[0]))
+	fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
 	assertPublished(t, publisher, "b", expected)
 }
 
@@ -686,7 +687,7 @@ func TestCConfigSource_Demote_many_keys(t *testing.T) {
 			source := replicaset.NewCConfigSource(collector, publisher, picker)
 			err := source.Demote(replicaset.DemoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
-			fmt.Println(string(publisher.Data[0]))
+			fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
 			assertPublished(t, publisher, tc.keys[0], expected)
 		})
 	}

--- a/cli/replicaset/integration_test.go
+++ b/cli/replicaset/integration_test.go
@@ -516,7 +516,7 @@ func TestEvalAny_error(t *testing.T) {
 func runTestMain(m *testing.M) int {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
-		fmt.Println("Failed to prepare test work dir:", err)
+		fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
 		return 1
 	}
 
@@ -530,21 +530,21 @@ func runTestMain(m *testing.M) int {
 		RetryTimeout: 100 * time.Millisecond,
 	})
 	if err != nil {
-		fmt.Println("Failed to prepare test tarantool:", err)
+		fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
 		return 1
 	}
 	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	conn, err := tarantool.Connect(context.Background(), dialer, opts)
 	if err != nil {
-		fmt.Println("Failed to check tarantool version:", err)
+		fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
 		return 1
 	}
 
 	_, err = conn.Do(tarantool.NewPingRequest()).Get()
 	conn.Close()
 	if err != nil {
-		fmt.Println("Failed to ping tarantool server:", err)
+		fmt.Fprintln(os.Stdout, "Failed to ping tarantool server:", err)
 		return 1
 	}
 

--- a/cli/replicaset/orchestrator.go
+++ b/cli/replicaset/orchestrator.go
@@ -48,7 +48,7 @@ func EvalOrchestrator(evaler connector.Evaler) (Orchestrator, error) {
 	data, err := evaler.Eval(getOrchestratorBody, []any{}, opts)
 	if err != nil {
 		return OrchestratorCustom,
-			fmt.Errorf("failed to recognize orchestrator: %s", err)
+			fmt.Errorf("failed to recognize orchestrator: %w", err)
 	}
 	if len(data) == 1 {
 		if str, ok := data[0].(string); ok {

--- a/cli/replicaset/orchestrators_test.go
+++ b/cli/replicaset/orchestrators_test.go
@@ -16,8 +16,8 @@ type instanceMockEvaler struct {
 }
 
 func (e *instanceMockEvaler) Eval(expr string,
-	args []interface{}, opts connector.RequestOpts,
-) ([]interface{}, error) {
+	args []any, opts connector.RequestOpts,
+) ([]any, error) {
 	defer func() { e.Called++ }()
 
 	var ret []any

--- a/cli/replicaset/rebootstrap.go
+++ b/cli/replicaset/rebootstrap.go
@@ -43,11 +43,11 @@ func cleanDataFiles(instCtx running.InstanceCtx) error {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return fmt.Errorf("cannot get info of %q: %s", fileToRemove, err)
+			return fmt.Errorf("cannot get info of %q: %w", fileToRemove, err)
 		}
 		if stat.Mode().IsRegular() {
 			if err = os.Remove(fileToRemove); err != nil {
-				return fmt.Errorf("cannot remove %q: %s", fileToRemove, err)
+				return fmt.Errorf("cannot remove %q: %w", fileToRemove, err)
 			}
 			log.Debugf("Removed %q", fileToRemove)
 		}
@@ -62,7 +62,7 @@ func Rebootstrap(cmdCtx cmdcontext.CmdCtx, cliOpts config.CliOpts, rbCtx Reboots
 	instances, err := running.CollectInstancesForApp(rbCtx.AppName, &cliOpts,
 		cmdCtx.Cli.ConfigDir, cmdCtx.Integrity, running.ConfigLoadAll)
 	if err != nil {
-		return fmt.Errorf("cannot collect application instances info: %s", err)
+		return fmt.Errorf("cannot collect application instances info: %w", err)
 	}
 
 	found := false
@@ -89,11 +89,11 @@ func Rebootstrap(cmdCtx cmdcontext.CmdCtx, cliOpts config.CliOpts, rbCtx Reboots
 
 	log.Debugf("Stopping the instance")
 	if err = running.Stop(&instCtx); err != nil {
-		return fmt.Errorf("failed to stop the instance %s: %s", rbCtx.InstanceName, err)
+		return fmt.Errorf("failed to stop the instance %s: %w", rbCtx.InstanceName, err)
 	}
 
 	if err = cleanDataFiles(instCtx); err != nil {
-		return fmt.Errorf("failed to remove instance's artifacts: %s", err)
+		return fmt.Errorf("failed to remove instance's artifacts: %w", err)
 	}
 
 	// TODO: need to support integrity check continuation on this start.
@@ -104,7 +104,7 @@ func Rebootstrap(cmdCtx cmdcontext.CmdCtx, cliOpts config.CliOpts, rbCtx Reboots
 		return err
 	}
 	if err = running.StartWatchdog(&cmdCtx, ttBin, instCtx, []string{}); err != nil {
-		return fmt.Errorf("failed to start the instance: %s", err)
+		return fmt.Errorf("failed to start the instance: %w", err)
 	}
 
 	return nil

--- a/cli/replicaset/roles.go
+++ b/cli/replicaset/roles.go
@@ -112,7 +112,7 @@ func newErrRolesChangeByAppNotSupported(orchestrator Orchestrator,
 // parseRoles is a function to convert roles type 'any'
 // from yaml config. Returns slice of roles and error.
 func parseRoles(value any) ([]string, error) {
-	sliceVal, ok := value.([]interface{})
+	sliceVal, ok := value.([]any)
 	if !ok {
 		return []string{}, fmt.Errorf("%v is not a slice", value)
 	}

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -92,7 +92,7 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 	output, err := exec.CommandContext(
 		context.Background(), cli.TarantoolCli.Executable, "--version").Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get tarantool version: %s", err)
+		return "", fmt.Errorf("failed to get tarantool version: %w", err)
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -88,7 +88,8 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 		return prefixPathFromEnv, nil
 	}
 
-	output, err := exec.Command(cli.TarantoolCli.Executable, "--version").Output()
+	output, err := exec.CommandContext(
+		context.Background(), cli.TarantoolCli.Executable, "--version").Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get tarantool version: %s", err)
 	}

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -26,6 +26,7 @@ const (
 	repoRocksPathEnvVarName   = "TT_CLI_REPO_ROCKS"
 	tarantoolPrefixEnvVarName = "TT_CLI_TARANTOOL_PREFIX"
 	tarantoolDefaultPrefixDir = "/usr"
+	minVersionOutputLines     = 3
 )
 
 // addLuarocksRepoOpts adds --server option to luarocks command line if rocks repository
@@ -95,7 +96,7 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(lines) < 3 {
+	if len(lines) < minVersionOutputLines {
 		return "", fmt.Errorf("failed to get prefix path: expected more data")
 	}
 

--- a/cli/running/cluster_instance.go
+++ b/cli/running/cluster_instance.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/util"
@@ -58,7 +57,7 @@ func (inst *clusterInstance) Start(ctx context.Context) error {
 	cmd.Cancel = func() error {
 		return cmd.Process.Signal(os.Interrupt)
 	}
-	cmd.WaitDelay = 30 * time.Second
+	cmd.WaitDelay = instanceCommandWaitDelay
 	cmd.Stdout = inst.stdOut
 	cmd.Stderr = inst.stdErr
 

--- a/cli/running/instance.go
+++ b/cli/running/instance.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const instanceCommandWaitDelay = 30 * time.Second
+
 // Instance describes a running tarantool instance.
 type Instance interface {
 	// Start starts the Instance with the specified parameters.

--- a/cli/running/process_controller.go
+++ b/cli/running/process_controller.go
@@ -87,7 +87,7 @@ func (pc *processController) StopWithSignal(waitTimeout time.Duration, stopSigna
 	// Trying to terminate the process by using a stopSignal.
 	// In case of failure a "SIGKILL" signal will be used.
 	if err := pc.SendSignal(stopSignal); err != nil {
-		return fmt.Errorf("failed to send %v to instance: %s", stopSignal, err)
+		return fmt.Errorf("failed to send %v to instance: %w", stopSignal, err)
 	}
 
 	// Terminate the process at any cost.
@@ -96,7 +96,7 @@ func (pc *processController) StopWithSignal(waitTimeout time.Duration, stopSigna
 		if pc.IsAlive() {
 			// Send "SIGKILL" signal if process is still alive.
 			if err := pc.Process.Kill(); err != nil {
-				return fmt.Errorf("failed to send SIGKILL to instance: %s", err)
+				return fmt.Errorf("failed to send SIGKILL to instance: %w", err)
 			} else {
 				// Wait for the process to terminate.
 				<-waitDone

--- a/cli/running/process_controller_test.go
+++ b/cli/running/process_controller_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestProcessController(t *testing.T) {
-	cmd := exec.Command("bash", "-c", "echo hello")
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", "echo hello")
 	out := strings.Builder{}
 	cmd.Stdout = &out
 	dpc, err := newProcessController(cmd)
@@ -33,7 +33,7 @@ func TestProcessController(t *testing.T) {
 	require.NoError(t, copy.Copy("./testdata/signal_handling.py",
 		filepath.Join(tmpDir, "signal_handling.py")))
 
-	cmd = exec.Command("python3", filepath.Join(tmpDir, "signal_handling.py"))
+	cmd = exec.CommandContext(t.Context(), "python3", filepath.Join(tmpDir, "signal_handling.py"))
 	outBuf := bytes.Buffer{}
 	cmd.Stdout = &outBuf
 	dpc, err = newProcessController(cmd)
@@ -54,7 +54,7 @@ func TestProcessController(t *testing.T) {
 	assert.False(t, dpc.IsAlive())
 
 	// Test unknown command.
-	cmd = exec.Command("unknown_command")
+	cmd = exec.CommandContext(t.Context(), "unknown_command")
 	dpc, err = newProcessController(cmd)
 	require.ErrorContains(t, err, "executable file not found")
 	require.Nil(t, dpc)

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -28,7 +28,11 @@ import (
 	"github.com/tarantool/tt/lib/integrity"
 )
 
-const defaultDirPerms = 0o770
+const (
+	defaultDirPerms        = 0o770
+	instanceCleanupTimeout = 10 * time.Second
+	watchdogRestartTimeout = 5 * time.Second
+)
 
 const (
 	// clusterConfigDefaultFileName is a default filename for the cluster config.
@@ -712,7 +716,7 @@ func RunInstance(ctx context.Context, cmdCtx *cmdcontext.CmdCtx, inst InstanceCt
 	}()
 
 	if err := process_utils.CreatePIDFile(inst.PIDFile, instance.GetPid()); err != nil {
-		instance.Stop(10 * time.Second)
+		instance.Stop(instanceCleanupTimeout)
 		return fmt.Errorf("cannot create the pid file %q: %s", inst.PIDFile, err)
 	}
 
@@ -737,7 +741,7 @@ func Start(cmdCtx *cmdcontext.CmdCtx, inst *InstanceCtx) error {
 		}
 		return nil
 	}
-	wd := NewWatchdog(inst.Restartable, 5*time.Second, logger,
+	wd := NewWatchdog(inst.Restartable, watchdogRestartTimeout, logger,
 		&provider, preStartAction, cmdCtx.Integrity,
 		time.Duration(cmdCtx.Cli.IntegrityCheckPeriod*int(time.Second)))
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -844,7 +844,8 @@ func Check(cmdCtx *cmdcontext.CmdCtx, run *InstanceCtx) error {
 	var errBuff bytes.Buffer
 	os.Setenv("TT_CLI_INSTANCE", run.InstanceScript)
 
-	cmd := exec.Command(cmdCtx.Cli.TarantoolCli.Executable, "-e", checkSyntax)
+	cmd := exec.CommandContext(
+		context.Background(), cmdCtx.Cli.TarantoolCli.Executable, "-e", checkSyntax)
 	cmd.Stderr = &errBuff
 	if err := cmd.Run(); err != nil {
 		return errors.New(errBuff.String())
@@ -914,7 +915,7 @@ func StartWatchdog(cmdCtx *cmdcontext.CmdCtx, ttExecutable string, instance Inst
 
 	log.Infof("Starting an instance [%s]...", appName)
 
-	wdCmd := exec.Command(ttExecutable, newArgs...)
+	wdCmd := exec.CommandContext(context.Background(), ttExecutable, newArgs...)
 	// Set new pgid for watchdog process, so it will not be killed after a session is closed.
 	wdCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return wdCmd.Start()

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -304,11 +304,11 @@ func getInstanceName(fullInstanceName string, isClusterInstance bool) string {
 		// If we have a cluster instance, delimiters are ignored.
 		return fullInstanceName
 	}
-	sepIndex := strings.Index(fullInstanceName, ".")
-	if sepIndex == -1 {
+	_, instanceName, hasDelimiter := strings.Cut(fullInstanceName, ".")
+	if !hasDelimiter {
 		return fullInstanceName
 	}
-	return fullInstanceName[sepIndex+1:]
+	return instanceName
 }
 
 // findInstanceScriptInAppDir searches for instance script.

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -440,11 +440,11 @@ func collectInstances(appName, applicationDir string,
 	// The user can select a specific instance from the application.
 	// Example: `tt status application:server`.
 	selectedInstName := ""
-	colonIds := strings.Index(appName, string(InstanceDelimiter))
-	if colonIds != -1 {
+	colonIDs := strings.Index(appName, string(InstanceDelimiter))
+	if colonIDs != -1 {
 		appNameTmp := appName
-		appName = appNameTmp[:colonIds]
-		selectedInstName = appNameTmp[colonIds+1:]
+		appName = appNameTmp[:colonIDs]
+		selectedInstName = appNameTmp[colonIDs+1:]
 	}
 	appName = strings.TrimSuffix(appName, ".lua")
 	expectedAppName := filepath.Base(filepath.Clean(applicationDir))

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -704,11 +704,11 @@ func RunInstance(ctx context.Context, cmdCtx *cmdcontext.CmdCtx, inst InstanceCt
 	}
 	instance, err := createInstance(*cmdCtx, inst, opts...)
 	if err != nil {
-		return fmt.Errorf("failed to create the instance %q: %s", inst.InstName, err)
+		return fmt.Errorf("failed to create the instance %q: %w", inst.InstName, err)
 	}
 	logger.Println("(INFO) Start")
 	if err = instance.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start the instance %q: %s", inst.InstName, err)
+		return fmt.Errorf("failed to start the instance %q: %w", inst.InstName, err)
 	}
 
 	defer func() {
@@ -717,7 +717,7 @@ func RunInstance(ctx context.Context, cmdCtx *cmdcontext.CmdCtx, inst InstanceCt
 
 	if err := process_utils.CreatePIDFile(inst.PIDFile, instance.GetPid()); err != nil {
 		instance.Stop(instanceCleanupTimeout)
-		return fmt.Errorf("cannot create the pid file %q: %s", inst.PIDFile, err)
+		return fmt.Errorf("cannot create the pid file %q: %w", inst.PIDFile, err)
 	}
 
 	return instance.Wait()
@@ -726,11 +726,11 @@ func RunInstance(ctx context.Context, cmdCtx *cmdcontext.CmdCtx, inst InstanceCt
 // Start an Instance.
 func Start(cmdCtx *cmdcontext.CmdCtx, inst *InstanceCtx) error {
 	if err := createInstanceDataDirectories(*inst); err != nil {
-		return fmt.Errorf("failed to create a directory: %s", err)
+		return fmt.Errorf("failed to create a directory: %w", err)
 	}
 	logger, err := createLogger(inst)
 	if err != nil {
-		return fmt.Errorf("cannot create a logger: %s", err)
+		return fmt.Errorf("cannot create a logger: %w", err)
 	}
 	logger.Println("[INFO] Start") // Create a log file before any other actions.
 
@@ -775,7 +775,7 @@ func Stop(run *InstanceCtx) error {
 func Kill(run InstanceCtx) error {
 	pid, err := process_utils.KillProcessGroup(run.PIDFile)
 	if err != nil {
-		return fmt.Errorf("failed to kill the processes: %s", err)
+		return fmt.Errorf("failed to kill the processes: %w", err)
 	}
 
 	// Remove PID files because due to SIGKILL watchdog can't cleanup itself.
@@ -791,7 +791,7 @@ func Kill(run InstanceCtx) error {
 func Quit(run InstanceCtx) error {
 	pid, err := process_utils.QuitProcess(run.PIDFile)
 	if err != nil {
-		return fmt.Errorf("failed to quit the process: %s", err)
+		return fmt.Errorf("failed to quit the process: %w", err)
 	}
 
 	if _, err := os.Stat(run.ConsoleSocket); err == nil {
@@ -834,7 +834,7 @@ func Logrotate(run *InstanceCtx) error {
 	}
 
 	if err := syscall.Kill(pid, syscall.SIGHUP); err != nil {
-		return fmt.Errorf(`can't rotate logs: "%v"`, err)
+		return fmt.Errorf(`can't rotate logs: "%w"`, err)
 	}
 
 	// Rotates logs [instance name pid].

--- a/cli/running/running_test_helpers.go
+++ b/cli/running/running_test_helpers.go
@@ -5,11 +5,13 @@ import (
 	"time"
 )
 
+const filePollInterval = 500 * time.Millisecond
+
 // waitForFile waits for the file to appear.
 func waitForFile(filePath string) int {
 	retries := 10
 	for retries > 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(filePollInterval)
 		if _, err := os.Stat(filePath); err == nil {
 			break
 		}

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/lib/integrity"
@@ -102,7 +101,7 @@ func (inst *scriptInstance) Start(ctx context.Context) error {
 	cmd.Cancel = func() error {
 		return cmd.Process.Signal(os.Interrupt)
 	}
-	cmd.WaitDelay = 30 * time.Second
+	cmd.WaitDelay = instanceCommandWaitDelay
 	cmd.Stdout = inst.stdOut
 	cmd.Stderr = inst.stdErr
 	StdinPipe, err := cmd.StdinPipe()

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -91,7 +91,7 @@ func TestInstanceBase(t *testing.T) {
 		binaryPort, logger)
 	t.Cleanup(func() { cleanupTestInstance(t, inst) })
 
-	conn, err := net.Dial("unix", consoleSock)
+	conn, err := (&net.Dialer{}).DialContext(t.Context(), "unix", consoleSock)
 	assert.Nilf(err, `Can't connect to console socket. Error: "%v".`, err)
 	conn.Close()
 }

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -54,7 +54,8 @@ type Watchdog struct {
 }
 
 const (
-	signalBufferSize = 128
+	signalBufferSize  = 128
+	signalStopTimeout = 30 * time.Second
 )
 
 // NewWatchdog creates a new instance of Watchdog.
@@ -210,7 +211,7 @@ func (wd *Watchdog) sendSignal(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
 		if wd.instance.IsAlive() {
-			wd.instance.StopWithSignal(30*time.Second, sig)
+			wd.instance.StopWithSignal(signalStopTimeout, sig)
 		}
 		return true
 	case syscall.SIGHUP:

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/fatih/color"
 )
 
+const writerInitialCapacity = 1024
+
 var (
 	errorColor     = color.New(color.FgRed, color.Bold)
 	logLevelColors = map[string]*color.Color{
@@ -31,7 +33,7 @@ func (f colorizedWriter) Write(msg []byte) (int, error) {
 // line depending on its log level.
 func NewColorizedPrefixWriter(writer io.Writer, color color.Color, prefix string) io.Writer {
 	buf := bytes.Buffer{}
-	buf.Grow(1024)
+	buf.Grow(writerInitialCapacity)
 	return colorizedWriter(func(msg []byte) (int, error) {
 		for _, line := range bytes.Split(msg, []byte{'\n'}) {
 			if len(line) == 0 {

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -35,7 +35,7 @@ func NewColorizedPrefixWriter(writer io.Writer, color color.Color, prefix string
 	buf := bytes.Buffer{}
 	buf.Grow(writerInitialCapacity)
 	return colorizedWriter(func(msg []byte) (int, error) {
-		for _, line := range bytes.Split(msg, []byte{'\n'}) {
+		for line := range bytes.SplitSeq(msg, []byte{'\n'}) {
 			if len(line) == 0 {
 				continue
 			}

--- a/cli/search/bundle.go
+++ b/cli/search/bundle.go
@@ -170,7 +170,7 @@ func getBundles(rawBundleInfoList map[string][]string, searchCtx *SearchCtx) (
 func FetchBundlesInfo(searchCtx *SearchCtx, cliOpts *config.CliOpts) (
 	BundleInfoSlice, error,
 ) {
-	searchCtx.Package = GetApiPackage(searchCtx.Program)
+	searchCtx.Package = GetAPIPackage(searchCtx.Program)
 	if searchCtx.Package == "" {
 		return nil, fmt.Errorf("there is no tarantool.io package for program: %s",
 			searchCtx.Program)

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -57,12 +57,12 @@ func printVersion(bindir string, program Program, versionStr string) {
 		target, _ := util.ResolveSymlink(filepath.Join(bindir, program.Exec()))
 
 		if path.Base(target) == program.String()+version.FsSeparator+versionStr {
-			fmt.Printf("%s [active]\n", versionStr)
+			fmt.Fprintf(os.Stdout, "%s [active]\n", versionStr)
 		} else {
-			fmt.Printf("%s [installed]\n", versionStr)
+			fmt.Fprintf(os.Stdout, "%s [installed]\n", versionStr)
 		}
 	} else {
-		fmt.Println(versionStr)
+		fmt.Fprintln(os.Stdout, versionStr)
 	}
 }
 

--- a/cli/search/search_git.go
+++ b/cli/search/search_git.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -31,7 +32,8 @@ func GetVersionsFromGitRemote(repo string) (version.VersionSlice, error) {
 		return nil, errors.New("'git' is required for 'tt search' to work")
 	}
 
-	output, err := exec.Command("git", "ls-remote", "--tags", "--refs", repo).Output()
+	output, err := exec.CommandContext(
+		context.Background(), "git", "ls-remote", "--tags", "--refs", repo).Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get versions from %s: %w", repo, err)
 	}
@@ -77,7 +79,7 @@ func GetCommitFromGitLocal(repo, input string) (string, error) {
 	if isPullRequest {
 		commandStr := "pull/" + pullRequestID +
 			"/head:" + input
-		cmd := exec.Command("git", "fetch", "origin", commandStr)
+		cmd := exec.CommandContext(context.Background(), "git", "fetch", "origin", commandStr)
 		cmd.Dir = repo
 		err := cmd.Run()
 		if err != nil {
@@ -85,7 +87,7 @@ func GetCommitFromGitLocal(repo, input string) (string, error) {
 		}
 	}
 
-	cmd := exec.Command("git", "show", input, "--quiet")
+	cmd := exec.CommandContext(context.Background(), "git", "show", input, "--quiet")
 	cmd.Dir = repo
 
 	output, err := cmd.Output()
@@ -113,8 +115,8 @@ func GetCommitFromGitRemote(repo, input string) (string, error) {
 
 	defer os.RemoveAll(tempRepoPath)
 
-	cmd := exec.Command("git", "clone", "--filter=blob:none", "--no-checkout",
-		repo, tempRepoPath)
+	cmd := exec.CommandContext(context.Background(), "git", "clone",
+		"--filter=blob:none", "--no-checkout", repo, tempRepoPath)
 
 	err = cmd.Run()
 	if err != nil {
@@ -132,7 +134,7 @@ func GetVersionsFromGitLocal(repo string) (version.VersionSlice, error) {
 		return nil, errors.New("'git' is required for 'tt search' to work")
 	}
 
-	output, err := exec.Command("git", "-C", repo, "tag").Output()
+	output, err := exec.CommandContext(context.Background(), "git", "-C", repo, "tag").Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get versions from %s: %w", repo, err)
 	}

--- a/cli/search/search_git.go
+++ b/cli/search/search_git.go
@@ -14,14 +14,15 @@ import (
 )
 
 const (
-	GitRepoTarantool = "https://github.com/tarantool/tarantool.git"
-	GitRepoTT        = "https://github.com/tarantool/tt.git"
+	GitRepoTarantool         = "https://github.com/tarantool/tarantool.git"
+	GitRepoTT                = "https://github.com/tarantool/tt.git"
+	minSupportedMajorVersion = 3
 )
 
 // isMasked function checks that the given version of tarantool is masked.
 // Tarantool 1.x and 2.x are no longer supported.
 func isMasked(version version.Version) bool {
-	return version.Major < 3
+	return version.Major < minSupportedMajorVersion
 }
 
 // GetVersionsFromGitRemote returns sorted versions list from specified remote git repo.

--- a/cli/search/search_sdk.go
+++ b/cli/search/search_sdk.go
@@ -7,8 +7,8 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
-// GetApiPackage returns the package name at tarantool.io for the given program.
-func GetApiPackage(program Program) string {
+// GetAPIPackage returns the package name at tarantool.io for the given program.
+func GetAPIPackage(program Program) string {
 	switch program {
 	case ProgramEe:
 		return "enterprise"

--- a/cli/search/search_sdk_test.go
+++ b/cli/search/search_sdk_test.go
@@ -45,7 +45,7 @@ func TestGetApiPackage(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := search.GetApiPackage(tc.input)
+			result := search.GetAPIPackage(tc.input)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -223,7 +224,8 @@ func sendApiRequest(request apiRequest, doer TntIoDoer) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal API request: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, ApiURI, bytes.NewBuffer(postData))
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, ApiURI, bytes.NewBuffer(postData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	TntIoURI = "https://www.tarantool.io/en/accounts/customer_zone"
-	ApiURI   = TntIoURI + "/api"
+	APIURI   = TntIoURI + "/api"
 	PkgURI   = TntIoURI + "/packages"
 )
 
@@ -103,7 +103,7 @@ func (d *httpDoer) Token() string {
 }
 
 // getOsForApi determines the OS type string required by the tarantool.io API.
-func getOsForApi(informer PlatformInformer) (string, error) {
+func getOsForAPI(informer PlatformInformer) (string, error) {
 	os, err := informer.GetOs()
 	if err != nil {
 		return "", fmt.Errorf("failed to get OS: %w", err)
@@ -120,7 +120,7 @@ func getOsForApi(informer PlatformInformer) (string, error) {
 }
 
 // getArchForApi determines the architecture type string required by the tarantool.io API.
-func getArchForApi(informer PlatformInformer, program Program) (string, error) {
+func getArchForAPI(informer PlatformInformer, program Program) (string, error) {
 	arch, err := informer.GetArch()
 	if err != nil {
 		return "", fmt.Errorf("failed to get architecture: %w", err)
@@ -163,19 +163,19 @@ func TntIoMakePkgURI(searchCtx *SearchCtx, tarball string) (string, error) {
 		return "", fmt.Errorf("no platform informer was applied")
 	}
 
-	arch, err := getArchForApi(searchCtx.platformInformer, searchCtx.Program)
+	arch, err := getArchForAPI(searchCtx.platformInformer, searchCtx.Program)
 	if err != nil {
 		return "", err
 	}
 
-	osType, err := getOsForApi(searchCtx.platformInformer)
+	osType, err := getOsForAPI(searchCtx.platformInformer)
 	if err != nil {
 		return "", err
 	}
 
 	uri = fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s",
 		PkgURI,
-		GetApiPackage(searchCtx.Program),
+		GetAPIPackage(searchCtx.Program),
 		getBuildType(searchCtx.DevBuilds),
 		osType,
 		arch,
@@ -187,17 +187,17 @@ func TntIoMakePkgURI(searchCtx *SearchCtx, tarball string) (string, error) {
 }
 
 // buildApiQuery constructs the query string for the tarantool.io API.
-func buildApiQuery(searchCtx *SearchCtx, credentials connect.UserCredentials) (
+func buildAPIQuery(searchCtx *SearchCtx, credentials connect.UserCredentials) (
 	apiRequest, error,
 ) {
 	buildType := getBuildType(searchCtx.DevBuilds)
 
-	arch, err := getArchForApi(searchCtx.platformInformer, searchCtx.Program)
+	arch, err := getArchForAPI(searchCtx.platformInformer, searchCtx.Program)
 	if err != nil {
 		return apiRequest{}, fmt.Errorf("failed to get architecture: %w", err)
 	}
 
-	osType, err := getOsForApi(searchCtx.platformInformer)
+	osType, err := getOsForAPI(searchCtx.platformInformer)
 	if err != nil {
 		return apiRequest{}, fmt.Errorf("failed to get OS type for API: %w", err)
 	}
@@ -218,14 +218,14 @@ func buildApiQuery(searchCtx *SearchCtx, credentials connect.UserCredentials) (
 }
 
 // sendApiRequest prepares and sends the request to the tarantool.io API.
-func sendApiRequest(request apiRequest, doer TntIoDoer) ([]byte, error) {
+func sendAPIRequest(request apiRequest, doer TntIoDoer) ([]byte, error) {
 	postData, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal API request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(
-		context.Background(), http.MethodPost, ApiURI, bytes.NewBuffer(postData))
+		context.Background(), http.MethodPost, APIURI, bytes.NewBuffer(postData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -262,7 +262,7 @@ func filterChecksums(apiReply map[string][]string) {
 }
 
 // parseApiResponse processes the HTTP response from the tarantool.io API.
-func parseApiResponse(respBody []byte) (map[string][]string, error) {
+func parseAPIResponse(respBody []byte) (map[string][]string, error) {
 	var apiReply map[string][]string
 	err := json.Unmarshal(respBody, &apiReply)
 	if err != nil {
@@ -286,17 +286,17 @@ func tntIoGetPkgVersions(credentials connect.UserCredentials, searchCtx *SearchC
 		return nil, fmt.Errorf("no platform informer was applied")
 	}
 
-	request, err := buildApiQuery(searchCtx, credentials)
+	request, err := buildAPIQuery(searchCtx, credentials)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := sendApiRequest(request, searchCtx.TntIoDoer)
+	resp, err := sendAPIRequest(request, searchCtx.TntIoDoer)
 	if err != nil {
 		return nil, err
 	}
 
-	apiReply, err := parseApiResponse(resp)
+	apiReply, err := parseAPIResponse(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/search/tntio_api_test.go
+++ b/cli/search/tntio_api_test.go
@@ -84,20 +84,20 @@ func (m *mockDoer) Do(req *http.Request) ([]byte, error) {
 	// Restore the body for potential re-reads.
 	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-	type expectedApiRequest struct {
+	type expectedAPIRequest struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 		Query    string `json:"query"`
 	}
 
-	var actualRequest expectedApiRequest
+	var actualRequest expectedAPIRequest
 	err = json.Unmarshal(bodyBytes, &actualRequest)
 	if err != nil {
 		m.t.Errorf("failed to unmarshal request body: %v. Body: %s", err, string(bodyBytes))
 		return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
 	}
 
-	expectedRequest := expectedApiRequest{
+	expectedRequest := expectedAPIRequest{
 		Username: testingUsername,
 		Password: testingPassword,
 		Query:    m.query,

--- a/cli/status/json_printer.go
+++ b/cli/status/json_printer.go
@@ -3,6 +3,7 @@ package status
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // JSONPrinter implements InstanceStatusPrinter for JSON output.
@@ -19,6 +20,6 @@ func (j JSONPrinter) Print(instances map[string]*instanceStatus) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal instances to JSON: %w", err)
 	}
-	fmt.Println(string(jsonData))
+	fmt.Fprintln(os.Stdout, string(jsonData))
 	return nil
 }

--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -23,8 +23,7 @@ var defaultModuleStatus = "--"
 
 func filterComments(script string) string {
 	var filteredLines []string
-	lines := strings.Split(script, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(script, "\n") {
 		trimmedLine := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmedLine, "--") {
 			filteredLines = append(filteredLines, line)

--- a/cli/status/table_printer.go
+++ b/cli/status/table_printer.go
@@ -9,6 +9,13 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
+const (
+	statusRowCapacity = 7
+	statusColumn      = 2
+	pidColumn         = 3
+	modeColumn        = 4
+)
+
 var (
 	printYellow = color.New(color.FgYellow).SprintFunc()
 	printRed    = color.New(color.FgRed).SprintFunc()
@@ -80,7 +87,7 @@ func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
 		table.Row{"INSTANCE", "STATUS", "PID", "MODE", "CONFIG", "BOX", "UPSTREAM"})
 
 	for instName, instData := range instances {
-		row := make([]any, 0, 7)
+		row := make([]any, 0, statusRowCapacity)
 		row = append(row, instName)
 		row = append(row, instData.procStatus.FormattedStatus())
 		if instData.PID == nil {
@@ -110,9 +117,9 @@ func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
 	}
 	ts.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 2, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 3, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
-		{Number: 4, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: statusColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: pidColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
+		{Number: modeColumn, Align: text.AlignLeft, AlignHeader: text.AlignLeft},
 	})
 	ts.Render()
 

--- a/cli/status/table_printer.go
+++ b/cli/status/table_printer.go
@@ -127,7 +127,7 @@ func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
 		msg := "\nThe status of some instances requires attention.\n" +
 			"Please rerun the command with the --details flag to see " +
 			"more information"
-		fmt.Println(msg)
+		fmt.Fprintln(os.Stdout, msg)
 	}
 
 	return nil
@@ -138,9 +138,9 @@ func (t TablePrinter) printInstanceAlerts(instanceName string, instStatus *insta
 	if len(instStatus.Alerts) == 0 {
 		return
 	}
-	fmt.Printf("Alerts for %s:\n", instanceName)
+	fmt.Fprintf(os.Stdout, "Alerts for %s:\n", instanceName)
 	for _, alert := range instStatus.Alerts {
-		fmt.Printf("  • %s\n", formatAlert(alert))
+		fmt.Fprintf(os.Stdout, "  • %s\n", formatAlert(alert))
 	}
-	fmt.Println()
+	fmt.Fprintln(os.Stdout)
 }

--- a/cli/status/yaml_printer.go
+++ b/cli/status/yaml_printer.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,6 +21,6 @@ func (y YAMLPrinter) Print(instances map[string]*instanceStatus) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal instances to YAML: %w", err)
 	}
-	fmt.Println(string(yamlData))
+	fmt.Fprintln(os.Stdout, string(yamlData))
 	return nil
 }

--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -32,11 +32,11 @@ func readWithTimeout(t *testing.T, ch <-chan string, timeout time.Duration) (str
 	}
 }
 
-func writeLogLines(t *testing.T, f *os.File, count int, line_fmt string) {
+func writeLogLines(t *testing.T, f *os.File, count int, lineFmt string) {
 	t.Helper()
 
 	for i := range count {
-		_, err := fmt.Fprintln(f, fmt.Sprintf(line_fmt, i+1))
+		_, err := fmt.Fprintln(f, fmt.Sprintf(lineFmt, i+1))
 		if err != nil {
 			t.Fatalf("Failed to write line %d: %v", i+1, err)
 		}
@@ -57,7 +57,7 @@ func createTmpLogFile(t *testing.T) string {
 	return f.Name()
 }
 
-func checksLinesInFile(t *testing.T, ch <-chan string, exp_fmt string) error {
+func checksLinesInFile(t *testing.T, ch <-chan string, expFmt string) error {
 	t.Helper()
 
 	for i := range linesPerStep {
@@ -68,7 +68,7 @@ func checksLinesInFile(t *testing.T, ch <-chan string, exp_fmt string) error {
 			return fmt.Errorf("failed to read line %d: %w", n, err)
 		}
 
-		expected := fmt.Sprintf(exp_fmt, n)
+		expected := fmt.Sprintf(expFmt, n)
 		if line != expected {
 			return fmt.Errorf("line %d mismatch: got %q, want %q", n, line, expected)
 		}
@@ -189,7 +189,7 @@ func TestFollow2_NonExistentFile(t *testing.T) {
 	}
 }
 
-func rotationTest(t *testing.T, use_delay bool) {
+func rotationTest(t *testing.T, useDelay bool) {
 	t.Helper()
 
 	lf := createTmpLogFile(t)
@@ -215,7 +215,7 @@ func rotationTest(t *testing.T, use_delay bool) {
 		t.Fatalf("Failed to rotate log file: %v", err)
 	}
 
-	if use_delay {
+	if useDelay {
 		time.Sleep(500 * time.Millisecond) // Add delay to avoid flaky fails.
 	}
 
@@ -252,23 +252,23 @@ func TestFollow2_FileRotation_Flaky(t *testing.T) {
 
 	const flakyRepeatCount = 3
 
-	test_pass := false
+	testPass := false
 
 	for i := range flakyRepeatCount {
 		t.Run(fmt.Sprintf("Rotation-%d", i+1), func(t *testing.T) {
 			rotationTest(t, i > 0)
 
-			test_pass = !t.Skipped()
+			testPass = !t.Skipped()
 		})
 
-		if test_pass {
+		if testPass {
 			break
 		}
 
 		t.Logf("FLAKY test %s failed, retrying flaky test iteration", t.Name())
 	}
 
-	if !test_pass {
+	if !testPass {
 		t.Fatalf("Test failed after all flaky iterations")
 	}
 }

--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -178,8 +178,7 @@ func TestFollow2_ContextCancellation(t *testing.T) {
 }
 
 func TestFollow2_NonExistentFile(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	f := tail.NewTailFollower("/path/to/nonexistent/file")
 

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -97,7 +97,7 @@ func newTailReader(ctx context.Context, reader io.ReadSeeker, count int) (io.Rea
 		}
 		readBytes, err := limitedReader.Read(buf)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, startPos, fmt.Errorf("failed to read: %s", err)
+			return nil, startPos, fmt.Errorf("failed to read: %w", err)
 		}
 		for i := readBytes - 1; i > 0; i-- {
 			if buf[i] == '\n' {

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -15,7 +15,11 @@ import (
 	"github.com/nxadm/tail"
 )
 
-const blockSize = 8192
+const (
+	blockSize               = 8192
+	formatterBufferCapacity = 512
+	outputChannelCapacity   = 8
+)
 
 // Reader is an interface for reading the last `lines` lines from a file.
 type Reader interface {
@@ -47,7 +51,7 @@ type LogFormatter func(str string) string
 // NewLogFormatter creates a function to make log prefix colored.
 func NewLogFormatter(prefix string, color color.Color) LogFormatter {
 	buf := strings.Builder{}
-	buf.Grow(512)
+	buf.Grow(formatterBufferCapacity)
 	return func(str string) string {
 		buf.Reset()
 		color.Fprint(&buf, prefix)
@@ -139,7 +143,7 @@ func TailN(ctx context.Context, logFormatter LogFormatter, fileName string,
 	}
 
 	scanner := bufio.NewScanner(reader)
-	out := make(chan string, 8)
+	out := make(chan string, outputChannelCapacity)
 	go func() {
 		defer close(out)
 		defer file.Close()

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -188,9 +188,7 @@ func Follow(ctx context.Context, out chan<- string, logFormatter LogFormatter, f
 		return err
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -210,6 +208,6 @@ func Follow(ctx context.Context, out chan<- string, logFormatter LogFormatter, f
 				out <- logFormatter(line.Text)
 			}
 		}
-	}()
+	})
 	return nil
 }

--- a/cli/tcm/log_printer.go
+++ b/cli/tcm/log_printer.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	indentSpaces = "  "
+	indentSpaces          = "  "
+	emptyJSONObjectLength = 2
 
 	logHeaderTime  = "time"
 	logHeaderLevel = "level"
@@ -108,7 +109,7 @@ func (l *logPrinter) format(str string) string {
 		return str
 	}
 
-	if len(json) > 2 { // If the JSON contains more than empty `{}`.
+	if len(json) > emptyJSONObjectLength { // If the JSON contains more than empty `{}`.
 		lines := strings.Split(string(json), "\n")
 		lines = lines[1 : len(lines)-1]
 		resultLines = append(resultLines, colorizeJSONLines(lines, color, colorFaint)...)

--- a/cli/tcm/log_printer.go
+++ b/cli/tcm/log_printer.go
@@ -111,7 +111,7 @@ func (l *logPrinter) format(str string) string {
 	if len(json) > 2 { // If the JSON contains more than empty `{}`.
 		lines := strings.Split(string(json), "\n")
 		lines = lines[1 : len(lines)-1]
-		resultLines = append(resultLines, colorizeJsonLines(lines, color, colorFaint)...)
+		resultLines = append(resultLines, colorizeJSONLines(lines, color, colorFaint)...)
 	}
 
 	resultLines = append(resultLines, color.Sprint("}"))
@@ -119,7 +119,7 @@ func (l *logPrinter) format(str string) string {
 	return strings.Join(resultLines, "\n")
 }
 
-func colorizeJsonLines(lines []string, cKey, cVal color.Color) []string {
+func colorizeJSONLines(lines []string, cKey, cVal color.Color) []string {
 	resultLines := make([]string, 0, len(lines))
 
 	for _, line := range lines {

--- a/cli/tcm/log_test.go
+++ b/cli/tcm/log_test.go
@@ -348,7 +348,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if *updateTestdata {
-		fmt.Println("Updating testdata files...")
+		fmt.Fprintln(os.Stdout, "Updating testdata files...")
 		os.RemoveAll(filepath.Join(testDataDir, expectedSubDir))
 	}
 

--- a/cli/templates/internal/engines/builtin_funcs.go
+++ b/cli/templates/internal/engines/builtin_funcs.go
@@ -9,9 +9,15 @@ type genState struct {
 	port, metricsPort int
 }
 
+const (
+	defaultPort        = 3301
+	defaultMetricsPort = 8081
+	alphabetSize       = 26
+)
+
 // newGenState creates genState.
 func newGenState() *genState {
-	return &genState{port: 3301, metricsPort: 8081}
+	return &genState{port: defaultPort, metricsPort: defaultMetricsPort}
 }
 
 // genPort generates port.
@@ -57,7 +63,7 @@ func genReplicasets(
 		replicasetName := fmt.Sprintf("%s-%03d", baseName, i+1)
 		instNames := make([]string, replicasetSize)
 		for j := range instNames {
-			if replicasetSize <= 26 {
+			if replicasetSize <= alphabetSize {
 				instNames[j] = fmt.Sprintf("%s-%c", replicasetName, 'a'+byte(j))
 			} else {
 				instNames[j] = fmt.Sprintf("%s-%03d", replicasetName, j+1)

--- a/cli/templates/internal/engines/go_text_engine.go
+++ b/cli/templates/internal/engines/go_text_engine.go
@@ -31,24 +31,24 @@ func makeTemplate(name string) *template.Template {
 func (GoTextEngine) RenderFile(srcPath, dstPath string, data any) error {
 	stat, err := os.Stat(srcPath)
 	if err != nil {
-		return fmt.Errorf("error getting file info %s: %s", srcPath, err)
+		return fmt.Errorf("error getting file info %s: %w", srcPath, err)
 	}
 	originFileMode := stat.Mode()
 
 	content, err := os.ReadFile(srcPath)
 	if err != nil {
-		return fmt.Errorf("error reading file %s: %s", srcPath, err)
+		return fmt.Errorf("error reading file %s: %w", srcPath, err)
 	}
 
 	parsedTemplate, err := makeTemplate(path.Base(srcPath)).Parse(string(content))
 	if err != nil {
-		return fmt.Errorf("error parsing %s: %s", srcPath, err)
+		return fmt.Errorf("error parsing %s: %w", srcPath, err)
 	}
 	parsedTemplate.Option("missingkey=error") // Treat missing variable as error.
 
 	outFile, err := os.Create(dstPath)
 	if err != nil {
-		return fmt.Errorf("error creating %s: %s", dstPath, err)
+		return fmt.Errorf("error creating %s: %w", dstPath, err)
 	}
 	defer func() {
 		outFile.Close()
@@ -56,7 +56,7 @@ func (GoTextEngine) RenderFile(srcPath, dstPath string, data any) error {
 	}()
 
 	if err := parsedTemplate.Execute(outFile, data); err != nil {
-		return fmt.Errorf("template execution failed: %s", err)
+		return fmt.Errorf("template execution failed: %w", err)
 	}
 	return nil
 }
@@ -65,13 +65,13 @@ func (GoTextEngine) RenderFile(srcPath, dstPath string, data any) error {
 func (GoTextEngine) RenderText(in string, data any) (string, error) {
 	parsedTemplate, err := makeTemplate("file").Parse(in)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse %s: %s", in, err)
+		return "", fmt.Errorf("failed to parse %s: %w", in, err)
 	}
 	parsedTemplate.Option("missingkey=error")
 
 	var buffer bytes.Buffer
 	if err = parsedTemplate.Execute(&buffer, &data); err != nil {
-		return "", fmt.Errorf("template execution failed: %s", err)
+		return "", fmt.Errorf("template execution failed: %w", err)
 	}
 
 	return buffer.String(), nil

--- a/cli/templates/internal/engines/go_text_engine.go
+++ b/cli/templates/internal/engines/go_text_engine.go
@@ -28,7 +28,7 @@ func makeTemplate(name string) *template.Template {
 }
 
 // RenderFile renders srcPath template to dstPath using go text/template engine.
-func (GoTextEngine) RenderFile(srcPath, dstPath string, data interface{}) error {
+func (GoTextEngine) RenderFile(srcPath, dstPath string, data any) error {
 	stat, err := os.Stat(srcPath)
 	if err != nil {
 		return fmt.Errorf("error getting file info %s: %s", srcPath, err)
@@ -62,7 +62,7 @@ func (GoTextEngine) RenderFile(srcPath, dstPath string, data interface{}) error 
 }
 
 // RenderText renders in text using go tex/template engine.
-func (GoTextEngine) RenderText(in string, data interface{}) (string, error) {
+func (GoTextEngine) RenderText(in string, data any) (string, error) {
 	parsedTemplate, err := makeTemplate("file").Parse(in)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse %s: %s", in, err)

--- a/cli/templates/templates.go
+++ b/cli/templates/templates.go
@@ -8,10 +8,10 @@ import (
 type TemplateEngine interface {
 	// RenderFile applies data to the template from srcPath.
 	// Instantiated template is saved as dstPath.
-	RenderFile(srcPath, dstPath string, data interface{}) error
+	RenderFile(srcPath, dstPath string, data any) error
 
 	// RenderText applies data to the template text. Returns instantiated text.
-	RenderText(in string, data interface{}) (string, error)
+	RenderText(in string, data any) (string, error)
 }
 
 // NewDefaultEngine creates and returns default template engine.

--- a/cli/ttlog/logger.go
+++ b/cli/ttlog/logger.go
@@ -11,6 +11,11 @@ import (
 )
 
 const (
+	logDirectoryMode = 0o755
+	logFileMode      = 0o640
+)
+
+const (
 	logOpenFlags   = os.O_CREATE | os.O_WRONLY | os.O_APPEND
 	logCreatePerms = 0o640
 )
@@ -90,12 +95,12 @@ func NewFileLogger(opts LoggerOpts) (Logger, error) {
 	dir := filepath.Dir(opts.Filename)
 	if _, err := os.Stat(dir); err != nil &&
 		errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, logDirectoryMode); err != nil {
 			return nil, err
 		}
 	}
 
-	file, err := os.OpenFile(opts.Filename, logOpenFlags, 0o640)
+	file, err := os.OpenFile(opts.Filename, logOpenFlags, logFileMode)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open the log file %q: %s", opts.Filename, err)
 	}

--- a/cli/ttlog/logger.go
+++ b/cli/ttlog/logger.go
@@ -102,7 +102,7 @@ func NewFileLogger(opts LoggerOpts) (Logger, error) {
 
 	file, err := os.OpenFile(opts.Filename, logOpenFlags, logFileMode)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open the log file %q: %s", opts.Filename, err)
+		return nil, fmt.Errorf("cannot open the log file %q: %w", opts.Filename, err)
 	}
 	return &fileLogger{
 		Logger:  log.New(file, opts.Prefix, log.LstdFlags),
@@ -138,7 +138,7 @@ func (logger *fileLogger) Rotate() error {
 
 	if logger.logFile, err = os.OpenFile(logger.opts.Filename, logOpenFlags,
 		logCreatePerms); err != nil {
-		return fmt.Errorf("cannot open the log file %q: %s", logger.opts.Filename, err)
+		return fmt.Errorf("cannot open the log file %q: %w", logger.opts.Filename, err)
 	}
 	logger.Logger = log.New(logger.logFile, logger.opts.Prefix, log.LstdFlags)
 	logger.Println("(INFO) log file has been reopened")

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -19,6 +19,8 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+const binaryNameMatchGroups = 2
+
 const (
 	progRegexp = "(?P<prog>.+)"
 
@@ -261,7 +263,7 @@ func searchLatestVersion(program search.Program, binDst, headerDst string) (stri
 		matches := util.FindNamedMatches(programRegex, binaryName)
 
 		// Need to match for the program and version.
-		if len(matches) != 2 {
+		if len(matches) != binaryNameMatchGroups {
 			log.Debugf("%q skipped: unexpected format", binaryName)
 			continue
 		}

--- a/cli/util/compress.go
+++ b/cli/util/compress.go
@@ -53,7 +53,7 @@ func ExtractTarGz(tarName, dstDir string) error {
 				//    user:   read/write/execute
 				//    group:  read/execute
 				//    others: read/execute
-				os.MkdirAll(filepath.Join(dstDir, dirName), 0o755)
+				os.MkdirAll(filepath.Join(dstDir, dirName), archiveDirectoryMode)
 			}
 			outFile, err := os.OpenFile(filepath.Join(dstDir, header.Name),
 				os.O_CREATE|os.O_WRONLY, header.FileInfo().Mode().Perm())

--- a/cli/util/execute.go
+++ b/cli/util/execute.go
@@ -115,7 +115,7 @@ func RunCommand(cmd *exec.Cmd, workingDir string, showOutput bool) error {
 		}
 
 		return fmt.Errorf(
-			"failed to run \n%s\n\n%s", cmd.String(), err,
+			"failed to run \n%s\n\n%w", cmd.String(), err,
 		)
 	}
 
@@ -129,7 +129,7 @@ func RunHook(hookPath string, showOutput bool) error {
 	hookDir := filepath.Dir(hookPath)
 
 	if isExec, err := IsExecOwner(hookPath); err != nil {
-		return fmt.Errorf("failed go check hook file `%s`: %s", hookName, err)
+		return fmt.Errorf("failed go check hook file `%s`: %w", hookName, err)
 	} else if !isExec {
 		return fmt.Errorf("hook `%s` should be executable", hookName)
 	}
@@ -137,7 +137,7 @@ func RunHook(hookPath string, showOutput bool) error {
 	hookCmd := exec.CommandContext(context.Background(), hookPath)
 	err := RunCommand(hookCmd, hookDir, showOutput)
 	if err != nil {
-		return fmt.Errorf("failed to run hook `%s`: %s", hookName, err)
+		return fmt.Errorf("failed to run hook `%s`: %w", hookName, err)
 	}
 
 	return nil
@@ -156,7 +156,7 @@ func IsExecOwner(path string) (bool, error) {
 
 func PrintFromStart(file *os.File) error {
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("failed to seek file begin: %s", err)
+		return fmt.Errorf("failed to seek file begin: %w", err)
 	}
 	if _, err := io.Copy(os.Stdout, file); err != nil {
 		log.Warnf("Failed to print file content: %s", err)

--- a/cli/util/execute.go
+++ b/cli/util/execute.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -133,7 +134,7 @@ func RunHook(hookPath string, showOutput bool) error {
 		return fmt.Errorf("hook `%s` should be executable", hookName)
 	}
 
-	hookCmd := exec.Command(hookPath)
+	hookCmd := exec.CommandContext(context.Background(), hookPath)
 	err := RunCommand(hookCmd, hookDir, showOutput)
 	if err != nil {
 		return fmt.Errorf("failed to run hook `%s`: %s", hookName, err)
@@ -169,7 +170,7 @@ func PrintFromStart(file *os.File) error {
 func ExecuteCommandGetOutput(program, workDir string, stdinData []byte,
 	args ...string,
 ) ([]byte, error) {
-	cmd := exec.Command(program, args...)
+	cmd := exec.CommandContext(context.Background(), program, args...)
 
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/cli/util/git.go
+++ b/cli/util/git.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -30,7 +31,7 @@ func CheckVersionFromGit(basePath string) (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command("git", "describe", "--tags", "--long")
+	cmd := exec.CommandContext(context.Background(), "git", "describe", "--tags", "--long")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = cmd.Run()
@@ -61,7 +62,7 @@ func isGitFetchJobsSupported(gitOutput string) bool {
 
 // IsGitFetchJobsSupported checks if fetchJobs option (-j) is supported by current git version.
 func IsGitFetchJobsSupported() bool {
-	cmd := exec.Command("git", "--version")
+	cmd := exec.CommandContext(context.Background(), "git", "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/cli/util/templates.go
+++ b/cli/util/templates.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetTextTemplatedStr returns the processed string text template.
-func GetTextTemplatedStr(text *string, obj interface{}) (string, error) {
+func GetTextTemplatedStr(text *string, obj any) (string, error) {
 	funcMap := textTemplate.FuncMap{
 		"ToLower": strings.ToLower,
 	}

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -134,7 +134,7 @@ func Find(src []string, find string) int {
 }
 
 // InternalError shows error information, version of tt and call stack.
-func InternalError(format string, f VersionFunc, err ...interface{}) error {
+func InternalError(format string, f VersionFunc, err ...any) error {
 	errorFmt := `whoops! It looks like something is wrong with this version of Tarantool CLI.
 Error: %s
 Version: %s
@@ -146,13 +146,13 @@ Stacktrace:
 }
 
 // ParseYAML parse yaml file at specified path.
-func ParseYAML(path string) (map[string]interface{}, error) {
+func ParseYAML(path string) (map[string]any, error) {
 	fileContent, err := GetFileContentBytes(path)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to read "%s" file: %s`, path, err)
 	}
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := yaml.Unmarshal(fileContent, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse YAML: %s", err)
 	}
@@ -756,7 +756,7 @@ func CreateDirectory(dirName string, fileMode os.FileMode) error {
 }
 
 // WriteYaml writes YAML encoding of object o to fileName.
-func WriteYaml(fileName string, o interface{}) error {
+func WriteYaml(fileName string, o any) error {
 	file, err := os.Create(fileName)
 	if err != nil {
 		return err

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"cmp"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -309,7 +310,7 @@ func AskConfirm(ioReader io.Reader, question string) (bool, error) {
 
 // GetArch returns Architecture of machine.
 func GetArch() (string, error) {
-	out, err := exec.Command("uname", "-m").Output()
+	out, err := exec.CommandContext(context.Background(), "uname", "-m").Output()
 	if err != nil {
 		return "", err
 	}
@@ -319,7 +320,7 @@ func GetArch() (string, error) {
 
 // GetOs returns the operating system version of the host.
 func GetOs() (OsType, error) {
-	out, err := exec.Command("uname", "-s").Output()
+	out, err := exec.CommandContext(context.Background(), "uname", "-s").Output()
 	if err != nil {
 		return OsUnknown, err
 	}
@@ -532,7 +533,7 @@ func ResolveSymlink(linkPath string) (string, error) {
 
 // RunCommandAndGetOutput returns output of command.
 func RunCommandAndGetOutput(program string, args ...string) (string, error) {
-	out, err := exec.Command(program, args...).Output()
+	out, err := exec.CommandContext(context.Background(), program, args...).Output()
 	if err != nil {
 		return "", err
 	}
@@ -612,7 +613,7 @@ func ExtractTar(tarName string) error {
 func ExecuteCommand(program string, isVerbose bool, writer io.Writer, workDir string,
 	args ...string,
 ) error {
-	cmd := exec.Command(program, args...)
+	cmd := exec.CommandContext(context.Background(), program, args...)
 	if isVerbose {
 		log.Infof("Run: %s\n", cmd)
 	}
@@ -640,7 +641,7 @@ func ExecuteCommand(program string, isVerbose bool, writer io.Writer, workDir st
 func ExecuteCommandStdin(program string, isVerbose bool, logFile *os.File, workDir string,
 	stdinData []byte, args ...string,
 ) error {
-	cmd := exec.Command(program, args...)
+	cmd := exec.CommandContext(context.Background(), program, args...)
 	if isVerbose {
 		log.Infof("Run: %s\n", cmd)
 	}

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -33,6 +33,8 @@ import (
 
 const bufSize int64 = 10000
 
+const archiveDirectoryMode = 0o755
+
 type OsType uint16
 
 const (
@@ -589,7 +591,7 @@ func ExtractTar(tarName string) error {
 				//    user:   read/write/execute
 				//    group:  read/execute
 				//    others: read/execute
-				os.MkdirAll(dir+header.Name[0:pos], 0o755)
+				os.MkdirAll(dir+header.Name[0:pos], archiveDirectoryMode)
 			}
 			outFile, err := os.Create(dir + header.Name)
 			if err != nil {

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -292,7 +292,7 @@ func AskConfirm(ioReader io.Reader, question string) (bool, error) {
 	reader := bufio.NewReader(ioReader)
 
 	for {
-		fmt.Printf("%s [y/n]: ", question)
+		fmt.Fprintf(os.Stdout, "%s [y/n]: ", question)
 
 		resp, err := reader.ReadString('\n')
 		resp = strings.ToLower(strings.TrimSpace(resp))

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -114,7 +114,7 @@ func JoinAbspath(paths ...string) (string, error) {
 	var err error
 	path := JoinPaths(paths...)
 	if path, err = filepath.Abs(path); err != nil {
-		return "", fmt.Errorf("failed to get absolute path: %s", err)
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
 	return path, nil
@@ -149,12 +149,12 @@ Stacktrace:
 func ParseYAML(path string) (map[string]any, error) {
 	fileContent, err := GetFileContentBytes(path)
 	if err != nil {
-		return nil, fmt.Errorf(`failed to read "%s" file: %s`, path, err)
+		return nil, fmt.Errorf(`failed to read "%s" file: %w`, path, err)
 	}
 
 	var raw map[string]any
 	if err := yaml.Unmarshal(fileContent, &raw); err != nil {
-		return nil, fmt.Errorf("failed to parse YAML: %s", err)
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
 	return raw, nil
@@ -171,12 +171,12 @@ func GetHomeDir() (string, error) {
 
 func readFromPos(readSeeker io.ReadSeeker, pos int64, buf *[]byte) (int, error) {
 	if _, err := readSeeker.Seek(pos, io.SeekStart); err != nil {
-		return 0, fmt.Errorf("failed to seek: %s", err)
+		return 0, fmt.Errorf("failed to seek: %w", err)
 	}
 
 	n, err := readSeeker.Read(*buf)
 	if err != nil {
-		return n, fmt.Errorf("failed to read: %s", err)
+		return n, fmt.Errorf("failed to read: %w", err)
 	}
 
 	return n, nil
@@ -194,13 +194,13 @@ func GetLastNLinesBegin(filepath string, lines int) (int64, error) {
 
 	f, err := os.Open(filepath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open file: %s", err)
+		return 0, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer f.Close()
 
 	var fileSize int64
 	if fileInfo, err := os.Stat(filepath); err != nil {
-		return 0, fmt.Errorf("failed to get fileinfo: %s", err)
+		return 0, fmt.Errorf("failed to get fileinfo: %w", err)
 	} else {
 		fileSize = fileInfo.Size()
 	}
@@ -270,11 +270,11 @@ func GetLastNLines(filepath string, linesN int) ([]string, error) {
 
 	file, err := os.Open(filepath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file: %s", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 
 	if _, err := file.Seek(lastNLinesBeginPos, io.SeekStart); err != nil {
-		return nil, fmt.Errorf("failed to seek in file: %s", err)
+		return nil, fmt.Errorf("failed to seek in file: %w", err)
 	}
 
 	lines := []string{}
@@ -451,7 +451,7 @@ func Chdir(newPath string) (func() error, error) {
 		return nil, fmt.Errorf("failed to get current directory: %w", err)
 	}
 	if err = os.Chdir(newPath); err != nil {
-		return nil, fmt.Errorf("failed to change directory: %s", err)
+		return nil, fmt.Errorf("failed to change directory: %w", err)
 	}
 
 	// Update PWD environment var.
@@ -686,7 +686,7 @@ func ExecuteCommandStdin(program string, isVerbose bool, logFile *os.File, workD
 func CreateSymlink(oldName, newName string, overwrite bool) error {
 	_, err := os.Stat(newName)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("symbolic link cannot be created: %s", err)
+		return fmt.Errorf("symbolic link cannot be created: %w", err)
 	}
 	if os.IsNotExist(err) {
 		return os.Symlink(oldName, newName)
@@ -789,7 +789,7 @@ func MergeFiles(destFilePath string, srcFilePaths ...string) error {
 	destFile, err := os.Create(destFilePath)
 	if err != nil {
 		_ = os.Remove(destFilePath)
-		return fmt.Errorf("failed to create result file %s: %s", destFilePath, err)
+		return fmt.Errorf("failed to create result file %s: %w", destFilePath, err)
 	}
 	defer destFile.Close()
 
@@ -797,7 +797,7 @@ func MergeFiles(destFilePath string, srcFilePaths ...string) error {
 		srcFile, err := os.Open(srcFilePath)
 		if err != nil {
 			_ = os.Remove(destFilePath)
-			return fmt.Errorf("failed to open source file %s: %s", srcFilePath, err)
+			return fmt.Errorf("failed to open source file %s: %w", srcFilePath, err)
 		}
 
 		_, err = io.Copy(destFile, srcFile)
@@ -873,7 +873,7 @@ func InstantiateFileFromTemplate(templatePath, templateContent string, params an
 
 	parsedTemplate, err := template.New(templatePath).Parse(unitContent)
 	if err != nil {
-		return fmt.Errorf("error parsing %s: %s", templatePath, err)
+		return fmt.Errorf("error parsing %s: %w", templatePath, err)
 	}
 	// spell-checker:ignore missingkey
 	parsedTemplate.Option("missingkey=error") // Treat missing variable as error.

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -360,7 +360,7 @@ func TestInstantiateFileFromTemplate(t *testing.T) {
 	type args struct {
 		unitPath     string
 		unitTemplate string
-		ctx          map[string]interface{}
+		ctx          map[string]any
 	}
 	tests := []struct {
 		name            string
@@ -373,11 +373,11 @@ func TestInstantiateFileFromTemplate(t *testing.T) {
 			args: args{
 				unitPath:     templatePath,
 				unitTemplate: templateContent,
-				ctx: map[string]interface{}{
+				ctx: map[string]any{
 					"TestName": 1,
 				},
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return err != nil
 			},
 			expectedContent: "1",
@@ -415,7 +415,7 @@ func TestParseYaml(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    map[string]interface{}
+		want    map[string]any
 		wantErr bool
 	}{
 		{

--- a/cli/version/version_match.go
+++ b/cli/version/version_match.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/tarantool/tt/cli/util"
 )
@@ -169,8 +170,7 @@ func MatchVersion(expected string, sortedVersions []Version) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for i := len(sortedVersions) - 1; i >= 0; i-- {
-		ver := sortedVersions[i]
+	for _, ver := range slices.Backward(sortedVersions) {
 		if compareVersions(reference, ver, fields) {
 			return ver.Str, nil
 		}

--- a/cli/version/version_tools.go
+++ b/cli/version/version_tools.go
@@ -22,7 +22,9 @@ const (
 	// CliSeparator is used in commands to specify version. E.g: program=version.
 	CliSeparator = "="
 	// FsSeparator is used in file names to specify version. E.g: program_version.
-	FsSeparator = "_"
+	FsSeparator          = "_"
+	optionalVersionParts = 3
+	semanticVersionParts = 3
 )
 
 type Release struct {
@@ -89,7 +91,7 @@ func createVersionRegexp(isStrict bool) *regexp.Regexp {
 		`(?:-(?P<additional>\d+))?` +
 		`(?:-(?P<hash>g[a-f0-9]+))?(?:-r(?P<revision>\d+))?(-gc64|-nogc64)?$`
 	if !isStrict {
-		matchString = strings.Replace(matchString, "{1}", "?", 3)
+		matchString = strings.Replace(matchString, "{1}", "?", optionalVersionParts)
 	}
 	return regexp.MustCompile(matchString)
 }
@@ -161,7 +163,7 @@ func ParseTt(verStr string) (Version, error) {
 
 	verStr = verToParse[:sepIndex]
 	numVersions := strings.Split(verStr, ".")
-	if len(numVersions) != 3 {
+	if len(numVersions) != semanticVersionParts {
 		return Version{}, fmt.Errorf("the version of %q does not match"+
 			" <major>.<minor>.<patch> format", verStr)
 	}

--- a/lib/cluster/file.go
+++ b/lib/cluster/file.go
@@ -6,6 +6,8 @@ import (
 	"os"
 )
 
+const publishedFileMode = 0o644
+
 type FileReadFunc func(path string) (io.ReadCloser, error)
 
 // FileCollector collects data from a YAML file.
@@ -63,7 +65,7 @@ func (publisher FilePublisher) Publish(revision int64, data []byte) error {
 			publisher.path)
 	}
 
-	if err := os.WriteFile(publisher.path, data, 0o644); err != nil {
+	if err := os.WriteFile(publisher.path, data, publishedFileMode); err != nil {
 		return fmt.Errorf("failed to publish data into %q: %w", publisher.path, err)
 	}
 	return nil

--- a/lib/cluster/integration_test.go
+++ b/lib/cluster/integration_test.go
@@ -502,31 +502,31 @@ func TestEtcdAllDataPublisher_collect_publish_collect(t *testing.T) {
 var testsIntegrity = []struct {
 	Name         string
 	Applicable   func(t *testing.T) bool
-	Setup        func(t *testing.T) interface{}
-	Shutdown     func(t *testing.T, inst interface{})
+	Setup        func(t *testing.T) any
+	Shutdown     func(t *testing.T, inst any)
 	NewPublisher func(
 		t *testing.T,
 		integrityOpts cluster.IntegrityOptions,
 		prefix, key string,
-		inst interface{},
+		inst any,
 	) (cluster.DataPublisher, func())
 	NewCollector func(
 		t *testing.T,
 		integrityOpts cluster.IntegrityOptions,
 		prefix, key string,
-		inst interface{},
+		inst any,
 	) (cluster.DataCollector, func())
 }{
 	{
 		Name:       "tarantool",
 		Applicable: tcsIsSupported,
-		Setup: func(t *testing.T) interface{} {
+		Setup: func(t *testing.T) any {
 			t.Helper()
 
 			inst := startTcs(t)
 			return inst
 		},
-		Shutdown: func(t *testing.T, inst interface{}) {
+		Shutdown: func(t *testing.T, inst any) {
 			t.Helper()
 
 			stopTcs(t, inst)
@@ -536,7 +536,7 @@ var testsIntegrity = []struct {
 			integrityOpts cluster.IntegrityOptions,
 			prefix,
 			key string,
-			inst interface{},
+			inst any,
 		) (cluster.DataPublisher, func()) {
 			t.Helper()
 
@@ -575,7 +575,7 @@ var testsIntegrity = []struct {
 			integrityOpts cluster.IntegrityOptions,
 			prefix,
 			key string,
-			inst interface{},
+			inst any,
 		) (cluster.DataCollector, func()) {
 			t.Helper()
 
@@ -620,13 +620,13 @@ var testsIntegrity = []struct {
 
 			return true
 		},
-		Setup: func(t *testing.T) interface{} {
+		Setup: func(t *testing.T) any {
 			t.Helper()
 
 			inst := startEtcd(t)
 			return inst
 		},
-		Shutdown: func(t *testing.T, inst interface{}) {
+		Shutdown: func(t *testing.T, inst any) {
 			t.Helper()
 
 			etcdInst, ok := inst.(*etcdtest.LazyCluster)
@@ -638,7 +638,7 @@ var testsIntegrity = []struct {
 			integrityOpts cluster.IntegrityOptions,
 			prefix,
 			key string,
-			inst interface{},
+			inst any,
 		) (cluster.DataPublisher, func()) {
 			t.Helper()
 
@@ -665,7 +665,7 @@ var testsIntegrity = []struct {
 			integrityOpts cluster.IntegrityOptions,
 			prefix,
 			key string,
-			inst interface{},
+			inst any,
 		) (cluster.DataCollector, func()) {
 			t.Helper()
 

--- a/lib/cluster/storage.go
+++ b/lib/cluster/storage.go
@@ -401,7 +401,7 @@ func connectTarantoolConnector(cfg gsconnect.Config) (tarantool.Connector, error
 // getEtcdCfg builds an etcd connection configuration from the given
 // connect options and URI options, resolving credentials from options
 // or environment variables as a fallback.
-func getEtcdCfg(connOpts ConnectOpts, uriOpts libconnect.UriOpts) gsconnect.Config {
+func getEtcdCfg(connOpts ConnectOpts, uriOpts libconnect.URIOpts) gsconnect.Config {
 	var endpoints []string
 	if uriOpts.Endpoint != "" {
 		endpoints = []string{uriOpts.Endpoint}
@@ -437,7 +437,7 @@ func getEtcdCfg(connOpts ConnectOpts, uriOpts libconnect.UriOpts) gsconnect.Conf
 // getTarantoolCfg builds a tarantool connection configuration from the given
 // connect options and URI options, resolving credentials from options
 // or environment variables as a fallback.
-func getTarantoolCfg(connOpts ConnectOpts, uriOpts libconnect.UriOpts) gsconnect.Config {
+func getTarantoolCfg(connOpts ConnectOpts, uriOpts libconnect.URIOpts) gsconnect.Config {
 	if uriOpts.Username == "" && uriOpts.Password == "" {
 		uriOpts.Username = connOpts.Username
 		uriOpts.Password = connOpts.Password
@@ -467,7 +467,7 @@ func getTarantoolCfg(connOpts ConnectOpts, uriOpts libconnect.UriOpts) gsconnect
 
 // NewStorageConnection determines a storage based on the opts.
 func NewStorageConnection(
-	connOpts ConnectOpts, opts libconnect.UriOpts,
+	connOpts ConnectOpts, opts libconnect.URIOpts,
 ) (gstorage.Storage, gsconnect.CleanupFunc, string, error) {
 	etcdCfg := getEtcdCfg(connOpts, opts)
 	etcdClient, errEtcd := connectEtcdClient(etcdCfg)

--- a/lib/connect/credentials.go
+++ b/lib/connect/credentials.go
@@ -27,21 +27,21 @@ func getCredsInteractive() (UserCredentials, error) {
 	res := UserCredentials{}
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Println("Signing in to Customer zone.")
-	fmt.Printf("Enter Email: ")
+	fmt.Fprintln(os.Stdout, "Signing in to Customer zone.")
+	fmt.Fprintf(os.Stdout, "Enter Email: ")
 	resp, err := reader.ReadString('\n')
 	if err != nil {
 		return res, err
 	}
 	res.Username = strings.TrimSpace(resp)
 
-	fmt.Printf("Enter Password: ")
+	fmt.Fprintf(os.Stdout, "Enter Password: ")
 	bytePass, err := term.ReadPassword(syscall.Stdin)
 	if err != nil {
 		return res, err
 	}
 	res.Password = strings.TrimSpace(string(bytePass))
-	fmt.Println("")
+	fmt.Fprintln(os.Stdout, "")
 
 	return res, nil
 }

--- a/lib/connect/credentials.go
+++ b/lib/connect/credentials.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/term"
 )
 
+const forbiddenCredentialPermissions = 0o077
+
 const (
 	EnvSdkUsername = "TT_CLI_EE_USERNAME"
 	EnvSdkPassword = "TT_CLI_EE_PASSWORD"
@@ -60,7 +62,7 @@ func getCredsFromFile(path string) (UserCredentials, error) {
 	}
 
 	// Check file permissions. Error if `group` or `other` bits are set.
-	if info.Mode().Perm()&os.FileMode(0o077) != 0 {
+	if info.Mode().Perm()&os.FileMode(forbiddenCredentialPermissions) != 0 {
 		return res, fmt.Errorf("permissions %q for %q are too open.\n\t%s\n\t%s %s'",
 			info.Mode(),
 			path,

--- a/lib/connect/credentials_test.go
+++ b/lib/connect/credentials_test.go
@@ -85,7 +85,7 @@ func Test_getCredsFromEnvVars(t *testing.T) {
 			name:    "Environment variables are not passed",
 			prepare: func() {},
 			want:    UserCredentials{Username: "", Password: ""},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return err.Error() == "no credentials in environment variables were found"
 			},
 		},
@@ -96,7 +96,7 @@ func Test_getCredsFromEnvVars(t *testing.T) {
 				t.Setenv(EnvSdkPassword, "tt_test")
 			},
 			want: UserCredentials{Username: "tt_test", Password: "tt_test"},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},

--- a/lib/connect/help.go
+++ b/lib/connect/help.go
@@ -98,8 +98,8 @@ The command supports the following environment variables:
 
 	makeEnvVars := func(key, info string) {
 		h := template.HTML(info)
-		if strings.HasSuffix(key, "_auth") {
-			envAuth[strings.TrimSuffix(key, "_auth")] = h
+		if authKey, isAuth := strings.CutSuffix(key, "_auth"); isAuth {
+			envAuth[authKey] = h
 		} else {
 			envVars[key] = h
 		}

--- a/lib/connect/uri.go
+++ b/lib/connect/uri.go
@@ -64,8 +64,8 @@ const (
 	defaultTimeoutParam = 3 * time.Second
 )
 
-// UriOpts is a universal list of connect options retrieved from an URI.
-type UriOpts struct {
+// URIOpts is a universal list of connect options retrieved from a URI.
+type URIOpts struct {
 	// Endpoint is a an endpoint to connect: [scheme://]host[:port].
 	Endpoint string
 	// Host is a an address to connect: host[:port].
@@ -224,13 +224,13 @@ func getDurationParam(param string, defaultValue time.Duration) (time.Duration, 
 }
 
 // parseUriOpts extract options from a URL to UriOpts.
-func parseUriOpts(uri *url.URL) (UriOpts, error) {
+func parseURIOpts(uri *url.URL) (URIOpts, error) {
 	var err error
 	endpoint := url.URL{
 		Scheme: uri.Scheme,
 		Host:   uri.Host,
 	}
-	opts := UriOpts{
+	opts := URIOpts{
 		Endpoint: endpoint.String(),
 		Host:     uri.Host,
 		Prefix:   uri.Path,
@@ -288,7 +288,7 @@ func parseUriOpts(uri *url.URL) (UriOpts, error) {
 
 // parseUrl returns a URL, nil if string could be recognized as a URL,
 // otherwise nil, an error.
-func parseUrl(str string) (*url.URL, error) {
+func parseURL(str string) (*url.URL, error) {
 	uri, err := url.Parse(str)
 	// The URL general form represented is:
 	// [scheme:][//[userinfo@]host][/]path[?query][#fragment]
@@ -306,12 +306,12 @@ func parseUrl(str string) (*url.URL, error) {
 	return uri, nil
 }
 
-// CreateUriOpts parse URL string and creates appropriated UriOpts.
-func CreateUriOpts(url string) (UriOpts, error) {
-	uri, err := parseUrl(url)
+// CreateURIOpts parses a URL string and creates appropriate URIOpts.
+func CreateURIOpts(url string) (URIOpts, error) {
+	uri, err := parseURL(url)
 	if err != nil {
-		return UriOpts{}, err
+		return URIOpts{}, err
 	}
 
-	return parseUriOpts(uri)
+	return parseURIOpts(uri)
 }

--- a/lib/connect/uri.go
+++ b/lib/connect/uri.go
@@ -262,21 +262,21 @@ func parseURIOpts(uri *url.URL) (URIOpts, error) {
 		case timeoutParam:
 			opts.Timeout, err = getDurationParam(v[0], defaultTimeoutParam)
 			if err != nil {
-				return opts, fmt.Errorf("invalid %q param, float (in seconds) expected: %s",
+				return opts, fmt.Errorf("invalid %q param, float (in seconds) expected: %w",
 					k, err)
 			}
 
 		case verifyHostParam:
 			verify, err := getBooleanParam(v[0], defaultVerifyHostParam)
 			if err != nil {
-				return opts, fmt.Errorf("invalid %q param, boolean expected: %s", k, err)
+				return opts, fmt.Errorf("invalid %q param, boolean expected: %w", k, err)
 			}
 			opts.SkipHostVerify = !verify
 
 		case verifyPeerParam:
 			verify, err := getBooleanParam(v[0], defaultVerifyHostParam)
 			if err != nil {
-				return opts, fmt.Errorf("invalid %q param, boolean expected: %s", k, err)
+				return opts, fmt.Errorf("invalid %q param, boolean expected: %w", k, err)
 			}
 			opts.SkipPeerVerify = !verify
 

--- a/lib/connect/uri.go
+++ b/lib/connect/uri.go
@@ -62,6 +62,8 @@ const (
 
 	// defaultTimeoutParam is a default TimeoutParam.
 	defaultTimeoutParam = 3 * time.Second
+
+	credentialURISections = 2
 )
 
 // URIOpts is a universal list of connect options retrieved from a URI.
@@ -191,7 +193,7 @@ func ParseCredentialsURI(str string) (string, string, string) {
 	re := regexp.MustCompile(userPassRe + `@`)
 	// Split the string into two parts by credentials to create a string
 	// without the credentials.
-	split := re.Split(str, 2)
+	split := re.Split(str, credentialURISections)
 	newStr := split[0] + split[1]
 
 	// Parse credentials.

--- a/lib/connect/uri_test.go
+++ b/lib/connect/uri_test.go
@@ -149,8 +149,8 @@ func TestIsCredentialsURIInvalid(t *testing.T) {
 
 func TestParseCredentialsURI(t *testing.T) {
 	cases := []struct {
-		srcUri string
-		newUri string
+		srcURI string
+		newURI string
 	}{
 		{"tcp://" + testUserPass + "@localhost:3013", "tcp://localhost:3013"},
 		{testUserPass + "@localhost:3013", "localhost:3013"},
@@ -169,9 +169,9 @@ func TestParseCredentialsURI(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(c.srcUri, func(t *testing.T) {
-			newUri, user, pass := connect.ParseCredentialsURI(c.srcUri)
-			assert.Equal(t, c.newUri, newUri, "a unexpected new URI")
+		t.Run(c.srcURI, func(t *testing.T) {
+			newURI, user, pass := connect.ParseCredentialsURI(c.srcURI)
+			assert.Equal(t, c.newURI, newURI, "a unexpected new URI")
 			assert.Equal(t, testUser, user, "a unexpected username")
 			assert.Equal(t, testPass, pass, "a unexpected password")
 		})
@@ -181,8 +181,8 @@ func TestParseCredentialsURI(t *testing.T) {
 func TestParseCredentialsURI_parseValid(t *testing.T) {
 	for _, uri := range validCredentialsUris {
 		t.Run(uri, func(t *testing.T) {
-			newUri, user, pass := connect.ParseCredentialsURI(uri)
-			assert.NotEqual(t, uri, newUri, "URI must change")
+			newURI, user, pass := connect.ParseCredentialsURI(uri)
+			assert.NotEqual(t, uri, newURI, "URI must change")
 			assert.NotEqual(t, "", user, "username must not be empty")
 			assert.NotEqual(t, "", pass, "password must not be empty")
 		})
@@ -198,8 +198,8 @@ func TestParseCredentialsURI_notParseInvalid(t *testing.T) {
 
 	for _, uri := range invalid {
 		t.Run(uri, func(t *testing.T) {
-			newUri, user, pass := connect.ParseCredentialsURI(uri)
-			assert.Equal(t, uri, newUri, "URI must no change")
+			newURI, user, pass := connect.ParseCredentialsURI(uri)
+			assert.Equal(t, uri, newURI, "URI must no change")
 			assert.Equal(t, "", user, "username must be empty")
 			assert.Equal(t, "", pass, "password must be empty")
 		})
@@ -251,39 +251,39 @@ func TestParseUriOpts(t *testing.T) {
 	const defaultTimeout = 3 * time.Second
 
 	cases := map[string]struct {
-		Url    string
-		Opts   connect.UriOpts
+		URL    string
+		Opts   connect.URIOpts
 		params map[string]string
 		Err    string
 	}{
 		"empty url": {
-			Url:  "",
-			Opts: connect.UriOpts{},
+			URL:  "",
+			Opts: connect.URIOpts{},
 			Err:  "URL must contain the scheme and the host parts",
 		},
 		"no scheme": {
-			Url:  "host",
-			Opts: connect.UriOpts{},
+			URL:  "host",
+			Opts: connect.URIOpts{},
 			Err:  "URL must contain the scheme and the host parts",
 		},
 		"invalid scheme": {
-			Url:  ":host",
-			Opts: connect.UriOpts{},
+			URL:  ":host",
+			Opts: connect.URIOpts{},
 			Err:  "missing protocol scheme",
 		},
 		"no host": {
-			Url:  "scheme:///prefix",
-			Opts: connect.UriOpts{},
+			URL:  "scheme:///prefix",
+			Opts: connect.URIOpts{},
 			Err:  "URL must contain the scheme and the host parts",
 		},
 		"with opaque": {
-			Url:  "scheme:host.com/prefix",
-			Opts: connect.UriOpts{},
+			URL:  "scheme:host.com/prefix",
+			Opts: connect.URIOpts{},
 			Err:  "URL must contain the scheme and the host parts",
 		},
 		"simple": {
-			Url: "scheme://localhost",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Timeout:  defaultTimeout,
@@ -291,8 +291,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with port": {
-			Url: "scheme://localhost:3013",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost:3013",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost:3013",
 				Host:     "localhost:3013",
 				Timeout:  defaultTimeout,
@@ -300,8 +300,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"user auth": {
-			Url: "scheme://user@localhost",
-			Opts: connect.UriOpts{
+			URL: "scheme://user@localhost",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Username: "user",
@@ -310,8 +310,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"user and pass": {
-			Url: "scheme://user:pass@localhost",
-			Opts: connect.UriOpts{
+			URL: "scheme://user:pass@localhost",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Username: "user",
@@ -321,8 +321,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"prefix root": {
-			Url: "scheme://localhost/",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/",
@@ -331,8 +331,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with prefix": {
-			Url: "scheme://localhost/prefix",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/prefix",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/prefix",
@@ -341,8 +341,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with prefix and fragment": {
-			Url: "scheme://localhost/prefix#Fragment",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/prefix#Fragment",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/prefix",
@@ -352,8 +352,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"only fragment": {
-			Url: "scheme://localhost#Fragment",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost#Fragment",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Tag:      "Fragment",
@@ -362,8 +362,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with param key": {
-			Url: "scheme://localhost/prefix?key=anykey",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/prefix?key=anykey",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/prefix",
@@ -373,8 +373,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with param name": {
-			Url: "scheme://localhost/prefix?name=anyname",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/prefix?name=anyname",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/prefix",
@@ -384,8 +384,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"no prefix with params": {
-			Url: "scheme://localhost?name=anyname#Fragment",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?name=anyname#Fragment",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Tag:      "Fragment",
@@ -395,8 +395,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"with empty param": {
-			Url: "scheme://localhost/prefix?name=",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost/prefix?name=",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Prefix:   "/prefix",
@@ -406,8 +406,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"ssl_key_file": {
-			Url: "scheme://localhost?ssl_key_file=/any/kfile",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?ssl_key_file=/any/kfile",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				KeyFile:  "/any/kfile",
@@ -416,8 +416,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"ssl_cert_file": {
-			Url: "scheme://localhost?ssl_cert_file=/any/certfile",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?ssl_cert_file=/any/certfile",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				CertFile: "/any/certfile",
@@ -426,8 +426,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"ssl_ca_path": {
-			Url: "scheme://localhost?ssl_ca_path=/any/capath",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?ssl_ca_path=/any/capath",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				CaPath:   "/any/capath",
@@ -436,8 +436,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"ssl_ca_file": {
-			Url: "scheme://localhost?ssl_ca_file=/any/cafile",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?ssl_ca_file=/any/cafile",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				CaFile:   "/any/cafile",
@@ -446,8 +446,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"verify peer and host": {
-			Url: "scheme://localhost?verify_peer=true&verify_host=true",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?verify_peer=true&verify_host=true",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Timeout:  defaultTimeout,
@@ -455,8 +455,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"verify peer and host is empty": {
-			Url: "scheme://localhost?verify_peer=&verify_host=",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?verify_peer=&verify_host=",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Timeout:  defaultTimeout,
@@ -464,8 +464,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"skip verify peer": {
-			Url: "scheme://localhost?verify_peer=false",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?verify_peer=false",
+			Opts: connect.URIOpts{
 				Endpoint:       "scheme://localhost",
 				Host:           "localhost",
 				SkipPeerVerify: true,
@@ -474,13 +474,13 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"invalid verify_peer": {
-			Url:  "scheme://localhost?verify_peer=asd",
-			Opts: connect.UriOpts{},
+			URL:  "scheme://localhost?verify_peer=asd",
+			Opts: connect.URIOpts{},
 			Err:  `invalid "verify_peer" param, boolean expected:`,
 		},
 		"skip verify host": {
-			Url: "scheme://localhost?verify_host=false",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?verify_host=false",
+			Opts: connect.URIOpts{
 				Endpoint:       "scheme://localhost",
 				Host:           "localhost",
 				SkipHostVerify: true,
@@ -489,13 +489,13 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"invalid verify_host": {
-			Url:  "scheme://localhost?verify_host=asd",
-			Opts: connect.UriOpts{},
+			URL:  "scheme://localhost?verify_host=asd",
+			Opts: connect.URIOpts{},
 			Err:  `invalid "verify_host" param, boolean expected:`,
 		},
 		"timeout": {
-			Url: "scheme://localhost?timeout=5.5",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?timeout=5.5",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Timeout:  time.Duration(float64(5.5) * float64(time.Second)),
@@ -503,8 +503,8 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"empty timeout": {
-			Url: "scheme://localhost?timeout=",
-			Opts: connect.UriOpts{
+			URL: "scheme://localhost?timeout=",
+			Opts: connect.URIOpts{
 				Endpoint: "scheme://localhost",
 				Host:     "localhost",
 				Timeout:  defaultTimeout,
@@ -512,19 +512,19 @@ func TestParseUriOpts(t *testing.T) {
 			Err: "",
 		},
 		"invalid timeout": {
-			Url:  "scheme://localhost?timeout=asd",
-			Opts: connect.UriOpts{},
+			URL:  "scheme://localhost?timeout=asd",
+			Opts: connect.URIOpts{},
 			Err:  `invalid "timeout" param, float (in seconds) expected:`,
 		},
 		"full set": {
-			Url: "scheme://user:pass@localhost:2012/prefix" +
+			URL: "scheme://user:pass@localhost:2012/prefix" +
 				"?key=anykey&name=anyname" +
 				"&ssl_key_file=kfile&ssl_cert_file=certfile" +
 				"&ssl_ca_path=capath&ssl_ca_file=cafile" +
 				"&ssl_ciphers=foo:bar:ciphers" +
 				"&verify_peer=true&verify_host=false&timeout=2" +
 				"#Fragment",
-			Opts: connect.UriOpts{
+			Opts: connect.URIOpts{
 				Endpoint:       "scheme://localhost:2012",
 				Host:           "localhost:2012",
 				Prefix:         "/prefix",
@@ -549,7 +549,7 @@ func TestParseUriOpts(t *testing.T) {
 			if tc.Opts.Params == nil {
 				tc.Opts.Params = make(map[string]string)
 			}
-			opts, err := connect.CreateUriOpts(tc.Url)
+			opts, err := connect.CreateURIOpts(tc.URL)
 			if tc.Err != "" {
 				assert.ErrorContains(t, err, tc.Err)
 			} else {

--- a/lib/dial/ssl_disable.go
+++ b/lib/dial/ssl_disable.go
@@ -1,5 +1,4 @@
 //go:build tt_ssl_disable
-// +build tt_ssl_disable
 
 package dial
 

--- a/lib/watchdog/watchdog.go
+++ b/lib/watchdog/watchdog.go
@@ -96,7 +96,7 @@ func (wd *Watchdog) Start(bin string, args ...string) error {
 
 		// Start the managed process.
 		wd.cmdMutex.Lock()
-		wd.cmd = exec.Command(bin, args...)
+		wd.cmd = exec.CommandContext(context.Background(), bin, args...)
 		// Create new process group for proper signal handling.
 		wd.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/lib/watchdog/watchdog_test.go
+++ b/lib/watchdog/watchdog_test.go
@@ -44,7 +44,7 @@ func TestWatchdog_Successful(t *testing.T) {
 	wd := NewWatchdog("test.pid", "wd.pid", 100*time.Millisecond)
 	t.Cleanup(cleanupPidFiles)
 
-	cmd := exec.Command("sleep", "1")
+	cmd := exec.CommandContext(t.Context(), "sleep", "1")
 	errChan := make(chan error, 1)
 
 	go func() { errChan <- wd.Start(cmd.Path, cmd.Args[1:]...) }()
@@ -64,7 +64,7 @@ func TestWatchdog_EarlyTermination(t *testing.T) {
 	wd := NewWatchdog("test.pid", "wd.pid", time.Second)
 	t.Cleanup(cleanupPidFiles)
 
-	cmd := exec.Command("sleep", "10")
+	cmd := exec.CommandContext(t.Context(), "sleep", "10")
 	errChan := make(chan error, 1)
 
 	go func() { errChan <- wd.Start(cmd.Path, cmd.Args[1:]...) }()
@@ -81,7 +81,7 @@ func TestWatchdog_ProcessRestart(t *testing.T) {
 	wd := NewWatchdog("test.pid", "wd.pid", 100*time.Millisecond)
 	t.Cleanup(cleanupPidFiles)
 
-	cmd := exec.Command("false")
+	cmd := exec.CommandContext(t.Context(), "false")
 	errChan := make(chan error, 1)
 
 	go func() { errChan <- wd.Start(cmd.Path, cmd.Args[1:]...) }()
@@ -137,11 +137,14 @@ func TestWatchdog_WritePIDFiles(t *testing.T) {
 		wdPidFile: wdPidFile,
 	}
 
-	cmd := exec.Command("sleep", "1")
+	cmd := exec.CommandContext(t.Context(), "sleep", "1")
 	err := cmd.Start()
 	require.NoError(t, err)
 
-	defer cmd.Process.Kill()
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
 
 	wd.cmd = cmd
 

--- a/magefile.go
+++ b/magefile.go
@@ -1,5 +1,4 @@
 //go:build mage
-// +build mage
 
 package main
 

--- a/magefile.go
+++ b/magefile.go
@@ -165,7 +165,7 @@ func buildTt(argUpdaters ...optsUpdater) error {
 		packagePath)
 	err = sh.RunWith(getBuildEnvironment(), goExecutableName, args...)
 	if err != nil {
-		return fmt.Errorf("failed to build tt executable: %s", err)
+		return fmt.Errorf("failed to build tt executable: %w", err)
 	}
 
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -175,34 +175,34 @@ type Build mg.Namespace
 
 // Release builds the release tt executable without debug info.
 func (Build) Release() error {
-	fmt.Println("Building release tt...")
+	fmt.Fprintln(os.Stdout, "Building release tt...")
 
 	return buildTt(appendTags, appendLdFlags("-s", "-w"))
 }
 
 // Debug builds the debug tt executable.
 func (Build) Debug() error {
-	fmt.Println("Building debug tt...")
+	fmt.Fprintln(os.Stdout, "Building debug tt...")
 
 	return buildTt(appendTags, appendLdFlags())
 }
 
 // Coverage builds the tt executable with coverage.
 func (Build) Coverage() error {
-	fmt.Println("Building release tt with coverage...")
+	fmt.Fprintln(os.Stdout, "Building release tt with coverage...")
 
 	err := buildTt(appendFlags("-cover"), appendTags, appendLdFlags("-s", "-w"))
 	if err != nil {
 		return err
 	}
-	fmt.Println(`Set coverage data destination directory (must exist) and run tt:
+	fmt.Fprintln(os.Stdout, `Set coverage data destination directory (must exist) and run tt:
 	GOCOVERDIR=./<coverage_dest_dir> tt <opts>`)
 	return nil
 }
 
 // CheckLicenses runs the license checker.
 func CheckLicenses() error {
-	fmt.Println("Running license checker...")
+	fmt.Fprintln(os.Stdout, "Running license checker...")
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -231,7 +231,7 @@ func (Lint) Golang() error {
 		return err
 	}
 
-	fmt.Printf("Running %s over %s...\n", linter, lintConfig)
+	fmt.Fprintf(os.Stdout, "Running %s over %s...\n", linter, lintConfig)
 
 	root, err := os.Getwd()
 	if err != nil {
@@ -303,7 +303,7 @@ func linterVersionOf(exe string) (string, error) {
 
 // Python runs python linters.
 func (Lint) Python() error {
-	fmt.Println("Running Ruff...")
+	fmt.Fprintln(os.Stdout, "Running Ruff...")
 
 	if err := sh.RunV(pythonExecutableName, "-m", "ruff", "check", "test"); err != nil {
 		return err
@@ -336,28 +336,28 @@ func runUnitTests(flags []string) error {
 
 // Default runs unit tests.
 func (Unit) Default() error {
-	fmt.Println("Running unit tests...")
+	fmt.Fprintln(os.Stdout, "Running unit tests...")
 
 	return runUnitTests([]string{})
 }
 
 // Full runs unit tests with Tarantool instance integration.
 func (Unit) Full() error {
-	fmt.Println("Running full unit tests...")
+	fmt.Fprintln(os.Stdout, "Running full unit tests...")
 
 	return runUnitTests([]string{"-tags", "integration,integration_docker"})
 }
 
 // FullSkipDocker runs unit tests with Tarantool instance integration, excluding docker tests.
 func (Unit) FullSkipDocker() error {
-	fmt.Println("Running full unit tests, excluding docker...")
+	fmt.Fprintln(os.Stdout, "Running full unit tests, excluding docker...")
 
 	return runUnitTests([]string{"-tags", "integration"})
 }
 
 // Coverage runs the full unit test set with code coverage.
 func (Unit) Coverage() error {
-	fmt.Println("Running full unit tests with code coverage...")
+	fmt.Fprintln(os.Stdout, "Running full unit tests with code coverage...")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -380,8 +380,8 @@ func (Unit) Coverage() error {
 	if err != nil {
 		relCoverDir = coverDir
 	}
-	fmt.Printf("Coverage data is saved to %q\n", relCoverDir)
-	fmt.Printf(`Example command for analysis:
+	fmt.Fprintf(os.Stdout, "Coverage data is saved to %q\n", relCoverDir)
+	fmt.Fprintf(os.Stdout, `Example command for analysis:
 	go tool covdata func -i %q
 `, relCoverDir)
 
@@ -406,7 +406,7 @@ func ensureCoverageDir(coverDir string) error {
 
 // Integration runs integration tests, excluding slow tests.
 func Integration() error {
-	fmt.Println("Running integration tests...")
+	fmt.Fprintln(os.Stdout, "Running integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow and not slow_ee "+
 		"and not notarantool", "test/integration")
@@ -414,7 +414,7 @@ func Integration() error {
 
 // IntegrationFull runs the full set of integration tests.
 func IntegrationFull() error {
-	fmt.Println("Running all integration tests...")
+	fmt.Fprintln(os.Stdout, "Running all integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool",
 		"test/integration")
@@ -422,7 +422,7 @@ func IntegrationFull() error {
 
 // IntegrationFullSkipDocker runs the full set of integration tests, excluding docker tests.
 func IntegrationFullSkipDocker() error {
-	fmt.Println("Running all integration tests, excluding docker...")
+	fmt.Fprintln(os.Stdout, "Running all integration tests, excluding docker...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m",
 		"not slow_ee and not notarantool and not docker", "test/integration")
@@ -430,7 +430,7 @@ func IntegrationFullSkipDocker() error {
 
 // IntegrationFullDocker runs only docker tests from the full set.
 func IntegrationFullDocker() error {
-	fmt.Println("Running docker integration tests...")
+	fmt.Fprintln(os.Stdout, "Running docker integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m",
 		"not slow_ee and not notarantool and docker", "test/integration")
@@ -438,14 +438,14 @@ func IntegrationFullDocker() error {
 
 // IntegrationEE runs the set of EE integration tests.
 func IntegrationEE() error {
-	fmt.Println("Running all EE integration tests...")
+	fmt.Fprintln(os.Stdout, "Running all EE integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "test/integration/ee")
 }
 
 // IntegrationNoTarantool runs integration tests without a system-wide Tarantool installation.
 func IntegrationNoTarantool() error {
-	fmt.Println("Running integration tests without Tarantool...")
+	fmt.Fprintln(os.Stdout, "Running integration tests without Tarantool...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "notarantool",
 		"test/integration")
@@ -453,7 +453,7 @@ func IntegrationNoTarantool() error {
 
 // CodeSpell runs code spell checks.
 func CodeSpell() error {
-	fmt.Println("Running code spell tests...")
+	fmt.Fprintln(os.Stdout, "Running code spell tests...")
 
 	return sh.RunV("codespell", ".") // spell-checker:disable-line
 }
@@ -470,7 +470,7 @@ func TestFull() {
 
 // Clean cleans up the directory.
 func Clean() {
-	fmt.Println("Cleaning directory...")
+	fmt.Fprintln(os.Stdout, "Cleaning directory...")
 
 	os.Remove(ttExecutableName)
 }

--- a/magefile.go
+++ b/magefile.go
@@ -150,7 +150,9 @@ func appendTags(args []string) ([]string, error) {
 // Building tt executable. Supported environment variables:
 // TT_CLI_BUILD_SSL=(no|static|shared).
 func buildTt(argUpdaters ...optsUpdater) error {
-	args := make([]string, 0, 8)
+	const buildArgsCapacity = 8
+
+	args := make([]string, 0, buildArgsCapacity)
 	args = append(args, "build", "-o", ttExecutableName)
 	var err error
 	for _, updateArguments := range argUpdaters {
@@ -388,9 +390,11 @@ func (Unit) Coverage() error {
 }
 
 func ensureCoverageDir(coverDir string) error {
+	const coverageDirectoryMode = 0o750
+
 	coverageDirInfo, err := os.Stat(coverDir)
 	if os.IsNotExist(err) {
-		return os.MkdirAll(coverDir, 0o750)
+		return os.MkdirAll(coverDir, coverageDirectoryMode)
 	}
 	if err != nil {
 		return err

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -95,13 +95,13 @@ func PublishRWS() error {
 
 		patterns, err := getPatterns(targetDistro)
 		if err != nil {
-			return fmt.Errorf("failed to publish package for %s/%s: %s",
+			return fmt.Errorf("failed to publish package for %s/%s: %w",
 				targetDistro.OS, targetDistro.Dist, err)
 		}
 
 		files, err := walkMatch(distPath, patterns)
 		if err != nil {
-			return fmt.Errorf("failed to publish package for %s/%s: %s",
+			return fmt.Errorf("failed to publish package for %s/%s: %w",
 				targetDistro.OS, targetDistro.Dist, err)
 		}
 
@@ -133,7 +133,7 @@ func PublishRWS() error {
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("failed to publish package for %s/%s: %s, %s",
+			return fmt.Errorf("failed to publish package for %s/%s: %w, %s",
 				targetDistro.OS, targetDistro.Dist, err, output)
 		}
 	}

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -105,15 +105,15 @@ func PublishRWS() error {
 				targetDistro.OS, targetDistro.Dist, err)
 		}
 
-		rwsUrlPart := os.Getenv("RWS_URL_PART")
-		if rwsUrlPart == "" {
+		rwsURLPart := os.Getenv("RWS_URL_PART")
+		if rwsURLPart == "" {
 			return fmt.Errorf("failed to publish package: RWS_URL_PART is not set")
 		}
 
 		flags := []string{
 			"-v",
 			"-LfsS",
-			"-X", "PUT", fmt.Sprintf("%s/%s/%s", rwsUrlPart, targetDistro.OS, targetDistro.Dist),
+			"-X", "PUT", fmt.Sprintf("%s/%s/%s", rwsURLPart, targetDistro.OS, targetDistro.Dist),
 			"-F", fmt.Sprintf("product=%s", packageName),
 		}
 

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -128,7 +129,7 @@ func PublishRWS() error {
 		}
 		flags = append(flags, "-u", rwsAuth)
 
-		cmd := exec.Command("curl", flags...)
+		cmd := exec.CommandContext(context.Background(), "curl", flags...)
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -88,10 +88,10 @@ func getPatterns(distro Distro) ([]string, error) {
 
 // PublishRWS puts packages to RWS (Repository Web Service).
 func PublishRWS() error {
-	fmt.Printf("Publish packages to RWS...\n")
+	fmt.Fprintf(os.Stdout, "Publish packages to RWS...\n")
 
 	for _, targetDistro := range targetDistros {
-		fmt.Printf("Publish package for %s/%s...\n", targetDistro.OS, targetDistro.Dist)
+		fmt.Fprintf(os.Stdout, "Publish package for %s/%s...\n", targetDistro.OS, targetDistro.Dist)
 
 		patterns, err := getPatterns(targetDistro)
 		if err != nil {
@@ -121,7 +121,7 @@ func PublishRWS() error {
 			flags = append(flags, "-F", fmt.Sprintf("%s=@./%s", filepath.Base(file), file))
 		}
 
-		fmt.Printf("curl flags (excluding secrets): %s\n", flags)
+		fmt.Fprintf(os.Stdout, "curl flags (excluding secrets): %s\n", flags)
 
 		rwsAuth := os.Getenv("RWS_AUTH")
 		if rwsAuth == "" {

--- a/test/integration/aeon/server/mock.go
+++ b/test/integration/aeon/server/mock.go
@@ -114,13 +114,11 @@ func main() {
 
 	// Run gRPC server.
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		if err := srv.Serve(getListener()); err != nil {
 			log.Fatalf("Failed to serve: %v", err)
 		}
-		wg.Done()
-	}()
+	})
 
 	// Shutdown on signals.
 	exitSig := make(chan os.Signal, 1)

--- a/test/integration/aeon/server/mock.go
+++ b/test/integration/aeon/server/mock.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
@@ -93,7 +94,7 @@ func getListener() net.Listener {
 		protocol = "tcp"
 		address = fmt.Sprintf("localhost:%d", *args.port)
 	}
-	lis, err := net.Listen(protocol, address)
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), protocol, address)
 	if err != nil {
 		log.Fatalf("Failed to listen: %v", err)
 	}

--- a/test/integration/aeon/server/mock.go
+++ b/test/integration/aeon/server/mock.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const defaultServerPort = 50051
+
 var args = struct {
 	isSsl      *bool
 	caFile     *string
@@ -34,7 +36,7 @@ var args = struct {
 	caFile:     flag.String("ca", "", "The CA file"),
 	certFile:   flag.String("cert", "", "The TLS cert file"),
 	keyFile:    flag.String("key", "", "The TLS key file"),
-	port:       flag.Int("port", 50051, "The server port"),
+	port:       flag.Int("port", defaultServerPort, "The server port"),
 	unixSocket: flag.String("unix", "", "The Unix socket name"),
 }
 

--- a/test/integration/aeon/server/mock.go
+++ b/test/integration/aeon/server/mock.go
@@ -23,41 +23,41 @@ import (
 )
 
 var args = struct {
-	is_ssl      *bool
-	ca_file     *string
-	cert_file   *string
-	key_file    *string
-	port        *int
-	unix_socket *string
+	isSsl      *bool
+	caFile     *string
+	certFile   *string
+	keyFile    *string
+	port       *int
+	unixSocket *string
 }{
-	is_ssl:      flag.Bool("ssl", false, "Connection uses SSL if set, (default plain TCP)"),
-	ca_file:     flag.String("ca", "", "The CA file"),
-	cert_file:   flag.String("cert", "", "The TLS cert file"),
-	key_file:    flag.String("key", "", "The TLS key file"),
-	port:        flag.Int("port", 50051, "The server port"),
-	unix_socket: flag.String("unix", "", "The Unix socket name"),
+	isSsl:      flag.Bool("ssl", false, "Connection uses SSL if set, (default plain TCP)"),
+	caFile:     flag.String("ca", "", "The CA file"),
+	certFile:   flag.String("cert", "", "The TLS cert file"),
+	keyFile:    flag.String("key", "", "The TLS key file"),
+	port:       flag.Int("port", 50051, "The server port"),
+	unixSocket: flag.String("unix", "", "The Unix socket name"),
 }
 
 func getCertificate() tls.Certificate {
-	if *args.cert_file == "" || *args.key_file == "" {
+	if *args.certFile == "" || *args.keyFile == "" {
 		log.Fatalln("Both 'key_file' and 'cert_file' required")
 	}
-	tls_cert, err := tls.LoadX509KeyPair(*args.cert_file, *args.key_file)
+	tlsCert, err := tls.LoadX509KeyPair(*args.certFile, *args.keyFile)
 	if err != nil {
 		log.Fatalf("Could not load server key pair: %v", err)
 	}
-	return tls_cert
+	return tlsCert
 }
 
-func getTlsConfig() *tls.Config {
-	if *args.ca_file == "" {
+func getTLSConfig() *tls.Config {
+	if *args.caFile == "" {
 		return &tls.Config{
 			Certificates: []tls.Certificate{getCertificate()},
 			ClientAuth:   tls.NoClientCert,
 		}
 	}
 
-	ca, err := os.ReadFile(*args.ca_file)
+	ca, err := os.ReadFile(*args.caFile)
 	if err != nil {
 		log.Fatalf("Failed to read CA file: %v", err)
 	}
@@ -73,10 +73,10 @@ func getTlsConfig() *tls.Config {
 }
 
 func getServerOpts() []grpc.ServerOption {
-	if !*args.is_ssl {
+	if !*args.isSsl {
 		return []grpc.ServerOption{}
 	}
-	creds := credentials.NewTLS(getTlsConfig())
+	creds := credentials.NewTLS(getTLSConfig())
 	return []grpc.ServerOption{grpc.Creds(creds)}
 }
 
@@ -84,9 +84,9 @@ func getListener() net.Listener {
 	var protocol string
 	var address string
 
-	if *args.unix_socket != "" {
+	if *args.unixSocket != "" {
 		protocol = "unix"
-		address = *args.unix_socket
+		address = *args.unixSocket
 		if strings.HasPrefix(address, "@") {
 			address = "\x00" + address[1:]
 		}
@@ -121,14 +121,14 @@ func main() {
 	}()
 
 	// Shutdown on signals.
-	exit_sig := make(chan os.Signal, 1)
-	signal.Notify(exit_sig,
+	exitSig := make(chan os.Signal, 1)
+	signal.Notify(exitSig,
 		syscall.SIGTERM,
 		syscall.SIGINT,
 		syscall.SIGQUIT,
 		syscall.SIGHUP,
 	)
-	s := <-exit_sig
+	s := <-exitSig
 	log.Println("Got terminate signal:", s)
 
 	srv.GracefulStop()

--- a/test/integration/aeon/server/service/server.go
+++ b/test/integration/aeon/server/service/server.go
@@ -49,6 +49,8 @@ func (s *Server) SQLStream(in *pb.SQLRequest, stream pb.SQLService_SQLStreamServ
 }
 
 func makeSQLResponse(query string) pb.SQLResponse {
+	const secondEntryID = 2
+
 	switch strings.ToLower(query) {
 	case "ok":
 		return pb.SQLResponse{
@@ -62,7 +64,7 @@ func makeSQLResponse(query string) pb.SQLResponse {
 				},
 				{
 					Fields: []*pb.Value{
-						{Kind: &pb.Value_IntegerValue{IntegerValue: 2}},
+						{Kind: &pb.Value_IntegerValue{IntegerValue: secondEntryID}},
 						{Kind: &pb.Value_StringValue{StringValue: "entry2"}},
 					},
 				},


### PR DESCRIPTION
- Enable: noctx, revive, mnd, modernize, forbidigo, errorlint
- Use context-aware process, request, dial, and listen APIs.
- Normalize Go identifiers and initialisms without changing serialized names.
- Replace numeric literals with domain-specific constants.
- Adopt modern standard-library helpers and type aliases.
- Route intentional CLI and Mage output through explicit writers.
- Preserve wrapped error chains and use errors.Is/errors.As for inspection.

Part of TNTP-9993