### PR TITLE
lint: enable err113 and perfsprint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
       # that sometimes leads to strange linter behavior.
     - depguard
     - dupl # Dupl is disabled, since we're generating a lot of boilerplate code.
-    - err113
     - errcheck
     - exhaustruct
     - exhaustruct_v5
@@ -42,7 +41,6 @@ linters:
     - nlreturn # Nlreturn is disabled, since it's duplicated by wsl_v5.return check.
     - noinlineerr
     - paralleltest
-    - perfsprint
     - testifylint
     # TODO: Enable after internal tests are converted to external test packages
     # without exporting production internals solely to satisfy the linter.

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -22,6 +22,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+var (
+	errEmptyAeonSQLResponse = errors.New("empty Aeon SQL response")
+	errFailedToAppendCAData = errors.New("failed to append CA data")
+	errTupleIsNil           = errors.New("tuple ")
+)
+
 // Client structure with parameters for gRPC connection to Aeon.
 type Client struct {
 	title  string
@@ -63,7 +69,7 @@ func getTLSConfig(args cmd.Ssl) (*tls.Config, error) {
 
 		pool = x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(ca) {
-			return nil, errors.New("failed to append CA data")
+			return nil, errFailedToAppendCAData
 		}
 	}
 	// Else if RootCAs is nil, TLS uses the host's root CA set.
@@ -180,7 +186,7 @@ func (c *Client) ping() error {
 // On any issue return an error.
 func parseSQLResponse(resp *pb.SQLResponse) any {
 	if resp == nil {
-		return errors.New("empty Aeon SQL response")
+		return errEmptyAeonSQLResponse
 	}
 	if responseError := resp.GetError(); responseError != nil {
 		return resultError{responseError}
@@ -201,7 +207,7 @@ func parseSQLResponse(resp *pb.SQLResponse) any {
 
 	for r, row := range tuples {
 		if row == nil {
-			return fmt.Errorf("tuple %d is nil", r)
+			return fmt.Errorf("%w%d is nil", errTupleIsNil, r)
 		}
 		for _, v := range row.GetFields() {
 			val, err := decodeValue(v)

--- a/cli/aeon/cmd/connection.go
+++ b/cli/aeon/cmd/connection.go
@@ -13,6 +13,11 @@ import (
 	libconnect "github.com/tarantool/tt/lib/connect"
 )
 
+var (
+	errInvalidConnectionURL      = errors.New("invalid connection url")
+	errTransportMustBeSSLOrPlain = errors.New("transport must be ssl or plain")
+)
+
 // FillConnectCtx takes a ConnectCtx object and fills it with data from a
 // collected configuration by given instanceName and libconnect.UriOpts.
 // It returns an error if fails to collect a configuration,
@@ -63,7 +68,7 @@ func FillConnectCtx(connectCtx *ConnectCtx, uriOpts libconnect.URIOpts,
 	}
 
 	if advertise.URI == "" {
-		return errors.New("invalid connection url")
+		return errInvalidConnectionURL
 	}
 
 	cleanedURL, err := util.RemoveScheme(advertise.URI)
@@ -74,7 +79,7 @@ func FillConnectCtx(connectCtx *ConnectCtx, uriOpts libconnect.URIOpts,
 	connectCtx.Network, connectCtx.Address = libconnect.ParseBaseURI(cleanedURL)
 
 	if (advertise.Params.Transport != "ssl") && (advertise.Params.Transport != "plain") {
-		return errors.New("transport must be ssl or plain")
+		return errTransportMustBeSSLOrPlain
 	}
 
 	if advertise.Params.Transport == "ssl" {

--- a/cli/aeon/cmd/transport.go
+++ b/cli/aeon/cmd/transport.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
+)
+
+var (
+	errMustBe = errors.New("must be ")
 )
 
 // Transport is a type, with a restriction on the list of supported connection modes.
@@ -37,7 +42,7 @@ var ValidTransport = map[Transport]string{
 func (t *Transport) Set(v string) error {
 	_, ok := ValidTransport[Transport(v)]
 	if !ok {
-		return fmt.Errorf(`must be %s`, ListValidTransports())
+		return fmt.Errorf("%w%s", errMustBe, ListValidTransports())
 	}
 	*t = Transport(v)
 	return nil

--- a/cli/aeon/decode.go
+++ b/cli/aeon/decode.go
@@ -1,7 +1,7 @@
 package aeon
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,13 +10,22 @@ import (
 	"github.com/tarantool/tt/cli/aeon/pb"
 )
 
+var (
+	errProtobufArrayValueIsNil    = errors.New("protobuf array value is nil")
+	errProtobufDatetimeValueIsNil = errors.New("protobuf datetime value is nil")
+	errProtobufIntervalValueIsNil = errors.New("protobuf interval value is nil")
+	errProtobufMapValueIsNil      = errors.New("protobuf map value is nil")
+	errProtobufValueIsNil         = errors.New("protobuf value is nil")
+	errUnsupportedTypeForValue    = errors.New("unsupported type for value")
+)
+
 // decodeValue convert a value obtained from protobuf into a value that can be used as an
 // argument to Tarantool functions.
 //
 // Copy from https://github.com/tarantool/aeon/blob/master/aeon/grpc/server/pb/decode.go
 func decodeValue(val *pb.Value) (any, error) {
 	if val == nil {
-		return nil, fmt.Errorf("protobuf value is nil")
+		return nil, errProtobufValueIsNil
 	}
 
 	switch val.GetKind().(type) {
@@ -49,7 +58,7 @@ func decodeValue(val *pb.Value) (any, error) {
 	case *pb.Value_DatetimeValue:
 		dateTime := val.GetDatetimeValue()
 		if dateTime == nil {
-			return nil, fmt.Errorf("protobuf datetime value is nil")
+			return nil, errProtobufDatetimeValueIsNil
 		}
 		sec := dateTime.GetSeconds()
 		nsec := dateTime.GetNsec()
@@ -70,7 +79,7 @@ func decodeValue(val *pb.Value) (any, error) {
 	case *pb.Value_IntervalValue:
 		interval := val.GetIntervalValue()
 		if interval == nil {
-			return nil, fmt.Errorf("protobuf interval value is nil")
+			return nil, errProtobufIntervalValueIsNil
 		}
 		res := datetime.Interval{
 			Year:   interval.GetYear(),
@@ -87,7 +96,7 @@ func decodeValue(val *pb.Value) (any, error) {
 	case *pb.Value_ArrayValue:
 		array := val.GetArrayValue()
 		if array == nil {
-			return nil, fmt.Errorf("protobuf array value is nil")
+			return nil, errProtobufArrayValueIsNil
 		}
 		fields := array.GetFields()
 		res := make([]any, len(fields))
@@ -102,7 +111,7 @@ func decodeValue(val *pb.Value) (any, error) {
 	case *pb.Value_MapValue:
 		mapValue := val.GetMapValue()
 		if mapValue == nil {
-			return nil, fmt.Errorf("protobuf map value is nil")
+			return nil, errProtobufMapValueIsNil
 		}
 		fields := mapValue.GetFields()
 		res := make(map[any]any, len(fields))
@@ -117,6 +126,6 @@ func decodeValue(val *pb.Value) (any, error) {
 	case *pb.Value_NullValue:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unsupported type for value")
+		return nil, errUnsupportedTypeForValue
 	}
 }

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -21,6 +21,12 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errNoBinariesInstalled = errors.New(
+		"there are no binaries installed in this environment of 'tt'",
+	)
+)
+
 // printBinaries outputs installed versions of the program.
 func printVersion(versionString string) {
 	if strings.HasSuffix(versionString, "[active]") {
@@ -106,7 +112,7 @@ func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) error {
 	binDirFilesList, err := os.ReadDir(binDir)
 
 	if len(binDirFilesList) == 0 || errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("there are no binaries installed in this environment of 'tt'")
+		return errNoBinariesInstalled
 	} else if err != nil {
 		return fmt.Errorf("error reading directory %q: %w", binDir, err)
 	}

--- a/cli/binary/list_test.go
+++ b/cli/binary/list_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -31,7 +30,7 @@ func TestParseBinaries(t *testing.T) {
 func TestParseBinariesTarantoolDev(t *testing.T) {
 	for _, dir := range []string{"bin", "bin_symlink_broken"} {
 		t.Run(dir, func(t *testing.T) {
-			testDir := fmt.Sprintf("./testdata/tarantool_dev/%s", dir)
+			testDir := "./testdata/tarantool_dev/" + dir
 			fileList, err := os.ReadDir(testDir)
 			assert.NoError(t, err)
 			versions, err := ParseBinaries(fileList, search.ProgramDev, testDir)

--- a/cli/binary/switch.go
+++ b/cli/binary/switch.go
@@ -17,6 +17,13 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errBinaryIsNotInstalledInCurrentEnvironment  = errors.New("binary ")
+	errHeadersIsNotInstalledInCurrentEnvironment = errors.New("headers ")
+	errThereAreNoInstalledInThisEnvironmentOfTT  = errors.New("there are no ")
+	errUnknownApplication                        = errors.New("unknown application: ")
+)
+
 // SwitchCtx contains information for switch command.
 type SwitchCtx struct {
 	// BinDir is a directory witch stores binaries.
@@ -63,7 +70,7 @@ func ChooseVersion(binDir string, program search.Program) (string, error) {
 	binDirFilesList, err := os.ReadDir(binDir)
 
 	if len(binDirFilesList) == 0 || errors.Is(err, fs.ErrNotExist) {
-		return "", fmt.Errorf("there are no binaries installed in this environment of 'tt'")
+		return "", errNoBinariesInstalled
 	} else if err != nil {
 		return "", fmt.Errorf("error reading directory %q: %w", binDir, err)
 	}
@@ -72,7 +79,8 @@ func ChooseVersion(binDir string, program search.Program) (string, error) {
 		return "", err
 	}
 	if len(versions) == 0 {
-		return "", fmt.Errorf("there are no %s installed in this environment of 'tt'", program)
+		return "", fmt.Errorf("%w%s installed in this environment of 'tt'",
+			errThereAreNoInstalledInThisEnvironmentOfTT, program)
 	}
 	var versionStr []string
 	for _, version := range versions {
@@ -99,7 +107,8 @@ func switchHeaders(switchCtx *SwitchCtx, versionStr string) error {
 	includeDir := filepath.Join(switchCtx.IncDir, "include")
 
 	if !util.IsDir(filepath.Join(includeDir, versionStr)) {
-		return fmt.Errorf("headers %s is not installed in current environment", versionStr)
+		return fmt.Errorf("%w%s is not installed in current environment",
+			errHeadersIsNotInstalledInCurrentEnvironment, versionStr)
 	}
 
 	err := util.CreateSymlink(versionStr,
@@ -115,7 +124,8 @@ func switchHeaders(switchCtx *SwitchCtx, versionStr string) error {
 func switchBinary(switchCtx *SwitchCtx, versionStr string) error {
 	newBinary := filepath.Join(switchCtx.BinDir, versionStr)
 	if !util.IsRegularFile(newBinary) {
-		return fmt.Errorf("binary %s is not installed in current environment", newBinary)
+		return fmt.Errorf("%w%s is not installed in current environment",
+			errBinaryIsNotInstalledInCurrentEnvironment, newBinary)
 	}
 
 	err := util.CreateSymlink(versionStr,
@@ -136,7 +146,7 @@ func Switch(switchCtx *SwitchCtx) error {
 		}
 
 	case search.ProgramUnknown:
-		return fmt.Errorf("unknown application: %s", switchCtx.Program)
+		return fmt.Errorf("%w%s", errUnknownApplication, switchCtx.Program)
 	case search.ProgramCe, search.ProgramEe, search.ProgramDev, search.ProgramTcm:
 		// These programs do not require tt version normalization.
 	}

--- a/cli/cfg/dump.go
+++ b/cli/cfg/dump.go
@@ -1,13 +1,17 @@
 package cfg
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	errTTConfigurationFileIsNotFound = errors.New("tt configuration file is not found")
 )
 
 // DumpCtx contains information for tt config dump.
@@ -30,7 +34,7 @@ func dumpRaw(writer io.Writer, cmdCtx *cmdcontext.CmdCtx) error {
 		writer.Write([]byte(cmdCtx.Cli.ConfigPath + ":\n"))
 		writer.Write(fileContent)
 	} else {
-		return fmt.Errorf("tt configuration file is not found")
+		return errTTConfigurationFileIsNotFound
 	}
 
 	return nil

--- a/cli/checkpoint/checkpoint.go
+++ b/cli/checkpoint/checkpoint.go
@@ -4,11 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 
 	"github.com/tarantool/tt/cli/cmdcontext"
+)
+
+var (
+	errResultOfPlay = errors.New("result of play: ")
 )
 
 // Opts contains flags for managing checkpoint files commands.
@@ -64,7 +69,7 @@ func Play(tntCli cmdcontext.TarantoolCli) error {
 	stdinPipe.Close()
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("result of play: %s", errBuff.String())
+		return fmt.Errorf("%w%s", errResultOfPlay, errBuff.String())
 	}
 
 	scanner := bufio.NewScanner(stdoutPipe)
@@ -75,7 +80,7 @@ func Play(tntCli cmdcontext.TarantoolCli) error {
 	cmd.Wait()
 
 	if len(errBuff.String()) > 0 {
-		return fmt.Errorf("result of play: %s", errBuff.String())
+		return fmt.Errorf("%w%s", errResultOfPlay, errBuff.String())
 	}
 
 	return nil

--- a/cli/cluster/cluster.go
+++ b/cli/cluster/cluster.go
@@ -13,6 +13,10 @@ import (
 	"github.com/tarantool/tt/lib/integrity"
 )
 
+var (
+	errAConfigurationFileMustBeSet = errors.New("a configuration file must be set")
+)
+
 // fillOnlyMerge copies leaf values from src into dst only when the key is not
 // already present in dst (fill-only semantics: never overwrite existing keys).
 func fillOnlyMerge(ctx context.Context, dst *goconfig.MutableConfig, src goconfig.Config) error {
@@ -57,7 +61,7 @@ func GetClusterConfig(
 	integ integrity.IntegrityCtx,
 ) (*goconfig.MutableConfig, error) {
 	if path == "" {
-		return nil, fmt.Errorf("a configuration file must be set")
+		return nil, errAConfigurationFileMustBeSet
 	}
 
 	// Phase-1: env (excluding *_DEFAULT) + file → mut.
@@ -110,7 +114,7 @@ func GetInstanceConfig(
 ) (goconfig.Config, error) {
 	if !HasInstance(cfg.Snapshot(), instance) {
 		return goconfig.Config{},
-			fmt.Errorf("an instance %q not found", instance)
+			fmt.Errorf("an %w%q not found", errInstanceNotFound, instance)
 	}
 	return InstanceConfig(cfg.Snapshot(), instance)
 }

--- a/cli/cluster/cmd/common.go
+++ b/cli/cluster/cmd/common.go
@@ -13,6 +13,10 @@ import (
 	libconnect "github.com/tarantool/tt/lib/connect"
 )
 
+var (
+	errInstanceNotFound = errors.New("instance ")
+)
+
 // printGoConfig prints a goconfig.Config to stdout as YAML.
 func printGoConfig(cfg goconfig.Config) error {
 	b, err := cfg.MarshalYAML()
@@ -56,7 +60,7 @@ func printInstanceConfig(goView goconfig.Config,
 ) error {
 	instView, err := cluster.InstanceConfig(goView, instance)
 	if err != nil {
-		return fmt.Errorf("instance %q not found", instance)
+		return fmt.Errorf("%w%q not found", errInstanceNotFound, instance)
 	}
 
 	var validateErr error

--- a/cli/cluster/cmd/common_test.go
+++ b/cli/cluster/cmd/common_test.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -174,7 +174,7 @@ groups:
 
 	for _, tc := range cases {
 		for _, full := range tc.Full {
-			t.Run(tc.Name+"_"+fmt.Sprint(full), func(t *testing.T) {
+			t.Run(tc.Name+"_"+strconv.FormatBool(full), func(t *testing.T) {
 				for k, v := range tc.Env {
 					t.Setenv(k, v)
 				}

--- a/cli/cluster/cmd/failover.go
+++ b/cli/cluster/cmd/failover.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -11,6 +12,10 @@ import (
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/connect"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	errTaskWithIDIsNotFound = errors.New("task with id `")
 )
 
 const (
@@ -166,7 +171,7 @@ func waitForSwitch(conn *libcluster.RawStorage, key string, yamlCmd []byte, time
 			return nil
 		}
 	}
-	if ctxWatch.Err() == context.DeadlineExceeded {
+	if errors.Is(ctxWatch.Err(), context.DeadlineExceeded) {
 		log.Info("Timeout for command execution reached.")
 		return nil
 	}
@@ -198,7 +203,7 @@ func SwitchStatus(url string, switchCtx SwitchStatusCtx) error {
 	}
 
 	if len(result) != 1 {
-		return fmt.Errorf("task with id `%s` is not found", switchCtx.TaskID)
+		return fmt.Errorf("%w%s` is not found", errTaskWithIDIsNotFound, switchCtx.TaskID)
 	}
 
 	fmt.Fprint(os.Stdout, string(result[0].Value))

--- a/cli/cluster/cmd/publish.go
+++ b/cli/cluster/cmd/publish.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	goconfig "github.com/tarantool/go-config"
@@ -9,6 +10,19 @@ import (
 	"github.com/tarantool/tt/cli/cluster"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/connect"
+)
+
+var (
+	errFailedToDetermineTheGroupOfTheReplicaset = errors.New(
+		"failed to determine the group of the ",
+	)
+	errReplicasetNameIsNotSpecifiedForInstanceConfiguration = errors.New(
+		"replicaset name is not specified for ",
+	)
+	errWrongGroupNameExpectedHave      = errors.New("wrong group name, expected ")
+	errWrongReplicasetNameExpectedHave = errors.New(
+		"wrong replicaset name, expected ",
+	)
 )
 
 // PublishCtx contains information about cluster publish command execution
@@ -131,24 +145,26 @@ func setInstanceConfig(group, replicaset, instance string, instanceMap map[strin
 	if !found {
 		// Instance not found: resolve group/replicaset.
 		if replicaset == "" {
-			return fmt.Errorf(
-				"replicaset name is not specified for %q instance configuration", instance)
+			return fmt.Errorf("%w%q instance configuration",
+				errReplicasetNameIsNotSpecifiedForInstanceConfiguration, instance)
 		}
 		if group == "" {
 			var ok bool
 			group, ok = cluster.FindGroupByReplicaset(snap, replicaset)
 			if !ok {
-				return fmt.Errorf("failed to determine the group of the %q replicaset", replicaset)
+				return fmt.Errorf("%w%q replicaset",
+					errFailedToDetermineTheGroupOfTheReplicaset, replicaset)
 			}
 		}
 	}
 	if found {
 		// Instance already exists: validate group/replicaset names.
 		if replicaset != "" && replicaset != rname {
-			return fmt.Errorf("wrong replicaset name, expected %q, have %q", rname, replicaset)
+			return fmt.Errorf("%w%q, have %q",
+				errWrongReplicasetNameExpectedHave, rname, replicaset)
 		}
 		if group != "" && group != gname {
-			return fmt.Errorf("wrong group name, expected %q, have %q", gname, group)
+			return fmt.Errorf("%w%q, have %q", errWrongGroupNameExpectedHave, gname, group)
 		}
 		group = gname
 		replicaset = rname

--- a/cli/cluster/cmd/replicaset.go
+++ b/cli/cluster/cmd/replicaset.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/replicaset"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/connect"
+)
+
+var (
+	errNoKeysForTheConfigPatching = errors.New("no keys for the config patching")
 )
 
 // dataKeyPublisher is a function implements replicaset.DataPublisher.
@@ -56,7 +61,7 @@ type PromoteCtx struct {
 // appears prompt with message of path in config to patch.
 func pickPatchKey(keys []string, force bool, pathMsg string) (int, error) {
 	if len(keys) == 0 {
-		return 0, fmt.Errorf("no keys for the config patching")
+		return 0, errNoKeysForTheConfigPatching
 	}
 	var (
 		pos = 0

--- a/cli/cluster/scope.go
+++ b/cli/cluster/scope.go
@@ -1,10 +1,15 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
 	goconfig "github.com/tarantool/go-config"
+)
+
+var (
+	errInstanceNotFound = errors.New("instance ")
 )
 
 const instancePathSegments = 6
@@ -104,5 +109,5 @@ func InstanceConfig(cfg goconfig.Config, name string) (goconfig.Config, error) {
 			return instCfg, nil
 		}
 	}
-	return goconfig.Config{}, fmt.Errorf("instance %q not found", name)
+	return goconfig.Config{}, fmt.Errorf("%w%q not found", errInstanceNotFound, name)
 }

--- a/cli/cluster/storage.go
+++ b/cli/cluster/storage.go
@@ -14,6 +14,12 @@ import (
 	"github.com/tarantool/tt/lib/integrity"
 )
 
+var (
+	errEndpointUnexpectedType       = errors.New("endpoint[")
+	errEndpointUnknownTransportType = errors.New("endpoint[")
+	errEtcdEndpointIsNotAString     = errors.New("etcd endpoint is not a string: ")
+)
+
 const defaultEtcdTimeout = 3 * time.Second
 
 // cfgGetString is a small helper that reads a string value at path from cfg.
@@ -203,7 +209,7 @@ func readEtcdEndpoints(
 		for _, e := range v {
 			s, ok := e.(string)
 			if !ok {
-				return nil, nil, fmt.Errorf("etcd endpoint is not a string: %T", e)
+				return nil, nil, fmt.Errorf("%w%T", errEtcdEndpointIsNotAString, e)
 			}
 			endpoints = append(endpoints, s)
 		}
@@ -348,7 +354,7 @@ func readTcsEndpoints(
 		epMap, ok := rawEp.(map[string]any)
 		if !ok {
 			connectionErrors = append(connectionErrors,
-				fmt.Errorf("endpoint[%d]: unexpected type %T", i, rawEp))
+				fmt.Errorf("%w%d]: unexpected type %T", errEndpointUnexpectedType, i, rawEp))
 			continue
 		}
 
@@ -387,8 +393,9 @@ func readTcsEndpoints(
 			sslEnable = sslKeyFile != "" || sslCertFile != "" || sslCaFile != "" ||
 				sslCiphers != "" || sslPassword != "" || sslPasswordFile != ""
 		default:
-			connectionErrors = append(connectionErrors,
-				fmt.Errorf("endpoint[%d] %q: unknown transport type: %s", i, addr, transport))
+			connectionErrors = append(connectionErrors, fmt.Errorf(
+				"%w%d] %q: unknown transport type: %s",
+				errEndpointUnknownTransportType, i, addr, transport))
 			continue
 		}
 

--- a/cli/cluster/validate.go
+++ b/cli/cluster/validate.go
@@ -11,6 +11,10 @@ import (
 	"github.com/tarantool/go-config/validators/jsonschema"
 )
 
+var (
+	errNoTarantoolSchemasRegistered = errors.New("no Tarantool schemas registered")
+)
+
 // Validate validates a goconfig.Config against the embedded JSON Schema for
 // the newest known Tarantool version.
 func Validate(cfg goconfig.Config) error {
@@ -24,7 +28,7 @@ func Validate(cfg goconfig.Config) error {
 
 	versions := gcttarantool.SchemaVersions()
 	if len(versions) == 0 {
-		return fmt.Errorf("no Tarantool schemas registered")
+		return errNoTarantoolSchemasRegistered
 	}
 	newest := versions[len(versions)-1]
 	schemaBytes, err := gcttarantool.Schema(newest)

--- a/cli/cmd/aeon.go
+++ b/cli/cmd/aeon.go
@@ -20,6 +20,28 @@ import (
 	libconnect "github.com/tarantool/tt/lib/connect"
 )
 
+var (
+	errFailedToRecognizeAConnectDestinationSeeTheCommandExamples = errors.New(
+		"failed to recognize a connect destination, see the command examples",
+	)
+	errFilesKeyAndCertMustBeSpecifiedBoth = errors.New(
+		"files Key and Cert must be specified both",
+	)
+	errInvalidConnectionURL             = errors.New("invalid connection url")
+	errNotValidPathToAPrivateSSLKeyFile = errors.New(
+		"not valid path to a private SSL key file=",
+	)
+	errNotValidPathToAnSSLCertificateFile = errors.New(
+		"not valid path to an SSL certificate file=",
+	)
+	errNotValidPathToTrustedCertificateAuthoritiesCAFile = errors.New(
+		"not valid path to trusted certificate authorities (CA) file=",
+	)
+	errTransportMustBeSSLOrPlain = errors.New(
+		"transport must be ssl or plain",
+	)
+)
+
 const (
 	aeonHistoryFileName = ".aeon_history"
 	aeonHistoryLines    = console.DefaultHistoryLines
@@ -72,7 +94,7 @@ func newAeonConnectCmd() *cobra.Command {
 	aeonCmd.Flags().StringVar(&connectCtx.Ssl.CaFile, "sslcafile", "",
 		"path to a trusted certificate authorities (CA) file")
 	aeonCmd.Flags().Var(&connectCtx.Transport, "transport",
-		fmt.Sprintf("allowed %s", aeoncmd.ListValidTransports()))
+		"allowed "+aeoncmd.ListValidTransports())
 	aeonCmd.RegisterFlagCompletionFunc("transport", aeonTransportCompletion)
 
 	return aeonCmd
@@ -132,7 +154,7 @@ func aeonConnectValidateArgs(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("failed to recognize a connect destination, see the command examples")
+		return errFailedToRecognizeAConnectDestinationSeeTheCommandExamples
 	}
 
 	if !cmd.Flags().Changed("transport") && (connectCtx.Ssl.KeyFile != "" ||
@@ -146,20 +168,20 @@ func aeonConnectValidateArgs(cmd *cobra.Command, args []string) error {
 
 	if connectCtx.Transport != aeoncmd.TransportPlain {
 		if cmd.Flags().Changed("sslkeyfile") != cmd.Flags().Changed("sslcertfile") {
-			return errors.New("files Key and Cert must be specified both")
+			return errFilesKeyAndCertMustBeSpecifiedBoth
 		}
 
 		if !checkFile(connectCtx.Ssl.KeyFile) {
-			return fmt.Errorf("not valid path to a private SSL key file=%q",
-				connectCtx.Ssl.KeyFile)
+			return fmt.Errorf("%w%q",
+				errNotValidPathToAPrivateSSLKeyFile, connectCtx.Ssl.KeyFile)
 		}
 		if !checkFile(connectCtx.Ssl.CertFile) {
-			return fmt.Errorf("not valid path to an SSL certificate file=%q",
-				connectCtx.Ssl.CertFile)
+			return fmt.Errorf("%w%q",
+				errNotValidPathToAnSSLCertificateFile, connectCtx.Ssl.CertFile)
 		}
 		if !checkFile(connectCtx.Ssl.CaFile) {
-			return fmt.Errorf("not valid path to trusted certificate authorities (CA) file=%q",
-				connectCtx.Ssl.CaFile)
+			return fmt.Errorf("%w%q",
+				errNotValidPathToTrustedCertificateAuthoritiesCAFile, connectCtx.Ssl.CaFile)
 		}
 	}
 	return nil
@@ -229,7 +251,7 @@ func readConfigFilePath(configPath, instance string) error {
 	}
 
 	if advertise.URI == "" {
-		return errors.New("invalid connection url")
+		return errInvalidConnectionURL
 	}
 
 	cleanedURL, err := util.RemoveScheme(advertise.URI)
@@ -240,7 +262,7 @@ func readConfigFilePath(configPath, instance string) error {
 	connectCtx.Network, connectCtx.Address = libconnect.ParseBaseURI(cleanedURL)
 
 	if (advertise.Params.Transport != "ssl") && (advertise.Params.Transport != "plain") {
-		return errors.New("transport must be ssl or plain")
+		return errTransportMustBeSSLOrPlain
 	}
 
 	if advertise.Params.Transport == "ssl" {

--- a/cli/cmd/binaries.go
+++ b/cli/cmd/binaries.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -8,6 +9,10 @@ import (
 	"github.com/tarantool/tt/cli/binary"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/search"
+)
+
+var (
+	errNotSupportedProgram = errors.New("not supported program: ")
 )
 
 var binariesSupportedPrograms = []string{
@@ -64,7 +69,7 @@ You will need to choose version using arrow keys in your console.
 func binariesSwitchValidateArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		if !slices.Contains(binariesSupportedPrograms, args[0]) {
-			return fmt.Errorf("not supported program: %s", args[0])
+			return fmt.Errorf("%w%s", errNotSupportedProgram, args[0])
 		}
 	}
 	return nil

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -16,6 +16,12 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errItIsRequiredToSpecifyAtLeastOneXlogSnapFileOrDirectory = errors.New(
+		"it is required to specify at least one .xlog/.snap file or directory",
+	)
+)
+
 // catFlags contains flags for cat command.
 // Initialized with default values at creation.
 var catFlags = checkpoint.Opts{
@@ -42,8 +48,7 @@ func NewCatCmd() *cobra.Command {
 			"  tt cat --recursive /path/to/dir1 /path/to/dir2",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("it is required to specify at least one .xlog/.snap file " +
-					"or directory")
+				return errItIsRequiredToSpecifyAtLeastOneXlogSnapFileOrDirectory
 			}
 			return nil
 		},

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,6 +18,16 @@ import (
 	"github.com/tarantool/tt/cli/util"
 	libconnect "github.com/tarantool/tt/lib/connect"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errCannotUpdateInstanceConfigurationWithoutClusterConfiguration = errors.New(
+		"can not to update an instance configuration " +
+			"if a cluster configuration file does not exist for the application",
+	)
+	errClusterConfigurationFileDoesNotExistForTheApplication = errors.New(
+		"cluster configuration file does not exist for the application",
+	)
 )
 
 const addAction = true
@@ -375,7 +386,7 @@ func internalClusterShowModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 	if configPath == "" {
-		return fmt.Errorf("cluster configuration file does not exist for the application")
+		return errClusterConfigurationFileDoesNotExistForTheApplication
 	}
 
 	showCtx.Integrity = cmdCtx.Integrity
@@ -410,8 +421,7 @@ func internalClusterPublishModule(cmdCtx *cmdcontext.CmdCtx, args []string) erro
 	}
 	if configPath == "" {
 		if instName != "" {
-			return fmt.Errorf("can not to update an instance configuration " +
-				"if a cluster configuration file does not exist for the application")
+			return errCannotUpdateInstanceConfigurationWithoutClusterConfiguration
 		}
 		configPath, err = running.GetClusterConfigPath(cmdCtx.Cli.ConfigDir, false)
 		if err != nil {
@@ -563,8 +573,7 @@ func checkRolesChangeFlags(isAdd bool) error {
 	}
 	if !rolesChangeCtx.IsGlobal && rolesChangeCtx.GroupName == "" &&
 		rolesChangeCtx.ReplicasetName == "" && rolesChangeCtx.InstName == "" {
-		return util.NewArgError(fmt.Sprintf("need to provide flag(s) with scope roles will %s",
-			action))
+		return util.NewArgError("need to provide flag(s) with scope roles will " + action)
 	}
 	return nil
 }

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -10,6 +11,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/rocks"
+)
+
+var (
+	errLuaRocksCompletionInjection = errors.New(
+		"failed to inject LuaRocks completions",
+	)
+	errSpecifiedShellTypeIsNotSupportedAvailable = errors.New(
+		"specified shell type is not supported. Available: ",
+	)
 )
 
 const (
@@ -29,7 +39,7 @@ func NewCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "completion <SHELL_TYPE>",
 		Short: "Generate autocomplete for a specified shell. " +
-			fmt.Sprintf("Supported shell type: %s", listShells()),
+			"Supported shell type: " + listShells(),
 		ValidArgs: shellSupported,
 		Run:       RunModuleFunc(internalCompletionCmd),
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
@@ -77,7 +87,7 @@ func injectRocksCompletion(shell string, completion []byte) ([]byte, error) {
 		label := []byte(`    # The user could have moved the cursor backwards on the command-line.`)
 		idx := bytes.Index(completion, label)
 		if idx == -1 {
-			return nil, fmt.Errorf("failed to inject LuaRocks completions")
+			return nil, errLuaRocksCompletionInjection
 		}
 
 		res.Write(completion[:idx])
@@ -124,7 +134,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		fmt.Fprint(os.Stdout, string(res))
 
 	default:
-		return fmt.Errorf("specified shell type is not supported. Available: %s", listShells())
+		return fmt.Errorf("%w%s", errSpecifiedShellTypeIsNotSupportedAvailable, listShells())
 	}
 
 	return nil

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -17,6 +18,17 @@ import (
 	"github.com/tarantool/tt/cli/util"
 	libconnect "github.com/tarantool/tt/lib/connect"
 	terminal "golang.org/x/term"
+)
+
+var (
+	errControlSocketCredentialsUnsupported = errors.New(
+		"username and password are not supported with a connection via a control socket",
+	)
+	errCredentialsSpecifiedByFlagsAndURI = errors.New(
+		"username and password are specified with flags and a URI",
+	)
+	errConnectionStringRequired = errors.New("should be specified one connection string")
+	errSpecifyInstanceName      = errors.New("specify instance name")
 )
 
 var (
@@ -140,12 +152,11 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 	switch {
 	case fillErr == nil:
 		if len(runningCtx.Instances) > 1 {
-			err = fmt.Errorf("specify instance name")
+			err = errSpecifyInstanceName
 			return connOpts, err
 		}
 		if (connectCtx.Username != "" || connectCtx.Password != "") && !connectCtx.Binary {
-			err = fmt.Errorf("username and password are not supported" +
-				" with a connection via a control socket")
+			err = errControlSocketCredentialsUnsupported
 			return connOpts, err
 		}
 		if connectCtx.Binary {
@@ -159,8 +170,7 @@ func resolveConnectOpts(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts,
 		}
 	case libconnect.IsCredentialsURI(target):
 		if connectCtx.Username != "" || connectCtx.Password != "" {
-			err = fmt.Errorf("username and password are specified with" +
-				" flags and a URI")
+			err = errCredentialsSpecifiedByFlagsAndURI
 			return connOpts, err
 		}
 		newURI, user, pass := libconnect.ParseCredentialsURI(target)
@@ -206,10 +216,10 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 
 	var ok bool
 	if connectCtx.Language, ok = connect.ParseLanguage(connectLanguage); !ok {
-		return util.NewArgError(fmt.Sprintf("unsupported language: %s", connectLanguage))
+		return util.NewArgError("unsupported language: " + connectLanguage)
 	}
 	if connectCtx.Format, ok = formatter.ParseFormat(connectFormat); !ok {
-		return util.NewArgError(fmt.Sprintf("unsupported output format: %s", connectFormat))
+		return util.NewArgError("unsupported output format: " + connectFormat)
 	}
 
 	connOpts, err := resolveConnectOpts(cmdCtx, cliOpts, &connectCtx, args[0])
@@ -229,7 +239,7 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			return nil
 		}
 	} else if len(args) != 1 {
-		return fmt.Errorf("should be specified one connection string")
+		return errConnectionStringRequired
 	}
 
 	if terminal.IsTerminal(syscall.Stdin) {

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -11,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/create/builtin_templates"
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errRequiresTemplateNameArgument = errors.New("requires template name argument")
 )
 
 var (
@@ -34,7 +38,7 @@ func NewCreateCmd() *cobra.Command {
 		Run:   RunModuleFunc(internalCreateModule),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires template name argument")
+				return errRequiresTemplateNameArgument
 			}
 			return nil
 		},

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -8,6 +8,13 @@ import (
 	"github.com/tarantool/tt/cli/download"
 )
 
+var (
+	errInvalidNumberOfParameters                        = errors.New("invalid number of parameters")
+	errToDownloadTarantoolSDKYouNeedToSpecifyTheVersion = errors.New(
+		"to download Tarantool SDK, you need to specify the version",
+	)
+)
+
 var downloadCtx download.DownloadCtx
 
 // NewDownloadCmd creates a command that downloads and saves the Tarantool SDK.
@@ -23,9 +30,9 @@ func NewDownloadCmd() *cobra.Command {
 		Run: RunModuleFunc(internalDownloadModule),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("to download Tarantool SDK, you need to specify the version")
+				return errToDownloadTarantoolSDKYouNeedToSpecifyTheVersion
 			} else if len(args) > 1 {
-				return errors.New("invalid number of parameters")
+				return errInvalidNumberOfParameters
 			}
 			return nil
 		},

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -40,15 +40,18 @@ func configureHelpCommand(rootCmd *cobra.Command, modulesInfo *modules.ModulesIn
 // getExternalCommandsString returns a pretty string
 // of descriptions for external modules.
 func getExternalCommandsString(modulesInfo *modules.ModulesInfo) string {
-	str := ""
+	var output strings.Builder
 	for _, path := range sortExternalModules() {
 		mf := (*modulesInfo)[path]
-		str += fmt.Sprintf("  %s\t%s\n", mf.Name, mf.Help)
+		output.WriteString("  ")
+		output.WriteString(mf.Name)
+		output.WriteByte('\t')
+		output.WriteString(mf.Help)
+		output.WriteByte('\n')
 	}
 
-	if str != "" {
-		str = util.Bold("\nEXTERNAL COMMANDS\n") + str
-		return strings.Trim(str, "\n")
+	if output.Len() != 0 {
+		return strings.Trim(util.Bold("\nEXTERNAL COMMANDS\n")+output.String(), "\n")
 	}
 
 	return ""

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -18,6 +18,12 @@ import (
 	libconnect "github.com/tarantool/tt/lib/connect"
 )
 
+var (
+	errReplaySourceRequired = errors.New(
+		"it is required to specify an URI and at least one .xlog/.snap file or directory",
+	)
+)
+
 // playFlags contains flags for play command.
 // Initialized with default values at creation.
 var playFlags = checkpoint.Opts{
@@ -93,8 +99,7 @@ func NewPlayCmd() *cobra.Command {
 // playValidateArgs validates non-flag arguments 'play' command.
 func playValidateArgs(cmd *cobra.Command, args []string) error {
 	if len(args) < playMinArgs {
-		return errors.New("it is required to specify an URI and at least one .xlog/.snap file " +
-			"or directory")
+		return errReplaySourceRequired
 	}
 	return nil
 }
@@ -122,8 +127,7 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		args[0] = runningCtx.Instances[0].BinaryPort
 	case libconnect.IsCredentialsURI(args[0]):
 		if playUsername != "" || playPassword != "" {
-			return errors.New("username and password are specified with" +
-				" flags and a URI")
+			return errCredentialsSpecifiedByFlagsAndURI
 		}
 		uri, user, pass := libconnect.ParseCredentialsURI(args[0])
 		playUsername = user

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -20,6 +20,55 @@ import (
 )
 
 var (
+	errAnInstanceNameIsNotSpecifiedPleaseUseAppInstanceFormat = errors.New(
+		"an instance name is not specified. Please use app:instance format",
+	)
+	errCannotConnectToAnyInstanceFromReplicaset = errors.New(
+		"cannot connect to any instance from replicaset",
+	)
+	errDifferentInstanceNames = errors.New(
+		"there are different instance names passed after app name and in flag arg",
+	)
+	errInstanceForRebootstrapIsNotSpecified = errors.New(
+		"instance for rebootstrap is not specified",
+	)
+	errInstanceNotFound                     = errors.New("instance ")
+	errNeedToSpecifyTheVersionToDowngradeTo = errors.New(
+		"need to specify the version to downgrade to",
+	)
+	errOnlyOneInstanceSupportedForReBootstrap = errors.New(
+		"only one instance supported for re-bootstrap",
+	)
+	errOnlyOneTypeOfOrchestratorCanBeForced = errors.New(
+		"only one type of orchestrator can be forced",
+	)
+	errRemoteInstanceDemotingIsNotSupported = errors.New(
+		"remote instance demoting is not supported",
+	)
+	errSpecifyAnInstanceToDemote = errors.New(
+		"specify an instance to demote",
+	)
+	errSpecifyAnInstanceToPromote = errors.New(
+		"specify an instance to promote",
+	)
+	errTheCommandExpectsArgumentApplicationNameInstanceName = errors.New(
+		"the command expects argument application_name:instance_name",
+	)
+	errThereAreNoRunningInstances = errors.New(
+		"there are no running instances",
+	)
+	errThereIsNoDestinationProvidedInWhichToAddRole = errors.New(
+		"there is no destination provided in which to add role",
+	)
+	errThereIsNoDestinationProvidedWhereToRemoveRole = errors.New(
+		"there is no destination provided where to remove role",
+	)
+	errVersionMustBeInTheFormatXXXWhereXIsANumber = errors.New(
+		"version must be in the format 'x.x.x', where x is a number",
+	)
+)
+
+var (
 	orchestratorCentralizedConfig bool
 	orchestratorCustom            bool
 	orchestratorsEnabled          = map[replicaset.Orchestrator]*bool{
@@ -87,10 +136,9 @@ func newDowngradeCmd() *cobra.Command {
 		return func(cmd *cobra.Command, args []string) error {
 			versionPattern := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 			if args[i] == "" {
-				return errors.New("need to specify the version to downgrade to")
+				return errNeedToSpecifyTheVersionToDowngradeTo
 			} else if !versionPattern.MatchString(args[i]) {
-				return errors.New("version must be in the format " +
-					"'x.x.x', where x is a number")
+				return errVersionMustBeInTheFormatXXXWhereXIsANumber
 			}
 			return nil
 		}
@@ -482,7 +530,7 @@ func fillReplicasetAppCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target 
 		return connOpts, nil
 	}
 	if len(ctx.RunningCtx.Instances) == 0 {
-		return connOpts, fmt.Errorf("there are no running instances")
+		return connOpts, errThereAreNoRunningInstances
 	}
 	// Trying to find alive instance to create connection with it.
 	var err error
@@ -501,7 +549,7 @@ func fillReplicasetAppCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target 
 		}
 	}
 	if err != nil {
-		return connOpts, fmt.Errorf("cannot connect to any instance from replicaset")
+		return connOpts, errCannotConnectToAnyInstanceFromReplicaset
 	}
 	return connOpts, nil
 }
@@ -511,8 +559,7 @@ func fillSingleReplicasetInstance(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx,
 ) (connector.ConnectOpts, error) {
 	var connOpts connector.ConnectOpts
 	if connectCtx.Username != "" || connectCtx.Password != "" {
-		return connOpts, fmt.Errorf("username and password are not supported" +
-			" with a connection via a control socket")
+		return connOpts, errControlSocketCredentialsUnsupported
 	}
 	connOpts = makeConnOpts(
 		connector.UnixNetwork,
@@ -525,7 +572,7 @@ func fillSingleReplicasetInstance(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx,
 		return connOpts, nil
 	}
 	if instName != ctx.RunningCtx.Instances[0].InstName {
-		return connOpts, fmt.Errorf("instance %q not found", instName)
+		return connOpts, fmt.Errorf("%w%q not found", errInstanceNotFound, instName)
 	}
 	// Re-fill context for an application.
 	ctx.InstName = instName
@@ -612,7 +659,7 @@ func internalReplicasetPromoteModule(cmdCtx *cmdcontext.CmdCtx, args []string) e
 		return err
 	}
 	if !ctx.IsInstanceConnect {
-		return fmt.Errorf("specify an instance to promote")
+		return errSpecifyAnInstanceToPromote
 	}
 	defer ctx.Conn.Close()
 
@@ -643,10 +690,10 @@ func internalReplicasetDemoteModule(cmdCtx *cmdcontext.CmdCtx, args []string) er
 		return err
 	}
 	if !ctx.IsApplication {
-		return fmt.Errorf("remote instance demoting is not supported")
+		return errRemoteInstanceDemotingIsNotSupported
 	}
 	if !ctx.IsInstanceConnect {
-		return fmt.Errorf("specify an instance to demote")
+		return errSpecifyAnInstanceToDemote
 	}
 	defer ctx.Conn.Close()
 
@@ -689,7 +736,7 @@ func internalReplicasetStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) er
 // internalReplicasetExpelModule is a "expel" command for the replicaset module.
 func internalReplicasetExpelModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	if _, _, found := strings.Cut(args[0], string(running.InstanceDelimiter)); !found {
-		return fmt.Errorf("the command expects argument application_name:instance_name")
+		return errTheCommandExpectsArgumentApplicationNameInstanceName
 	}
 	var ctx replicasetCtx
 	if err := replicasetFillCtx(cmdCtx, &ctx, args[0], true, running.ConfigLoadAll); err != nil {
@@ -779,7 +826,7 @@ func getOrchestrator() (replicaset.Orchestrator, error) {
 		}
 	}
 	if cnt > 1 {
-		return orchestrator, fmt.Errorf("only one type of orchestrator can be forced")
+		return orchestrator, errOnlyOneTypeOfOrchestratorCanBeForced
 	}
 	return orchestrator, nil
 }
@@ -787,13 +834,13 @@ func getOrchestrator() (replicaset.Orchestrator, error) {
 // replicasetRebootstrapValidateArgs validates "rebootstrap" command arguments.
 func replicasetRebootstrapValidateArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		return errors.New("only one instance supported for re-bootstrap")
+		return errOnlyOneInstanceSupportedForReBootstrap
 	}
 	if len(args) < 1 {
-		return errors.New("instance for rebootstrap is not specified")
+		return errInstanceForRebootstrapIsNotSpecified
 	}
 	if !strings.Contains(args[0], string(running.InstanceDelimiter)) {
-		return errors.New("an instance name is not specified. Please use app:instance format")
+		return errAnInstanceNameIsNotSpecifiedPleaseUseAppInstanceFormat
 	}
 	return nil
 }
@@ -817,12 +864,11 @@ func internalReplicasetRolesAddModule(cmdCtx *cmdcontext.CmdCtx, args []string) 
 	defer ctx.Conn.Close()
 	if ctx.IsApplication && replicasetInstanceName == "" && ctx.InstName == "" &&
 		!replicasetIsGlobal && replicasetGroupName == "" && replicasetReplicasetName == "" {
-		return fmt.Errorf("there is no destination provided in which to add role")
+		return errThereIsNoDestinationProvidedInWhichToAddRole
 	}
 	if ctx.InstName != "" && replicasetInstanceName != "" &&
 		replicasetInstanceName != ctx.InstName {
-		return fmt.Errorf("there are different instance names passed after" +
-			" app name and in flag arg")
+		return errDifferentInstanceNames
 	}
 	if replicasetInstanceName != "" {
 		ctx.InstName = replicasetInstanceName
@@ -861,12 +907,11 @@ func internalReplicasetRolesRemoveModule(cmdCtx *cmdcontext.CmdCtx, args []strin
 	defer ctx.Conn.Close()
 	if ctx.IsApplication && replicasetInstanceName == "" && ctx.InstName == "" &&
 		!replicasetIsGlobal && replicasetGroupName == "" && replicasetReplicasetName == "" {
-		return fmt.Errorf("there is no destination provided where to remove role")
+		return errThereIsNoDestinationProvidedWhereToRemoveRole
 	}
 	if ctx.InstName != "" && replicasetInstanceName != "" &&
 		replicasetInstanceName != ctx.InstName {
-		return fmt.Errorf("there are different instance names passed after" +
-			" app name and in flag arg")
+		return errDifferentInstanceNames
 	}
 	if replicasetInstanceName != "" {
 		ctx.InstName = replicasetInstanceName

--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/apex/log"
@@ -46,7 +45,7 @@ func internalRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	}
 
 	if cmdCtx.Cli.TarantoolCli.Executable == "" {
-		return fmt.Errorf("tarantool binary is not found")
+		return errTarantoolBinaryNotFound
 	}
 
 	if !autoYes {
@@ -54,10 +53,9 @@ func internalRestartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if len(args) == 0 {
 			instancesToConfirm = "all instances"
 		} else {
-			instancesToConfirm = fmt.Sprintf("'%s'", args[0])
+			instancesToConfirm = "'" + args[0] + "'"
 		}
-		confirmed, err := util.AskConfirm(os.Stdin, fmt.Sprintf("Confirm restart of %s",
-			instancesToConfirm))
+		confirmed, err := util.AskConfirm(os.Stdin, "Confirm restart of "+instancesToConfirm)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,6 +22,11 @@ import (
 )
 
 var (
+	errNilCommandRoot = errors.New("can't inject commands. The root is nil")
+	errUnknownCommand = errors.New("unknown command ")
+)
+
+var (
 	cmdCtx      cmdcontext.CmdCtx
 	cliOpts     *config.CliOpts
 	modulesInfo modules.ModulesInfo
@@ -42,7 +47,7 @@ func GetCmdCtxPtr() *cmdcontext.CmdCtx {
 // TT-EE.
 func injectCmds(root *cobra.Command) error {
 	if root == nil {
-		return fmt.Errorf("can't inject commands. The root is nil")
+		return errNilCommandRoot
 	}
 
 	if InjectedCmds == nil {
@@ -135,7 +140,7 @@ func NewCmdRoot() *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			} else {
-				return fmt.Errorf("unknown command %s", args[0])
+				return fmt.Errorf("%w%s", errUnknownCommand, args[0])
 			}
 		},
 		ValidArgsFunction: RootShellCompletionCommands,

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -19,6 +19,10 @@ import (
 )
 
 var (
+	errTarantoolBinaryNotFound = errors.New("tarantool binary is not found")
+)
+
+var (
 	// "watchdog" is a hidden flag used to daemonize a process.
 	// In go, we can't just fork the process (reason - goroutines).
 	// So, for daemonize, we restarts the process with "watchdog" flag.
@@ -117,7 +121,7 @@ func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	}
 
 	if cmdCtx.Cli.TarantoolCli.Executable == "" {
-		return fmt.Errorf("cannot start: tarantool binary is not found")
+		return fmt.Errorf("cannot start: %w", errTarantoolBinaryNotFound)
 	}
 
 	var runningCtx running.RunningCtx
@@ -126,8 +130,8 @@ func internalStartModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		return err
 	}
 
-	if canStart, reason := running.IsAbleToStartInstances(runningCtx.Instances, cmdCtx); !canStart {
-		return errors.New(reason)
+	if canStart, err := running.IsAbleToStartInstances(runningCtx.Instances, cmdCtx); !canStart {
+		return err
 	}
 
 	if !watchdog {

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -8,6 +9,10 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/running"
 	"github.com/tarantool/tt/cli/status"
+)
+
+var (
+	errInvalidFormatValidFormatsAreJSONYAMLTablePrettyTable = errors.New("invalid format: ")
 )
 
 // statusOpts contains options for tt status.
@@ -84,8 +89,8 @@ func internalStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		"pretty-table": true,
 	}
 	if !validFormats[opts.format] {
-		return fmt.Errorf("invalid format: %s. Valid formats are: json, yaml, table, pretty-table",
-			opts.format)
+		return fmt.Errorf("%w%s. Valid formats are: json, yaml, table, pretty-table",
+			errInvalidFormatValidFormatsAreJSONYAMLTablePrettyTable, opts.format)
 	}
 
 	var runningCtx running.RunningCtx

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/apex/log"
@@ -47,10 +46,9 @@ func internalStopWithConfirmationModule(cmdCtx *cmdcontext.CmdCtx, args []string
 		if len(args) == 0 {
 			instancesToConfirm = "all instances"
 		} else {
-			instancesToConfirm = fmt.Sprintf("'%s'", args[0])
+			instancesToConfirm = "'" + args[0] + "'"
 		}
-		confirmed, err := util.AskConfirm(os.Stdin, fmt.Sprintf("Confirm stop of %s",
-			instancesToConfirm))
+		confirmed, err := util.AskConfirm(os.Stdin, "Confirm stop of "+instancesToConfirm)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/tcm.go
+++ b/cli/cmd/tcm.go
@@ -21,6 +21,11 @@ import (
 	libwatchdog "github.com/tarantool/tt/lib/watchdog"
 )
 
+var (
+	errCannotStartTCMBinaryIsNotFound = errors.New("cannot start: tcm binary is not found")
+	errProcessIsNotRunning            = errors.New("process is not running")
+)
+
 var tcmCtx = tcmCmd.TcmCtx{}
 
 const (
@@ -124,7 +129,7 @@ func startTcmInteractive(logLevel string) error {
 	}
 
 	if tcmApp == nil || tcmApp.Process == nil {
-		return errors.New("process is not running")
+		return errProcessIsNotRunning
 	}
 
 	err := process_utils.CreatePIDFile(tcmPidFile, tcmApp.Process.Pid)
@@ -146,11 +151,11 @@ func startTcmUnderWatchDog() error {
 
 func internalStartTcm(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 	if cmdCtx.Cli.TarantoolCli.Executable == "" {
-		return errors.New("cannot start: tarantool binary is not found")
+		return fmt.Errorf("cannot start: %w", errTarantoolBinaryNotFound)
 	}
 
 	if cmdCtx.Cli.TcmCli.Executable == "" {
-		return errors.New("cannot start: tcm binary is not found")
+		return errCannotStartTCMBinaryIsNotFound
 	}
 
 	tcmCtx.Executable = cmdCtx.Cli.TcmCli.Executable

--- a/cli/cmdcontext/cmdcontext.go
+++ b/cli/cmdcontext/cmdcontext.go
@@ -2,6 +2,7 @@ package cmdcontext
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -9,6 +10,16 @@ import (
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errFailedToGetTarantoolVersionCorruptedData = errors.New(
+		"failed to get tarantool version: corrupted data",
+	)
+	errFileNotFound                                           = errors.New("file ")
+	errTarantoolExecutableIsNotSetUnableToGetTarantoolVersion = errors.New(
+		"tarantool executable is not set, unable to get tarantool version",
+	)
 )
 
 // CmdCtx is the main structure of the program context.
@@ -48,8 +59,7 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	}
 
 	if tntCli.Executable == "" {
-		return tntCli.version, fmt.Errorf(
-			"tarantool executable is not set, unable to get tarantool version")
+		return tntCli.version, errTarantoolExecutableIsNotSetUnableToGetTarantoolVersion
 	}
 	output, err := exec.CommandContext(
 		context.Background(), tntCli.Executable, "--version").Output()
@@ -61,7 +71,7 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 	versionLine := strings.Split(versionOut[0], " ")
 
 	if len(versionLine) < minVersionFields {
-		return tntCli.version, fmt.Errorf("failed to get tarantool version: corrupted data")
+		return tntCli.version, errFailedToGetTarantoolVersionCorruptedData
 	}
 
 	tntVersion, err := version.Parse(versionLine[len(versionLine)-1])
@@ -77,7 +87,7 @@ func (tntCli *TarantoolCli) GetVersion() (version.Version, error) {
 // GetTtVersion returns version of Tt provided by its executable path.
 func GetTtVersion(pathToBin string) (version.Version, error) {
 	if !util.IsRegularFile(pathToBin) {
-		return version.Version{}, fmt.Errorf("file %q not found", pathToBin)
+		return version.Version{}, fmt.Errorf("%w%q not found", errFileNotFound, pathToBin)
 	}
 
 	output, err := exec.CommandContext(context.Background(), pathToBin, "--self", "version",

--- a/cli/cmdcontext/cmdcontext_test.go
+++ b/cli/cmdcontext/cmdcontext_test.go
@@ -118,16 +118,16 @@ func TestTtCli_GetVersion(t *testing.T) {
 			versionToCheck: "2131f7cc1de",
 			expectedVer:    version.Version{},
 			isErr:          true,
-			expectedErrMsg: fmt.Sprintf(`failed to parse version "2131f7cc1de\n":` +
-				` format is not valid`),
+			expectedErrMsg: `failed to parse version "2131f7cc1de\n":` +
+				` format is not valid`,
 		},
 		{
 			name:           "version does not match",
 			versionToCheck: "2.1.3.1.f7cc1de",
 			expectedVer:    version.Version{},
 			isErr:          true,
-			expectedErrMsg: fmt.Sprintf(`the version of "2.1.3.1" does not match` +
-				` <major>.<minor>.<patch> format`),
+			expectedErrMsg: `the version of "2.1.3.1" does not match` +
+				` <major>.<minor>.<patch> format`,
 		},
 		{
 			name:           "hash does not match",

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -1,6 +1,7 @@
 package configure
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +15,36 @@ import (
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errExpectedAStringValueGot = errors.New(
+		"expected a string value, got ",
+	)
+	errFailedToFindTarantoolCLIConfigFor = errors.New(
+		"failed to find Tarantool CLI config for '",
+	)
+	errFailedToParseDaemonConfigurationMissingDaemonSection = errors.New(
+		"failed to parse daemon configuration: missing daemon section",
+	)
+	errFailedToParseTarantoolCLIConfigurationMissingTTSection = errors.New(
+		"failed to parse Tarantool CLI configuration: missing tt section",
+	)
+	errIntegrityCheckPeriodMustTakeNonNegativeValue = errors.New(
+		"--integrity-check-period must take non-negative value",
+	)
+	errIntegrityCheckPublicKeyRequired = errors.New(
+		"need to specify public key in --integrity-check to use --integrity-check-period",
+	)
+	errYouCanSpecifyOnlyOneOfLLocalAndSSystemOptions = errors.New(
+		"you can specify only one of -L(--local) and -S(--system) options",
+	)
+	errYouCanSpecifyOnlyOneOfLLocalCCfgAndTTCLICfgOptions = errors.New(
+		"you can specify only one of -L(--local), -c(--cfg) and 'TT_CLI_CFG' options",
+	)
+	errYouCanSpecifyOnlyOneOfSSystemCCfgAndTTCLICfgOptions = errors.New(
+		"you can specify only one of -S(--system), -c(--cfg) and 'TT_CLI_CFG' options",
+	)
 )
 
 const (
@@ -235,7 +266,7 @@ func decodeStringAsArrayField(from, to reflect.Type, value any) (
 	}
 	str, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("expected a string value, got %T", value)
+		return nil, fmt.Errorf("%w%T", errExpectedAStringValueGot, value)
 	}
 	return []string{str}, nil
 }
@@ -286,7 +317,7 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 
 		if cfg == nil {
 			return nil, "",
-				fmt.Errorf("failed to parse Tarantool CLI configuration: missing tt section")
+				errFailedToParseTarantoolCLIConfigurationMissingTTSection
 		}
 	case err != nil && !os.IsNotExist(err):
 		// TODO: Add warning in next patches, discussion
@@ -339,7 +370,7 @@ func GetDaemonOpts(configurePath string) (*config.DaemonOpts, error) {
 	}
 
 	if cfg.DaemonConfig == nil {
-		return nil, fmt.Errorf("failed to parse daemon configuration: missing daemon section")
+		return nil, errFailedToParseDaemonConfigurationMissingDaemonSection
 	}
 
 	if cfg.DaemonConfig.PIDFile == "" {
@@ -370,22 +401,19 @@ func GetDaemonOpts(configurePath string) (*config.DaemonOpts, error) {
 func ValidateCliOpts(cliCtx *cmdcontext.CliCtx) error {
 	if cliCtx.LocalLaunchDir != "" {
 		if cliCtx.IsSystem {
-			return fmt.Errorf("you can specify only one of -L(--local) and -S(--system) options")
+			return errYouCanSpecifyOnlyOneOfLLocalAndSSystemOptions
 		}
 		if cliCtx.ConfigPath != "" {
-			return fmt.Errorf(
-				"you can specify only one of -L(--local), -c(--cfg) and 'TT_CLI_CFG' options")
+			return errYouCanSpecifyOnlyOneOfLLocalCCfgAndTTCLICfgOptions
 		}
 	} else if cliCtx.IsSystem && cliCtx.ConfigPath != "" {
-		return fmt.Errorf(
-			"you can specify only one of -S(--system), -c(--cfg) and 'TT_CLI_CFG' options")
+		return errYouCanSpecifyOnlyOneOfSSystemCCfgAndTTCLICfgOptions
 	}
 	if len(cliCtx.IntegrityCheck) == 0 && cliCtx.IntegrityCheckPeriod != 0 {
-		return fmt.Errorf("need to specify public key in --integrity-check to " +
-			"use --integrity-check-period")
+		return errIntegrityCheckPublicKeyRequired
 	}
 	if cliCtx.IntegrityCheckPeriod < 0 {
-		return fmt.Errorf("--integrity-check-period must take non-negative value")
+		return errIntegrityCheckPeriodMustTakeNonNegativeValue
 	}
 	return nil
 }
@@ -569,8 +597,8 @@ func ensureCliConfigPath(cmdCtx *cmdcontext.CmdCtx, launchDir string) error {
 		return nil
 	}
 	if cmdCtx.Cli.LocalLaunchDir != "" {
-		return fmt.Errorf("failed to find Tarantool CLI config for '%s'",
-			cmdCtx.Cli.LocalLaunchDir)
+		return fmt.Errorf("%w%s'",
+			errFailedToFindTarantoolCLIConfigFor, cmdCtx.Cli.LocalLaunchDir)
 	}
 	cmdCtx.Cli.ConfigPath = getSystemConfigPath()
 	return nil
@@ -730,13 +758,13 @@ func getDaemonCfgPath(configName string) (string, error) {
 	homeDir := os.Getenv("HOME")
 
 	if xdgConfigHome != "" {
-		xdgConfigDir = fmt.Sprintf("%s/tt", xdgConfigHome)
+		xdgConfigDir = xdgConfigHome + "/tt"
 	} else {
-		xdgConfigDir = fmt.Sprintf("%s/.config/tt", homeDir)
+		xdgConfigDir = homeDir + "/.config/tt"
 	}
 
 	// Config in $XDG_CONFIG_HOME.
-	configPath := fmt.Sprintf("%s/%s", xdgConfigDir, configName)
+	configPath := xdgConfigDir + "/" + configName
 	if _, err := os.Stat(configPath); err == nil {
 		return configPath, nil
 	}

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -13,6 +13,17 @@ import (
 	"github.com/tarantool/tt/cli/formatter"
 )
 
+var (
+	errTheCommandDoesNotExpectArguments      = errors.New("the command does not expect arguments")
+	errTheCommandExpectsOneOf                = errors.New("the command expects one of: ")
+	errTheCommandExpectsZeroOrSingleArgument = errors.New(
+		"the command expects zero or single argument",
+	)
+	errUnsupportedDialect  = errors.New("unsupported dialect: ")
+	errUnsupportedFormat   = errors.New("unsupported format: ")
+	errUnsupportedLanguage = errors.New("unsupported language: ")
+)
+
 // cmd is the interface that must be implemented by a console command.
 type cmd interface {
 	// Aliases returns a list of all command's aliases.
@@ -131,7 +142,7 @@ func (command noArgsCmdDecorator) Run(console *Console,
 	cmd string, args []string,
 ) (string, error) {
 	if len(args) != 0 {
-		return "", fmt.Errorf("the command does not expect arguments")
+		return "", errTheCommandDoesNotExpectArguments
 	}
 	return command.base.Run(console, cmd, args)
 }
@@ -166,8 +177,8 @@ func (command argSetCmdDecorator) Run(console *Console,
 	cmd string, args []string,
 ) (string, error) {
 	if len(command.sorted) > 0 && (len(args) != 1 || !find(command.sorted, args[0])) {
-		return "", fmt.Errorf("the command expects one of: %s",
-			strings.Join(command.sorted, ", "))
+		return "", fmt.Errorf("%w%s",
+			errTheCommandExpectsOneOf, strings.Join(command.sorted, ", "))
 	}
 
 	return command.base.Run(console, cmd, args)
@@ -320,7 +331,7 @@ func setLanguageFunc(console *Console, cmd string, args []string) (string, error
 			console.language = lang
 		}
 	} else {
-		return "", fmt.Errorf("unsupported language: %s", args[0])
+		return "", fmt.Errorf("%w%s", errUnsupportedLanguage, args[0])
 	}
 	return "", nil
 }
@@ -332,7 +343,7 @@ func setFormatFunc(console *Console, cmd string, args []string) (string, error) 
 		console.format = newFormat
 	} else {
 		// It should not happen in practice.
-		return "", fmt.Errorf("unsupported format: %s", formatStr)
+		return "", fmt.Errorf("%w%s", errUnsupportedFormat, formatStr)
 	}
 	return "", nil
 }
@@ -344,7 +355,7 @@ func setTableDialectFunc(console *Console, cmd string, args []string) (string, e
 		console.formatOpts.TableDialect = dialect
 	} else {
 		// It should not happen in practice.
-		return "", fmt.Errorf("unsupported dialect: %s", dialectStr)
+		return "", fmt.Errorf("%w%s", errUnsupportedDialect, dialectStr)
 	}
 	return "", nil
 }
@@ -385,7 +396,7 @@ func setDelimiterMarker(console *Console, cmd string, args []string) (string, er
 	case 1:
 		console.delimiter = args[0]
 	default:
-		return "", fmt.Errorf("the command expects zero or single argument")
+		return "", errTheCommandExpectsZeroOrSingleArgument
 	}
 	return "", nil
 }

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,13 @@ import (
 	"github.com/tarantool/tt/cli/formatter"
 	terminal "golang.org/x/term"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	errInteractiveInputSource = errors.New(
+		"can't use interactive input as a source file",
+	)
+	errUnexpectedResponseType = errors.New("unexpected response type: ")
 )
 
 // ConnectCtx contains information for connecting to the instance.
@@ -55,7 +63,7 @@ const (
 func getEvalCmd(connectCtx ConnectCtx) (string, error) {
 	if connectCtx.SrcFile == "-" {
 		if terminal.IsTerminal(syscall.Stdin) {
-			return "", fmt.Errorf("can't use interactive input as a source file")
+			return "", errInteractiveInputSource
 		}
 		cmdByte, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -131,7 +139,7 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 		if str, ok := response[0].(string); ok {
 			resYAML = str
 		} else {
-			return nil, fmt.Errorf("unexpected response type: %T", response[0])
+			return nil, fmt.Errorf("%w%T", errUnexpectedResponseType, response[0])
 		}
 	}
 	var checkMock any

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -363,11 +363,11 @@ func setTitle(console *Console, title string) {
 }
 
 func setPrefix(console *Console) {
-	console.prefix = fmt.Sprintf("%s> ", console.title)
+	console.prefix = console.title + "> "
 
 	livePrefixIndent := min(len(console.title), MaxLivePrefixIndent)
 
-	console.livePrefix = fmt.Sprintf("%s> ", strings.Repeat(" ", livePrefixIndent))
+	console.livePrefix = strings.Repeat(" ", livePrefixIndent) + "> "
 
 	console.livePrefixFunc = func() (string, bool) {
 		return console.livePrefix, console.livePrefixEnabled

--- a/cli/connect/input.go
+++ b/cli/connect/input.go
@@ -1,7 +1,6 @@
 package connect
 
 import (
-	"fmt"
 	"strings"
 	"unicode"
 
@@ -51,7 +50,7 @@ func (s *LuaValidator) Validate(str string) bool {
 		return true
 	}
 
-	if _, err := s.state.LoadString(fmt.Sprintf("return %s", str)); err == nil {
+	if _, err := s.state.LoadString("return " + str); err == nil {
 		// Certain obscure inputs like '(42\n)' yield the same error as
 		// incomplete statement.
 		return true

--- a/cli/connect/language.go
+++ b/cli/connect/language.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -8,6 +9,11 @@ import (
 
 	"github.com/tarantool/tt/cli/connect/internal/luabody"
 	"github.com/tarantool/tt/cli/connector"
+)
+
+var (
+	errReturnsFalse       = errors.New(" returns false")
+	errUnexpectedResponse = errors.New("unexpected response: ")
 )
 
 const (
@@ -74,15 +80,15 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 	}
 
 	if len(response) == 0 {
-		return fmt.Errorf("unexpected response: empty")
+		return fmt.Errorf("%wempty", errUnexpectedResponse)
 	} else if len(response) > 1 {
-		return fmt.Errorf("unexpected response: %v", response)
+		return fmt.Errorf("%w%v", errUnexpectedResponse, response)
 	}
 
 	var ret string
 	var ok bool
 	if ret, ok = response[0].(string); !ok {
-		return fmt.Errorf("unexpected response: %v", response)
+		return fmt.Errorf("%w%v", errUnexpectedResponse, response)
 	}
 
 	var decoded any
@@ -92,16 +98,16 @@ func ChangeLanguage(evaler connector.Evaler, lang Language) error {
 
 	var decodedArray []any
 	if decodedArray, ok = decoded.([]any); !ok || len(decodedArray) != 1 {
-		return fmt.Errorf("unexpected response: %s", ret)
+		return fmt.Errorf("%w%s", errUnexpectedResponse, ret)
 	}
 
 	var value bool
 	if value, ok = decodedArray[0].(bool); !ok {
-		return fmt.Errorf("unexpected response: %s", ret)
+		return fmt.Errorf("%w%s", errUnexpectedResponse, ret)
 	}
 
 	if !value {
-		return fmt.Errorf("%s returns false", languageCmd)
+		return fmt.Errorf("%s%w", languageCmd, errReturnsFalse)
 	}
 
 	return nil

--- a/cli/connect/language_test.go
+++ b/cli/connect/language_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/tarantool/tt/cli/connector"
 )
 
+var (
+	errAnyError = errors.New("any error")
+)
+
 func TestLanguage_ParseLanguage(t *testing.T) {
 	cases := []struct {
 		str      string
@@ -81,7 +85,7 @@ func (evaler *inputEvaler) Eval(fun string,
 	evaler.args = args
 	evaler.opts = opts
 
-	return nil, errors.New("any error")
+	return nil, errAnyError
 }
 
 func TestChangeLanguage_requestInputs(t *testing.T) {
@@ -135,7 +139,7 @@ func TestChangeLanguage_requestOutputsInvalid(t *testing.T) {
 		expected string
 	}{
 		{nil, nil, "unexpected response: empty"},
-		{nil, errors.New("any error"), "any error"},
+		{nil, errAnyError, "any error"},
 		{[]any{true}, nil, "unexpected response: [true]"},
 		{[]any{",,,"}, nil, "unable to decode response: yaml:" +
 			" did not find expected node content"},

--- a/cli/connector/binary.go
+++ b/cli/connector/binary.go
@@ -13,6 +13,10 @@ import (
 	_ "github.com/tarantool/go-tarantool/v2/uuid"
 )
 
+var (
+	errIOTimeout = errors.New("i/o timeout")
+)
+
 // BinaryConnector implements Connector interface for a connection that sends
 // and receives data via IPROTO.
 type BinaryConnector struct {
@@ -106,5 +110,5 @@ func replaceContextDone(err error) error {
 	if err == nil || !strings.HasPrefix(err.Error(), "context is done") {
 		return err
 	}
-	return errors.New("i/o timeout")
+	return errIOTimeout
 }

--- a/cli/connector/binary_test.go
+++ b/cli/connector/binary_test.go
@@ -1,7 +1,6 @@
 package connector_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,7 @@ func TestBinaryConnector_Close(t *testing.T) {
 
 func TestBinaryConnector_Close_error(t *testing.T) {
 	const errMsg = "any error"
-	stub := &binaryConnectorStub{err: errors.New(errMsg)}
+	stub := &binaryConnectorStub{err: errAnyError}
 	conn := NewBinaryConnector(stub)
 
 	assert.EqualError(t, conn.Close(), errMsg)

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -14,6 +14,14 @@ import (
 	"github.com/tarantool/tt/lib/dial"
 )
 
+var (
+	errEncryptionRequired = errors.New(
+		"unencrypted connection established, but encryption required",
+	)
+	errSocketNameIsLongerThanSymbols = errors.New("socket name is longer than ")
+	errUnsupportedProtocol           = errors.New("unsupported protocol: ")
+)
+
 const (
 	greetingOperationTimeout = 3 * time.Second
 	maxSocketPathLinux       = 108
@@ -64,7 +72,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		os.Chdir(filepath.Dir(opts.Address))
 		opts.Address = "./" + filepath.Base(opts.Address)
 		if len(opts.Address)+1 > maxSocketPath {
-			return nil, fmt.Errorf("socket name is longer than %d symbols: %s",
+			return nil, fmt.Errorf("%w%d symbols: %s", errSocketNameIsLongerThanSymbols,
 				maxSocketPath-socketPathPrefixLength, filepath.Base(opts.Address))
 		}
 		defer os.Chdir(workDir)
@@ -91,8 +99,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		}
 	} else if ssl {
 		greetingConn.Close()
-		errMsg := "unencrypted connection established, but encryption required"
-		return nil, errors.New(errMsg)
+		return nil, errEncryptionRequired
 	}
 
 	// Reset the deadline. From the SetDeadline doc:
@@ -129,6 +136,6 @@ func Connect(opts ConnectOpts) (Connector, error) {
 		}
 		return NewBinaryConnector(conn), nil
 	default:
-		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
+		return nil, fmt.Errorf("%w%s", errUnsupportedProtocol, protocol)
 	}
 }

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var (
+	errConnectionWasClosed    = errors.New("connection was closed")
+	errExpectedOneResultFound = errors.New("expected one result, found ")
+)
+
 const (
 	startOfYamlOutput = "---\n"
 
@@ -30,6 +36,12 @@ const (
 	decodeBufferSize = 256
 	pushLineParts    = 2
 )
+
+type evaluationError string
+
+func (err evaluationError) Error() string {
+	return string(err)
+}
 
 type EvalPlainTextOpts struct {
 	ReadTimeout  time.Duration
@@ -83,7 +95,7 @@ func formatAndSendEvalFunc(conn net.Conn, funcBody string, args []any,
 
 	evalFunc, err := util.GetTextTemplatedStr(&evalFuncTmpl, map[string]string{
 		"FunctionBody": funcBody,
-		"ArgsEncoded":  fmt.Sprintf("%x", argsEncoded),
+		"ArgsEncoded":  hex.EncodeToString(argsEncoded),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to instantiate eval function template: %w", err)
@@ -262,7 +274,7 @@ func readDataPortionFromPlainTextConn(conn net.Conn, buffer *bytes.Buffer,
 	}
 
 	if len(data) == 0 {
-		return nil, fmt.Errorf("connection was closed")
+		return nil, errConnectionWasClosed
 	}
 
 	return data, nil
@@ -370,7 +382,7 @@ func getPlainTextEvalResYaml(resBytes []byte) (string, error) {
 	}
 
 	if len(evalResults) != 1 {
-		return "", fmt.Errorf("expected one result, found %d", len(evalResults))
+		return "", fmt.Errorf("%w%d", errExpectedOneResultFound, len(evalResults))
 	}
 
 	evalResult := evalResults[0]
@@ -389,7 +401,7 @@ func getPlainTextEvalError(resBytes []byte, parseErr error) error {
 	if !found {
 		return fmt.Errorf("failed to parse eval result: %w", parseErr)
 	}
-	return errors.New(errStr)
+	return evaluationError(errStr)
 }
 
 func getPlainTextEvalResLua(resBytes []byte) (string, error) {
@@ -405,7 +417,7 @@ func getPlainTextEvalResLua(resBytes []byte) (string, error) {
 	luaRes := L.Env.RawGetString("res")
 
 	if luaRes.Type() == lua.LTString {
-		return "", errors.New(lua.LVAsString(luaRes))
+		return "", evaluationError(lua.LVAsString(luaRes))
 	}
 
 	encodedDataLV := L.GetTable(luaRes, lua.LString("data_enc"))

--- a/cli/connector/protocol.go
+++ b/cli/connector/protocol.go
@@ -1,9 +1,14 @@
 package connector
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
+)
+
+var (
+	errFailedToParseTarantoolGreeting = errors.New("failed to parse Tarantool greeting: ")
 )
 
 const (
@@ -49,7 +54,7 @@ func GetProtocol(reader io.Reader) (Protocol, error) {
 	}
 
 	if protocol, ok := ParseProtocol(string(greeting)); !ok {
-		err := fmt.Errorf("failed to parse Tarantool greeting: %s", greeting)
+		err := fmt.Errorf("%w%s", errFailedToParseTarantoolGreeting, greeting)
 		return BinaryProtocol, err
 	} else {
 		return protocol, nil

--- a/cli/connector/protocol_test.go
+++ b/cli/connector/protocol_test.go
@@ -10,6 +10,10 @@ import (
 	. "github.com/tarantool/tt/cli/connector"
 )
 
+var (
+	errAnyError = errors.New("any error")
+)
+
 func TestProtocol_String(t *testing.T) {
 	cases := []struct {
 		protocol Protocol
@@ -50,7 +54,7 @@ func (stub *greetingReadStub) Read(dst []byte) (int, error) {
 
 func TestGetProtocol(t *testing.T) {
 	// spell-checker:ignore asdasdasd asdasdasdqwe
-	err := errors.New("any error")
+	err := errAnyError
 	cases := []struct {
 		greeting string
 		err      error

--- a/cli/connector/text_test.go
+++ b/cli/connector/text_test.go
@@ -1,7 +1,6 @@
 package connector_test
 
 import (
-	"errors"
 	"net"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestTextConnector_Close(t *testing.T) {
 
 func TestTextConnector_Close_error(t *testing.T) {
 	const errMsg = "any error"
-	stub := &plainConnectorStub{err: errors.New(errMsg)}
+	stub := &plainConnectorStub{err: errAnyError}
 	conn := NewTextConnector(stub)
 
 	assert.EqualError(t, conn.Close(), errMsg)

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -15,6 +15,11 @@ import (
 	"github.com/tarantool/go-prompt"
 )
 
+var (
+	errConsoleStopped                 = errors.New("can't run on stopped console")
+	errNoHandlerForCommandsHasBeenSet = errors.New("no handler for commands has been set")
+)
+
 const (
 	maxLivePrefixIndent = 15
 	// See https://github.com/tarantool/tarantool/blob/b53cb2aeceedc39f356ceca30bd0087ee8de7c16/
@@ -53,7 +58,7 @@ type Console struct {
 // NewConsole creates a new console connected to the tarantool instance.
 func NewConsole(opts ConsoleOpts) (Console, error) {
 	if opts.Handler == nil {
-		return Console{quit: true}, errors.New("no handler for commands has been set")
+		return Console{quit: true}, errNoHandlerForCommandsHasBeenSet
 	}
 	c := Console{
 		impl: opts,
@@ -66,7 +71,7 @@ func NewConsole(opts ConsoleOpts) (Console, error) {
 // Run starts console.
 func (c *Console) Run() error {
 	if c.quit {
-		return errors.New("can't run on stopped console")
+		return errConsoleStopped
 	}
 	if !term.IsTerminal(syscall.Stdin) {
 		return c.runOnPipe()
@@ -207,11 +212,11 @@ func (c *Console) complete(input prompt.Document) []prompt.Suggest {
 
 // setPrefix adjust console prefix string.
 func (c *Console) setPrefix() {
-	c.prefix = fmt.Sprintf("%s> ", c.title())
+	c.prefix = c.title() + "> "
 
 	livePrefixIndent := min(len(c.title()), maxLivePrefixIndent)
 
-	c.livePrefix = fmt.Sprintf("%s> ", strings.Repeat(" ", livePrefixIndent))
+	c.livePrefix = strings.Repeat(" ", livePrefixIndent) + "> "
 }
 
 // getPromptOptions prepare option for prompt.

--- a/cli/console/format.go
+++ b/cli/console/format.go
@@ -1,9 +1,14 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tarantool/tt/cli/formatter"
+)
+
+var (
+	errUnsupportedFormatType = errors.New("can't format type=")
 )
 
 // Format aggregate formatter options.
@@ -38,7 +43,7 @@ func (f Format) Sprint(data any) (string, error) {
 		return s, nil
 	} else if eo, ok := data.(error); ok {
 		// Then checking is it has `Error` method.
-		return fmt.Sprintf("Error: %s", eo.Error()), nil
+		return "Error: " + eo.Error(), nil
 	}
-	return "", fmt.Errorf("can't format type=%T", data)
+	return "", fmt.Errorf("%w%T", errUnsupportedFormatType, data)
 }

--- a/cli/console/format_test.go
+++ b/cli/console/format_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/tarantool/tt/cli/console"
 )
 
+var (
+	errFormatterErrorMessage = errors.New("formatter error message")
+	errJustErrorMessage      = errors.New("just error message")
+)
+
 type formatterImpl struct {
 	data string
 }
@@ -16,7 +21,7 @@ func (f formatterImpl) Format(_ console.Format) (string, error) {
 	if len(f.data) > 0 {
 		return f.data, nil
 	}
-	return "", errors.New("formatter error message")
+	return "", errFormatterErrorMessage
 }
 
 type stringerImpl int
@@ -54,7 +59,7 @@ func TestFormat_Print(t *testing.T) {
 		},
 		{
 			"error",
-			errors.New("just error message"),
+			errJustErrorMessage,
 			"Error: just error message",
 			false,
 		},

--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -2,7 +2,7 @@ package create
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"os"
 
 	"github.com/tarantool/tt/cli/config"
@@ -11,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/create/internal/steps"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
+)
+
+var (
+	errTemplateNameIsMissing = errors.New("template name is missing")
 )
 
 // FillCtx fills create context.
@@ -74,7 +78,7 @@ func Run(createCtx *create_ctx.CreateCtx) error {
 // checkCtx checks create context for validity.
 func checkCtx(ctx *create_ctx.CreateCtx) error {
 	if ctx.TemplateName == "" {
-		return fmt.Errorf("template name is missing")
+		return errTemplateNameIsMissing
 	}
 
 	return nil

--- a/cli/create/internal/app_template/manifest.go
+++ b/cli/create/internal/app_template/manifest.go
@@ -1,11 +1,17 @@
 package app_template
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errMissingUserPrompt   = errors.New("missing user prompt")
+	errMissingVariableName = errors.New("missing variable name")
 )
 
 const (
@@ -46,10 +52,10 @@ type TemplateManifest struct {
 func validateManifest(manifest *TemplateManifest) error {
 	for _, varInfo := range manifest.Vars {
 		if varInfo.Prompt == "" {
-			return fmt.Errorf("missing user prompt")
+			return errMissingUserPrompt
 		}
 		if varInfo.Name == "" {
-			return fmt.Errorf("missing variable name")
+			return errMissingVariableName
 		}
 	}
 	return nil

--- a/cli/create/internal/steps/collect_template_vars.go
+++ b/cli/create/internal/steps/collect_template_vars.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -8,6 +9,11 @@ import (
 
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/create/internal/app_template"
+)
+
+var (
+	errInvalidFormatOfVariable = errors.New("invalid format of ")
+	errVariableValueIsNotSet   = errors.New(" variable value is not set")
 )
 
 // stringReader is the interface that wraps the ReadString method.
@@ -36,7 +42,7 @@ func validateExistingValue(createCtx *create_ctx.CreateCtx, varInfo app_template
 		return true, nil
 	}
 	if createCtx.SilentMode {
-		return false, fmt.Errorf("invalid format of %s variable", varInfo.Name)
+		return false, fmt.Errorf("%w%s variable", errInvalidFormatOfVariable, varInfo.Name)
 	}
 	fmt.Fprintf(os.Stdout, "Invalid format of %s variable.\n", varInfo.Name)
 	return false, nil
@@ -66,7 +72,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 		for !matched {
 			if varInfo.Default == "" {
 				if createCtx.SilentMode {
-					return fmt.Errorf("%s variable value is not set", varInfo.Name)
+					return fmt.Errorf("%s%w", varInfo.Name, errVariableValueIsNotSet)
 				}
 				fmt.Fprintf(os.Stdout, "%s: ", varInfo.Prompt)
 			} else {
@@ -105,7 +111,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 			}
 			if !matched {
 				if createCtx.SilentMode {
-					return fmt.Errorf("invalid format of %s variable", varInfo.Name)
+					return fmt.Errorf("%w%s variable", errInvalidFormatOfVariable, varInfo.Name)
 				}
 				fmt.Fprintln(os.Stdout, "Invalid format. Try again.")
 			}

--- a/cli/create/internal/steps/copy_app_template.go
+++ b/cli/create/internal/steps/copy_app_template.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -14,6 +15,10 @@ import (
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/create/internal/app_template"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errTemplateIsNotFound = errors.New("template '")
 )
 
 // CopyAppTemplate represents template -> app directory copy step.
@@ -105,5 +110,5 @@ func (CopyAppTemplate) Run(createCtx *create_ctx.CreateCtx,
 		}
 	}
 
-	return fmt.Errorf("template '%s' is not found", templateName)
+	return fmt.Errorf("%w%s' is not found", errTemplateIsNotFound, templateName)
 }

--- a/cli/create/internal/steps/create_temporary_app_dir.go
+++ b/cli/create/internal/steps/create_temporary_app_dir.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -9,6 +10,11 @@ import (
 	"github.com/apex/log"
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/create/internal/app_template"
+)
+
+var (
+	errApplicationAlreadyExists     = errors.New("application ")
+	errApplicationNameCannotBeEmpty = errors.New("application name cannot be empty")
 )
 
 // CreateTemporaryAppDirectory represents create temporary application directory step.
@@ -22,7 +28,7 @@ func (CreateTemporaryAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 	var err error
 
 	if createCtx.AppName == "" {
-		return fmt.Errorf("application name cannot be empty")
+		return errApplicationNameCannotBeEmpty
 	}
 
 	if createCtx.DestinationDir != "" {
@@ -33,7 +39,8 @@ func (CreateTemporaryAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 
 	if _, err = os.Stat(appDirectory); err == nil {
 		if !createCtx.ForceMode {
-			return fmt.Errorf("application %s already exists: %s", createCtx.AppName, appDirectory)
+			return fmt.Errorf("%w%s already exists: %s",
+				errApplicationAlreadyExists, createCtx.AppName, appDirectory)
 		}
 	}
 

--- a/cli/create/internal/steps/fill_template_vars_from_cli.go
+++ b/cli/create/internal/steps/fill_template_vars_from_cli.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,14 +10,14 @@ import (
 	"github.com/tarantool/tt/cli/create/internal/app_template"
 )
 
-const varDefFormatError = `wrong variable definition format: %s
-Format: var-name=value`
+var errWrongVariableDefinitionFormat = errors.New("wrong variable definition format: ")
 
 func parseVarDefinition(varDefText string) (struct{ name, value string }, error) {
 	varDefinition := strings.TrimSpace(strings.TrimSuffix(varDefText, "\n"))
 	varName, value, found := strings.Cut(varDefinition, "=")
 	if !found || varName == "" || value == "" {
-		return struct{ name, value string }{}, fmt.Errorf(varDefFormatError, varDefText)
+		return struct{ name, value string }{}, fmt.Errorf("%w%s\nFormat: var-name=value",
+			errWrongVariableDefinitionFormat, varDefText)
 	}
 	return struct{ name, value string }{name: varName, value: value}, nil
 }

--- a/cli/create/internal/steps/move_app_dir.go
+++ b/cli/create/internal/steps/move_app_dir.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -8,6 +9,10 @@ import (
 	"github.com/otiai10/copy"
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/create/internal/app_template"
+)
+
+var (
+	errAlreadyExists = errors.New("already exists")
 )
 
 // MoveAppDirectory represents temporary application directory move step.
@@ -23,7 +28,7 @@ func (MoveAppDirectory) Run(createCtx *create_ctx.CreateCtx,
 
 	if _, err := os.Stat(templateCtx.TargetAppPath); err == nil {
 		if !createCtx.ForceMode {
-			return fmt.Errorf("'%s' already exists", templateCtx.TargetAppPath)
+			return fmt.Errorf("'%s' %w", templateCtx.TargetAppPath, errAlreadyExists)
 		}
 		if err = os.RemoveAll(templateCtx.TargetAppPath); err != nil {
 			return fmt.Errorf("failed to remove %s: %w", templateCtx.TargetAppPath, err)

--- a/cli/create/internal/steps/run_hook.go
+++ b/cli/create/internal/steps/run_hook.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,10 @@ import (
 	"github.com/apex/log"
 	create_ctx "github.com/tarantool/tt/cli/create/context"
 	"github.com/tarantool/tt/cli/create/internal/app_template"
+)
+
+var (
+	errInvalidHookType = errors.New("invalid hook type ")
 )
 
 // RunHook represents run hook step.
@@ -31,7 +36,7 @@ func (hook RunHook) Run(ctx *create_ctx.CreateCtx, templateCtx *app_template.Tem
 	case "post":
 		hookPath = templateCtx.Manifest.PostHook
 	default:
-		return fmt.Errorf("invalid hook type %s", hook.HookType)
+		return fmt.Errorf("%w%s", errInvalidHookType, hook.HookType)
 	}
 
 	// Check if hook is present.

--- a/cli/daemon/api/http.go
+++ b/cli/daemon/api/http.go
@@ -15,6 +15,10 @@ import (
 	"github.com/tarantool/tt/cli/ttlog"
 )
 
+var (
+	errNoValidIPFound = errors.New("no valid IP found")
+)
+
 // DaemonHandler is used to communicate with the daemon over HTTP.
 type DaemonHandler struct {
 	cmdPath string
@@ -109,7 +113,7 @@ func (handler *DaemonHandler) callCommand(ctx context.Context, ttCmd *command) (
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {
-		err = errors.New(fmt.Sprint(err) + ": " + stderr.String())
+		err = fmt.Errorf("%w: %s", err, stderr.String())
 	}
 
 	return stdout.String() + stderr.String(), err
@@ -159,5 +163,5 @@ func (handler *DaemonHandler) getClientIP(req *http.Request) (string, error) {
 		return req.RemoteAddr, nil
 	}
 
-	return "", fmt.Errorf("no valid IP found")
+	return "", errNoValidIPFound
 }

--- a/cli/daemon/api/parser.go
+++ b/cli/daemon/api/parser.go
@@ -3,10 +3,16 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/mitchellh/mapstructure"
+)
+
+var (
+	errFailedToParseCommandParams = errors.New("failed to parse command params: \"")
+	errFailedToReadRequestBody    = errors.New("failed to read request body: ")
 )
 
 // commandJSON describes the tt command sent using the HTTP API.
@@ -32,7 +38,7 @@ func parseCommand(r io.Reader, cmd *command) (string, error) {
 	// Read data to log raw JSON request.
 	bodyBytes, err := io.ReadAll(r)
 	if err != nil {
-		return err.Error(), fmt.Errorf(`failed to read request body: %s`, err.Error())
+		return err.Error(), fmt.Errorf("%w%s", errFailedToReadRequestBody, err.Error())
 	}
 
 	rawBody := string(bodyBytes)
@@ -49,7 +55,7 @@ func parseCommand(r io.Reader, cmd *command) (string, error) {
 	// Parse cmdJSON to a "command" structure.
 	// Additionally, all types of parameters will be checked.
 	if err := mapstructure.Decode(cmdJSON, cmd); err != nil {
-		return rawBody, fmt.Errorf(`failed to parse command params: "%v"`, err.Error())
+		return rawBody, fmt.Errorf("%w%v\"", errFailedToParseCommandParams, err.Error())
 	}
 
 	return rawBody, nil

--- a/cli/daemon/httpserver.go
+++ b/cli/daemon/httpserver.go
@@ -2,7 +2,7 @@ package daemon
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 	"strconv"
@@ -10,6 +10,12 @@ import (
 
 	"github.com/tarantool/tt/cli/daemon/api"
 	"github.com/tarantool/tt/cli/ttlog"
+)
+
+var (
+	errInterfaceDown          = errors.New("interface down")
+	errListenIPIsNotAvailable = errors.New("listen IP is not available")
+	errServerIsNotStarted     = errors.New("server is not started")
 )
 
 const (
@@ -76,7 +82,7 @@ func (httpServer *HTTPServer) Start(ttPath string) {
 		httpServer.logger.Fatal(err)
 	}
 
-	if err := httpServer.srv.Serve(socket); err != http.ErrServerClosed {
+	if err := httpServer.srv.Serve(socket); !errors.Is(err, http.ErrServerClosed) {
 		httpServer.logger.Fatalf("Can't start HTTP server")
 	}
 }
@@ -86,7 +92,7 @@ func (httpServer *HTTPServer) Stop() error {
 	var err error
 
 	if httpServer.srv == nil {
-		return fmt.Errorf("server is not started")
+		return errServerIsNotStarted
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), httpServer.timeout)
@@ -112,7 +118,7 @@ func (httpServer *HTTPServer) listenIP() (string, error) {
 	}
 
 	if iface.Flags&net.FlagUp == 0 {
-		return "", fmt.Errorf("interface down")
+		return "", errInterfaceDown
 	}
 
 	addrs, err := iface.Addrs()
@@ -144,5 +150,5 @@ func (httpServer *HTTPServer) listenIP() (string, error) {
 		return ip.String(), nil
 	}
 
-	return "", fmt.Errorf("listen IP is not available")
+	return "", errListenIPIsNotAvailable
 }

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -103,7 +103,7 @@ func (process *Process) Start() error {
 	}
 
 	cmd := exec.CommandContext(context.Background(), process.cmdPath, process.cmdArgs...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=true", process.DaemonTag))
+	cmd.Env = append(os.Environ(), process.DaemonTag+"=true")
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/cli/daemon/process_test_helpers.go
+++ b/cli/daemon/process_test_helpers.go
@@ -2,12 +2,17 @@ package daemon
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"syscall"
 	"time"
+)
+
+var (
+	errInvalidPID = errors.New("invalid pid ")
 )
 
 const (
@@ -62,7 +67,7 @@ func readPID(filePath string) (int, error) {
 // IsDaemonAlive checks is daemon alive by process pid.
 func IsDaemonAlive(pid int) (bool, error) {
 	if pid <= 0 {
-		return false, fmt.Errorf("invalid pid %v", pid)
+		return false, fmt.Errorf("%w%v", errInvalidPID, pid)
 	}
 
 	proc, err := os.FindProcess(pid)

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,11 @@ import (
 	mobyclient "github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/term"
+)
+
+var (
+	errContainerExitCodeIs       = errors.New("container exit code is ")
+	errTheOperationIsInterrupted = errors.New("the operation is interrupted")
 )
 
 // spell-checker:ignore jsonmessage stdcopy
@@ -94,8 +100,8 @@ func buildDockerImage(dockerClient *mobyclient.Client, imageTag, buildContextDir
 	termFd, isTerm := term.GetFdInfo(writer)
 	if err = jsonmessage.DisplayJSONMessagesStream(buildResult.Body,
 		writer, termFd, isTerm, nil); err != nil {
-		if ctx.Err() == context.Canceled {
-			return fmt.Errorf("the operation is interrupted")
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return errTheOperationIsInterrupted
 		}
 		return err
 	}
@@ -192,17 +198,17 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 		mobyclient.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})
 	select {
 	case err := <-waitResult.Error:
-		if ctx.Err() == context.Canceled {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			if _, err = dockerClient.ContainerStop(context.Background(), containerID,
 				mobyclient.ContainerStopOptions{}); err != nil {
 				log.Warnf("Failed to stop the container %s", containerID[:12])
 			}
-			return fmt.Errorf("the operation is interrupted")
+			return errTheOperationIsInterrupted
 		}
 		return err
 	case st := <-waitResult.Result:
 		if st.StatusCode != 0 {
-			return fmt.Errorf("container exit code is %d", st.StatusCode)
+			return fmt.Errorf("%w%d", errContainerExitCodeIs, st.StatusCode)
 		}
 	}
 	return nil

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -5,7 +5,6 @@ package docker
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,7 +131,7 @@ func TestRunContainer(t *testing.T) {
 		BuildCtxDir: "testdata",
 		ImageTag:    "ubuntu:tt_test",
 		Command:     []string{"touch", "/work/file_from_container"},
-		Binds:       []string{fmt.Sprintf("%s:/work", tmpDir)},
+		Binds:       []string{tmpDir + ":/work"},
 	}, os.Stdout)
 	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(tmpDir, "file_from_container"))
@@ -149,7 +148,7 @@ func TestRunContainerInvalidDockerfile(t *testing.T) {
 		BuildCtxDir: tmpDir,
 		ImageTag:    "ubuntu:tt_test",
 		Command:     []string{"touch", "/work/file_from_container"},
-		Binds:       []string{fmt.Sprintf("%s:/work", tmpDir)},
+		Binds:       []string{tmpDir + ":/work"},
 	}, os.Stdout)
 	require.True(t, strings.Contains(err.Error(), "dockerfile parse error"))
 	assert.NoFileExists(t, filepath.Join(tmpDir, "file_from_container"))
@@ -162,7 +161,7 @@ func TestRunContainerFailContainerCommand(t *testing.T) {
 		BuildCtxDir: "testdata",
 		ImageTag:    "ubuntu:tt_test",
 		Command:     []string{"touch", "/file_in_root"},
-		Binds:       []string{fmt.Sprintf("%s:/work", tmpDir)},
+		Binds:       []string{tmpDir + ":/work"},
 	}, os.Stdout)
 	require.Error(t, err)
 
@@ -176,7 +175,7 @@ func TestRunContainerNotExistingBind(t *testing.T) {
 		BuildCtxDir: "testdata",
 		ImageTag:    "ubuntu:tt_test",
 		Command:     []string{"touch", "/work/file_from_container"},
-		Binds:       []string{fmt.Sprintf("%s:/work", filepath.Join(tmpDir, "non_existing_dir"))},
+		Binds:       []string{filepath.Join(tmpDir, "non_existing_dir") + ":/work"},
 	}, os.Stdout)
 	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(tmpDir, "non_existing_dir", "file_from_container"))

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
 	"golang.org/x/sys/unix"
+)
+
+var (
+	errCurrentDirectoryUnavailable = errors.New("can't get current dir: ")
 )
 
 type DownloadCtx struct {
@@ -50,7 +55,7 @@ func DownloadSDK(cmdCtx *cmdcontext.CmdCtx, downloadCtx DownloadCtx,
 	if len(downloadCtx.DirectoryPrefix) == 0 {
 		downloadCtx.DirectoryPrefix, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("can't get current dir: %s", err.Error())
+			return fmt.Errorf("%w%s", errCurrentDirectoryUnavailable, err.Error())
 		}
 	}
 
@@ -66,8 +71,7 @@ func DownloadSDK(cmdCtx *cmdcontext.CmdCtx, downloadCtx DownloadCtx,
 	bundleName := ver.Version.Tarball
 	bundlePath := filepath.Join(downloadCtx.DirectoryPrefix, bundleName)
 	if _, err := os.Stat(bundlePath); err == nil {
-		confirmed, err := util.AskConfirm(os.Stdin, fmt.Sprintf("Confirm overwrite %s",
-			bundlePath))
+		confirmed, err := util.AskConfirm(os.Stdin, "Confirm overwrite "+bundlePath)
 		if err != nil {
 			return err
 		}

--- a/cli/formatter/table.go
+++ b/cli/formatter/table.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -12,6 +13,14 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	errExpectedAMapGot                          = errors.New("expected a map, got ")
+	errExpectedAnArrayGot                       = errors.New("expected an array, got ")
+	errUnknownParsingCaseWithCurrentRenderBatch = errors.New(
+		"unknown parsing case with current render batch",
+	)
 )
 
 // lazyDecodeYaml decodes yaml string as []lazyMessage content.
@@ -149,7 +158,7 @@ func renderArrays(batch []any, transpose bool, opts Opts) (string, error) {
 	if isSingleArrayOfArrays(batch) {
 		array, ok := batch[0].([]any)
 		if !ok {
-			return "", fmt.Errorf("expected an array, got %T", batch[0])
+			return "", fmt.Errorf("%w%T", errExpectedAnArrayGot, batch[0])
 		}
 		return renderArraysAsTable(array, transpose, opts)
 	} else {
@@ -163,7 +172,7 @@ func renderArraysAsTable(batch []any, transpose bool, opts Opts) (string, error)
 	for _, item := range batch {
 		array, ok := item.([]any)
 		if !ok {
-			return "", fmt.Errorf("expected an array, got %T", item)
+			return "", fmt.Errorf("%w%T", errExpectedAnArrayGot, item)
 		}
 		itemLen := len(array)
 		if itemLen > maxLen {
@@ -179,7 +188,7 @@ func renderArraysAsTable(batch []any, transpose bool, opts Opts) (string, error)
 	for _, item := range batch {
 		array, ok := item.([]any)
 		if !ok {
-			return "", fmt.Errorf("expected an array, got %T", item)
+			return "", fmt.Errorf("%w%T", errExpectedAnArrayGot, item)
 		}
 		itemMap := createUnorderedMap[any](maxLen)
 
@@ -389,7 +398,7 @@ func renderBatch(batch []any, transpose bool, opts Opts) (string, error) {
 			case map[any]any:
 				castedMap = castMapToUMap(n)
 			default:
-				return "", fmt.Errorf("expected a map, got %T", node)
+				return "", fmt.Errorf("%w%T", errExpectedAMapGot, node)
 			}
 			anyMaps = append(anyMaps, castedMap)
 		}
@@ -424,7 +433,7 @@ func renderBatch(batch []any, transpose bool, opts Opts) (string, error) {
 	case isSingleType(batch, arrayNodeType):
 		return renderArrays(batch, transpose, opts)
 	default:
-		return "", fmt.Errorf("unknown parsing case with current render batch")
+		return "", errUnknownParsingCaseWithCurrentRenderBatch
 	}
 }
 

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/apex/log"
@@ -29,6 +30,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var (
+	errBinDirNotSet                          = errors.New("bin_dir is not set, check ")
+	errDistfilesDirectoryNotFound            = errors.New("can't find distfiles directory")
+	errCouldNotGetInstalledVersionCommitHash = errors.New(
+		"could not get commit hash of the versionof an installed ",
+	)
+	errInvalidDirectory                     = errors.New("directory ")
+	errHashHasAWrongFormat                  = errors.New("hash has a wrong format")
+	errIncDirIsNotSetCheck                  = errors.New("inc_dir is not set, check ")
+	errNoVersionFound                       = errors.New("no version found")
+	errNoVersionsWereFetched                = errors.New("no versions were fetched")
+	errTarantoolBinaryWasNotFoundInThePaths = errors.New(
+		"tarantool binary was not found in the paths",
+	)
+	errUnableToGetHashInfo        = errors.New(": unable to get hash info")
+	errUnableToGetPullRequestInfo = errors.New(": unable to get pull-request info")
+	errUnknownApplication         = errors.New("unknown application: ")
+	errUnknownOS                  = errors.New("unknown OS")
+)
+
 const (
 	// defaultDirPermissions is rights used to create folders.
 	// 0755 - drwxr-xr-x
@@ -38,6 +59,12 @@ const (
 	gitCloneArgsCapacity  = 10
 	dockerfileMode        = 0o664
 )
+
+type missingPackagesError string
+
+func (err missingPackagesError) Error() string {
+	return string(err)
+}
 
 // programGitRepoUrls contains URLs of programs git repositories.
 var programGitRepoUrls = map[string]string{
@@ -161,7 +188,7 @@ func detectOsName() (string, error) {
 		distroInfo, err := getDistroInfo()
 		return distroInfo.Name, err
 	}
-	return "", fmt.Errorf("unknown OS")
+	return "", errUnknownOS
 }
 
 // getVersionsFromRepo returns all available versions from github repository.
@@ -350,7 +377,7 @@ func programDependenciesInstalled(program search.Program) error {
 			}
 		}
 		errMsg.WriteString("Usage: tt install -f if you already have those packages installed")
-		return errors.New(errMsg.String())
+		return missingPackagesError(errMsg.String())
 	}
 	return nil
 }
@@ -412,7 +439,7 @@ func checkCommit(input, programName string, installCtx InstallCtx,
 			programName, input)
 		if err != nil {
 			return input, pullRequestHash,
-				fmt.Errorf("%s: unable to get pull-request info", input)
+				fmt.Errorf("%s%w", input, errUnableToGetPullRequestInfo)
 		}
 		pullRequestHash = pullRequestHash[0:util.MinCommitHashLength]
 		return input, pullRequestHash, nil
@@ -424,12 +451,12 @@ func checkCommit(input, programName string, installCtx InstallCtx,
 	}
 
 	if !isRightFormat {
-		return input, pullRequestHash, fmt.Errorf("hash has a wrong format")
+		return input, pullRequestHash, errHashHasAWrongFormat
 	}
 
 	returnedHash, err := getCommit(installCtx.Local, distfiles, programName, input)
 	if err != nil {
-		return input, pullRequestHash, fmt.Errorf("%s: unable to get hash info", input)
+		return input, pullRequestHash, fmt.Errorf("%s%w", input, errUnableToGetHashInfo)
 	}
 
 	return returnedHash, pullRequestHash, nil
@@ -526,7 +553,7 @@ func resolveTtInstallVersion(installCtx InstallCtx, distfiles string) (
 			return resolvedInstallVersion{}, err
 		}
 		if len(versions) == 0 {
-			return resolvedInstallVersion{}, fmt.Errorf("no versions were fetched")
+			return resolvedInstallVersion{}, errNoVersionsWereFetched
 		}
 		result.version = versions[len(versions)-1].Str
 	}
@@ -568,7 +595,7 @@ func resolveTarantoolInstallVersion(installCtx InstallCtx, distfiles string) (
 		}
 		result.version = getLatestRelease(versions)
 		if result.version == "" {
-			return resolvedInstallVersion{}, fmt.Errorf("no version found")
+			return resolvedInstallVersion{}, errNoVersionFound
 		}
 	}
 
@@ -598,11 +625,11 @@ func prepareTarantoolInstall(binDir, incDir string, installCtx InstallCtx, distf
 ) {
 	if binDir == "" {
 		return resolvedInstallVersion{},
-			fmt.Errorf("bin_dir is not set, check %s", configure.ConfigName)
+			fmt.Errorf("%w%s", errBinDirNotSet, configure.ConfigName)
 	}
 	if incDir == "" {
 		return resolvedInstallVersion{},
-			fmt.Errorf("inc_dir is not set, check %s", configure.ConfigName)
+			fmt.Errorf("%w%s", errIncDirIsNotSetCheck, configure.ConfigName)
 	}
 	return resolveTarantoolInstallVersion(installCtx, distfiles)
 }
@@ -649,7 +676,7 @@ func downloadTtSource(path, ttVersion, distfiles string, resolved resolvedInstal
 ) error {
 	if installCtx.Local {
 		if !util.IsDir(filepath.Join(distfiles, "tt")) {
-			return fmt.Errorf("can't find distfiles directory")
+			return errDistfilesDirectoryNotFound
 		}
 		log.Infof("Local files found, installing from them...")
 		localPath, _ := util.JoinAbspath(distfiles, "tt")
@@ -714,7 +741,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 
 	// Check binary directory.
 	if binDir == "" {
-		return fmt.Errorf("bin_dir is not set, check %s", configure.ConfigName)
+		return fmt.Errorf("%w%s", errBinDirNotSet, configure.ConfigName)
 	}
 
 	logFile, err := os.CreateTemp("", "tarantool_install")
@@ -812,7 +839,7 @@ func prepareMakeOpts(installCtx InstallCtx) []string {
 		makeOpts = append(makeOpts, "install")
 	}
 	if _, isMakeFlagsSet := os.LookupEnv("MAKEFLAGS"); !isMakeFlagsSet {
-		maxThreads := fmt.Sprint(runtime.NumCPU())
+		maxThreads := strconv.Itoa(runtime.NumCPU())
 		makeOpts = append(makeOpts, "-j", maxThreads)
 	}
 	return makeOpts
@@ -858,7 +885,7 @@ func copyLocalTarantool(distfiles, path, tarVersion string,
 		}
 		err = gitCheckout(path, tarVersion, installCtx.verbose, logFile)
 	} else {
-		return fmt.Errorf("can't find distfiles directory")
+		return errDistfilesDirectoryNotFound
 	}
 	return err
 }
@@ -1233,8 +1260,7 @@ func isUpdatePossible(installCtx InstallCtx,
 		// We need to trim first rune to get commit hash
 		// from string structure 'g<commitHash>'.
 		if len(binVersion.Hash) < 1 {
-			return false, fmt.Errorf("could not get commit hash of the version"+
-				"of an installed %s", program)
+			return false, fmt.Errorf("%w%s", errCouldNotGetInstalledVersionCommitHash, program)
 		}
 		curBinHash = binVersion.Hash[1:]
 	case search.ProgramTt:
@@ -1269,8 +1295,8 @@ func searchTarantoolHeaders(buildDir, includeDir string) (string, error) {
 			return "", err
 		}
 		if !util.IsDir(includeDir) {
-			return "", fmt.Errorf("directory %v doesn't exist, "+
-				"or isn't a directory", includeDir)
+			return "", fmt.Errorf("%w%v doesn't exist, or isn't a directory",
+				errInvalidDirectory, includeDir)
 		}
 		return includeDir, nil
 	}
@@ -1293,7 +1319,8 @@ func installTarantoolDev(ttBinDir, ttIncludeDir, buildDir,
 		return fmt.Errorf("failed to get absolute path: %w", err)
 	}
 	if !util.IsDir(buildDir) {
-		return fmt.Errorf("directory %v doesn't exist, or isn't directory", buildDir)
+		return fmt.Errorf("%w%v doesn't exist, or isn't directory",
+			errInvalidDirectory, buildDir)
 	}
 
 	checkedBinaryPaths := make([]string, 0)
@@ -1353,8 +1380,8 @@ func installTarantoolDev(ttBinDir, ttIncludeDir, buildDir,
 		return nil
 	}
 
-	return fmt.Errorf("tarantool binary was not found in the paths:\n%s",
-		strings.Join(checkedBinaryPaths, "\n"))
+	return fmt.Errorf("%w:\n%s",
+		errTarantoolBinaryWasNotFoundInThePaths, strings.Join(checkedBinaryPaths, "\n"))
 }
 
 // subDirIsWritable checks if the passed dir doesn't exist but can be created.
@@ -1385,9 +1412,9 @@ func Install(installCtx InstallCtx, cliOpts *config.CliOpts) error {
 			continue
 		}
 		if !dirIsWritable(dir) {
-			return fmt.Errorf("the directory %s is not writeable for the current user.\n"+
+			return fmt.Errorf("%w%s is not writeable for the current user.\n"+
 				"     Please, update rights to the directory or use 'sudo' for successful install",
-				dir)
+				errTheDirectoryIsNotWriteableForTheCurrentUser, dir)
 		}
 	}
 	includeDir = filepath.Join(includeDir, "include")
@@ -1406,7 +1433,7 @@ func Install(installCtx InstallCtx, cliOpts *config.CliOpts) error {
 		err = installTarantoolDev(binDir, includeDir, installCtx.buildDir,
 			installCtx.IncDir)
 	default:
-		return fmt.Errorf("unknown application: %s", installCtx.Program)
+		return fmt.Errorf("%w%s", errUnknownApplication, installCtx.Program)
 	}
 
 	return err

--- a/cli/install/install_bundle.go
+++ b/cli/install/install_bundle.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,27 @@ import (
 	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
+)
+
+var (
+	errASpecificVersionMustBeProvidedToInstall = errors.New(
+		"a specific version must be provided to install ",
+	)
+	errCouldNotFindBinaryAt                         = errors.New("could not find binary at ")
+	errIncludeDirIsNotSetCheck                      = errors.New("include_dir is not set, check ")
+	errInstallationFailedDuringExecutionPhaseSeeLog = errors.New(
+		"installation failed during execution phase (see log: ",
+	)
+	errInstallationFailedDuringFinaleUpdateSymlinks = errors.New(
+		"installation failed during finale update symlinks",
+	)
+	errInstallationPathOrAlreadyExists       = errors.New("installation path ")
+	errLocalBundleFileNotFound               = errors.New("local bundle file not found: ")
+	errLocalRepositoryInstallDirectoryNotSet = errors.New(
+		"cannot install from local repository: " +
+			"distribution files directory (repo.install) is not set",
+	)
+	errTheDirectoryIsNotWriteableForTheCurrentUser = errors.New("the directory ")
 )
 
 // bundleParams holds the parameters required for the bundle installation process.
@@ -41,12 +63,12 @@ type bundleParams struct {
 // checkInstallDirs validates that binary and include directories are configured and writable.
 func checkInstallDirs(binDir, includeDir string) error {
 	if binDir == "" {
-		return fmt.Errorf("bin_dir is not set, check %s", configure.ConfigName)
+		return fmt.Errorf("%w%s", errBinDirNotSet, configure.ConfigName)
 	}
 
 	if includeDir == "" {
 		// For bundle installs, includeDir is usually required.
-		return fmt.Errorf("include_dir is not set, check %s", configure.ConfigName)
+		return fmt.Errorf("%w%s", errIncludeDirIsNotSetCheck, configure.ConfigName)
 	}
 
 	// Reuse the writability checks from the main Install function.
@@ -56,7 +78,8 @@ func checkInstallDirs(binDir, includeDir string) error {
 		}
 
 		if !dirIsWritable(dir) {
-			return fmt.Errorf("the directory %s is not writeable for the current user", dir)
+			return fmt.Errorf("%w%s is not writeable for the current user",
+				errTheDirectoryIsNotWriteableForTheCurrentUser, dir)
 		}
 	}
 	return nil
@@ -119,15 +142,14 @@ func checkDependencies(program search.Program, force bool) error {
 func copyBundle(bp *bundleParams) error {
 	distfiles := bp.opts.Repo.Install
 	if distfiles == "" {
-		return fmt.Errorf("cannot install from local repository: " +
-			"distribution files directory (repo.install) is not set")
+		return errLocalRepositoryInstallDirectoryNotSet
 	}
 
 	log.Infof("Checking local files...")
 	bundleName := bp.bundleInfo.Version.Tarball
 	localBundlePath := filepath.Join(distfiles, bundleName)
 	if !util.IsRegularFile(localBundlePath) {
-		return fmt.Errorf("local bundle file not found: %s", localBundlePath)
+		return fmt.Errorf("%w%s", errLocalBundleFileNotFound, localBundlePath)
 	}
 
 	log.Infof("Local files found, installing from %s...", bundleName)
@@ -206,7 +228,7 @@ func findBundlePathsInDir(baseDir string, program search.Program) (
 
 	binPath := filepath.Join(baseDir, subDir, program.Exec())
 	if !util.IsRegularFile(binPath) {
-		return "", "", fmt.Errorf("could not find binary at %q", binPath)
+		return "", "", fmt.Errorf("%w%q", errCouldNotFindBinaryAt, binPath)
 	}
 
 	incPath := filepath.Join(baseDir, subDir, "include", program.Exec())
@@ -223,8 +245,8 @@ func prepareForReinstall(bp *bundleParams) error {
 
 	if !bp.inst.Reinstall {
 		if util.IsRegularFile(destBinPath) || util.IsDir(destIncPath) {
-			return fmt.Errorf("installation path %s or %s already exists",
-				destBinPath, destIncPath)
+			return fmt.Errorf("%w%s or %s already exists",
+				errInstallationPathOrAlreadyExists, destBinPath, destIncPath)
 		}
 		return nil
 	}
@@ -321,7 +343,7 @@ func updateSymlinks(bp *bundleParams) error {
 // performInitialChecks performs initial validation before starting the installation.
 func performInitialChecks(bp *bundleParams) error {
 	if bp.inst.version == "" {
-		return fmt.Errorf("a specific version must be provided to install %s", bp.inst.Program)
+		return fmt.Errorf("%w%s", errASpecificVersionMustBeProvidedToInstall, bp.inst.Program)
 	}
 
 	if err := checkInstallDirs(bp.opts.Env.BinDir, bp.inst.IncDir); err != nil {
@@ -465,12 +487,12 @@ func installBundleProgram(installCtx *InstallCtx, cliOpts *config.CliOpts) error
 	log.Infof("Installing %s=%s", bp.inst.Program, bp.bundleInfo.Version.Str)
 	logFilePath, err := executeBundleInstallation(&bp)
 	if err != nil {
-		return fmt.Errorf("installation failed during execution phase (see log: %s)", logFilePath)
+		return fmt.Errorf("%w%s)", errInstallationFailedDuringExecutionPhaseSeeLog, logFilePath)
 	}
 
 	err = updateSymlinks(&bp)
 	if err != nil {
-		return fmt.Errorf("installation failed during finale update symlinks")
+		return errInstallationFailedDuringFinaleUpdateSymlinks
 	}
 
 	log.Infof("Successfully installed %s version %s", bp.inst.Program, bp.bundleInfo.Version.Str)

--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -2,6 +2,7 @@ package install_ee
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,13 @@ import (
 
 	"github.com/tarantool/tt/cli/search"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errDestinationDirectoryMissing    = errors.New("destination directory doesn't exist: ")
+	errDestinationPathIsNotADirectory = errors.New("destination path is not a directory: ")
+	errHTTPRequestError               = errors.New("HTTP request error: ")
+	errTarantoolIODoerMissing         = errors.New("no tarantool.io doer was applied")
 )
 
 // httpDoer is a struct that implements the search.TntIoDoer interface using the http package.
@@ -44,7 +52,7 @@ func (d *httpDoer) Do(req *http.Request) ([]byte, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP request error: %s", http.StatusText(res.StatusCode))
+		return nil, fmt.Errorf("%w%s", errHTTPRequestError, http.StatusText(res.StatusCode))
 	}
 
 	respBody, err := io.ReadAll(res.Body)
@@ -62,11 +70,11 @@ func (d *httpDoer) Token() string {
 // validateDestination checks if the destination path exists and is a directory.
 func validateDestination(dst string) error {
 	if _, err := os.Stat(dst); os.IsNotExist(err) {
-		return fmt.Errorf("destination directory doesn't exist: %s", dst)
+		return fmt.Errorf("%w%s", errDestinationDirectoryMissing, dst)
 	}
 
 	if !util.IsDir(dst) {
-		return fmt.Errorf("destination path is not a directory: %s", dst)
+		return fmt.Errorf("%w%s", errDestinationPathIsNotADirectory, dst)
 	}
 
 	return nil
@@ -124,7 +132,7 @@ func saveResponseBodyToFile(body []byte, destFilePath string) (errRet error) {
 // It handles potential redirects and uses the provided token for authentication via cookies.
 func DownloadBundle(doer search.TntIoDoer, bundleName, bundleSource, dst string) error {
 	if doer == nil || reflect.ValueOf(doer).IsNil() {
-		return fmt.Errorf("no tarantool.io doer was applied")
+		return errTarantoolIODoerMissing
 	}
 
 	if err := validateDestination(dst); err != nil {

--- a/cli/install_ee/install_ee_test.go
+++ b/cli/install_ee/install_ee_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/tarantool/tt/cli/search"
 )
 
+var (
+	errSimulatedNetworkError = errors.New("simulated network error")
+)
+
 const (
 	// testToken is a token for the TntIoDownloader.
 	testToken = "test-token"
@@ -96,7 +100,7 @@ func TestDownloadBundle(t *testing.T) {
 			dstSetup:     defaultDstSetup,
 			doer: &mockBundleDoer{
 				token:  testToken,
-				resErr: errors.New("simulated network error"),
+				resErr: errSimulatedNetworkError,
 			},
 			errMsg: "simulated network error",
 		},

--- a/cli/modules/modules.go
+++ b/cli/modules/modules.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,19 @@ import (
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	errHelpFieldIsMandatoryForModuleManifest = errors.New(
+		"help field is mandatory for module Manifest",
+	)
+	errModuleIsDisabledToOverride                      = errors.New("module ")
+	errSpecifiedPathInConfigurationFileIsNotADirectory = errors.New(
+		"specified path in configuration file is not a directory",
+	)
+	errVersionFieldIsMandatoryForModuleManifest = errors.New(
+		"version field is mandatory for module Manifest",
+	)
 )
 
 const (
@@ -76,10 +90,10 @@ func readManifest(dir, manifest string) (Manifest, error) {
 	}
 
 	if mf.Version == "" {
-		return mf, fmt.Errorf("version field is mandatory for module Manifest")
+		return mf, errVersionFieldIsMandatoryForModuleManifest
 	}
 	if mf.Help == "" {
-		return mf, fmt.Errorf("help field is mandatory for module Manifest")
+		return mf, errHelpFieldIsMandatoryForModuleManifest
 	}
 
 	return mf, nil
@@ -141,7 +155,7 @@ func collectDirectoriesList(paths []string) ([]string, error) {
 	for _, dir := range paths {
 		if info, err := os.Stat(dir); err == nil {
 			if !info.IsDir() {
-				return dirs, fmt.Errorf("specified path in configuration file is not a directory")
+				return dirs, errSpecifiedPathInConfigurationFileIsNotADirectory
 			}
 			dirs = append(dirs, dir)
 		}
@@ -238,7 +252,8 @@ func getExternalModules(paths []string) (possibleModules, error) {
 			}
 
 			if slices.Contains(disabledOverride, d) {
-				return modules, fmt.Errorf("module %q is disabled to override", d)
+				return modules, fmt.Errorf("%w%q is disabled to override",
+					errModuleIsDisabledToOverride, d)
 			}
 
 			if modEntry, isModule := isPossibleModule(modPath); isModule {

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -13,6 +13,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	errReplyForDescriptionIsMandatoryForModule = errors.New(
+		"reply for --description is mandatory for module",
+	)
+	errReplyForVersionIsMandatoryForModule = errors.New(
+		"reply for --version is mandatory for module",
+	)
+)
+
 // InternalFunc is a type of function that implements
 // the external behavior of the module.
 type InternalFunc func(*cmdcontext.CmdCtx, []string) error
@@ -104,10 +113,10 @@ func fillManifest(mf Manifest) (Manifest, error) {
 	}
 
 	if info.Version == "" {
-		return mf, fmt.Errorf("reply for --version is mandatory for module")
+		return mf, errReplyForVersionIsMandatoryForModule
 	}
 	if info.Help == "" {
-		return mf, fmt.Errorf("reply for --description is mandatory for module")
+		return mf, errReplyForDescriptionIsMandatoryForModule
 	}
 
 	mf.Version = info.Version

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -1,6 +1,7 @@
 package process_utils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,13 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+)
+
+var (
+	errProcessTermination         = errors.New("can't terminate the process")
+	errProcessSIGQUIT             = errors.New("can't terminate the process with SIGQUIT")
+	errTheProcessAlreadyExistsPID = errors.New("the process already exists. PID: ")
+	errTheProcessIsNotRunning     = errors.New("the process ")
 )
 
 // Create a new directory.
@@ -106,7 +114,7 @@ func CheckPIDFile(pidFileName string) error {
 			return fmt.Errorf(`pID file exists, but PID can't be read. Error: "%w"`, err)
 		}
 		if res, _ := IsProcessAlive(pid); res {
-			return fmt.Errorf("the process already exists. PID: %d", pid)
+			return fmt.Errorf("%w%d", errTheProcessAlreadyExistsPID, pid)
 		} else {
 			os.Remove(pidFileName)
 		}
@@ -133,7 +141,7 @@ func ExistsAndRecord(pidFileName string) (bool, error) {
 		}
 	} else if !os.IsNotExist(err) {
 		return false, fmt.Errorf(`something went wrong while trying to read the`+
-			`PID file. Error: "%v"`, err)
+			`PID file. Error: "%w"`, err)
 	}
 
 	return false, nil
@@ -187,7 +195,7 @@ func getRunningPid(pidFile string) (int, error) {
 	if alive, err := IsProcessAlive(pid); err != nil {
 		return 0, fmt.Errorf("failed to check if the process %v is running: %w", pid, err)
 	} else if !alive {
-		return 0, fmt.Errorf("the process %v is not running", pid)
+		return 0, fmt.Errorf("%w%v is not running", errTheProcessIsNotRunning, pid)
 	}
 
 	return pid, nil
@@ -205,7 +213,7 @@ func StopProcess(pidFile string) (int, error) {
 	}
 
 	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
-		return 0, fmt.Errorf("can't terminate the process")
+		return 0, errProcessTermination
 	}
 
 	return pid, nil
@@ -223,7 +231,7 @@ func QuitProcess(pidFile string) (int, error) {
 	}
 
 	if res := waitProcessTermination(pid, processTerminationTimeout, processPollInterval); !res {
-		return 0, fmt.Errorf("can't terminate the process with SIGQUIT")
+		return 0, errProcessSIGQUIT
 	}
 
 	return pid, nil

--- a/cli/replicaset/bootstrap.go
+++ b/cli/replicaset/bootstrap.go
@@ -1,6 +1,15 @@
 package replicaset
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errBootstrapIsNotSupported = errors.New(
+		"bootstrap is not supported for ",
+	)
+)
 
 // BootstrapCtx describes the context to bootstrap an instance/application.
 type BootstrapCtx struct {
@@ -24,13 +33,13 @@ type Bootstrapper interface {
 // newErrBootstrapByInstanceNotSupported creates a new error that bootstrap is not
 // supported by the orchestrator for a single instance.
 func newErrBootstrapByInstanceNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("bootstrap is not supported for a single instance by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wa single instance by %q orchestrator",
+		errBootstrapIsNotSupported, orchestrator)
 }
 
 // newErrBootstrapByAppNotSupported creates a new error that bootstrap is not
 // supported by the orchestrator for an application.
 func newErrBootstrapByAppNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("bootstrap is not supported for an application by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wan application by %q orchestrator",
+		errBootstrapIsNotSupported, orchestrator)
 }

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -22,6 +22,45 @@ import (
 )
 
 var (
+	errAllInstancesInTheTargetReplicasetShouldBeOnline = errors.New(
+		"all instances in the target replicaset should be online, ",
+	)
+	errAllOtherInstancesInTheTargetReplicasetShouldBeOnline = errors.New(
+		"all other instances in the target replicaset should be online, ",
+	)
+	errAnInstanceMustBeTheLeaderOfTheReplicasetToDemoteIt = errors.New(
+		"an instance must be the leader of the replicaset to demote it",
+	)
+	errFailedToReloadInstanceConfiguration = errors.New(
+		"failed to reload instance configuration for: ",
+	)
+	errInstanceNotFound                = errors.New("instance ")
+	errInstanceShouldBeOnline          = errors.New("instance ")
+	errNoInstanceFoundInTheApplication = errors.New(
+		"no instance found in the application",
+	)
+	errNotFoundAnyOtherInstanceJoinedToAReplicaset = errors.New(
+		"not found any other instance joined to a replicaset",
+	)
+	errNotFoundAnyVshardRouterInReplicaset = errors.New(
+		"not found any vshard router in replicaset",
+	)
+	errPathReplicationIsNotAMap = errors.New(
+		"path [\"replication\"] is not a map",
+	)
+	errThereAreNoRunningInstances = errors.New(
+		"there are no running instances",
+	)
+	errUnexpectedElectionModeCandidateExpected  = errors.New("unexpected election_mode: ")
+	errUnexpectedElectionModeTypeStringExpected = errors.New(
+		"unexpected election_mode type: ",
+	)
+	errUnexpectedFailover                   = errors.New("unexpected failover: ")
+	errUnexpectedFailoverTypeStringExpected = errors.New("unexpected failover type: ")
+	errUnexpectedRoleType                   = errors.New("unexpected role type: ")
+)
+
+var (
 	//go:embed lua/cconfig/get_instance_topology_body.lua
 	cconfigGetInstanceTopologyBody string
 
@@ -187,13 +226,14 @@ func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
 
 	targetReplicaset, targetInstance, found := findInstanceByAlias(replicasets, ctx.InstName)
 	if !found {
-		return fmt.Errorf("instance %q not found in a configured replicaset", ctx.InstName)
+		return fmt.Errorf("%w%q not found in a configured replicaset",
+			errInstanceNotFound, ctx.InstName)
 	}
 	if !targetInstance.InstanceCtxFound {
-		return fmt.Errorf("instance %q should be online", ctx.InstName)
+		return fmt.Errorf("%w%q should be online", errInstanceShouldBeOnline, ctx.InstName)
 	}
 	if len(targetReplicaset.Instances) == 1 {
-		return fmt.Errorf("not found any other instance joined to a replicaset")
+		return errNotFoundAnyOtherInstanceJoinedToAReplicaset
 	}
 
 	var instances []running.InstanceCtx
@@ -209,10 +249,10 @@ func (c *CConfigApplication) Expel(ctx ExpelCtx) error {
 		}
 	}
 	if len(unavailable) > 0 {
-		msg := fmt.Sprintf("could not connect to: %s", strings.Join(unavailable, ","))
+		msg := "could not connect to: " + strings.Join(unavailable, ",")
 		if !ctx.Force {
 			return fmt.Errorf(
-				"all other instances in the target replicaset should be online, %s", msg)
+				"%w%s", errAllOtherInstancesInTheTargetReplicasetShouldBeOnline, msg)
 		}
 		log.Warn(msg)
 	}
@@ -237,7 +277,7 @@ func getCConfigInstanceTopology(evaler connector.Evaler) (cconfigTopology, error
 	}
 
 	if len(data) != 1 {
-		return topology, fmt.Errorf("unexpected response: %v", data)
+		return topology, fmt.Errorf("%w: %v", errUnexpectedResponse, data)
 	}
 
 	if err := mapstructure.Decode(data[0], &topology); err != nil {
@@ -338,10 +378,11 @@ func (c *CConfigApplication) Promote(ctx PromoteCtx) error {
 	}
 	targetReplicaset, targetInstance, found := findInstanceByAlias(replicasets, ctx.InstName)
 	if !found {
-		return fmt.Errorf("instance %q not found in a configured replicaset", ctx.InstName)
+		return fmt.Errorf("%w%q not found in a configured replicaset",
+			errInstanceNotFound, ctx.InstName)
 	}
 	if !targetInstance.InstanceCtxFound {
-		return fmt.Errorf("instance %q should be online", ctx.InstName)
+		return fmt.Errorf("%w%q should be online", errInstanceShouldBeOnline, ctx.InstName)
 	}
 
 	var instances []running.InstanceCtx
@@ -354,9 +395,9 @@ func (c *CConfigApplication) Promote(ctx PromoteCtx) error {
 		}
 	}
 	if len(unavailable) > 0 {
-		msg := fmt.Sprintf("could not connect to: %s", strings.Join(unavailable, ","))
+		msg := "could not connect to: " + strings.Join(unavailable, ",")
 		if !ctx.Force {
-			return fmt.Errorf("all instances in the target replicaset should be online, %s", msg)
+			return fmt.Errorf("%w%s", errAllInstancesInTheTargetReplicasetShouldBeOnline, msg)
 		}
 		log.Warn(msg)
 	}
@@ -377,10 +418,11 @@ func (c *CConfigApplication) Demote(ctx DemoteCtx) error {
 	}
 	targetReplicaset, targetInstance, found := findInstanceByAlias(replicasets, ctx.InstName)
 	if !found {
-		return fmt.Errorf("instance %q not found in a configured replicaset", ctx.InstName)
+		return fmt.Errorf("%w%q not found in a configured replicaset",
+			errInstanceNotFound, ctx.InstName)
 	}
 	if !targetInstance.InstanceCtxFound {
-		return fmt.Errorf("instance %q should be online", ctx.InstName)
+		return fmt.Errorf("%w%q should be online", errInstanceShouldBeOnline, ctx.InstName)
 	}
 
 	var instances []running.InstanceCtx
@@ -393,9 +435,9 @@ func (c *CConfigApplication) Demote(ctx DemoteCtx) error {
 		}
 	}
 	if len(unavailable) > 0 {
-		msg := fmt.Sprintf("could not connect to: %s", strings.Join(unavailable, ","))
+		msg := "could not connect to: " + strings.Join(unavailable, ",")
 		if !ctx.Force {
-			return fmt.Errorf("all instances in the target replicaset should be online, %s", msg)
+			return fmt.Errorf("%w%s", errAllInstancesInTheTargetReplicasetShouldBeOnline, msg)
 		}
 		log.Warn(msg)
 	}
@@ -437,7 +479,7 @@ func (c *CConfigApplication) BootstrapVShard(ctx VShardBootstrapCtx) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("not found any vshard router in replicaset")
+		return errNotFoundAnyVshardRouterInReplicaset
 	}
 	return nil
 }
@@ -477,10 +519,11 @@ func (c *CConfigApplication) RolesChange(ctx RolesChangeCtx,
 		targetReplicaset, targetInstance, found :=
 			findInstanceByAlias(replicasets, ctx.InstName)
 		if !found {
-			return fmt.Errorf("instance %q not found in a configured replicaset", ctx.InstName)
+			return fmt.Errorf("%w%q not found in a configured replicaset",
+				errInstanceNotFound, ctx.InstName)
 		}
 		if !targetInstance.InstanceCtxFound {
-			return fmt.Errorf("instance %q should be online", ctx.InstName)
+			return fmt.Errorf("%w%q should be online", errInstanceShouldBeOnline, ctx.InstName)
 		}
 		for _, inst := range targetReplicaset.Instances {
 			if !inst.InstanceCtxFound {
@@ -493,7 +536,7 @@ func (c *CConfigApplication) RolesChange(ctx RolesChangeCtx,
 	if len(unavailable) > 0 {
 		msg := "could not connect to: " + strings.Join(unavailable, ",")
 		if !ctx.Force {
-			return fmt.Errorf("all instances in the target replicaset should be online, %s", msg)
+			return fmt.Errorf("%w%s", errAllInstancesInTheTargetReplicasetShouldBeOnline, msg)
 		}
 		log.Warn(msg)
 	}
@@ -531,7 +574,7 @@ func (c *CConfigApplication) discovery() (Replicasets, error) {
 	}
 
 	if len(topologies) == 0 {
-		return Replicasets{}, fmt.Errorf("no instance found in the application")
+		return Replicasets{}, errNoInstanceFoundInTheApplication
 	}
 
 	return mergeCConfigTopologies(topologies)
@@ -566,18 +609,18 @@ func cconfigGetShardingRoles(evaler connector.Evaler) ([]string, error) {
 		return nil, err
 	}
 	if len(resp) != 1 {
-		return nil, fmt.Errorf("unexpected response length: %d", len(resp))
+		return nil, fmt.Errorf("%w length: %d", errUnexpectedResponse, len(resp))
 	}
 	rolesAnyArray, ok := resp[0].([]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected response type: %T", resp[0])
+		return nil, fmt.Errorf("%w type: %T", errUnexpectedResponse, resp[0])
 	}
 	var ret []string
 	for _, role := range rolesAnyArray {
 		if roleStr, ok := role.(string); ok {
 			ret = append(ret, roleStr)
 		} else {
-			return nil, fmt.Errorf("unexpected role type: %T", role)
+			return nil, fmt.Errorf("%w%T", errUnexpectedRoleType, role)
 		}
 	}
 	return ret, nil
@@ -601,9 +644,9 @@ func reloadCConfig(instances []running.InstanceCtx) error {
 			", please try to do it manually with `require('config'):reload()`: %w", err)
 	}
 	if len(errored) > 0 {
-		return fmt.Errorf("failed to reload instance configuration for: %s, "+
+		return fmt.Errorf("%w%s, "+
 			"please try to do it manually with `require('config'):reload()`",
-			strings.Join(errored, ", "))
+			errFailedToReloadInstanceConfiguration, strings.Join(errored, ", "))
 	}
 	return nil
 }
@@ -670,12 +713,12 @@ func (c *CConfigApplication) demote(instance Instance,
 			return false, err
 		}
 		if electionMode != ElectionModeCandidate {
-			return false,
-				fmt.Errorf(`unexpected election_mode: %q, "candidate" expected`, electionMode)
+			return false, fmt.Errorf("%w%q, \"candidate\" expected",
+				errUnexpectedElectionModeCandidateExpected, electionMode)
 		}
 		if replicaset.LeaderUUID != instance.UUID {
 			return false,
-				fmt.Errorf("an instance must be the leader of the replicaset to demote it")
+				errAnInstanceMustBeTheLeaderOfTheReplicasetToDemoteIt
 		}
 		return c.demoteElection(instance.InstanceCtx, cconfigInstance, ctx.Timeout)
 	}
@@ -772,7 +815,7 @@ func (c *CConfigApplication) rolesChange(ctx RolesChangeCtx,
 	action RolesChangerAction,
 ) (bool, error) {
 	if len(c.runningCtx.Instances) == 0 {
-		return false, fmt.Errorf("there are no running instances")
+		return false, errThereAreNoRunningInstances
 	}
 	clusterCfgPath := c.runningCtx.Instances[0].ClusterConfigPath
 
@@ -873,7 +916,7 @@ func cconfigGetFailover(cfg goconfig.Config, instName string) (Failover, error) 
 		failoverStr, ok := raw.(string)
 		if !ok {
 			return FailoverOff,
-				fmt.Errorf("unexpected failover type: %T, string expected", raw)
+				fmt.Errorf("%w%T, string expected", errUnexpectedFailoverTypeStringExpected, raw)
 		}
 		return ParseFailover(failoverStr), nil
 	}
@@ -890,7 +933,7 @@ func cconfigGetFailover(cfg goconfig.Config, instName string) (Failover, error) 
 	}
 	var repMap map[string]any
 	if innerErr := repVal.Get(&repMap); innerErr != nil {
-		return FailoverOff, fmt.Errorf(`path ["replication"] is not a map`)
+		return FailoverOff, errPathReplicationIsNotAMap
 	}
 	return FailoverOff, nil
 }
@@ -917,7 +960,7 @@ func cconfigGetElectionMode(cfg goconfig.Config, instName string) (ElectionMode,
 	electionModeStr, ok := raw.(string)
 	if !ok {
 		return ElectionModeCandidate,
-			fmt.Errorf("unexpected election_mode type: %T, string expected", raw)
+			fmt.Errorf("%w%T, string expected", errUnexpectedElectionModeTypeStringExpected, raw)
 	}
 	return ParseElectionMode(electionModeStr), nil
 }
@@ -972,7 +1015,7 @@ func patchCConfigPromote(config *goconfig.MutableConfig,
 			"groups/%s/replicasets/%s/leader",
 			groupName, replicasetName)), instName)
 	default:
-		return nil, fmt.Errorf("unexpected failover: %q", failover)
+		return nil, fmt.Errorf("%w%q", errUnexpectedFailover, failover)
 	}
 	return config, err
 }
@@ -1015,7 +1058,7 @@ func patchCConfigDemote(config *goconfig.MutableConfig,
 		instName       = inst.name
 	)
 	if failover != FailoverOff {
-		return nil, fmt.Errorf("unexpected failover: %q", failover)
+		return nil, fmt.Errorf("%w%q", errUnexpectedFailover, failover)
 	}
 	instPath := goconfig.NewKeyPath(fmt.Sprintf(
 		"groups/%s/replicasets/%s/instances/%s", groupName, replicasetName, instName))
@@ -1067,7 +1110,8 @@ func getCConfigInstance(cfg goconfig.Config, instName string) (cconfigInstance, 
 
 	g, r, found := cluster.FindInstance(cfg, instName)
 	if !found {
-		return inst, fmt.Errorf("instance %q not found in the cluster configuration", instName)
+		return inst, fmt.Errorf("%w%q not found in the cluster configuration",
+			errInstanceNotFound, instName)
 	}
 	inst.groupName = g
 	inst.replicasetName = r

--- a/cli/replicaset/cconfig_test.go
+++ b/cli/replicaset/cconfig_test.go
@@ -2,7 +2,6 @@ package replicaset_test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/running"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errSomeError = errors.New("some error")
 )
 
 // spell-checker:ignore somealias someinstanceuuid someleaderuuid somereplicasetuuid anyuri
@@ -413,7 +416,7 @@ func TestCConfigInstance_Discovery_errors(t *testing.T) {
 	}{
 		{
 			Name:     "error",
-			Evaler:   &instanceMockEvaler{Error: []error{errors.New("foo")}},
+			Evaler:   &instanceMockEvaler{Error: []error{errFoo}},
 			Expected: "foo",
 		},
 		{
@@ -456,7 +459,7 @@ func TestCConfigInstance_Discovery_errors(t *testing.T) {
 }
 
 func TestCConfigInstance_Promote_error(t *testing.T) {
-	err := fmt.Errorf("some error")
+	err := errSomeError
 	evaler := &instanceMockEvaler{
 		Error: []error{err},
 	}

--- a/cli/replicaset/cmd/bootstrap.go
+++ b/cli/replicaset/cmd/bootstrap.go
@@ -1,6 +1,7 @@
 package replicasetcmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,15 @@ import (
 	"github.com/tarantool/tt/cli/running"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errTheReplicasetCanNotBeSpecifiedInTheCaseOfApplicationBootstrapping = errors.New(
+		"the replicaset can not be specified in the case of application bootstrapping",
+	)
+	errTheReplicasetMustBeSpecifiedToBootstrapAnInstance = errors.New(
+		"the replicaset must be specified to bootstrap an instance",
+	)
 )
 
 // BootstrapCtx describes context to bootstrap an instance or application.
@@ -32,12 +42,11 @@ type BootstrapCtx struct {
 func Bootstrap(ctx BootstrapCtx) error {
 	if ctx.Instance != "" {
 		if ctx.Replicaset == "" {
-			return fmt.Errorf("the replicaset must be specified to bootstrap an instance")
+			return errTheReplicasetMustBeSpecifiedToBootstrapAnInstance
 		}
 	} else {
 		if ctx.Replicaset != "" {
-			return fmt.Errorf(
-				"the replicaset can not be specified in the case of application bootstrapping")
+			return errTheReplicasetCanNotBeSpecifiedInTheCaseOfApplicationBootstrapping
 		}
 	}
 

--- a/cli/replicaset/cmd/common.go
+++ b/cli/replicaset/cmd/common.go
@@ -1,6 +1,7 @@
 package replicasetcmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tarantool/tt/cli/connector"
@@ -8,6 +9,10 @@ import (
 	"github.com/tarantool/tt/cli/running"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errUnsupportedOrchestrator = errors.New("unsupported orchestrator: ")
 )
 
 const (
@@ -44,7 +49,7 @@ func makeApplicationOrchestrator(
 	case replicaset.OrchestratorCustom:
 		orchestrator = replicaset.NewCustomApplication(runningCtx)
 	default:
-		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		err = fmt.Errorf("%w%s", errUnsupportedOrchestrator, orchestratorType)
 	}
 	return orchestrator, err
 }
@@ -63,7 +68,7 @@ func makeInstanceOrchestrator(orchestratorType replicaset.Orchestrator,
 	case replicaset.OrchestratorCustom:
 		orchestrator = replicaset.NewCustomInstance(conn)
 	default:
-		err = fmt.Errorf("unsupported orchestrator: %s", orchestratorType)
+		err = fmt.Errorf("%w%s", errUnsupportedOrchestrator, orchestratorType)
 	}
 	return orchestrator, err
 }

--- a/cli/replicaset/cmd/downgrade.go
+++ b/cli/replicaset/cmd/downgrade.go
@@ -2,6 +2,7 @@ package replicasetcmd
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/replicaset"
 	"github.com/tarantool/tt/cli/running"
+)
+
+var (
+	errMasterInstanceDowngradeFailed = errors.New("master instance downgrade failed - ")
 )
 
 // DowngradeOpts contains options used for the downgrade process.
@@ -90,8 +95,8 @@ func downgradeMaster(master *instanceMeta, version string) (syncInfo, error) {
 
 	if downgradeInfo.Err != nil {
 		return downgradeInfo, fmt.Errorf(
-			"master instance downgrade failed - %s: %s",
-			fullMasterName, *downgradeInfo.Err)
+			"%w%s: %s",
+			errMasterInstanceDowngradeFailed, fullMasterName, *downgradeInfo.Err)
 	}
 	return downgradeInfo, nil
 }

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -1,6 +1,7 @@
 package replicasetcmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -11,6 +12,12 @@ import (
 	"github.com/tarantool/tt/cli/running"
 	libcluster "github.com/tarantool/tt/lib/cluster"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errUnknownOrEmptyReplicasetsConfiguration = errors.New(
+		"unknown or empty replicasets configuration",
+	)
 )
 
 // DiscoveryCtx contains information about replicaset discovery.
@@ -60,7 +67,7 @@ func Status(discoveryCtx DiscoveryCtx) error {
 // statusReplicasets show the current status of known replicasets.
 func statusReplicasets(replicasets replicaset.Replicasets) error {
 	if replicasets.State == replicaset.StateUnknown {
-		return fmt.Errorf("unknown or empty replicasets configuration")
+		return errUnknownOrEmptyReplicasetsConfiguration
 	}
 
 	fmt.Fprintln(os.Stdout, "Orchestrator:     ", replicasets.Orchestrator)

--- a/cli/replicaset/cmd/upgrade.go
+++ b/cli/replicaset/cmd/upgrade.go
@@ -13,6 +13,17 @@ import (
 	"github.com/tarantool/tt/cli/running"
 )
 
+var (
+	errAndAreBothMasters           = errors.New(" are both masters")
+	errCannotDetermineInstanceMode = errors.New(
+		"can't determine RO/RW mode on instance",
+	)
+	errCurrentLSNIsBehindRequiredMasterLSN  = errors.New("current LSN ")
+	errEmptyResultFromLSNQuery              = errors.New("empty result from LSN query")
+	errReplicasetNotFound                   = errors.New("replicaset with alias ")
+	errSnapshotCommandReturnedInvalidResult = errors.New("snapshot command on ")
+)
+
 // UpgradeOpts contains options used for the upgrade process.
 type UpgradeOpts struct {
 	// List of replicaset names specified by the user for the upgrade.
@@ -55,7 +66,7 @@ func filterReplicasetsByAliases(replicasets replicaset.Replicasets,
 	for _, alias := range chosenReplicasetAliases {
 		rs, exists := replicasetMap[alias]
 		if !exists {
-			return nil, fmt.Errorf("replicaset with alias %q doesn't exist", alias)
+			return nil, fmt.Errorf("%w%q doesn't exist", errReplicasetNotFound, alias)
 		}
 		chosenReplicasets = append(chosenReplicasets, rs)
 	}
@@ -162,16 +173,16 @@ func collectRwRoInfo(rs replicaset.Replicaset,
 				[]any{}, connector.RequestOpts{})
 			if err != nil || len(res) == 0 {
 				return nil, nil, fmt.Errorf(
-					"can't determine RO/RW mode on instance: %s",
-					fullInstanceName)
+					"%w: %s",
+					errCannotDetermineInstanceMode, fullInstanceName)
 			}
 			isReadOnly, ok := res[0].(bool)
 			if !ok {
 				conn.Close()
 				closeConnectors(master, replicas)
 				return nil, nil, fmt.Errorf(
-					"can't determine RO/RW mode on instance %s: expected bool, got %T",
-					fullInstanceName, res[0])
+					"%w %s: expected bool, got %T",
+					errCannotDetermineInstanceMode, fullInstanceName, res[0])
 			}
 			isRW = !isReadOnly
 		} else {
@@ -181,8 +192,8 @@ func collectRwRoInfo(rs replicaset.Replicaset,
 		switch {
 		case isRW && master != nil:
 			closeConnectors(master, replicas)
-			return nil, nil, fmt.Errorf("%s and %s are both masters",
-				running.GetAppInstanceName(master.run), fullInstanceName)
+			return nil, nil, fmt.Errorf("%s and %s%w",
+				running.GetAppInstanceName(master.run), fullInstanceName, errAndAreBothMasters)
 		case isRW:
 			master = &instanceMeta{run, conn}
 		default:
@@ -203,7 +214,7 @@ func waitLSN(conn connector.Connector, masterIID uint32, masterLSN uint64, lsnTi
 		case err != nil:
 			lastError = fmt.Errorf("failed to evaluate LSN query: %w", err)
 		case len(res) == 0:
-			lastError = errors.New("empty result from LSN query")
+			lastError = errEmptyResultFromLSNQuery
 		default:
 			var lsn uint64
 			if err := mapstructure.Decode(res[0], &lsn); err != nil {
@@ -211,8 +222,8 @@ func waitLSN(conn connector.Connector, masterIID uint32, masterLSN uint64, lsnTi
 			} else if lsn >= masterLSN {
 				return nil
 			} else {
-				lastError = fmt.Errorf("current LSN %d is behind required "+
-					"master LSN %d", lsn, masterLSN)
+				lastError = fmt.Errorf("%w%d is behind required master LSN %d",
+					errCurrentLSNIsBehindRequiredMasterLSN, lsn, masterLSN)
 			}
 		}
 
@@ -257,13 +268,15 @@ func snapshot(instance *instanceMeta) error {
 		return fmt.Errorf("failed to execute snapshot on replica: %w", err)
 	}
 	if len(res) == 0 {
-		return fmt.Errorf("snapshot command on %s returned an empty result, "+
-			"'ok' expected", running.GetAppInstanceName(instance.run))
+		return fmt.Errorf("%w%s returned an empty result, 'ok' expected",
+			errSnapshotCommandReturnedInvalidResult,
+			running.GetAppInstanceName(instance.run))
 	}
 
 	if result, ok := res[0].(string); !ok || result != "ok" {
-		return fmt.Errorf("snapshot command on %s returned unexpected result: '%v', "+
-			"'ok' expected", running.GetAppInstanceName(instance.run), res[0])
+		return fmt.Errorf("%w%s returned unexpected result: '%v', 'ok' expected",
+			errSnapshotCommandReturnedInvalidResult,
+			running.GetAppInstanceName(instance.run), res[0])
 	}
 	return nil
 }

--- a/cli/replicaset/configsource.go
+++ b/cli/replicaset/configsource.go
@@ -13,6 +13,14 @@ import (
 	libcluster "github.com/tarantool/tt/lib/cluster"
 )
 
+var (
+	errCannotFindGroup                             = errors.New("cannot find group ")
+	errCannotFindInstanceAboveGroupAndOrReplicaset = errors.New("cannot find instance ")
+	errCannotFindReplicasetAboveGroup              = errors.New("cannot find replicaset ")
+	errUnknownFailover                             = errors.New("unknown failover")
+	errUnsupportedFailover                         = errors.New("unsupported failover")
+)
+
 const configPathSuffixSegments = 2
 
 // KeyPicker picks a key to patch.
@@ -267,9 +275,9 @@ func getCConfigRolesPath(goView goconfig.Config,
 		})
 	}
 	if ctx.GroupName != "" {
-		p := goconfig.NewKeyPath(fmt.Sprintf("groups/%s", ctx.GroupName))
+		p := goconfig.NewKeyPath("groups/" + ctx.GroupName)
 		if _, ok := goView.Lookup(p); !ok {
-			return []path{}, fmt.Errorf("cannot find group %q", ctx.GroupName)
+			return []path{}, fmt.Errorf("%w%q", errCannotFindGroup, ctx.GroupName)
 		}
 		paths = append(paths, path{
 			path:  append(p, "roles"),
@@ -280,7 +288,8 @@ func getCConfigRolesPath(goView goconfig.Config,
 		var group string
 		var ok bool
 		if group, ok = cluster.FindGroupByReplicaset(goView, ctx.ReplicasetName); !ok {
-			return []path{}, fmt.Errorf("cannot find replicaset %q above group", ctx.ReplicasetName)
+			return []path{}, fmt.Errorf("%w%q above group",
+				errCannotFindReplicasetAboveGroup, ctx.ReplicasetName)
 		}
 		p := goconfig.NewKeyPath(fmt.Sprintf("groups/%s/replicasets/%s", group, ctx.ReplicasetName))
 		paths = append(paths, path{
@@ -292,8 +301,8 @@ func getCConfigRolesPath(goView goconfig.Config,
 		var group, replicaset string
 		var ok bool
 		if group, replicaset, ok = cluster.FindInstance(goView, ctx.InstName); !ok {
-			return []path{}, fmt.Errorf("cannot find instance %q above group and/or replicaset",
-				ctx.InstName)
+			return []path{}, fmt.Errorf("%w%q above group and/or replicaset",
+				errCannotFindInstanceAboveGroupAndOrReplicaset, ctx.InstName)
 		}
 		p := goconfig.NewKeyPath(fmt.Sprintf(
 			"groups/%s/replicasets/%s/instances/%s", group, replicaset, ctx.InstName))
@@ -333,9 +342,10 @@ func getCConfigPromotePath(inst cconfigInstance) (goconfig.KeyPath, int, error) 
 			groupName, replicasetName))
 		depth = len(path) - 1
 	case FailoverElection:
-		err = fmt.Errorf(`unsupported failover: %q, supported: "manual", "off"`, failover)
+		err = fmt.Errorf("%w: %q, supported: \"manual\", \"off\"",
+			errUnsupportedFailover, failover)
 	default:
-		err = fmt.Errorf(`unknown failover, supported: "manual", "off"`)
+		err = fmt.Errorf("%w, supported: \"manual\", \"off\"", errUnknownFailover)
 	}
 	return path, depth, err
 }
@@ -359,9 +369,9 @@ func getCConfigDemotePath(inst cconfigInstance) (goconfig.KeyPath, int, error) {
 			groupName, replicasetName, instName))
 		depth = len(path) - configPathSuffixSegments
 	case FailoverManual, FailoverElection:
-		err = fmt.Errorf(`unsupported failover: %q, supported: "off"`, failover)
+		err = fmt.Errorf("%w: %q, supported: \"off\"", errUnsupportedFailover, failover)
 	default:
-		err = fmt.Errorf(`unknown failover, supported: "off"`)
+		err = fmt.Errorf("%w, supported: \"off\"", errUnknownFailover)
 	}
 	return path, depth, err
 }

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -2,6 +2,7 @@ package replicaset_test
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/tt/cli/replicaset"
 	libcluster "github.com/tarantool/tt/lib/cluster"
+)
+
+var (
+	errFailed            = errors.New("failed")
+	errItSTooLate        = errors.New("it's too late")
+	errSharksChewedWires = errors.New("sharks chewed wires")
+	errUnexpectedCall    = errors.New("unexpected call")
 )
 
 // spell-checker:ignore lexi
@@ -54,7 +62,7 @@ type mockDataCollector struct {
 
 func (m *mockDataCollector) Collect() ([]libcluster.Data, error) {
 	if m.Called >= len(m.Ret) {
-		return nil, fmt.Errorf("unexpected call")
+		return nil, errUnexpectedCall
 	}
 	data := m.Ret[m.Called].Data
 	err := m.Ret[m.Called].Err
@@ -83,7 +91,7 @@ type mockDataPublisher struct {
 
 func (m *mockDataPublisher) Publish(key string, revision int64, data []byte) error {
 	if m.Called >= len(m.Err) {
-		return fmt.Errorf("unexpected call")
+		return errUnexpectedCall
 	}
 	m.Keys = append(m.Keys, key)
 	m.Revisions = append(m.Revisions, revision)
@@ -139,7 +147,7 @@ func TestCConfigSource_collect_config_error(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err := fmt.Errorf("sharks chewed wires")
+		err := errSharksChewedWires
 		collector := newOnceMockDataCollector(nil, err)
 		source := replicaset.NewCConfigSource(collector, nil, nil)
 		actual := tc.runFunc(source)
@@ -194,7 +202,7 @@ func TestCConfigSource_Promote_unexpected_failover(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(fmt.Sprint(tc.failover), func(t *testing.T) {
+		t.Run(tc.failover, func(t *testing.T) {
 			cfg := []byte(fmt.Sprintf(`groups:
   group-001:
     replication:
@@ -344,7 +352,7 @@ func TestCConfigSource_publish_error(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err := fmt.Errorf("failed")
+		err := errFailed
 		publisher := newOnceMockDataPublisher(err)
 		collector := newOnceMockDataCollector([]libcluster.Data{
 			{Source: "all", Value: cfg},
@@ -397,7 +405,7 @@ func TestCConfigSource_keypick_error(t *testing.T) {
 		collector := newOnceMockDataCollector([]libcluster.Data{
 			{Source: "all", Value: cfg},
 		}, nil)
-		err := fmt.Errorf("it's too late")
+		err := errItSTooLate
 		keyPicker := replicaset.KeyPicker(func(_ []string, _ bool, _ string) (int, error) {
 			return 0, err
 		})
@@ -591,7 +599,7 @@ func TestCConfigSource_Demote_unexpected_failover(t *testing.T) {
 		{"true", "unexpected failover type: bool, string expected"},
 	}
 	for _, tc := range cases {
-		t.Run(fmt.Sprint(tc.failover), func(t *testing.T) {
+		t.Run(tc.failover, func(t *testing.T) {
 			cfg := []byte(fmt.Sprintf(`groups:
   group-001:
     replication:

--- a/cli/replicaset/custom.go
+++ b/cli/replicaset/custom.go
@@ -189,7 +189,7 @@ func getCustomInstanceTopology(name string,
 	}
 
 	if len(data) != 1 {
-		return topology, fmt.Errorf("unexpected response: %v", data)
+		return topology, fmt.Errorf("%w: %v", errUnexpectedResponse, data)
 	}
 
 	if err := mapstructure.Decode(data[0], &topology); err != nil {

--- a/cli/replicaset/custom_test.go
+++ b/cli/replicaset/custom_test.go
@@ -1,7 +1,6 @@
 package replicaset_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -404,7 +403,7 @@ func TestCustomInstance_Discovery_errors(t *testing.T) {
 	}{
 		{
 			Name:     "error",
-			Evaler:   &instanceMockEvaler{Error: []error{errors.New("foo")}},
+			Evaler:   &instanceMockEvaler{Error: []error{errFoo}},
 			Expected: "foo",
 		},
 		{

--- a/cli/replicaset/demote.go
+++ b/cli/replicaset/demote.go
@@ -1,6 +1,15 @@
 package replicaset
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errDemoteIsNotSupported = errors.New(
+		"demote is not supported for ",
+	)
+)
 
 // DemoteCtx describes a context for an instance demoting.
 type DemoteCtx struct {
@@ -23,13 +32,13 @@ type Demoter interface {
 // newErrDemoteByInstanceNotSupported creates a new error that demote is not
 // supported by the orchestrator for a single instance.
 func newErrDemoteByInstanceNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("demote is not supported for a single instance by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wa single instance by %q orchestrator",
+		errDemoteIsNotSupported, orchestrator)
 }
 
 // newErrDemoteByAppNotSupported creates a new error that demote is not
 // supported by the orchestrator for an application.
 func newErrDemoteByAppNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("demote is not supported for an application by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wan application by %q orchestrator",
+		errDemoteIsNotSupported, orchestrator)
 }

--- a/cli/replicaset/eval.go
+++ b/cli/replicaset/eval.go
@@ -1,12 +1,18 @@
 package replicaset
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/apex/log"
 
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/running"
+)
+
+var (
+	errFailedToConnectToAnyInstance = errors.New("failed to connect to any instance")
+	errNoInstancesToConnect         = errors.New("no instances to connect")
 )
 
 // EvalFunc is a function that implements connector.Evaler.
@@ -85,7 +91,7 @@ func evalForeach(instances []running.InstanceCtx,
 	iEvaler InstanceEvaler, skipConnectError bool,
 ) error {
 	if len(instances) == 0 {
-		return fmt.Errorf("no instances to connect")
+		return errNoInstancesToConnect
 	}
 
 	connected := 0
@@ -117,7 +123,7 @@ func evalForeach(instances []running.InstanceCtx,
 		}
 	}
 	if connected == 0 {
-		return fmt.Errorf("failed to connect to any instance")
+		return errFailedToConnectToAnyInstance
 	}
 	return nil
 }

--- a/cli/replicaset/expel.go
+++ b/cli/replicaset/expel.go
@@ -1,6 +1,15 @@
 package replicaset
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errExpelIsNotSupported = errors.New(
+		"expel is not supported for ",
+	)
+)
 
 // ExpelCtx describes a context for an instance expelling.
 type ExpelCtx struct {
@@ -23,13 +32,13 @@ type Expeller interface {
 // newErrExpelByInstanceNotSupported creates a new error that expel is not
 // supported by the orchestrator for a single instance.
 func newErrExpelByInstanceNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("expel is not supported for a single instance by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wa single instance by %q orchestrator",
+		errExpelIsNotSupported, orchestrator)
 }
 
 // newErrExpelByAppNotSupported creates a new error that expel by URI is not
 // supported by the orchestrator for an application.
 func newErrExpelByAppNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("expel is not supported for an application by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wan application by %q orchestrator",
+		errExpelIsNotSupported, orchestrator)
 }

--- a/cli/replicaset/integration_test.go
+++ b/cli/replicaset/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -230,7 +231,7 @@ func TestEvalForeach_stops_after_evaler_error(t *testing.T) {
 		validInstance,
 	}
 
-	evaler := &instanceEvalerMock{T: t, Error: fmt.Errorf("foo")}
+	evaler := &instanceEvalerMock{T: t, Error: errFoo}
 	err := replicaset.EvalForeach(instances, evaler)
 	assert.EqualError(t, err, "foo")
 	assert.Equal(t, evaler.Instances, []running.InstanceCtx{validInstance})
@@ -360,7 +361,7 @@ func TestEvalForeachAlive_stops_after_evaler_err(t *testing.T) {
 		validInstance,
 	}
 
-	evaler := &instanceEvalerMock{T: t, Error: fmt.Errorf("foo")}
+	evaler := &instanceEvalerMock{T: t, Error: errFoo}
 	err := replicaset.EvalForeachAlive(instances, evaler)
 	assert.EqualError(t, err, "foo")
 	assert.Equal(t, evaler.Instances, []running.InstanceCtx{validInstance})
@@ -455,7 +456,7 @@ func TestEvalAny_ignore_evaler_done(t *testing.T) {
 		},
 	}
 	for _, tc := range []bool{true, false} {
-		t.Run(fmt.Sprintf("%t", tc), func(t *testing.T) {
+		t.Run(strconv.FormatBool(tc), func(t *testing.T) {
 			evaler := &instanceEvalerMock{T: t, Done: tc}
 			err := replicaset.EvalAny(instances, evaler)
 			assert.NoError(t, err)
@@ -472,7 +473,7 @@ func TestEvalAny_stop_after_evaler_error(t *testing.T) {
 		},
 	}
 
-	evaler := &instanceEvalerMock{T: t, Error: fmt.Errorf("foo")}
+	evaler := &instanceEvalerMock{T: t, Error: errFoo}
 	err := replicaset.EvalAny(instances, evaler)
 	assert.EqualError(t, err, "foo")
 }

--- a/cli/replicaset/orchestrator.go
+++ b/cli/replicaset/orchestrator.go
@@ -2,10 +2,16 @@ package replicaset
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/tarantool/tt/cli/connector"
+)
+
+var (
+	errUnexpectedResponse  = errors.New("unexpected response")
+	errUnknownOrchestrator = errors.New("unknown orchestrator: ")
 )
 
 //go:embed lua/get_orchestrator.lua
@@ -54,10 +60,10 @@ func EvalOrchestrator(evaler connector.Evaler) (Orchestrator, error) {
 		if str, ok := data[0].(string); ok {
 			parsed := ParseOrchestrator(str)
 			if parsed == OrchestratorUnknown {
-				return parsed, fmt.Errorf("unknown orchestrator: %s", str)
+				return parsed, fmt.Errorf("%w%s", errUnknownOrchestrator, str)
 			}
 			return parsed, nil
 		}
 	}
-	return OrchestratorCustom, fmt.Errorf("unexpected response")
+	return OrchestratorCustom, errUnexpectedResponse
 }

--- a/cli/replicaset/orchestrator_test.go
+++ b/cli/replicaset/orchestrator_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/tarantool/tt/cli/replicaset"
 )
 
+var (
+	errFoo = errors.New("foo")
+)
+
 func TestOrchestrator_String(t *testing.T) {
 	cases := []struct {
 		Orchestrator replicaset.Orchestrator
@@ -108,7 +112,7 @@ func TestEvalOrchestrator_unknown(t *testing.T) {
 func TestEvalOrchestrator_error(t *testing.T) {
 	_, err := replicaset.EvalOrchestrator(orchestratorEvalerMock{
 		ret: []any{"unknown"},
-		err: errors.New("foo"),
+		err: errFoo,
 	})
 	require.EqualError(t, err, "failed to recognize orchestrator: foo")
 }

--- a/cli/replicaset/promote.go
+++ b/cli/replicaset/promote.go
@@ -1,6 +1,15 @@
 package replicaset
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errPromoteIsNotSupported = errors.New(
+		"promote is not supported for ",
+	)
+)
 
 // PromoteCtx describes a context for an instance promoting.
 type PromoteCtx struct {
@@ -23,13 +32,13 @@ type Promoter interface {
 // newErrPromoteByInstanceNotSupported creates a new error that promote is not
 // supported by the orchestrator for a single instance.
 func newErrPromoteByInstanceNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("promote is not supported for a single instance by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wa single instance by %q orchestrator",
+		errPromoteIsNotSupported, orchestrator)
 }
 
 // newErrPromoteByAppNotSupported creates a new error that promote is not
 // supported by the orchestrator for an application.
 func newErrPromoteByAppNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("promote is not supported for an application by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wan application by %q orchestrator",
+		errPromoteIsNotSupported, orchestrator)
 }

--- a/cli/replicaset/rebootstrap.go
+++ b/cli/replicaset/rebootstrap.go
@@ -75,7 +75,7 @@ func Rebootstrap(cmdCtx cmdcontext.CmdCtx, cliOpts config.CliOpts, rbCtx Reboots
 	}
 
 	if !found {
-		return fmt.Errorf("instance %q is not found", rbCtx.InstanceName)
+		return fmt.Errorf("%w%q is not found", errInstanceNotFound, rbCtx.InstanceName)
 	}
 
 	if !rbCtx.Confirmed {

--- a/cli/replicaset/roles.go
+++ b/cli/replicaset/roles.go
@@ -1,8 +1,17 @@
 package replicaset
 
 import (
+	"errors"
 	"fmt"
 	"slices"
+)
+
+var (
+	errIsNotASlice              = errors.New(" is not a slice")
+	errIsNotAString             = errors.New(" is not a string")
+	errRoleAlreadyExists        = errors.New("role ")
+	errRoleChangeIsNotSupported = errors.New("roles ")
+	errRoleNotFound             = errors.New("role ")
 )
 
 // RoleAction is a type that describes an action that will
@@ -29,7 +38,7 @@ type RolesAdder struct{}
 // Change implements addition of role.
 func (RolesAdder) Change(roles []string, r string) ([]string, error) {
 	if len(roles) > 0 && slices.Index(roles, r) != -1 {
-		return []string{}, fmt.Errorf("role %q already exists", r)
+		return []string{}, fmt.Errorf("%w%q already exists", errRoleAlreadyExists, r)
 	}
 	return append(roles, r), nil
 }
@@ -46,7 +55,7 @@ type RolesRemover struct{}
 func (RolesRemover) Change(roles []string, r string) ([]string, error) {
 	idx := slices.Index(roles, r)
 	if idx == -1 {
-		return []string{}, fmt.Errorf("role %q not found", r)
+		return []string{}, fmt.Errorf("%w%q not found", errRoleNotFound, r)
 	}
 	if len(roles) == 1 {
 		return []string{}, nil
@@ -90,11 +99,12 @@ type RolesChanger interface {
 func newErrRolesChangeByInstanceNotSupported(orchestrator Orchestrator,
 	changeRoleAction RolesChangerAction,
 ) error {
-	msg := "roles %s is not supported for a single instance by %q orchestrator"
 	if changeRoleAction.Action() == RemoveAction {
-		return fmt.Errorf(msg, "remove", orchestrator)
+		return fmt.Errorf("%w%s is not supported for a single instance by %q orchestrator",
+			errRoleChangeIsNotSupported, "remove", orchestrator)
 	}
-	return fmt.Errorf(msg, "add", orchestrator)
+	return fmt.Errorf("%w%s is not supported for a single instance by %q orchestrator",
+		errRoleChangeIsNotSupported, "add", orchestrator)
 }
 
 // newErrRolesChangeByAppNotSupported creates a new error that 'roles add/remove' by URI is not
@@ -102,11 +112,12 @@ func newErrRolesChangeByInstanceNotSupported(orchestrator Orchestrator,
 func newErrRolesChangeByAppNotSupported(orchestrator Orchestrator,
 	changeRoleAction RolesChangerAction,
 ) error {
-	msg := "roles %s is not supported for an application by %q orchestrator"
 	if changeRoleAction.Action() == RemoveAction {
-		return fmt.Errorf(msg, "remove", orchestrator)
+		return fmt.Errorf("%w%s is not supported for an application by %q orchestrator",
+			errRoleChangeIsNotSupported, "remove", orchestrator)
 	}
-	return fmt.Errorf(msg, "add", orchestrator)
+	return fmt.Errorf("%w%s is not supported for an application by %q orchestrator",
+		errRoleChangeIsNotSupported, "add", orchestrator)
 }
 
 // parseRoles is a function to convert roles type 'any'
@@ -114,13 +125,13 @@ func newErrRolesChangeByAppNotSupported(orchestrator Orchestrator,
 func parseRoles(value any) ([]string, error) {
 	sliceVal, ok := value.([]any)
 	if !ok {
-		return []string{}, fmt.Errorf("%v is not a slice", value)
+		return []string{}, fmt.Errorf("%v%w", value, errIsNotASlice)
 	}
 	existingRoles := make([]string, 0, len(sliceVal)+1)
 	for _, v := range sliceVal {
 		vStr, ok := v.(string)
 		if !ok {
-			return []string{}, fmt.Errorf("%v is not a string", v)
+			return []string{}, fmt.Errorf("%v%w", v, errIsNotAString)
 		}
 		existingRoles = append(existingRoles, vStr)
 	}

--- a/cli/replicaset/vshard.go
+++ b/cli/replicaset/vshard.go
@@ -1,6 +1,15 @@
 package replicaset
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errBootstrapVshardIsNotSupported = errors.New(
+		"bootstrap vshard is not supported for ",
+	)
+)
 
 // VShardBootstrapCtx describes context to bootstrap vshard.
 type VShardBootstrapCtx struct {
@@ -18,13 +27,13 @@ type VShardBootstrapper interface {
 // newErrBootstrapVShardByInstanceNotSupported creates a new error that vshard bootstrap is not
 // supported by the orchestrator for a single instance.
 func newErrBootstrapVShardByInstanceNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("bootstrap vshard is not supported for a single instance by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wa single instance by %q orchestrator",
+		errBootstrapVshardIsNotSupported, orchestrator)
 }
 
 // newErrBootstrapVShardByAppNotSupported creates a new error that vshard bootstrap is not
 // supported by the orchestrator for an application.
 func newErrBootstrapVShardByAppNotSupported(orchestrator Orchestrator) error {
-	return fmt.Errorf("bootstrap vshard is not supported for an application by %q orchestrator",
-		orchestrator)
+	return fmt.Errorf("%wan application by %q orchestrator",
+		errBootstrapVshardIsNotSupported, orchestrator)
 }

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -3,6 +3,7 @@ package rocks
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,6 +17,11 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errPrefixPathExpectedMoreData = errors.New("failed to get prefix path: expected more data")
+	errPrefixPathRegexpMismatch   = errors.New("failed to get prefix path: regexp does not match")
 )
 
 //go:embed completions/*
@@ -97,13 +103,13 @@ func GetTarantoolPrefix(cli *cmdcontext.CliCtx, cliOpts *config.CliOpts) (string
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(lines) < minVersionOutputLines {
-		return "", fmt.Errorf("failed to get prefix path: expected more data")
+		return "", errPrefixPathExpectedMoreData
 	}
 
 	re := regexp.MustCompile(`^.*\s-DCMAKE_INSTALL_PREFIX=(?P<prefix>\/.*)\s.*$`)
 	matches := util.FindNamedMatches(re, lines[2])
 	if len(matches) == 0 {
-		return "", fmt.Errorf("failed to get prefix path: regexp does not match")
+		return "", errPrefixPathRegexpMismatch
 	}
 
 	prefixDir := matches["prefix"]

--- a/cli/rocks/rocks_test.go
+++ b/cli/rocks/rocks_test.go
@@ -1,7 +1,6 @@
 package rocks
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -175,7 +174,7 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 		IsTarantoolBinFromRepo: false,
 		TarantoolCli:           cmdcontext.TarantoolCli{Executable: tntBinPath},
 	}, data: &tntBadData0}] = prefixOutput{
-		err: fmt.Errorf("failed to get prefix path: regexp does not match"),
+		err: errPrefixPathRegexpMismatch,
 	}
 
 	tntBadData1 := []byte("#!/bin/sh\n" +
@@ -186,7 +185,7 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 		IsTarantoolBinFromRepo: false,
 		TarantoolCli:           cmdcontext.TarantoolCli{Executable: tntBinPath},
 	}, data: &tntBadData1}] = prefixOutput{
-		err: fmt.Errorf("failed to get prefix path: expected more data"),
+		err: errPrefixPathExpectedMoreData,
 	}
 
 	appOpts := config.TtEnvOpts{IncludeDir: "hdr"}

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -2,7 +2,6 @@ package running
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -12,6 +11,11 @@ import (
 	"github.com/apex/log"
 	"github.com/tarantool/tt/cli/ttlog"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errInstanceIsNotStarted          = errors.New("instance is not started")
+	errTarantoolExecutableIsNotFound = errors.New("tarantool executable is not found")
 )
 
 // baseInstance represents a tarantool instance.
@@ -120,7 +124,7 @@ func StdLoggerOpt(logger ttlog.Logger) InstanceOption {
 // Wait waits for the child process to complete.
 func (inst *baseInstance) Wait() error {
 	if inst.processController == nil {
-		return fmt.Errorf("instance is not started")
+		return errInstanceIsNotStarted
 	}
 	return inst.processController.Wait()
 }
@@ -128,7 +132,7 @@ func (inst *baseInstance) Wait() error {
 // SendSignal sends a signal to tarantool instance.
 func (inst *baseInstance) SendSignal(sig os.Signal) error {
 	if inst.processController == nil {
-		return fmt.Errorf("instance is not started")
+		return errInstanceIsNotStarted
 	}
 	return inst.processController.SendSignal(sig)
 }
@@ -154,7 +158,7 @@ func (inst *baseInstance) Run(opts RunOpts) error {
 	f, err := inst.integrityCtx.Repository.Read(inst.tarantoolPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return errors.New("tarantool executable is not found")
+			return errTarantoolExecutableIsNotFound
 		}
 		return err
 	}

--- a/cli/running/cluster_instance.go
+++ b/cli/running/cluster_instance.go
@@ -2,6 +2,7 @@ package running
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errApplicationIsNotADirectory = errors.New("application ")
 )
 
 // clusterInstance describes tarantool 3 instance running using cluster config.
@@ -80,7 +85,7 @@ func (inst *clusterInstance) Start(ctx context.Context) error {
 		cmd.Env = append(cmd.Env, "TT_CONSOLE_SOCKET_DEFAULT="+consoleSocket)
 		cmd.Env = append(cmd.Env, "TT_IPROTO_LISTEN_DEFAULT="+"[{\"uri\":\""+inst.binaryPort+"\"}]")
 	} else {
-		return fmt.Errorf("application %q is not a directory", inst.appDir)
+		return fmt.Errorf("%w%q is not a directory", errApplicationIsNotADirectory, inst.appDir)
 	}
 
 	var err error

--- a/cli/running/cluster_instance_test.go
+++ b/cli/running/cluster_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,11 @@ import (
 	"github.com/tarantool/tt/cli/cmdcontext"
 	"github.com/tarantool/tt/cli/ttlog"
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errTarantoolExited    = errors.New("tarantool exited: ")
+	errTimedOutWaitingFor = errors.New("timed out waiting for ")
 )
 
 var tntCli = cmdcontext.TarantoolCli{Executable: "tarantool"}
@@ -39,11 +45,11 @@ func waitForMsgInBuffer(reader io.Reader, msgToWait string, waitFor time.Duratio
 		if strings.Contains(line, msgToWait) {
 			break
 		} else if strings.Contains(line, "exiting") {
-			return fmt.Errorf("tarantool exited: %q", previousLine)
+			return fmt.Errorf("%w%q", errTarantoolExited, previousLine)
 		}
 		previousLine = line
 		if time.Now().After(waitUntil) { // Timeout.
-			return fmt.Errorf("timed out waiting for %q", msgToWait)
+			return fmt.Errorf("%w%q", errTimedOutWaitingFor, msgToWait)
 		}
 	}
 	return nil

--- a/cli/running/internal/layout/multi_inst_layout.go
+++ b/cli/running/internal/layout/multi_inst_layout.go
@@ -1,10 +1,16 @@
 package layout
 
 import (
-	"fmt"
+	"errors"
 	"path/filepath"
 
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errApplicationNameCannotBeEmpty = errors.New("application name cannot be empty")
+	errBaseDirectoryCannotBeEmpty   = errors.New("base directory cannot be empty")
+	errInstanceNameCannotBeEmpty    = errors.New("instance name cannot be empty")
 )
 
 // MultiInstLayout implements Layout interface for multi-instance applications.
@@ -17,13 +23,13 @@ type MultiInstLayout struct {
 // NewMultiInstLayout creates new multi-instance layout.
 func NewMultiInstLayout(baseDir, appName, instanceName string) (*MultiInstLayout, error) {
 	if baseDir == "" {
-		return nil, fmt.Errorf("base directory cannot be empty")
+		return nil, errBaseDirectoryCannotBeEmpty
 	}
 	if appName == "" {
-		return nil, fmt.Errorf("application name cannot be empty")
+		return nil, errApplicationNameCannotBeEmpty
 	}
 	if instanceName == "" {
-		return nil, fmt.Errorf("instance name cannot be empty")
+		return nil, errInstanceNameCannotBeEmpty
 	}
 
 	return &MultiInstLayout{

--- a/cli/running/process_controller.go
+++ b/cli/running/process_controller.go
@@ -1,12 +1,17 @@
 package running
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
+)
+
+var (
+	errTheInstanceHasnTStartedYet = errors.New("the instance hasn't started yet")
 )
 
 // newProcessController create new process controller.
@@ -51,7 +56,7 @@ func (pc *processController) Wait() error {
 // SendSignal sends a signal to tarantool instance.
 func (pc *processController) SendSignal(sig os.Signal) error {
 	if pc.Cmd == nil || pc.Process == nil {
-		return fmt.Errorf("the instance hasn't started yet")
+		return errTheInstanceHasnTStartedYet
 	}
 	return pc.Process.Signal(sig)
 }

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -28,6 +28,34 @@ import (
 	"github.com/tarantool/tt/lib/integrity"
 )
 
+var (
+	errApplicationNotFound      = errors.New("application ")
+	errCannotGetConfigValueAtAs = errors.New(
+		"cannot get config value at ",
+	)
+	errClusterConfigRequiresInstancesYAML = errors.New("cluster config ")
+	errInvalidApplicationDirectory        = errors.New(
+		" doesn't exist or not a directory",
+	)
+	errInitLuaOrInitLuaIsMissing = errors.New("init.lua or ")
+	errInstanceDead              = errors.New(
+		process_utils.ProcStateDead.String(),
+	)
+	errInstancesNotFound = errors.New(
+		"instance(s) not found",
+	)
+	errLoggerChangedCheckFailedPassingNullAsAnInstanceContext = errors.New(
+		"logger changed check failed: passing null as an instance context",
+	)
+	errNotFound                                   = errors.New(" not found")
+	errRequiredFilesMissingInApplicationDirectory = errors.New(
+		"require files are missing in application directory ",
+	)
+	errTheInstanceIsNotRunningItMustBeStarted = errors.New(
+		": the instance is not running, it must be started",
+	)
+)
+
 const (
 	defaultDirPerms        = 0o770
 	instanceCleanupTimeout = 10 * time.Second
@@ -40,7 +68,11 @@ const (
 	clusterConfigDefaultFileName = "config.yml"
 )
 
-var instStateDead = process_utils.ProcStateDead
+type syntaxCheckError string
+
+func (err syntaxCheckError) Error() string {
+	return string(err)
+}
 
 // RunningCtx contains information about application instances.
 type RunningCtx struct {
@@ -186,7 +218,7 @@ func isLoggerChanged(logger ttlog.Logger, instanceCtx *InstanceCtx) (bool, error
 		return true, nil
 	}
 	if instanceCtx == nil {
-		return true, fmt.Errorf("logger changed check failed: passing null as an instance context")
+		return true, errLoggerChangedCheckFailedPassingNullAsAnInstanceContext
 	}
 	loggerOpts := logger.GetOpts()
 
@@ -324,7 +356,8 @@ func findInstanceScriptInAppDir(appDir, instName, clusterCfgPath, defaultScript 
 		if defaultScript != "" {
 			return defaultScript, nil
 		} else {
-			return "", fmt.Errorf("init.lua or %s.init.lua is missing", instName)
+			return "", fmt.Errorf("%w%s.init.lua is missing",
+				errInitLuaOrInitLuaIsMissing, instName)
 		}
 	}
 	return script, nil
@@ -353,7 +386,7 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 ) {
 	log.Debugf("Collecting instances from application directory %q", appDir)
 	if !util.IsDir(appDir) {
-		return nil, fmt.Errorf("%q doesn't exist or not a directory", appDir)
+		return nil, fmt.Errorf("%q%w", appDir, errInvalidApplicationDirectory)
 	}
 
 	appDirFiles, err := collectAppDirFiles(appDir)
@@ -365,7 +398,8 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 		if appDirFiles.clusterCfgPath != "" {
 			// Cluster config will work only if instances.yml exists nearby.
 			return nil, fmt.Errorf(
-				"cluster config %q is found, but instances config (instances.yml) is missing",
+				"%w%q is found, but instances config (instances.yml) is missing",
+				errClusterConfigRequiresInstancesYAML,
 				appDirFiles.clusterCfgPath)
 		}
 		if appDirFiles.defaultLuaPath != "" {
@@ -378,9 +412,9 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 			}}, nil
 		}
 		if loadConfig == ConfigLoadAll || loadConfig == ConfigLoadScripts {
-			return nil, fmt.Errorf("require files are missing in application directory %q: "+
+			return nil, fmt.Errorf("%w%q: "+
 				"there must be instances config or the default instance script (%q)",
-				appDir, "init.lua")
+				errRequiredFilesMissingInApplicationDirectory, appDir, "init.lua")
 		}
 	}
 
@@ -430,7 +464,7 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 	}
 
 	if len(instances) == 0 {
-		return nil, fmt.Errorf("instance(s) not found")
+		return nil, errInstancesNotFound
 	}
 
 	return instances, nil
@@ -453,7 +487,7 @@ func collectInstances(appName, applicationDir string,
 	appName = strings.TrimSuffix(appName, ".lua")
 	expectedAppName := filepath.Base(filepath.Clean(applicationDir))
 	if appName != expectedAppName {
-		return nil, fmt.Errorf("application %q not found", appName)
+		return nil, fmt.Errorf("%w%q not found", errApplicationNotFound, appName)
 	}
 
 	// A single application can be represented by `<appName>.lua` or by
@@ -516,7 +550,7 @@ func mapValuesFromConfig[T any](cfg goconfig.Config, mapFunc func(val T) (T, err
 		}
 		castedValue, ok := raw.(T)
 		if !ok {
-			return fmt.Errorf("cannot get config value at %q as %T", cfgMapping.path, *new(T))
+			return fmt.Errorf("%w%q as %T", errCannotGetConfigValueAtAs, cfgMapping.path, *new(T))
 		}
 		newValue, err := mapFunc(castedValue)
 		if err != nil {
@@ -663,7 +697,7 @@ func FillCtx(cliOpts *config.CliOpts, cmdCtx *cmdcontext.CmdCtx,
 	// All relative paths are built from the path of the tt.yaml file.
 	// If tt.yaml does not exists we must return error.
 	if cmdCtx.Cli.ConfigPath == "" {
-		return fmt.Errorf(`%s not found`, configure.ConfigName)
+		return fmt.Errorf("%s%w", configure.ConfigName, errNotFound)
 	}
 
 	var appName string
@@ -825,12 +859,12 @@ func Logrotate(run *InstanceCtx) error {
 
 	pid, err := process_utils.GetPIDFromFile(run.PIDFile)
 	if err != nil {
-		return fmt.Errorf("%s: the instance is not running, it must be started", fullInstanceName)
+		return fmt.Errorf("%s%w", fullInstanceName, errTheInstanceIsNotRunningItMustBeStarted)
 	}
 
 	alive, _ := process_utils.IsProcessAlive(pid)
 	if !alive {
-		return errors.New(instStateDead.String())
+		return errInstanceDead
 	}
 
 	if err := syscall.Kill(pid, syscall.SIGHUP); err != nil {
@@ -852,7 +886,7 @@ func Check(cmdCtx *cmdcontext.CmdCtx, run *InstanceCtx) error {
 		context.Background(), cmdCtx.Cli.TarantoolCli.Executable, "-e", checkSyntax)
 	cmd.Stderr = &errBuff
 	if err := cmd.Run(); err != nil {
-		return errors.New(errBuff.String())
+		return syntaxCheckError(errBuff.String())
 	}
 
 	return nil
@@ -873,12 +907,12 @@ func GetAppInstanceName(instance InstanceCtx) string {
 
 // IsAbleToStartInstances checks if it is possible to start instances.
 func IsAbleToStartInstances(instances []InstanceCtx, cmdCtx *cmdcontext.CmdCtx) (
-	bool, string,
+	bool, error,
 ) {
 	if _, err := cmdCtx.Cli.TarantoolCli.GetVersion(); err != nil {
-		return false, err.Error()
+		return false, err
 	}
-	return true, ""
+	return true, nil
 }
 
 // StartWatchdog starts tarantool instance with watchdog.

--- a/cli/running/running_test.go
+++ b/cli/running/running_test.go
@@ -351,7 +351,7 @@ echo "Tarantool 3.0.0"`),
 		[]byte(`#!/bin/bash
 echo "Tarantool 3.0.0"`), 0o644)
 	require.NoError(t, err)
-	canStart, reason := IsAbleToStartInstances([]InstanceCtx{
+	canStart, err = IsAbleToStartInstances([]InstanceCtx{
 		{
 			InstanceScript: "init.lua",
 		},
@@ -363,7 +363,7 @@ echo "Tarantool 3.0.0"`), 0o644)
 		},
 	})
 	assert.False(t, canStart)
-	assert.Contains(t, reason, "permission denied")
+	assert.ErrorContains(t, err, "permission denied")
 }
 
 func TestCollectInstancesForFileApp(t *testing.T) {

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -3,6 +3,7 @@ package running
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/lib/integrity"
+)
+
+var (
+	errSocketPathIsLongerThanSymbols = errors.New("socket path is longer than ")
 )
 
 const (
@@ -54,8 +59,8 @@ func verifySocketLength(socketPath string) error {
 
 	if socketPath != "" {
 		if len(socketPath) >= maxSocketPath {
-			return fmt.Errorf("socket path is longer than %d symbols: %q",
-				maxSocketPath-1, socketPath)
+			return fmt.Errorf("%w%d symbols: %q",
+				errSocketPathIsLongerThanSymbols, maxSocketPath-1, socketPath)
 		}
 		return nil
 	}

--- a/cli/search/bundle.go
+++ b/cli/search/bundle.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -11,6 +12,18 @@ import (
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
 	"github.com/tarantool/tt/lib/connect"
+)
+
+var (
+	errNoAvailableVersions                      = errors.New("no available versions")
+	errNoPackagesFoundForThisOSOrReleaseVersion = errors.New(
+		"no packages found for this OS or release version",
+	)
+	errTarantoolIOPackageNotFound = errors.New(
+		"there is no tarantool.io package for program: ",
+	)
+	errUnknownVersionFormatForProgram = errors.New("unknown version format for program: ")
+	errVersionNotFound                = errors.New(" version doesn't found")
 )
 
 // BundleInfo is a structure that contains specific information about SDK bundle.
@@ -89,7 +102,7 @@ func compileVersionRegexp(prg Program) (*regexp.Regexp, error) {
 	case ProgramTcm:
 		expr = `^(?P<tarball>tcm-(?P<version>\d+\.\d+\.\d+[^.]*).*\.tar\.gz)$`
 	default:
-		return nil, fmt.Errorf("unknown version format for program: %q", prg)
+		return nil, fmt.Errorf("%w%q", errUnknownVersionFormatForProgram, prg)
 	}
 
 	re := regexp.MustCompile(expr)
@@ -157,7 +170,7 @@ func getBundles(rawBundleInfoList map[string][]string, searchCtx *SearchCtx) (
 	}
 
 	if len(bundles) == 0 {
-		return nil, fmt.Errorf("no packages found for this OS or release version")
+		return nil, errNoPackagesFoundForThisOSOrReleaseVersion
 	}
 
 	sort.Sort(bundles)
@@ -172,8 +185,8 @@ func FetchBundlesInfo(searchCtx *SearchCtx, cliOpts *config.CliOpts) (
 ) {
 	searchCtx.Package = GetAPIPackage(searchCtx.Program)
 	if searchCtx.Package == "" {
-		return nil, fmt.Errorf("there is no tarantool.io package for program: %s",
-			searchCtx.Program)
+		return nil, fmt.Errorf("%w%s",
+			errTarantoolIOPackageNotFound, searchCtx.Program)
 	}
 
 	var credPath string
@@ -203,7 +216,7 @@ func FetchBundlesInfo(searchCtx *SearchCtx, cliOpts *config.CliOpts) (
 // If no version is specified, it returns the latest version.
 func SelectVersion(bs BundleInfoSlice, ver string) (BundleInfo, error) {
 	if bs == nil || bs.Len() == 0 {
-		return BundleInfo{}, fmt.Errorf("no available versions")
+		return BundleInfo{}, errNoAvailableVersions
 	}
 	if ver == "" {
 		// No version specified, return the latest one.
@@ -216,5 +229,5 @@ func SelectVersion(bs BundleInfoSlice, ver string) (BundleInfo, error) {
 		}
 	}
 
-	return BundleInfo{}, fmt.Errorf("%q version doesn't found", ver)
+	return BundleInfo{}, fmt.Errorf("%q%w", ver, errVersionNotFound)
 }

--- a/cli/search/program_types.go
+++ b/cli/search/program_types.go
@@ -1,6 +1,13 @@
 package search
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errUnknownProgram = errors.New("unknown program: ")
+)
 
 // Program represents a strictly typed enum for program types.
 type Program int
@@ -54,7 +61,7 @@ func ParseProgram(s string) (Program, error) {
 	if p, ok := stringToProgram[s]; ok {
 		return p, nil
 	}
-	return ProgramUnknown, fmt.Errorf("unknown program: %q", s)
+	return ProgramUnknown, fmt.Errorf("%w%q", errUnknownProgram, s)
 }
 
 // Exec returns an executable name of the Program.

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -10,6 +11,10 @@ import (
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
+)
+
+var (
+	errRemoteSearchForProgramIsNotImplemented = errors.New("remote search for program '")
 )
 
 type SearchFlags int64
@@ -81,7 +86,8 @@ func SearchVersions(searchCtx SearchCtx, cliOpts *config.CliOpts) error {
 	case ProgramEe, ProgramTcm: // Group of API-based searches.
 		vers, err = searchVersionsTntIo(cliOpts, &searchCtx)
 	default:
-		return fmt.Errorf("remote search for program '%s' is not implemented", prg)
+		return fmt.Errorf("%w%s' is not implemented",
+			errRemoteSearchForProgramIsNotImplemented, prg)
 	}
 
 	if err != nil {

--- a/cli/search/search_git.go
+++ b/cli/search/search_git.go
@@ -13,6 +13,16 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errGitRequired = errors.New(
+		"'git' is required for 'tt search' to work",
+	)
+	errUnableToGetCommitsGitCommandIsMissing = errors.New(
+		"unable to get commits: `git` command is missing",
+	)
+	errUnexpectedDataFrom = errors.New("unexpected Data from ")
+)
+
 const (
 	GitRepoTarantool         = "https://github.com/tarantool/tarantool.git"
 	GitRepoTT                = "https://github.com/tarantool/tt.git"
@@ -30,7 +40,7 @@ func GetVersionsFromGitRemote(repo string) (version.VersionSlice, error) {
 	versions := version.VersionSlice{}
 
 	if _, err := exec.LookPath("git"); err != nil {
-		return nil, errors.New("'git' is required for 'tt search' to work")
+		return nil, errGitRequired
 	}
 
 	output, err := exec.CommandContext(
@@ -49,7 +59,7 @@ func GetVersionsFromGitRemote(repo string) (version.VersionSlice, error) {
 	for _, line := range lines {
 		slashIdx := strings.LastIndex(line, "/")
 		if slashIdx == -1 {
-			return nil, fmt.Errorf("unexpected Data from %s", repo)
+			return nil, fmt.Errorf("%w%s", errUnexpectedDataFrom, repo)
 		} else {
 			slashIdx += 1
 		}
@@ -72,7 +82,7 @@ func GetVersionsFromGitRemote(repo string) (version.VersionSlice, error) {
 // GetCommitFromGitLocal returns hash or pr/ID info from specified local git repo.
 func GetCommitFromGitLocal(repo, input string) (string, error) {
 	if _, err := exec.LookPath("git"); err != nil {
-		return "", errors.New("unable to get commits: `git` command is missing")
+		return "", errUnableToGetCommitsGitCommandIsMissing
 	}
 
 	isPullRequest, pullRequestID := util.IsPullRequest(input)
@@ -106,7 +116,7 @@ func GetCommitFromGitLocal(repo, input string) (string, error) {
 // GetCommitFromGitRemote returns hash or pr/ID info from specified remote git repo.
 func GetCommitFromGitRemote(repo, input string) (string, error) {
 	if _, err := exec.LookPath("git"); err != nil {
-		return "", errors.New("unable to get commits: `git` command is missing")
+		return "", errUnableToGetCommitsGitCommandIsMissing
 	}
 
 	tempRepoPath, err := os.MkdirTemp("", "tt_install_repo")
@@ -132,7 +142,7 @@ func GetVersionsFromGitLocal(repo string) (version.VersionSlice, error) {
 	versions := version.VersionSlice{}
 
 	if _, err := exec.LookPath("git"); err != nil {
-		return nil, errors.New("'git' is required for 'tt search' to work")
+		return nil, errGitRequired
 	}
 
 	output, err := exec.CommandContext(context.Background(), "git", "-C", repo, "tag").Output()

--- a/cli/search/search_local.go
+++ b/cli/search/search_local.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -12,6 +13,11 @@ import (
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/util"
 	"github.com/tarantool/tt/cli/version"
+)
+
+var (
+	errLocalSDKFileSearchNotSupportedFor = errors.New("local SDK file search not supported for ")
+	errLocalSearchNotSupportedForProgram = errors.New("local search not supported for program '")
 )
 
 // searchVersionsLocalGit handles searching versions from a local Git repository clone.
@@ -100,7 +106,7 @@ func FindLocalBundles(program Program, fsys fs.FS) (BundleInfoSlice, error) {
 	case ProgramTcm:
 		prefix = "tcm-"
 	default:
-		return nil, fmt.Errorf("local SDK file search not supported for %q", program)
+		return nil, fmt.Errorf("%w%q", errLocalSDKFileSearchNotSupportedFor, program)
 	}
 
 	for _, v := range localFiles {
@@ -155,7 +161,7 @@ func SearchVersionsLocal(searchCtx SearchCtx, cliOpts *config.CliOpts, cfgPath s
 	case ProgramEe, ProgramTcm:
 		vers, err = searchVersionsLocalSDK(prg, localDir)
 	default:
-		return fmt.Errorf("local search not supported for program '%s'", prg)
+		return fmt.Errorf("%w%s'", errLocalSearchNotSupportedForProgram, prg)
 	}
 
 	if err != nil {

--- a/cli/search/search_local_test.go
+++ b/cli/search/search_local_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errNotImplemented = errors.New("not implemented")
+)
+
 // mockDirEntry is a mock implementation of fs.DirEntry for testing.
 type mockDirEntry struct {
 	name  string
@@ -24,7 +28,7 @@ func (m mockDirEntry) Name() string      { return m.name }
 func (m mockDirEntry) IsDir() bool       { return m.isDir }
 func (m mockDirEntry) Type() fs.FileMode { return 0 }
 func (m mockDirEntry) Info() (fs.FileInfo, error) {
-	return nil, errors.New("not implemented")
+	return nil, errNotImplemented
 }
 
 // mockFS is a mock implementation of fs.FS for testing.
@@ -47,7 +51,7 @@ func (m mockFS) ReadDir(name string) ([]fs.DirEntry, error) {
 
 // Open returns a dummy file for compatibility with interface [fs.FS].
 func (m mockFS) Open(name string) (fs.File, error) {
-	return nil, errors.New("not implemented")
+	return nil, errNotImplemented
 }
 
 func TestFindLocalBundles(t *testing.T) {

--- a/cli/search/search_sdk.go
+++ b/cli/search/search_sdk.go
@@ -1,10 +1,15 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tarantool/tt/cli/config"
 	"github.com/tarantool/tt/cli/version"
+)
+
+var (
+	errNoVersionsFoundForMatchingTheCriteria = errors.New("no versions found for ")
 )
 
 // GetAPIPackage returns the package name at tarantool.io for the given program.
@@ -31,8 +36,8 @@ func searchVersionsTntIo(cliOpts *config.CliOpts, searchCtx *SearchCtx) (
 	}
 
 	if len(bundles) == 0 {
-		return nil, fmt.Errorf("no versions found for %s matching the criteria",
-			searchCtx.Program)
+		return nil, fmt.Errorf("%w%s matching the criteria",
+			errNoVersionsFoundForMatchingTheCriteria, searchCtx.Program)
 	}
 
 	vers := make(version.VersionSlice, bundles.Len())

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -15,6 +15,14 @@ import (
 	"github.com/tarantool/tt/lib/connect"
 )
 
+var (
+	errNoAPIDoerWasApplied          = errors.New("no API doer was applied")
+	errNoPlatformInformerWasApplied = errors.New("no platform informer was applied")
+	errTarantoolIODoerMissing       = errors.New("no tarantool.io doer was applied")
+	errUnsupportedArchitecture      = errors.New("unsupported architecture: ")
+	errUnsupportedOS                = errors.New("unsupported OS: ")
+)
+
 const (
 	TntIoURI = "https://www.tarantool.io/en/accounts/customer_zone"
 	APIURI   = TntIoURI + "/api"
@@ -115,7 +123,7 @@ func getOsForAPI(informer PlatformInformer) (string, error) {
 	case util.OsMacos:
 		return "macos", nil
 	default:
-		return "", fmt.Errorf("unsupported OS: %d", os)
+		return "", fmt.Errorf("%w%d", errUnsupportedOS, os)
 	}
 }
 
@@ -145,7 +153,7 @@ func getArchForAPI(informer PlatformInformer, program Program) (string, error) {
 		// Return arch only if it in valid mapping.
 		return arch, nil
 	}
-	return "", fmt.Errorf("unsupported architecture: %s", arch)
+	return "", fmt.Errorf("%w%s", errUnsupportedArchitecture, arch)
 }
 
 func getBuildType(isDev bool) string {
@@ -160,7 +168,7 @@ func TntIoMakePkgURI(searchCtx *SearchCtx, tarball string) (string, error) {
 	var uri string
 
 	if searchCtx.platformInformer == nil || reflect.ValueOf(searchCtx.platformInformer).IsNil() {
-		return "", fmt.Errorf("no platform informer was applied")
+		return "", errNoPlatformInformerWasApplied
 	}
 
 	arch, err := getArchForAPI(searchCtx.platformInformer, searchCtx.Program)
@@ -235,7 +243,7 @@ func sendAPIRequest(request apiRequest, doer TntIoDoer) ([]byte, error) {
 	if doer != nil {
 		return doer.Do(req)
 	}
-	return nil, errors.New("no API doer was applied")
+	return nil, errNoAPIDoerWasApplied
 }
 
 // getSessionToken parse cookies to get session token.
@@ -280,10 +288,10 @@ func tntIoGetPkgVersions(credentials connect.UserCredentials, searchCtx *SearchC
 	map[string][]string, error,
 ) {
 	if searchCtx.TntIoDoer == nil {
-		return nil, fmt.Errorf("no tarantool.io doer was applied")
+		return nil, errTarantoolIODoerMissing
 	}
 	if searchCtx.platformInformer == nil {
-		return nil, fmt.Errorf("no platform informer was applied")
+		return nil, errNoPlatformInformerWasApplied
 	}
 
 	request, err := buildAPIQuery(searchCtx, credentials)

--- a/cli/search/tntio_api_test.go
+++ b/cli/search/tntio_api_test.go
@@ -20,6 +20,15 @@ import (
 	"github.com/tarantool/tt/cli/util"
 )
 
+var (
+	errInvalidContentType         = errors.New("invalid content type")
+	errInvalidRequestBodyContent  = errors.New("invalid request body content")
+	errInvalidRequestMethod       = errors.New("invalid request method")
+	errInvalidRequestPath         = errors.New("invalid request path")
+	errMissingRequestBody         = errors.New("missing request body")
+	errMockArchitectureNotApplied = errors.New("mock architecture not applied")
+)
+
 const (
 	testingUsername = "test-user"
 	testingPassword = "test-pass"
@@ -36,7 +45,7 @@ func (p *platformInfo) GetOs() (util.OsType, error) {
 
 func (p *platformInfo) GetArch() (string, error) {
 	if p.arch == "" {
-		return "", errors.New("mock architecture not applied")
+		return "", errMockArchitectureNotApplied
 	}
 	return p.arch, nil
 }
@@ -57,24 +66,24 @@ func (m *mockDoer) Do(req *http.Request) ([]byte, error) {
 
 	if req.Method != http.MethodPost {
 		m.t.Errorf("expected POST method, got %s", req.Method)
-		return nil, errors.New("invalid request method")
+		return nil, errInvalidRequestMethod
 	}
 
 	if req.URL.Path != "/en/accounts/customer_zone/api" {
 		m.t.Errorf("expected /en/accounts/customer_zone/api path, got %s", req.URL.Path)
-		return nil, errors.New("invalid request path")
+		return nil, errInvalidRequestPath
 	}
 
 	if req.Header.Get("Content-Type") != "application/json" {
 		m.t.Errorf("expected application/json content type, got %s",
 			req.Header.Get("Content-Type"))
-		return nil, errors.New("invalid content type")
+		return nil, errInvalidContentType
 	}
 
 	// Read and check the request body.
 	if req.Body == nil {
 		m.t.Error("expected request body, got nil")
-		return nil, errors.New("missing request body")
+		return nil, errMissingRequestBody
 	}
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
@@ -105,7 +114,7 @@ func (m *mockDoer) Do(req *http.Request) ([]byte, error) {
 
 	require.Equal(m.t, expectedRequest, actualRequest, "request body mismatch")
 	if m.t.Failed() {
-		return nil, errors.New("invalid request body content")
+		return nil, errInvalidRequestBodyContent
 	}
 
 	return json.Marshal(m.content)

--- a/cli/status/status.go
+++ b/cli/status/status.go
@@ -2,13 +2,19 @@ package status
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/tarantool/tt/cli/connector"
 	"github.com/tarantool/tt/cli/process_utils"
 	"github.com/tarantool/tt/cli/running"
+)
+
+var (
+	errNoDataReturnedFromLuaScript = errors.New("no data returned from Lua script")
 )
 
 // InstanceStatusPrinter interface defines methods to output instance status information.
@@ -120,11 +126,9 @@ func processReplicationInfo(instStatus *instanceStatus, uuid2name map[string]str
 
 		var upstreamInstanceDesc string
 		if ok || repl.Name != nil {
-			upstreamInstanceDesc = fmt.Sprintf("instance with name %q",
-				fullInstanceUpstreamName)
+			upstreamInstanceDesc = "instance with name " + strconv.Quote(fullInstanceUpstreamName)
 		} else {
-			upstreamInstanceDesc = fmt.Sprintf("instance with UUID %s",
-				fullInstanceUpstreamName)
+			upstreamInstanceDesc = "instance with UUID " + fullInstanceUpstreamName
 		}
 		instStatus.addAlert(fmt.Sprintf(
 			"[upstream][warning]: replication from %s is in %q status: %q",
@@ -177,10 +181,9 @@ func collectInstanceState(run running.InstanceCtx, fullInstanceName string,
 	}
 
 	if len(res) == 0 {
-		instStatus.addAlert(fmt.Sprintf(
-			"No data returned from Lua script on instance %s",
-			fullInstanceName), severityError)
-		return instanceState, fmt.Errorf("no data returned from Lua script")
+		instStatus.addAlert("No data returned from Lua script on instance "+fullInstanceName,
+			severityError)
+		return instanceState, errNoDataReturnedFromLuaScript
 	}
 
 	err = mapstructure.Decode(res[0], &instanceState)

--- a/cli/tail/follow.go
+++ b/cli/tail/follow.go
@@ -13,6 +13,12 @@ import (
 	"github.com/nxadm/tail"
 )
 
+var (
+	errFailedToReEstablishTailingForAfterRetries = errors.New("failed to re-establish tailing for ")
+	errNotFoundFile                              = errors.New("not found file ")
+	errTailerForIsNilAfterReopening              = errors.New("tailer for ")
+)
+
 const (
 	linesChannelCapacity = 64
 	maxRetriesReopen     = 5
@@ -50,7 +56,7 @@ func (f *fileFollower) Follow(ctx context.Context, lines int) (<-chan string, er
 
 	if err := f.startFollowing(ctx, out, lines); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("not found file %q", f.name)
+			return nil, fmt.Errorf("%w%q", errNotFoundFile, f.name)
 		}
 
 		return nil, fmt.Errorf("cannot read file %q: %w", f.name, err)
@@ -107,8 +113,8 @@ func (f *fileFollower) tryReopenTailer(ctx context.Context, cfg *tail.Config) (*
 		log.Warnf("Retry(%d) for %q: failed to re-initialize tailer: %v.", i, f.name, err)
 	}
 
-	return nil, fmt.Errorf("failed to re-establish tailing for %q after %d retries",
-		f.name, maxRetriesReopen)
+	return nil, fmt.Errorf("%w%q after %d retries",
+		errFailedToReEstablishTailingForAfterRetries, f.name, maxRetriesReopen)
 }
 
 func (f *fileFollower) handleTailerStopStatus(ctx context.Context, curT *tail.Tail) (
@@ -127,7 +133,8 @@ func (f *fileFollower) handleTailerStopStatus(ctx context.Context, curT *tail.Ta
 		}
 
 		if t == nil || t.Lines == nil {
-			return nil, fmt.Errorf("tailer for %q is nil after reopening", f.name)
+			return nil, fmt.Errorf("%w%q is nil after reopening",
+				errTailerForIsNilAfterReopening, f.name)
 		}
 
 		if ctx.Err() != nil {

--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -2,12 +2,18 @@ package tail_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/tarantool/tt/cli/tail"
+)
+
+var (
+	errLineMismatchGotWant   = errors.New("line ")
+	errTimeoutWaitingForData = errors.New("timeout waiting for data")
 )
 
 const (
@@ -28,7 +34,7 @@ func readWithTimeout(t *testing.T, ch <-chan string, timeout time.Duration) (str
 	case s := <-ch:
 		return s, nil
 	case <-timer.C:
-		return "", fmt.Errorf("timeout waiting for data")
+		return "", errTimeoutWaitingForData
 	}
 }
 
@@ -70,7 +76,8 @@ func checksLinesInFile(t *testing.T, ch <-chan string, expFmt string) error {
 
 		expected := fmt.Sprintf(expFmt, n)
 		if line != expected {
-			return fmt.Errorf("line %d mismatch: got %q, want %q", n, line, expected)
+			return fmt.Errorf("%w%d mismatch: got %q, want %q",
+				errLineMismatchGotWant, n, line, expected)
 		}
 	}
 

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -15,6 +15,10 @@ import (
 	"github.com/nxadm/tail"
 )
 
+var (
+	errNegativeLinesCountIsNotSupported = errors.New("negative lines count is not supported")
+)
+
 const (
 	blockSize               = 8192
 	formatterBufferCapacity = 512
@@ -128,7 +132,7 @@ func TailN(ctx context.Context, logFormatter LogFormatter, fileName string,
 	n int,
 ) (<-chan string, error) {
 	if n < 0 {
-		return nil, fmt.Errorf("negative lines count is not supported")
+		return nil, errNegativeLinesCountIsNotSupported
 	}
 
 	file, err := os.Open(fileName)

--- a/cli/tcm/log_test.go
+++ b/cli/tcm/log_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/tarantool/tt/cli/tcm"
 )
 
+var (
+	errFileOpen = errors.New("can't open file")
+)
+
 var updateTestdata = flag.Bool("update-testdata", false,
 	`Update "golden" data files for specified test(s)`)
 
@@ -262,7 +266,7 @@ var testCases = map[string]testCase{
 		isColor:  true,
 		lines:    10,
 		log:      "not-readable-file.log",
-		error:    errors.New("can't open file"),
+		error:    errFileOpen,
 		wantErr:  true,
 	},
 }

--- a/cli/templates/internal/engines/builtin_funcs.go
+++ b/cli/templates/internal/engines/builtin_funcs.go
@@ -1,7 +1,13 @@
 package engines
 
 import (
+	"errors"
 	"fmt"
+)
+
+var (
+	errReplicasetsizeMustBeIn    = errors.New("replicasetSize must be in [")
+	errReplicasetsnumberMustBeIn = errors.New("replicasetsNumber must be in [")
 )
 
 // genState describes template generation state.
@@ -52,10 +58,10 @@ func genReplicasets(
 	replicasetSize int,
 ) ([]replicaset, error) {
 	if replicasetsNumber <= 0 || replicasetsNumber > maxReplicasetsNumber {
-		return nil, fmt.Errorf("replicasetsNumber must be in [%d, %d]", 0, maxReplicasetsNumber)
+		return nil, fmt.Errorf("%w%d, %d]", errReplicasetsnumberMustBeIn, 0, maxReplicasetsNumber)
 	}
 	if replicasetSize <= 0 || replicasetSize > maxReplicasetSize {
-		return nil, fmt.Errorf("replicasetSize must be in [%d, %d]", 0, maxReplicasetSize)
+		return nil, fmt.Errorf("%w%d, %d]", errReplicasetsizeMustBeIn, 0, maxReplicasetSize)
 	}
 
 	replicasets := make([]replicaset, replicasetsNumber)

--- a/cli/uninstall/uninstall.go
+++ b/cli/uninstall/uninstall.go
@@ -19,6 +19,14 @@ import (
 	"github.com/tarantool/tt/cli/version"
 )
 
+var (
+	errDirectoryNotFound                = errors.New("couldn't find ")
+	errHasNoInstalledVersion            = errors.New(" has no installed version")
+	errMultipleInstalledVersions        = errors.New(" has more than one installed version, ")
+	errThereWasSomeProblemLocating      = errors.New("there was some problem locating ")
+	errThereWasSomeProblemWithDirectory = errors.New("there was some problem with ")
+)
+
 const binaryNameMatchGroups = 2
 
 const (
@@ -29,7 +37,7 @@ const (
 	MajorMinorPatchRegexp = `^[0-9]+\.[0-9]+\.[0-9]+`
 )
 
-var errNotInstalled = errors.New("program is not installed")
+var errNotInstalled = errors.New("not installed")
 
 // remove removes binary/directory and symlinks from directory.
 // It returns true if symlink was removed, error.
@@ -42,18 +50,18 @@ func remove(program search.Program, programVersion, directory string) (bool, err
 	}
 
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		return false, fmt.Errorf("couldn't find %s directory", directory)
+		return false, fmt.Errorf("%w%s directory", errDirectoryNotFound, directory)
 	} else if err != nil {
-		return false, fmt.Errorf("there was some problem with %s directory", directory)
+		return false, fmt.Errorf("%w%s directory", errThereWasSomeProblemWithDirectory, directory)
 	}
 
 	fileName := program.String() + version.FsSeparator + programVersion
 	path := filepath.Join(directory, fileName)
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return false, errNotInstalled
+		return false, fmt.Errorf("program is %w", errNotInstalled)
 	} else if err != nil {
-		return false, fmt.Errorf("there was some problem locating %s", path)
+		return false, fmt.Errorf("%w%s", errThereWasSomeProblemLocating, path)
 	}
 
 	var isSymlinkRemoved bool
@@ -103,7 +111,7 @@ func UninstallProgram(
 			return err
 		}
 		if !isTarantoolDevInstalled {
-			return fmt.Errorf("%s is not installed", program)
+			return fmt.Errorf("%s is %w", program, errNotInstalled)
 		}
 		if err := os.Remove(tarantoolBinarySymlink); err != nil {
 			return err
@@ -194,15 +202,15 @@ func getDefault(program search.Program, dir string) (string, error) {
 	for _, file := range installedPrograms {
 		matches := util.FindNamedMatches(re, file.Name())
 		if ver != "" {
-			return "", fmt.Errorf("%s has more than one installed version, "+
-				"please specify the version to uninstall", program)
+			return "", fmt.Errorf("%s%wplease specify the version to uninstall",
+				program, errMultipleInstalledVersions)
 		} else {
 			ver = matches["ver"]
 		}
 	}
 
 	if ver == "" {
-		return "", fmt.Errorf("%s has no installed version", program)
+		return "", fmt.Errorf("%s%w", program, errHasNoInstalledVersion)
 	}
 	return ver, nil
 }

--- a/cli/util/compress.go
+++ b/cli/util/compress.go
@@ -70,7 +70,8 @@ func ExtractTarGz(tarName, dstDir string) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
+			return fmt.Errorf("%w%b in %s",
+				errUnknownArchiveEntryType, header.Typeflag, header.Name)
 		}
 	}
 	return nil

--- a/cli/util/crypto.go
+++ b/cli/util/crypto.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 	"io"
 	"os"
 )
@@ -23,7 +23,7 @@ func FileSHA256Hex(path string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // FileSHA1Hex computes SHA1 for a given file.
@@ -40,7 +40,7 @@ func FileSHA1Hex(path string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // FileMD5 computes MD5 for a given file.
@@ -68,7 +68,7 @@ func FileMD5Hex(path string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", fileMD5), nil
+	return hex.EncodeToString(fileMD5), nil
 }
 
 // StringSHA1Hex computes SHA1 for a given string
@@ -77,5 +77,5 @@ func StringSHA1Hex(source string) string {
 	hasher := sha1.New()
 	hasher.Write([]byte(source))
 
-	return fmt.Sprintf("%x", hasher.Sum(nil))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/cli/util/execute.go
+++ b/cli/util/execute.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,10 @@ import (
 
 	"github.com/apex/log"
 	"github.com/briandowns/spinner"
+)
+
+var (
+	errHookShouldBeExecutable = errors.New("hook `")
 )
 
 type emptyStruct struct{}
@@ -62,7 +67,7 @@ func StartCommandSpinner(readyChannel readyChan, wg *sync.WaitGroup, prefix stri
 
 	spinner := spinner.New(spinnerPicture, spinnerUpdateTime)
 	if prefix != "" {
-		spinner.Prefix = fmt.Sprintf("%s ", strings.TrimSpace(prefix))
+		spinner.Prefix = strings.TrimSpace(prefix) + " "
 	}
 
 	spinner.Start()
@@ -131,7 +136,7 @@ func RunHook(hookPath string, showOutput bool) error {
 	if isExec, err := IsExecOwner(hookPath); err != nil {
 		return fmt.Errorf("failed go check hook file `%s`: %w", hookName, err)
 	} else if !isExec {
-		return fmt.Errorf("hook `%s` should be executable", hookName)
+		return fmt.Errorf("%w%s` should be executable", errHookShouldBeExecutable, hookName)
 	}
 
 	hookCmd := exec.CommandContext(context.Background(), hookPath)

--- a/cli/util/git.go
+++ b/cli/util/git.go
@@ -3,7 +3,7 @@ package util
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"regexp"
@@ -13,6 +13,12 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+var (
+	errEmptyPathIsPassed  = errors.New("empty path is passed")
+	errNoGitVersionFound  = errors.New("no git version found")
+	errCommitHashTooShort = errors.New("the hash must contain at least 7 characters")
+)
+
 // MinCommitHashLength is the Git default for a short SHA.
 const MinCommitHashLength = 7
 
@@ -20,7 +26,7 @@ const MinCommitHashLength = 7
 // it is a git repo, parses and returns a normalized string.
 func CheckVersionFromGit(basePath string) (string, error) {
 	if basePath == "" {
-		return "", fmt.Errorf("empty path is passed")
+		return "", errEmptyPathIsPassed
 	}
 	startPath, _ := os.Getwd()
 	defer func() {
@@ -36,7 +42,7 @@ func CheckVersionFromGit(basePath string) (string, error) {
 	cmd.Stdout = &out
 	err = cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("no git version found")
+		return "", errNoGitVersionFound
 	}
 
 	version := strings.TrimSpace(out.String())
@@ -75,7 +81,7 @@ func IsGitFetchJobsSupported() bool {
 // IsValidCommitHash checks hash format.
 func IsValidCommitHash(hash string) (bool, error) {
 	if len(hash) < MinCommitHashLength {
-		return false, fmt.Errorf("the hash must contain at least 7 characters")
+		return false, errCommitHashTooShort
 	}
 	return regexp.MatchString(`^[0-9a-f]+$`, hash)
 }

--- a/cli/util/regexputil/regexp.go
+++ b/cli/util/regexputil/regexp.go
@@ -1,11 +1,16 @@
 package regexputil
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"regexp"
 	"slices"
 	"strings"
+)
+
+var (
+	errMissingVarsInTemplateString = errors.New("missing vars: ")
 )
 
 var varPattern = regexp.MustCompile(`{{\s*([^ ]+)\s*}}`)
@@ -25,7 +30,8 @@ func ApplyVars(templateStr string, data map[string]string) (string, error) {
 	})
 
 	if len(missingVars) > 0 {
-		return renderedStr, fmt.Errorf("missing vars: %s\nin template string: %q",
+		return renderedStr, fmt.Errorf("%w%s\nin template string: %q",
+			errMissingVarsInTemplateString,
 			strings.Join(slices.Collect(maps.Keys(missingVars)), ","), templateStr)
 	}
 

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -31,6 +31,22 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var (
+	errAlreadyExistsAndIsNotADirectory = errors.New("already exists and is not a directory")
+	errInternal                        = errors.New(
+		"whoops! It looks like something is wrong with this version of Tarantool CLI.\nError: ",
+	)
+	errMissedRequiredBinaries                         = errors.New("missed required binaries ")
+	errMoreThanOneYAMLFilesAreFoundAmbiguousSelection = errors.New(
+		"more than one YAML files are found",
+	)
+	errInvalidYAMLFileExtension                 = errors.New("provided file '")
+	errSymbolicLinkCannotBeCreatedAlreadyExists = errors.New(
+		"symbolic link cannot be created: '",
+	)
+	errUnknownArchiveEntryType = errors.New("unknown type: ")
+)
+
 const bufSize int64 = 10000
 
 const archiveDirectoryMode = 0o755
@@ -135,14 +151,10 @@ func Find(src []string, find string) int {
 
 // InternalError shows error information, version of tt and call stack.
 func InternalError(format string, f VersionFunc, err ...any) error {
-	errorFmt := `whoops! It looks like something is wrong with this version of Tarantool CLI.
-Error: %s
-Version: %s
-Stacktrace:
-%s`
 	version := f(false, false)
 
-	return fmt.Errorf(errorFmt, fmt.Sprintf(format, err...), version, debug.Stack())
+	return fmt.Errorf("%w%s\nVersion: %s\nStacktrace:\n%s",
+		errInternal, fmt.Sprintf(format, err...), version, debug.Stack())
 }
 
 // ParseYAML parse yaml file at specified path.
@@ -605,7 +617,8 @@ func ExtractTar(tarName string) error {
 			outFile.Close()
 
 		default:
-			return fmt.Errorf("unknown type: %b in %s", header.Typeflag, header.Name)
+			return fmt.Errorf("%w%b in %s",
+				errUnknownArchiveEntryType, header.Typeflag, header.Name)
 		}
 	}
 	return nil
@@ -692,7 +705,8 @@ func CreateSymlink(oldName, newName string, overwrite bool) error {
 		return os.Symlink(oldName, newName)
 	}
 	if !overwrite {
-		return fmt.Errorf("symbolic link cannot be created: '%s' already exists", newName)
+		return fmt.Errorf("%w%s' already exists",
+			errSymbolicLinkCannotBeCreatedAlreadyExists, newName)
 	}
 	log.Debugf("Replace existing '%s' with new symlink.", newName)
 	if err := os.Remove(newName); err != nil {
@@ -730,7 +744,7 @@ func CheckRequiredBinaries(binaries ...string) error {
 	missedBinaries := getMissedBinaries(binaries...)
 
 	if len(missedBinaries) > 0 {
-		return fmt.Errorf("missed required binaries %s", strings.Join(missedBinaries, ", "))
+		return fmt.Errorf("%w%s", errMissedRequiredBinaries, strings.Join(missedBinaries, ", "))
 	}
 
 	return nil
@@ -745,7 +759,7 @@ func CreateDirectory(dirName string, fileMode os.FileMode) error {
 		}
 	} else {
 		if !stat.IsDir() {
-			return fmt.Errorf("'%s' already exists and is not a directory", dirName)
+			return fmt.Errorf("'%s' %w", dirName, errAlreadyExistsAndIsNotADirectory)
 		}
 		return nil
 	}
@@ -826,10 +840,11 @@ func GetYamlFileName(fileName string, mustExist bool) (string, error) {
 	case "":
 		fileBaseName = fileName
 	default:
-		return "", fmt.Errorf("provided file '%s' has no .yaml/.yml extension", fileName)
+		return "", fmt.Errorf("%w%s' has no .yaml/.yml extension",
+			errInvalidYAMLFileExtension, fileName)
 	}
 	foundYamlFiles := []string{}
-	if foundFiles, err := filepath.Glob(fmt.Sprintf("%s.y*ml", fileBaseName)); err == nil {
+	if foundFiles, err := filepath.Glob(fileBaseName + ".y*ml"); err == nil {
 		for _, fileName := range foundFiles {
 			switch filepath.Ext(fileName) {
 			case ".yaml", ".yml":
@@ -842,8 +857,8 @@ func GetYamlFileName(fileName string, mustExist bool) (string, error) {
 	yamlFilesCount := len(foundYamlFiles)
 	switch {
 	case yamlFilesCount > 1:
-		return "", fmt.Errorf("more than one YAML files are found:\n%s\nAmbiguous selection",
-			strings.Join(foundYamlFiles, ", "))
+		return "", fmt.Errorf("%w:\n%s\nAmbiguous selection",
+			errMoreThanOneYAMLFilesAreFoundAmbiguousSelection, strings.Join(foundYamlFiles, ", "))
 	case yamlFilesCount == 1:
 		return foundYamlFiles[0], nil
 	case !mustExist:

--- a/cli/version/version_match.go
+++ b/cli/version/version_match.go
@@ -1,10 +1,20 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
 	"github.com/tarantool/tt/cli/util"
+)
+
+var (
+	errMinorVersionRequiresMajorToBeSpecified = errors.New(
+		"minor version requires major to be specified",
+	)
+	errPatchVersionRequiresMinorToBeSpecified = errors.New(
+		"patch version requires minor to be specified",
+	)
 )
 
 type (
@@ -62,7 +72,7 @@ func exploreMatchVersion(verStr string) (Version, requiredFields, error) {
 
 	if matches["minor"] != "" {
 		if matches["major"] == "" {
-			return version, fields, fmt.Errorf("minor version requires major to be specified")
+			return version, fields, errMinorVersionRequiresMajorToBeSpecified
 		}
 		if version.Minor, err = util.AtoiUint64(matches["minor"]); err != nil {
 			return version, fields, fmt.Errorf("can't parse Minor: %w", err)
@@ -72,7 +82,7 @@ func exploreMatchVersion(verStr string) (Version, requiredFields, error) {
 
 	if matches["patch"] != "" {
 		if matches["minor"] == "" {
-			return version, fields, fmt.Errorf("patch version requires minor to be specified")
+			return version, fields, errPatchVersionRequiresMinorToBeSpecified
 		}
 		if version.Patch, err = util.AtoiUint64(matches["patch"]); err != nil {
 			return version, fields, fmt.Errorf("can't parse Patch version: %w", err)

--- a/cli/version/version_tools.go
+++ b/cli/version/version_tools.go
@@ -1,12 +1,25 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/tarantool/tt/cli/util"
 )
+
+var (
+	errFailedToParseVersionFormatIsNotValid = errors.New("failed to parse version ")
+	errHashHasAWrongFormat                  = errors.New("hash ")
+	errVersionDoesNotMatchSemanticFormat    = errors.New("the version of ")
+	errUnknownReleaseType                   = errors.New("unknown release type ")
+)
+
+func newInvalidVersionError(version string) error {
+	return fmt.Errorf("%w%q: format is not valid",
+		errFailedToParseVersionFormatIsNotValid, version)
+}
 
 type ReleaseType uint16
 
@@ -47,7 +60,7 @@ func newRelease(release, releaseNum string) (Release, error) {
 		case "entrypoint":
 			newRelease.Type = TypeNightly
 		default:
-			return newRelease, fmt.Errorf("unknown release type %q", release)
+			return newRelease, fmt.Errorf("%w%q", errUnknownReleaseType, release)
 		}
 		if releaseNum != "" {
 			var err error
@@ -100,7 +113,7 @@ func matchVersionParts(version string, isStrict bool) (map[string]string, error)
 	re := createVersionRegexp(isStrict)
 	matches := util.FindNamedMatches(re, version)
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("failed to parse version %q: format is not valid", version)
+		return nil, newInvalidVersionError(version)
 	}
 	return matches, nil
 }
@@ -158,14 +171,14 @@ func ParseTt(verStr string) (Version, error) {
 	verToParse := strings.Trim(verStr, "\n")
 	sepIndex := strings.LastIndex(verToParse, ".")
 	if sepIndex == -1 {
-		return Version{}, fmt.Errorf("failed to parse version %q: format is not valid", verStr)
+		return Version{}, newInvalidVersionError(verStr)
 	}
 
 	verStr = verToParse[:sepIndex]
 	numVersions := strings.Split(verStr, ".")
 	if len(numVersions) != semanticVersionParts {
-		return Version{}, fmt.Errorf("the version of %q does not match"+
-			" <major>.<minor>.<patch> format", verStr)
+		return Version{}, fmt.Errorf("%w%q does not match <major>.<minor>.<patch> format",
+			errVersionDoesNotMatchSemanticFormat, verStr)
 	}
 
 	var err error
@@ -190,7 +203,7 @@ func ParseTt(verStr string) (Version, error) {
 		return Version{}, err
 	}
 	if !isHashValid {
-		return Version{}, fmt.Errorf("hash %q has a wrong format", hashStr)
+		return Version{}, fmt.Errorf("%w%q has a wrong format", errHashHasAWrongFormat, hashStr)
 	}
 	ttVersion.Hash = hashStr
 	ttVersion.Str = verToParse

--- a/cli/version/version_tools_test.go
+++ b/cli/version/version_tools_test.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -192,18 +191,17 @@ func TestParseVersion(t *testing.T) {
 
 	testCases["2.8"] = returnValueParseVersion{
 		Version{},
-		fmt.Errorf("failed to parse version \"2.8\": format is not valid"),
+		newInvalidVersionError("2.8"),
 	}
 
 	testCases["42"] = returnValueParseVersion{
 		Version{},
-		fmt.Errorf("failed to parse version \"42\": format is not valid"),
+		newInvalidVersionError("42"),
 	}
 
 	testCases["2.11.0-0-gc9673ebb7-r575-gc32"] = returnValueParseVersion{
 		Version{},
-		fmt.Errorf("failed to parse version \"2.11.0-0-gc9673ebb7-r575-gc32\": " +
-			"format is not valid"),
+		newInvalidVersionError("2.11.0-0-gc9673ebb7-r575-gc32"),
 	}
 
 	for input, output := range testCases {
@@ -253,16 +251,16 @@ func TestParseTt(t *testing.T) {
 			inputVer:    "2131f7cc1de",
 			expectedVer: Version{},
 			isErr:       true,
-			expectedErrMsg: fmt.Sprintf(`failed to parse version "2131f7cc1de":` +
-				` format is not valid`),
+			expectedErrMsg: `failed to parse version "2131f7cc1de":` +
+				` format is not valid`,
 		},
 		{
 			name:        "version does not match",
 			inputVer:    "2.1.3.1.f7cc1de",
 			expectedVer: Version{},
 			isErr:       true,
-			expectedErrMsg: fmt.Sprintf(`the version of "2.1.3.1" does not match` +
-				` <major>.<minor>.<patch> format`),
+			expectedErrMsg: `the version of "2.1.3.1" does not match` +
+				` <major>.<minor>.<patch> format`,
 		},
 		{
 			name:           "hash does not match",

--- a/lib/cluster/factory.go
+++ b/lib/cluster/factory.go
@@ -1,12 +1,18 @@
 package cluster
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/tarantool/go-storage"
 	gcrypto "github.com/tarantool/go-storage/crypto"
 	"github.com/tarantool/go-storage/hasher"
+)
+
+var (
+	errPublishingIntoAFileWithIntegrityDataIsNotSupported = errors.New(
+		"publishing into a file with integrity data is not supported",
+	)
 )
 
 // IntegrityOptions configure integrity-aware typed storage builder options.
@@ -73,7 +79,7 @@ func (f Factory) NewFileCollector(path string) DataCollector {
 // auxiliary data needed for signatures).
 func (f Factory) NewFilePublisher(path string) (DataPublisher, error) {
 	if f.integrity != nil {
-		return nil, fmt.Errorf("publishing into a file with integrity data is not supported")
+		return nil, errPublishingIntoAFileWithIntegrityDataIsNotSupported
 	}
 	return NewFilePublisher(path), nil
 }

--- a/lib/cluster/file.go
+++ b/lib/cluster/file.go
@@ -1,9 +1,14 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+)
+
+var (
+	errFilePathIsEmpty = errors.New("file path is empty")
 )
 
 const publishedFileMode = 0o644
@@ -54,15 +59,14 @@ func NewFilePublisher(path string) FilePublisher {
 // Publish publishes the data to a file for the given path.
 func (publisher FilePublisher) Publish(revision int64, data []byte) error {
 	if revision != 0 {
-		return fmt.Errorf("failed to publish data into file: target revision %d is not supported",
-			revision)
+		return fmt.Errorf("failed to publish data into file: %w%d is not supported",
+			errTargetRevisionIsNotSupported, revision)
 	}
 	if publisher.path == "" {
-		return fmt.Errorf("file path is empty")
+		return errFilePathIsEmpty
 	}
 	if data == nil {
-		return fmt.Errorf("failed to publish data into %q: data does not exist",
-			publisher.path)
+		return fmt.Errorf("failed to publish data into %q: %w", publisher.path, errDataMissing)
 	}
 
 	if err := os.WriteFile(publisher.path, data, publishedFileMode); err != nil {

--- a/lib/cluster/file_test.go
+++ b/lib/cluster/file_test.go
@@ -2,7 +2,6 @@ package cluster_test
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,6 +18,8 @@ const (
 	testYamlPath    = "testdata/test.yaml"
 )
 
+var errFoo = errors.New("foo")
+
 func TestNewFileCollector(t *testing.T) {
 	var collector cluster.DataCollector = cluster.NewFileCollector(testYamlPath)
 
@@ -30,7 +31,7 @@ func TestNewFileCollector_fileReadFunc_error(t *testing.T) {
 
 	factory := cluster.NewFactory(
 		cluster.WithFileReadFunc(func(path string) (io.ReadCloser, error) {
-			return nil, errors.New(errMsg)
+			return nil, errFoo
 		}),
 	)
 	collector := factory.NewFileCollector("foo")
@@ -39,7 +40,7 @@ func TestNewFileCollector_fileReadFunc_error(t *testing.T) {
 	data, err := collector.Collect()
 
 	assert.Nil(t, data)
-	assert.EqualError(t, err, fmt.Sprintf("unable to read file \"foo\": %s", errMsg))
+	assert.EqualError(t, err, "unable to read file \"foo\": "+errMsg)
 }
 
 func TestFileCollector_valid(t *testing.T) {

--- a/lib/cluster/integration_test.go
+++ b/lib/cluster/integration_test.go
@@ -2,6 +2,7 @@ package cluster_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,11 @@ import (
 	tcs_helper "github.com/tarantool/go-tarantool/v2/test_helpers/tcs"
 
 	"github.com/tarantool/tt/lib/cluster"
+)
+
+var (
+	errAnyError = errors.New("any error")
+	errDataSig  = errors.New("data ")
 )
 
 // yamlUnmarshal is a thin wrapper for unmarshalling YAML in tests.
@@ -723,7 +729,7 @@ func (sv echoSignerVerifier) Sign(data []byte) ([]byte, error) {
 
 func (sv echoSignerVerifier) Verify(data []byte, sig []byte) error {
 	if string(data) != string(sig) {
-		return fmt.Errorf("data %q != sig %q", string(data), string(sig))
+		return fmt.Errorf("%w%q != sig %q", errDataSig, string(data), string(sig))
 	}
 
 	return nil
@@ -1006,7 +1012,7 @@ func TestIntegrityDataPublisher_CollectorAll_check_error(t *testing.T) {
 					Verifiers: []gcrypto.Verifier{
 						failingSignerVerifier{
 							name: "sig",
-							err:  fmt.Errorf("any error"),
+							err:  errAnyError,
 						},
 					},
 				},
@@ -1054,7 +1060,7 @@ func TestIntegrityDataPublisher_CollectorKey_check_error(t *testing.T) {
 					Verifiers: []gcrypto.Verifier{
 						failingSignerVerifier{
 							name: "sig",
-							err:  fmt.Errorf("any error"),
+							err:  errAnyError,
 						},
 					},
 				}, testPrefix, "all", inst)
@@ -1085,7 +1091,7 @@ func TestIntegrityDataPublisherKey_sign_error(t *testing.T) {
 					SignerVerifiers: []gcrypto.SignerVerifier{
 						failingSignerVerifier{
 							name: "sig",
-							err:  fmt.Errorf("any error"),
+							err:  errAnyError,
 						},
 					},
 				}, testPrefix, "bar", inst)
@@ -1116,7 +1122,7 @@ func TestIntegrityDataPublisherAll_sign_error(t *testing.T) {
 					SignerVerifiers: []gcrypto.SignerVerifier{
 						failingSignerVerifier{
 							name: "sig",
-							err:  fmt.Errorf("any error"),
+							err:  errAnyError,
 						},
 					},
 				}, testPrefix, "", inst)

--- a/lib/cluster/storage.go
+++ b/lib/cluster/storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -26,6 +27,16 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+)
+
+var (
+	errAConfigurationDataNotFoundInForPrefix = errors.New(
+		"a configuration data not found in ",
+	)
+	errFailedToConnectToTarantoolAtLeastOneEndpointIsRequired = errors.New(
+		"failed to connect to tarantool: at least one endpoint is required",
+	)
+	errTargetRevisionIsNotSupported = errors.New("target revision ")
 )
 
 // WatchEvent is delivered on Watch channels when a watched key changes.
@@ -135,8 +146,8 @@ func (r *RawStorage) Collect() ([]Data, error) {
 		return nil, fmt.Errorf("failed to fetch data from %s: %w", r.storageType, err)
 	}
 	if len(kvs) == 0 {
-		return nil, fmt.Errorf("a configuration data not found in %s for prefix %q",
-			r.storageType, r.prefix)
+		return nil, fmt.Errorf("%w%s for prefix %q",
+			errAConfigurationDataNotFoundInForPrefix, r.storageType, r.prefix)
 	}
 
 	data := make([]Data, 0, len(kvs))
@@ -171,8 +182,8 @@ func (r *RawStorage) Publish(revision int64, data []byte) error {
 	}
 
 	if revision != 0 {
-		return fmt.Errorf("failed to publish data into %s: target revision %d is not supported",
-			r.storageType, revision)
+		return fmt.Errorf("failed to publish data into %s: %w%d is not supported",
+			r.storageType, errTargetRevisionIsNotSupported, revision)
 	}
 	if err := r.storage.Delete(ctx, "/", integrity.WithPrefix()); err != nil {
 		return fmt.Errorf("failed to clean data from %s: %w", r.storageType, err)
@@ -361,7 +372,7 @@ func makeEtcdTLSConfig(sslCfg gsconnect.SSLConfig) (*tls.Config, error) {
 // using the provided configuration for address, credentials and TLS.
 func connectTarantoolConnector(cfg gsconnect.Config) (tarantool.Connector, error) {
 	if len(cfg.Endpoints) == 0 {
-		return nil, fmt.Errorf("failed to connect to tarantool: at least one endpoint is required")
+		return nil, errFailedToConnectToTarantoolAtLeastOneEndpointIsRequired
 	}
 
 	dialOpts := dial.Opts{
@@ -449,7 +460,7 @@ func getTarantoolCfg(connOpts ConnectOpts, uriOpts libconnect.URIOpts) gsconnect
 		}
 	}
 
-	addr := fmt.Sprintf("tcp://%s", uriOpts.Host)
+	addr := "tcp://" + uriOpts.Host
 
 	return gsconnect.Config{
 		Endpoints:   []string{addr},

--- a/lib/connect/credentials.go
+++ b/lib/connect/credentials.go
@@ -2,12 +2,22 @@ package connect
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"syscall"
 
 	"golang.org/x/term"
+)
+
+var (
+	errLoginNotSet                                  = errors.New("login not set")
+	errNoCredentialsInEnvironmentVariablesWereFound = errors.New(
+		"no credentials in environment variables were found",
+	)
+	errPasswordNotSet           = errors.New("password not set")
+	errPermissionsForAreTooOpen = errors.New("permissions ")
 )
 
 const forbiddenCredentialPermissions = 0o077
@@ -63,8 +73,8 @@ func getCredsFromFile(path string) (UserCredentials, error) {
 
 	// Check file permissions. Error if `group` or `other` bits are set.
 	if info.Mode().Perm()&os.FileMode(forbiddenCredentialPermissions) != 0 {
-		return res, fmt.Errorf("permissions %q for %q are too open.\n\t%s\n\t%s %s'",
-			info.Mode(),
+		return res, fmt.Errorf("%w%q for %q are too open.\n\t%s\n\t%s %s'",
+			errPermissionsForAreTooOpen, info.Mode(),
 			path,
 			"It is required that the credential file is NOT accessible by others.",
 			"Can be fixed by running: 'chmod 0600",
@@ -83,10 +93,10 @@ func getCredsFromFile(path string) (UserCredentials, error) {
 	}
 
 	if len(res.Username) == 0 {
-		return res, fmt.Errorf("login not set")
+		return res, errLoginNotSet
 	}
 	if len(res.Password) == 0 {
-		return res, fmt.Errorf("password not set")
+		return res, errPasswordNotSet
 	}
 
 	return res, nil
@@ -98,7 +108,7 @@ func getCredsFromEnvVars() (UserCredentials, error) {
 	res.Username = os.Getenv(EnvSdkUsername)
 	res.Password = os.Getenv(EnvSdkPassword)
 	if res.Username == "" || res.Password == "" {
-		return res, fmt.Errorf("no credentials in environment variables were found")
+		return res, errNoCredentialsInEnvironmentVariablesWereFound
 	}
 	return res, nil
 }

--- a/lib/connect/credentials_test.go
+++ b/lib/connect/credentials_test.go
@@ -1,11 +1,17 @@
 package connect
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	errMissingCredentialsFile = errors.New(
+		"open ./testdata/nonexisting: no such file or directory",
+	)
 )
 
 type getCredsFromFileInputValue struct {
@@ -26,7 +32,7 @@ func TestGetCredsFromFile(t *testing.T) {
 		path: "./testdata/nonexisting",
 	}] = getCredsFromFileOutputValue{
 		result: UserCredentials{},
-		err:    fmt.Errorf("open ./testdata/nonexisting: no such file or directory"),
+		err:    errMissingCredentialsFile,
 	}
 
 	file, err := os.CreateTemp("/tmp", "tt-unittest-*.bat")
@@ -49,7 +55,7 @@ func TestGetCredsFromFile(t *testing.T) {
 
 	testCases[getCredsFromFileInputValue{path: file.Name()}] = getCredsFromFileOutputValue{
 		result: UserCredentials{},
-		err:    fmt.Errorf("login not set"),
+		err:    errLoginNotSet,
 	}
 
 	file, err = os.CreateTemp("/tmp", "tt-unittest-*.bat")
@@ -59,7 +65,7 @@ func TestGetCredsFromFile(t *testing.T) {
 
 	testCases[getCredsFromFileInputValue{path: file.Name()}] = getCredsFromFileOutputValue{
 		result: UserCredentials{},
-		err:    fmt.Errorf("password not set"),
+		err:    errPasswordNotSet,
 	}
 
 	for input, output := range testCases {

--- a/lib/connect/help.go
+++ b/lib/connect/help.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"fmt"
 	"html/template"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -89,8 +90,8 @@ The command supports the following environment variables:
 		"ssl_ciphers":         sslCiphersParam,
 		"verify_host":         verifyHostParam,
 		"verify_peer":         verifyPeerParam,
-		"default_verify_host": fmt.Sprintf("%t", defaultVerifyHostParam),
-		"default_verify_peer": fmt.Sprintf("%t", defaultVerifyPeerParam),
+		"default_verify_host": strconv.FormatBool(defaultVerifyHostParam),
+		"default_verify_peer": strconv.FormatBool(defaultVerifyPeerParam),
 	}
 
 	envAuth := map[string]template.HTML{}

--- a/lib/connect/uri.go
+++ b/lib/connect/uri.go
@@ -12,6 +12,12 @@ import (
 	"time"
 )
 
+var (
+	errURLMustContainTheSchemeAndTheHostParts = errors.New(
+		"URL must contain the scheme and the host parts",
+	)
+)
+
 const (
 	TCPNetwork  = "tcp"
 	UnixNetwork = "unix"
@@ -303,7 +309,7 @@ func parseURL(str string) (*url.URL, error) {
 		return nil, err
 	}
 	if uri.Scheme == "" || uri.Host == "" {
-		return nil, errors.New("URL must contain the scheme and the host parts")
+		return nil, errURLMustContainTheSchemeAndTheHostParts
 	}
 	return uri, nil
 }

--- a/lib/dial/dial.go
+++ b/lib/dial/dial.go
@@ -1,9 +1,14 @@
 package dial
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tarantool/go-tarantool/v2"
+)
+
+var (
+	errUnsupportedTransportType = errors.New("unsupported transport type: ")
 )
 
 // New creates new dialer according to the options.
@@ -32,6 +37,6 @@ func New(opts Opts) (tarantool.Dialer, error) {
 	case TransportSsl:
 		return ssl(opts)
 	default:
-		return nil, fmt.Errorf("unsupported transport type: %s", opts.Transport)
+		return nil, fmt.Errorf("%w%s", errUnsupportedTransportType, opts.Transport)
 	}
 }

--- a/lib/dial/ssl_disable.go
+++ b/lib/dial/ssl_disable.go
@@ -8,6 +8,10 @@ import (
 	"github.com/tarantool/go-tarantool/v2"
 )
 
+var (
+	errSSLSupportIsDisabled = errors.New("SSL support is disabled")
+)
+
 func ssl(opts Opts) (tarantool.Dialer, error) {
-	return nil, errors.New("SSL support is disabled")
+	return nil, errSSLSupportIsDisabled
 }

--- a/lib/dial/transport.go
+++ b/lib/dial/transport.go
@@ -1,6 +1,13 @@
 package dial
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errUnknownTransportType = errors.New("unknown Transport type: ")
+)
 
 const (
 	transportDefault string = ""
@@ -31,7 +38,7 @@ func Parse(tr string) (Transport, error) {
 	case transportSsl:
 		return TransportSsl, nil
 	default:
-		return TransportDefault, fmt.Errorf("unknown Transport type: %s", tr)
+		return TransportDefault, fmt.Errorf("%w%s", errUnknownTransportType, tr)
 	}
 }
 

--- a/lib/watchdog/watchdog.go
+++ b/lib/watchdog/watchdog.go
@@ -15,6 +15,10 @@ import (
 	"github.com/tarantool/tt/cli/process_utils"
 )
 
+var (
+	errProcessIsNotRunning = errors.New("process is not running")
+)
+
 // Watchdog manages a child process, ensuring reliable startup, automatic restarts on failure,
 // and graceful shutdown. It handles system signals, maintains PID file consistency,
 // and provides thread-safe operations for concurrent process management.
@@ -232,7 +236,7 @@ func (wd *Watchdog) writePIDFiles() error {
 	defer wd.pidFileMutex.Unlock()
 
 	if wd.cmd == nil || wd.cmd.Process == nil {
-		return errors.New("process is not running")
+		return errProcessIsNotRunning
 	}
 
 	if err := process_utils.CreatePIDFile(wd.pidFile, wd.cmd.Process.Pid); err != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +15,13 @@ import (
 	"github.com/apex/log"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+)
+
+var (
+	errCannotParseAVersionOutOf                  = errors.New("cannot parse a version out of ")
+	errIsGolangciLintWantTheProjectPinnedVersion = errors.New(" is golangci-lint ")
+	errIsNotADirectory                           = errors.New(" is not a directory")
+	errUnsupportedBuildType                      = errors.New("unsupported build type: ")
 )
 
 // spell-checker:ignore trimpath extldflags asmflags covdata GOEXE TTEXE GOCOVERDIR
@@ -139,9 +147,10 @@ func appendTags(args []string) ([]string, error) {
 		tags = append(tags, "openssl_static")
 	case BuildTypeShared:
 	default:
-		return []string{}, fmt.Errorf("unsupported build type: %s, supported: "+
+		return []string{}, fmt.Errorf("%w%s, supported: "+
 			"%s, %s, %s",
-			buildType, BuildTypeNoCgo, BuildTypeStatic, BuildTypeShared)
+			errUnsupportedBuildType, buildType,
+			BuildTypeNoCgo, BuildTypeStatic, BuildTypeShared)
 	}
 	return append(append(args, "-tags"), strings.Join(tags, ",")), nil
 }
@@ -275,8 +284,8 @@ func resolveLinter() (string, error) {
 
 	if version != lintVersion {
 		return "", fmt.Errorf(
-			"%s is golangci-lint %s, want the project-pinned version %s",
-			linter, version, lintVersion)
+			"%s%w%s, want the project-pinned version %s",
+			linter, errIsGolangciLintWantTheProjectPinnedVersion, version, lintVersion)
 	}
 
 	return linter, nil
@@ -295,7 +304,7 @@ func linterVersionOf(exe string) (string, error) {
 
 	match := lintVersionRe.FindStringSubmatch(out)
 	if match == nil {
-		return "", fmt.Errorf("cannot parse a version out of %q", strings.TrimSpace(out))
+		return "", fmt.Errorf("%w%q", errCannotParseAVersionOutOf, strings.TrimSpace(out))
 	}
 
 	return match[1] + "." + match[2] + "." + match[3], nil
@@ -371,7 +380,7 @@ func (Unit) Coverage() error {
 	err = runUnitTests([]string{
 		"-tags", "integration,integration_docker",
 		"-cover",
-		"-args", fmt.Sprintf(`-test.gocoverdir=%s`, coverDir),
+		"-args", "-test.gocoverdir=" + coverDir,
 	})
 	if err != nil {
 		return err
@@ -399,7 +408,7 @@ func ensureCoverageDir(coverDir string) error {
 		return err
 	}
 	if !coverageDirInfo.IsDir() {
-		return fmt.Errorf("%q is not a directory", coverDir)
+		return fmt.Errorf("%q%w", coverDir, errIsNotADirectory)
 	}
 	return nil
 }

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -4,10 +4,21 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+)
+
+var (
+	errFailedToPublishPackageRWSAuthIsNotSet = errors.New(
+		"failed to publish package: RWS_AUTH is not set",
+	)
+	errFailedToPublishPackageRWSURLPartIsNotSet = errors.New(
+		"failed to publish package: RWS_URL_PART is not set",
+	)
+	errUnknownOS = errors.New("unknown OS: ")
 )
 
 const distPath = "dist"
@@ -83,7 +94,7 @@ func getPatterns(distro Distro) ([]string, error) {
 		return []string{"*.deb", "*.dsc"}, nil
 	}
 
-	return nil, fmt.Errorf("unknown OS: %s", distro.OS)
+	return nil, fmt.Errorf("%w%s", errUnknownOS, distro.OS)
 }
 
 // PublishRWS puts packages to RWS (Repository Web Service).
@@ -107,14 +118,14 @@ func PublishRWS() error {
 
 		rwsURLPart := os.Getenv("RWS_URL_PART")
 		if rwsURLPart == "" {
-			return fmt.Errorf("failed to publish package: RWS_URL_PART is not set")
+			return errFailedToPublishPackageRWSURLPartIsNotSet
 		}
 
 		flags := []string{
 			"-v",
 			"-LfsS",
 			"-X", "PUT", fmt.Sprintf("%s/%s/%s", rwsURLPart, targetDistro.OS, targetDistro.Dist),
-			"-F", fmt.Sprintf("product=%s", packageName),
+			"-F", "product=" + packageName,
 		}
 
 		for _, file := range files {
@@ -125,7 +136,7 @@ func PublishRWS() error {
 
 		rwsAuth := os.Getenv("RWS_AUTH")
 		if rwsAuth == "" {
-			return fmt.Errorf("failed to publish package: RWS_AUTH is not set")
+			return errFailedToPublishPackageRWSAuthIsNotSet
 		}
 		flags = append(flags, "-u", rwsAuth)
 

--- a/test/integration/aeon/server/service/server.go
+++ b/test/integration/aeon/server/service/server.go
@@ -8,6 +8,12 @@ import (
 	"github.com/tarantool/tt/cli/aeon/pb"
 )
 
+var (
+	errSQLCheckRequestIsNil  = errors.New("sql check request is nil")
+	errSQLRequestIsNil       = errors.New("sql request is nil")
+	errSQLStreamRequestIsNil = errors.New("sql stream request is nil")
+)
+
 // Server mock functions: SQL[Check|Stream] accepts SQL request with string ["ok", "error", ""].
 // SQLCheck returns appropriate SQLCheckStatus value: "VALID", "INVALID", "INCOMPLETE".
 // SQL[Stream] returns SQLResponse with two tuples on "ok" request and with Error other way.
@@ -19,7 +25,7 @@ func (s *Server) SQLCheck(ctx context.Context,
 	request *pb.SQLRequest,
 ) (*pb.SQLCheckResponse, error) {
 	if request == nil {
-		return nil, errors.New("sql check request is nil")
+		return nil, errSQLCheckRequestIsNil
 	}
 	status := pb.SQLCheckStatus_SQL_QUERY_INCOMPLETE
 	switch strings.ToLower(request.GetQuery()) {
@@ -33,7 +39,7 @@ func (s *Server) SQLCheck(ctx context.Context,
 
 func (s *Server) SQL(ctx context.Context, in *pb.SQLRequest) (*pb.SQLResponse, error) {
 	if in == nil {
-		return nil, errors.New("sql request is nil")
+		return nil, errSQLRequestIsNil
 	}
 	res := makeSQLResponse(in.GetQuery())
 	return &res, nil
@@ -41,7 +47,7 @@ func (s *Server) SQL(ctx context.Context, in *pb.SQLRequest) (*pb.SQLResponse, e
 
 func (s *Server) SQLStream(in *pb.SQLRequest, stream pb.SQLService_SQLStreamServer) error {
 	if in == nil {
-		return errors.New("sql stream request is nil")
+		return errSQLStreamRequestIsNil
 	}
 	res := makeSQLResponse(in.GetQuery())
 	stream.Send(&res)


### PR DESCRIPTION
- Enable: err113, perfsprint
- Introduce reusable package sentinels for stable error identity.
- Preserve dynamic error details through wrapping.
- Replace avoidable formatting with direct conversions.

Part of TNTP-9993