### PR TITLE
lint: enable errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,33 +24,20 @@ linters:
   disable:
     - cyclop # Cyclop is disabled, since cyclomatic complexity is a very abstract metric
       # that sometimes leads to strange linter behavior.
-    - depguard
     - dupl # Dupl is disabled, since we're generating a lot of boilerplate code.
-    - errcheck
-    - exhaustruct
-    - exhaustruct_v5
+    - exhaustruct # Deprecated since golangci-lint v2.13.0; exhaustruct_v5 is enabled instead.
     - funlen # Funlen is disabled, function length limits are too restrictive.
-    - gochecknoglobals
+    - gochecknoglobals # Gochecknoglobals is disabled until cli/cmd is refactored.
+      # Re-enable it after the refactoring.
     - gocognit # Gocognit is disabled, cognitive complexity is too restrictive.
-    - goconst
     - godox # Godox is disabled to allow TODO comments for unimplemented functionality.
-    - gomodguard
-    - gosec
+    - gomodguard # Deprecated since golangci-lint v2.12.0; gomodguard_v2 is enabled instead.
     - ireturn # Ireturn is disabled, since it's not needed.
     - maintidx # Maintidx is disabled, purpose of this metric is unknown.
     - nlreturn # Nlreturn is disabled, since it's duplicated by wsl_v5.return check.
-    - noinlineerr
-    - paralleltest
-    - testifylint
-    # TODO: Enable after internal tests are converted to external test packages
-    # without exporting production internals solely to satisfy the linter.
-    - testpackage
-    - tparallel
-    - varnamelen
-    - wrapcheck
-    - wsl # WSL is disabled, since it's obsolete; its replacement is disabled
-      # separately below.
-    - wsl_v5
+    - paralleltest # Paralleltest is disabled because some tests use shared process-wide state.
+    - tparallel # Tests intentionally run serially because they share process-wide state.
+    - wsl # Deprecated since golangci-lint v2.2.0; wsl_v5 is enabled instead.
 
   exclusions:
     generated: lax
@@ -62,11 +49,36 @@ linters:
       # and pack are the ones still outstanding.
       - path-except: (^|/)cli/manifest/((deps|install|resolve|rocks|state|version)/|[^/]+\.go$)
         text: ".*"
+      # Manifest fixtures deliberately construct partial model values; keep the
+      # stricter exhaustruct variant enabled everywhere else.
+      - path: (^|/)cli/manifest/
+        linters:
+          - exhaustruct_v5
+      # The project directory is selected by the caller and the lock-file name
+      # is constant, so writing the lock next to the manifest is intentional.
+      - path: ^cli/manifest/deps/deps\.go$
+        text: "G703: Path traversal via taint analysis"
+        linters:
+          - gosec
+      # Keep the existing source-level suppression compatible with nolintlint
+      # without changing manifest code.
+      - path: ^cli/manifest/deps/deps\.go$
+        text: 'directive `//nolint:gosec'
+        linters:
+          - nolintlint
+      # Keep established compact error checks while applying every other WSL
+      # rule, including future findings in these files.
+      - path: ^cli/manifest/(install/reconcile_internal_test|manifest|resolve/resolve|version/version_test)\.go$
+        source: '^\s*(var exit \*ExitError|var strict \*toml\.StrictMissingError|var conflict \*pinConflictError|t\.Helper\(\))$'
+        linters:
+          - wsl_v5
       - path: _test.go
         linters:
           - wrapcheck
           - err113
           - funlen
+          # Test fixtures intentionally repeat representative values.
+          - goconst
           # Table-driven and fixture tests build partial structs on purpose;
           # requiring every field spelled out is noise in tests.
           - exhaustruct
@@ -74,6 +86,13 @@ linters:
       # its existing compatibility directive is intentionally retained.
       - path: ^cli/manifest/constraint\.go$
         text: 'directive `//nolint:recvcheck'
+        linters:
+          - nolintlint
+      # The resolver deliberately adds dependency context above its cache
+      # boundary; keep its existing wrapcheck suppressions without touching
+      # manifest code.
+      - path: ^cli/manifest/resolve/cache\.go$
+        text: 'directive `//nolint:wrapcheck'
         linters:
           - nolintlint
       # This repeated word is intentional YAML test data, not prose.
@@ -110,6 +129,12 @@ linters:
           - staticcheck
 
   settings:
+    wrapcheck:
+      # Errors returned by tt packages are already contextualized at the
+      # external boundary. Wrapping them again at every internal package
+      # boundary only duplicates context in user-facing messages.
+      ignore-package-globs:
+        - github.com/tarantool/tt/*
     gomoddirectives:
       replace-local: true
       replace-allow-list:

--- a/cli/aeon/client.go
+++ b/cli/aeon/client.go
@@ -159,7 +159,7 @@ func (c *Client) Execute(input string) any {
 
 // Close implements console.Handler interface.
 func (c *Client) Close() {
-	c.conn.Close()
+	_ = c.conn.Close()
 }
 
 // Complete implements console.Handler interface.

--- a/cli/binary/list.go
+++ b/cli/binary/list.go
@@ -30,9 +30,9 @@ var (
 // printBinaries outputs installed versions of the program.
 func printVersion(versionString string) {
 	if strings.HasSuffix(versionString, "[active]") {
-		fmt.Fprintf(os.Stdout, "	%s\n", util.Bold(color.GreenString(versionString)))
+		_, _ = fmt.Fprintf(os.Stdout, "	%s\n", util.Bold(color.GreenString(versionString)))
 	} else {
-		fmt.Fprintf(os.Stdout, "	%s\n", color.YellowString(versionString))
+		_, _ = fmt.Fprintf(os.Stdout, "	%s\n", color.YellowString(versionString))
 	}
 }
 
@@ -124,7 +124,7 @@ func ListBinaries(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts) error {
 		search.ProgramEe,
 		search.ProgramTcm,
 	}
-	fmt.Fprintln(os.Stdout, "List of installed binaries:")
+	_, _ = fmt.Fprintln(os.Stdout, "List of installed binaries:")
 	for _, program := range programs {
 		binaryVersions, err := ParseBinaries(binDirFilesList, program, binDir)
 		if err != nil {

--- a/cli/cfg/dump.go
+++ b/cli/cfg/dump.go
@@ -31,8 +31,8 @@ func dumpRaw(writer io.Writer, cmdCtx *cmdcontext.CmdCtx) error {
 		if err != nil {
 			return err
 		}
-		writer.Write([]byte(cmdCtx.Cli.ConfigPath + ":\n"))
-		writer.Write(fileContent)
+		_, _ = writer.Write([]byte(cmdCtx.Cli.ConfigPath + ":\n"))
+		_, _ = writer.Write(fileContent)
 	} else {
 		return errTTConfigurationFileIsNotFound
 	}
@@ -46,7 +46,7 @@ func dumpConfiguration(writer io.Writer, cmdCtx *cmdcontext.CmdCtx,
 ) error {
 	if cmdCtx.Cli.ConfigPath != "" {
 		if _, err := os.Stat(cmdCtx.Cli.ConfigPath); err == nil {
-			writer.Write([]byte(cmdCtx.Cli.ConfigPath + ":\n"))
+			_, _ = writer.Write([]byte(cmdCtx.Cli.ConfigPath + ":\n"))
 		}
 	}
 	err := yaml.NewEncoder(writer).Encode(cliOpts)

--- a/cli/checkpoint/checkpoint.go
+++ b/cli/checkpoint/checkpoint.go
@@ -40,8 +40,8 @@ func Cat(tntCli cmdcontext.TarantoolCli) error {
 	if err != nil {
 		return err
 	}
-	stdinPipe.Write([]byte(catFile))
-	stdinPipe.Close()
+	_, _ = stdinPipe.Write([]byte(catFile))
+	_ = stdinPipe.Close()
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("result of cat: %w", err)
@@ -65,8 +65,8 @@ func Play(tntCli cmdcontext.TarantoolCli) error {
 	if err != nil {
 		return err
 	}
-	stdinPipe.Write([]byte(playFile))
-	stdinPipe.Close()
+	_, _ = stdinPipe.Write([]byte(playFile))
+	_ = stdinPipe.Close()
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("%w%s", errResultOfPlay, errBuff.String())
@@ -75,9 +75,9 @@ func Play(tntCli cmdcontext.TarantoolCli) error {
 	scanner := bufio.NewScanner(stdoutPipe)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		fmt.Fprintln(os.Stdout, scanner.Text())
+		_, _ = fmt.Fprintln(os.Stdout, scanner.Text())
 	}
-	cmd.Wait()
+	_ = cmd.Wait()
 
 	if len(errBuff.String()) > 0 {
 		return fmt.Errorf("%w%s", errResultOfPlay, errBuff.String())

--- a/cli/cluster/cluster_test.go
+++ b/cli/cluster/cluster_test.go
@@ -260,7 +260,7 @@ groups:
 	// temp file that has the above content.
 	f, err := os.CreateTemp(t.TempDir(), "tt-tcs-test-*.yaml")
 	require.NoError(t, err)
-	t.Cleanup(func() { os.Remove(f.Name()) })
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
 	_, err = f.WriteString(cfgYAML)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
@@ -299,7 +299,7 @@ groups:
 `
 	f, err := os.CreateTemp(t.TempDir(), "tt-etcd-env-test-*.yaml")
 	require.NoError(t, err)
-	t.Cleanup(func() { os.Remove(f.Name()) })
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
 	_, err = f.WriteString(cfgYAML)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/cli/cluster/cmd/common.go
+++ b/cli/cluster/cmd/common.go
@@ -23,7 +23,7 @@ func printGoConfig(cfg goconfig.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-	fmt.Fprint(os.Stdout, string(b))
+	_, _ = fmt.Fprint(os.Stdout, string(b))
 	return nil
 }
 

--- a/cli/cluster/cmd/common_test.go
+++ b/cli/cluster/cmd/common_test.go
@@ -184,7 +184,7 @@ groups:
 				err = validateGoConfig(view, full)
 
 				for k := range tc.Env {
-					os.Unsetenv(k)
+					_ = os.Unsetenv(k)
 				}
 
 				if tc.Err == nil {

--- a/cli/cluster/cmd/failover.go
+++ b/cli/cluster/cmd/failover.go
@@ -107,7 +107,9 @@ func Switch(url string, switchCtx SwitchCtx) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	cmd := switchCmd{
 		Command:   "switch",
@@ -135,7 +137,7 @@ func Switch(url string, switchCtx SwitchCtx) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "%s\n%s '%s' %s\n",
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n%s '%s' %s\n",
 		"To check the switching status, run:",
 		"tt cluster failover switch-status",
 		url, uuid)
@@ -166,7 +168,7 @@ func waitForSwitch(conn *libcluster.RawStorage, key string, yamlCmd []byte, time
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "%s", ev.Value)
+		_, _ = fmt.Fprintf(os.Stdout, "%s", ev.Value)
 		if result.Status == "success" || result.Status == "failed" {
 			return nil
 		}
@@ -190,7 +192,9 @@ func SwitchStatus(url string, switchCtx SwitchStatusCtx) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	key := uriOpts.Prefix + failoverPath + switchCtx.TaskID
 
@@ -206,7 +210,7 @@ func SwitchStatus(url string, switchCtx SwitchStatusCtx) error {
 		return fmt.Errorf("%w%s` is not found", errTaskWithIDIsNotFound, switchCtx.TaskID)
 	}
 
-	fmt.Fprint(os.Stdout, string(result[0].Value))
+	_, _ = fmt.Fprint(os.Stdout, string(result[0].Value))
 
 	return nil
 }

--- a/cli/cluster/integration_test.go
+++ b/cli/cluster/integration_test.go
@@ -74,7 +74,9 @@ func startEtcd(t *testing.T, opts etcdOpts) *etcdtest.LazyCluster {
 		Endpoints: inst.EndpointsGRPC(),
 	})
 	require.NoError(t, err)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	if err := doWithCtx(func(ctx context.Context) error {
 		_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
@@ -128,7 +130,7 @@ func etcdPut(t *testing.T, etcd *clientv3.Client, key, value string) {
 		pResp *clientv3.PutResponse
 		err   error
 	)
-	doWithCtx(func(ctx context.Context) error {
+	_ = doWithCtx(func(ctx context.Context) error {
 		pResp, err = etcd.Put(ctx, key, value)
 		return nil
 	})
@@ -175,7 +177,9 @@ func TestGetClusterConfig_etcd(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/test/config/all", `wal:
   dir: etcddir
@@ -242,7 +246,9 @@ func TestGetClusterConfig_etcd_connect_from_env(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, prefix+"/config/all", `wal:
   dir: etcddir

--- a/cli/cmd/aeon.go
+++ b/cli/cmd/aeon.go
@@ -95,7 +95,7 @@ func newAeonConnectCmd() *cobra.Command {
 		"path to a trusted certificate authorities (CA) file")
 	aeonCmd.Flags().Var(&connectCtx.Transport, "transport",
 		"allowed "+aeoncmd.ListValidTransports())
-	aeonCmd.RegisterFlagCompletionFunc("transport", aeonTransportCompletion)
+	_ = aeonCmd.RegisterFlagCompletionFunc("transport", aeonTransportCompletion)
 
 	return aeonCmd
 }
@@ -292,7 +292,7 @@ func getConfigURI(cmdCtx *cmdcontext.CmdCtx, url, instanceName string) error {
 	}
 
 	if uri, err := libconnect.CreateURIOpts(url); err == nil {
-		aeoncmd.FillConnectCtx(&connectCtx, uri, instanceName, factory)
+		_ = aeoncmd.FillConnectCtx(&connectCtx, uri, instanceName, factory)
 	}
 
 	return nil

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -91,9 +91,9 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 
-	os.Setenv("TT_CLI_CAT_FILES", string(filesJSON))
-	os.Setenv("TT_CLI_CAT_SHOW_SYS", strconv.FormatBool(catFlags.ShowSystem))
-	os.Setenv("TT_CLI_CAT_FORMAT", catFlags.Format)
+	_ = os.Setenv("TT_CLI_CAT_FILES", string(filesJSON))
+	_ = os.Setenv("TT_CLI_CAT_SHOW_SYS", strconv.FormatBool(catFlags.ShowSystem))
+	_ = os.Setenv("TT_CLI_CAT_FORMAT", catFlags.Format)
 
 	// List of spaces is passed to lua cat script via environment variable in json format.
 	spacesJSON, err := json.Marshal(catFlags.Space)
@@ -103,17 +103,17 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 	if string(spacesJSON) != "null" {
-		os.Setenv("TT_CLI_CAT_SPACES", string(spacesJSON))
+		_ = os.Setenv("TT_CLI_CAT_SPACES", string(spacesJSON))
 	}
 
-	os.Setenv("TT_CLI_CAT_FROM", strconv.FormatUint(catFlags.From, 10))
-	os.Setenv("TT_CLI_CAT_TO", strconv.FormatUint(catFlags.To, 10))
+	_ = os.Setenv("TT_CLI_CAT_FROM", strconv.FormatUint(catFlags.From, 10))
+	_ = os.Setenv("TT_CLI_CAT_TO", strconv.FormatUint(catFlags.To, 10))
 
 	timestamp, err := util.StringToTimestamp(catFlags.Timestamp)
 	if err != nil {
 		return fmt.Errorf("failed to parse a timestamp: %w", err)
 	}
-	os.Setenv("TT_CLI_CAT_TIMESTAMP", timestamp)
+	_ = os.Setenv("TT_CLI_CAT_TIMESTAMP", timestamp)
 
 	// List of replicas is passed to lua cat script via environment variable in json format.
 	replicasJSON, err := json.Marshal(catFlags.Replica)
@@ -123,7 +123,7 @@ func internalCatModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 	if string(replicasJSON) != "null" {
-		os.Setenv("TT_CLI_CAT_REPLICAS", string(replicasJSON))
+		_ = os.Setenv("TT_CLI_CAT_REPLICAS", string(replicasJSON))
 	}
 
 	log.Infof("Running cat with files: %s\n", args)

--- a/cli/cmd/cfg.go
+++ b/cli/cmd/cfg.go
@@ -12,7 +12,7 @@ func NewCfgCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Environment configuration management utility",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+			_ = cmd.Help()
 		},
 		Example: `# Print tt environment configuration:
 

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -111,7 +111,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(os.Stdout, string(res))
+		_, _ = fmt.Fprint(os.Stdout, string(res))
 
 	case shellZsh:
 		if err := rootCmd.GenZshCompletion(&buf); err != nil {
@@ -121,7 +121,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(os.Stdout, string(res))
+		_, _ = fmt.Fprint(os.Stdout, string(res))
 
 	case shellFish:
 		if err := rootCmd.GenFishCompletion(&buf, true); err != nil {
@@ -131,7 +131,7 @@ func internalCompletionCmd(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(os.Stdout, string(res))
+		_, _ = fmt.Fprint(os.Stdout, string(res))
 
 	default:
 		return fmt.Errorf("%w%s", errSpecifiedShellTypeIsNotSupportedAvailable, listShells())

--- a/cli/cmd/connect.go
+++ b/cli/cmd/connect.go
@@ -114,7 +114,7 @@ func NewConnectCmd() *cobra.Command {
 		`use the provided Lua expression as an interpreter for user's input of the connection.
 If the evaler code is prefixed with @, the rest should be a file name to read the evaler
 code from`)
-	connectCmd.Flags().MarkHidden("evaler")
+	_ = connectCmd.Flags().MarkHidden("evaler")
 
 	return connectCmd
 }
@@ -234,7 +234,7 @@ func internalConnectModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		}
 		// "Println" is used instead of "log..." to print the result without
 		// any decoration.
-		fmt.Fprintln(os.Stdout, string(res))
+		_, _ = fmt.Fprintln(os.Stdout, string(res))
 		if !connectInteractive || !terminal.IsTerminal(syscall.Stdin) {
 			return nil
 		}

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -23,13 +23,13 @@ func TestCreateValidArgsFunction(t *testing.T) {
 	defer func() {
 		cliOpts = oldOpts
 	}()
-	os.Create(tempsDir1 + "/" + "excess.A")
-	os.Create(tempsDir1 + "/" + "archive.tgz")
+	_, _ = os.Create(tempsDir1 + "/" + "excess.A")
+	_, _ = os.Create(tempsDir1 + "/" + "archive.tgz")
 	tDir1 := filepath.Join(tempsDir1, "template1")
 	assert.NoError(t, os.Mkdir(tDir1, 0o755))
 
-	os.Create(tempsDir2 + "/" + "excess.B")
-	os.Create(tempsDir2 + "/" + "template2.tar.gz")
+	_, _ = os.Create(tempsDir2 + "/" + "excess.B")
+	_, _ = os.Create(tempsDir2 + "/" + "template2.tar.gz")
 	tDir2 := filepath.Join(tempsDir2, "template2")
 	assert.NoError(t, os.Mkdir(tDir2, 0o755))
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -19,7 +19,7 @@ func configureHelpCommand(rootCmd *cobra.Command, modulesInfo *modules.ModulesIn
 		if err != nil {
 			return err
 		}
-		cmd.Help()
+		_ = cmd.Help()
 		return nil
 	}
 

--- a/cli/cmd/log.go
+++ b/cli/cmd/log.go
@@ -57,7 +57,7 @@ func printLines(ctx context.Context, in <-chan string) error {
 			if !ok {
 				return nil
 			}
-			fmt.Fprintln(os.Stdout, line)
+			_, _ = fmt.Fprintln(os.Stdout, line)
 		}
 	}
 }

--- a/cli/cmd/modules.go
+++ b/cli/cmd/modules.go
@@ -63,17 +63,17 @@ func internalModulesList(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 		m := modulesInfo[path]
 
 		if showVersion {
-			fmt.Fprintf(os.Stdout, "%-5s\t", m.Version)
+			_, _ = fmt.Fprintf(os.Stdout, "%-5s\t", m.Version)
 		}
-		fmt.Fprintf(os.Stdout, "%s - ", m.Name)
+		_, _ = fmt.Fprintf(os.Stdout, "%s - ", m.Name)
 
 		if showPath {
-			fmt.Fprint(os.Stdout, m.Main)
+			_, _ = fmt.Fprint(os.Stdout, m.Main)
 		} else {
-			fmt.Fprint(os.Stdout, m.Help)
+			_, _ = fmt.Fprint(os.Stdout, m.Help)
 		}
 
-		fmt.Fprint(os.Stdout, "\n")
+		_, _ = fmt.Fprint(os.Stdout, "\n")
 	}
 	return nil
 }

--- a/cli/cmd/package.go
+++ b/cli/cmd/package.go
@@ -143,10 +143,10 @@ func runPackageAdd(name, constraint string) error {
 	}
 
 	if result.Change.Existed {
-		fmt.Fprintf(os.Stdout, "changed %s in [%s]: %s -> %s\n",
+		_, _ = fmt.Fprintf(os.Stdout, "changed %s in [%s]: %s -> %s\n",
 			name, table, result.Change.Previous, declared)
 	} else {
-		fmt.Fprintf(os.Stdout, "added %s %s to [%s]\n", name, declared, table)
+		_, _ = fmt.Fprintf(os.Stdout, "added %s %s to [%s]\n", name, declared, table)
 	}
 
 	printMoves(result.Moves)
@@ -191,7 +191,7 @@ func runPackageRemove(name string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "removed %s %s\n", name, result.Change.Previous)
+	_, _ = fmt.Fprintf(os.Stdout, "removed %s %s\n", name, result.Change.Previous)
 	printMoves(result.Moves)
 
 	return nil
@@ -240,7 +240,7 @@ func runPackageUpdate(name string) error {
 	}
 
 	if len(result.Moves) == 0 {
-		fmt.Fprintln(os.Stdout, "everything is already up to date")
+		_, _ = fmt.Fprintln(os.Stdout, "everything is already up to date")
 
 		return nil
 	}
@@ -281,11 +281,11 @@ func printMoves(moves []deps.Move) {
 	for _, move := range moves {
 		switch {
 		case move.From == "":
-			fmt.Fprintf(os.Stdout, "  %s %s\n", move.Name, move.To)
+			_, _ = fmt.Fprintf(os.Stdout, "  %s %s\n", move.Name, move.To)
 		case move.To == "":
-			fmt.Fprintf(os.Stdout, "  %s %s -> (dropped)\n", move.Name, move.From)
+			_, _ = fmt.Fprintf(os.Stdout, "  %s %s -> (dropped)\n", move.Name, move.From)
 		default:
-			fmt.Fprintf(os.Stdout, "  %s %s -> %s\n", move.Name, move.From, move.To)
+			_, _ = fmt.Fprintf(os.Stdout, "  %s %s -> %s\n", move.Name, move.From, move.To)
 		}
 	}
 }
@@ -401,15 +401,15 @@ func runPackageUninstall(name string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "removed %s %s from %s scope\n",
+	_, _ = fmt.Fprintf(os.Stdout, "removed %s %s from %s scope\n",
 		result.Package, result.Version, result.Scope)
 
 	for _, dep := range result.RemovedDependencies {
-		fmt.Fprintf(os.Stdout, "  removed unused dependency %s\n", dep)
+		_, _ = fmt.Fprintf(os.Stdout, "  removed unused dependency %s\n", dep)
 	}
 
 	for _, dep := range result.KeptDependencies {
-		fmt.Fprintf(os.Stdout, "  kept %s (%s)\n", dep.Name, keptReason(dep))
+		_, _ = fmt.Fprintf(os.Stdout, "  kept %s (%s)\n", dep.Name, keptReason(dep))
 	}
 
 	return nil
@@ -515,7 +515,7 @@ func runPackageInstall(archives []string) error {
 			continue
 		}
 
-		fmt.Fprintf(os.Stdout, "installed %s %s into %s scope\n",
+		_, _ = fmt.Fprintf(os.Stdout, "installed %s %s into %s scope\n",
 			one.Package, one.Version, one.Scope)
 	}
 
@@ -626,7 +626,7 @@ func runPackagePack() error {
 		return err
 	}
 
-	fmt.Fprintln(os.Stdout, result.Path)
+	_, _ = fmt.Fprintln(os.Stdout, result.Path)
 
 	return nil
 }

--- a/cli/cmd/play.go
+++ b/cli/cmd/play.go
@@ -163,32 +163,32 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 
-	os.Setenv("TT_CLI_PLAY_FILES_AND_URI", string(filesAndURIJSON))
+	_ = os.Setenv("TT_CLI_PLAY_FILES_AND_URI", string(filesAndURIJSON))
 	if playUsername != "" {
-		os.Setenv("TT_CLI_PLAY_USERNAME", playUsername)
+		_ = os.Setenv("TT_CLI_PLAY_USERNAME", playUsername)
 	}
 	if playPassword != "" {
-		os.Setenv("TT_CLI_PLAY_PASSWORD", playPassword)
+		_ = os.Setenv("TT_CLI_PLAY_PASSWORD", playPassword)
 	}
 
 	if playSslCertFile != "" {
-		os.Setenv("TT_CLI_PLAY_SSL_CERT_FILE", playSslCertFile)
+		_ = os.Setenv("TT_CLI_PLAY_SSL_CERT_FILE", playSslCertFile)
 	}
 	if playSslKeyFile != "" {
-		os.Setenv("TT_CLI_PLAY_SSL_KEY_FILE", playSslKeyFile)
+		_ = os.Setenv("TT_CLI_PLAY_SSL_KEY_FILE", playSslKeyFile)
 	}
 	if playSslCaFile != "" {
-		os.Setenv("TT_CLI_PLAY_SSL_CA_FILE", playSslCaFile)
+		_ = os.Setenv("TT_CLI_PLAY_SSL_CA_FILE", playSslCaFile)
 	}
 	if playSslCiphers != "" {
-		os.Setenv("TT_CLI_PLAY_SSL_CIPHERS", playSslCiphers)
+		_ = os.Setenv("TT_CLI_PLAY_SSL_CIPHERS", playSslCiphers)
 	}
 	if playSslCertFile != "" || playSslKeyFile != "" ||
 		playSslCaFile != "" || playSslCiphers != "" {
-		os.Setenv("TT_CLI_PLAY_TRANSPORT", "ssl")
+		_ = os.Setenv("TT_CLI_PLAY_TRANSPORT", "ssl")
 	}
 
-	os.Setenv("TT_CLI_PLAY_SHOW_SYS", strconv.FormatBool(playFlags.ShowSystem))
+	_ = os.Setenv("TT_CLI_PLAY_SHOW_SYS", strconv.FormatBool(playFlags.ShowSystem))
 
 	// List of spaces is passed to lua play script via environment variable in json format.
 	spacesJSON, err := json.Marshal(playFlags.Space)
@@ -198,17 +198,17 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 	if string(spacesJSON) != "null" {
-		os.Setenv("TT_CLI_PLAY_SPACES", string(spacesJSON))
+		_ = os.Setenv("TT_CLI_PLAY_SPACES", string(spacesJSON))
 	}
 
-	os.Setenv("TT_CLI_PLAY_FROM", strconv.FormatUint(playFlags.From, 10))
-	os.Setenv("TT_CLI_PLAY_TO", strconv.FormatUint(playFlags.To, 10))
+	_ = os.Setenv("TT_CLI_PLAY_FROM", strconv.FormatUint(playFlags.From, 10))
+	_ = os.Setenv("TT_CLI_PLAY_TO", strconv.FormatUint(playFlags.To, 10))
 
 	timestamp, err := util.StringToTimestamp(playFlags.Timestamp)
 	if err != nil {
 		return fmt.Errorf("failed to parse a timestamp: %w", err)
 	}
-	os.Setenv("TT_CLI_PLAY_TIMESTAMP", timestamp)
+	_ = os.Setenv("TT_CLI_PLAY_TIMESTAMP", timestamp)
 
 	// List of replicas is passed to lua play script via environment variable in json format.
 	replicasJSON, err := json.Marshal(playFlags.Replica)
@@ -218,7 +218,7 @@ func internalPlayModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
 			version.GetVersion, err)
 	}
 	if string(replicasJSON) != "null" {
-		os.Setenv("TT_CLI_PLAY_REPLICAS", string(replicasJSON))
+		_ = os.Setenv("TT_CLI_PLAY_REPLICAS", string(replicasJSON))
 	}
 
 	log.Infof("Running play with URI=%s and files: %s\n", args[0], args[1:])

--- a/cli/cmd/replicaset.go
+++ b/cli/cmd/replicaset.go
@@ -544,7 +544,7 @@ func fillReplicasetAppCtx(cmdCtx *cmdcontext.CmdCtx, ctx *replicasetCtx, target 
 		conn, err = connector.Connect(connOpts)
 		if err == nil {
 			ctx.IsInstanceConnect = true
-			conn.Close()
+			_ = conn.Close()
 			break
 		}
 	}
@@ -591,7 +591,9 @@ func internalReplicasetUpgradeModule(cmdCtx *cmdcontext.CmdCtx, args []string) e
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 
 	connectCtx := connect.ConnectCtx{
@@ -626,7 +628,9 @@ func internalReplicasetDowngradeModule(cmdCtx *cmdcontext.CmdCtx, args []string)
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 
 	connectCtx := connect.ConnectCtx{
@@ -661,7 +665,9 @@ func internalReplicasetPromoteModule(cmdCtx *cmdcontext.CmdCtx, args []string) e
 	if !ctx.IsInstanceConnect {
 		return errSpecifyAnInstanceToPromote
 	}
-	defer ctx.Conn.Close()
+	defer func() {
+		_ = ctx.Conn.Close()
+	}()
 
 	collectors, publishers, err := cluster.NewCollectorAndPublisherFactories(
 		cmdCtx.Integrity, replicasetIntegrityPrivateKey)
@@ -695,7 +701,9 @@ func internalReplicasetDemoteModule(cmdCtx *cmdcontext.CmdCtx, args []string) er
 	if !ctx.IsInstanceConnect {
 		return errSpecifyAnInstanceToDemote
 	}
-	defer ctx.Conn.Close()
+	defer func() {
+		_ = ctx.Conn.Close()
+	}()
 
 	collectors, publishers, err := cluster.NewCollectorAndPublisherFactories(
 		cmdCtx.Integrity, replicasetIntegrityPrivateKey)
@@ -723,7 +731,9 @@ func internalReplicasetStatusModule(cmdCtx *cmdcontext.CmdCtx, args []string) er
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 	return replicasetcmd.Status(replicasetcmd.DiscoveryCtx{
 		IsApplication: ctx.IsApplication,
@@ -743,7 +753,9 @@ func internalReplicasetExpelModule(cmdCtx *cmdcontext.CmdCtx, args []string) err
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 	collectors, publishers, err := cluster.NewCollectorAndPublisherFactories(
 		cmdCtx.Integrity, replicasetIntegrityPrivateKey)
@@ -771,7 +783,9 @@ func internalReplicasetBootstrapVShardModule(cmdCtx *cmdcontext.CmdCtx, args []s
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 	collectors, publishers, err := cluster.NewCollectorAndPublisherFactories(
 		cmdCtx.Integrity, replicasetIntegrityPrivateKey)
@@ -799,7 +813,9 @@ func internalReplicasetBootstrapModule(cmdCtx *cmdcontext.CmdCtx, args []string)
 		return err
 	}
 	if ctx.IsInstanceConnect {
-		defer ctx.Conn.Close()
+		defer func() {
+			_ = ctx.Conn.Close()
+		}()
 	}
 	bootstrapCtx := replicasetcmd.BootstrapCtx{
 		Orchestrator:    ctx.Orchestrator,
@@ -861,7 +877,9 @@ func internalReplicasetRolesAddModule(cmdCtx *cmdcontext.CmdCtx, args []string) 
 	if err := replicasetFillCtx(cmdCtx, &ctx, args[0], false, running.ConfigLoadAll); err != nil {
 		return err
 	}
-	defer ctx.Conn.Close()
+	defer func() {
+		_ = ctx.Conn.Close()
+	}()
 	if ctx.IsApplication && replicasetInstanceName == "" && ctx.InstName == "" &&
 		!replicasetIsGlobal && replicasetGroupName == "" && replicasetReplicasetName == "" {
 		return errThereIsNoDestinationProvidedInWhichToAddRole
@@ -904,7 +922,9 @@ func internalReplicasetRolesRemoveModule(cmdCtx *cmdcontext.CmdCtx, args []strin
 	if err := replicasetFillCtx(cmdCtx, &ctx, args[0], false, running.ConfigLoadAll); err != nil {
 		return err
 	}
-	defer ctx.Conn.Close()
+	defer func() {
+		_ = ctx.Conn.Close()
+	}()
 	if ctx.IsApplication && replicasetInstanceName == "" && ctx.InstName == "" &&
 		!replicasetIsGlobal && replicasetGroupName == "" && replicasetReplicasetName == "" {
 		return errThereIsNoDestinationProvidedWhereToRemoveRole

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -226,7 +226,7 @@ func Execute() {
 		var argError *util.ArgError
 		if errors.As(err, &argError) {
 			log.Error(argError.Error())
-			rootCmd.Usage()
+			_ = rootCmd.Usage()
 		}
 		os.Exit(1)
 	}
@@ -237,7 +237,7 @@ func Execute() {
 // modules and configure `help` module.
 func InitRoot() {
 	rootCmd = NewCmdRoot()
-	rootCmd.ParseFlags(os.Args[1:])
+	_ = rootCmd.ParseFlags(os.Args[1:])
 
 	var err error
 

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestRootFlags(t *testing.T) {
 	rootCmd = NewCmdRoot()
-	rootCmd.ParseFlags([]string{"--cfg", "one.yaml", "rocks", "--cfg", "second.yaml"})
+	_ = rootCmd.ParseFlags([]string{"--cfg", "one.yaml", "rocks", "--cfg", "second.yaml"})
 	assert.Equal(t, cmdCtx.Cli.ConfigPath, "one.yaml")
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -25,7 +25,7 @@ are passed after '--'.
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, opt := range args {
 				if opt == "-h" || opt == "--help" {
-					cmd.Help()
+					_ = cmd.Help()
 					return
 				}
 			}

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -55,7 +55,7 @@ func NewStartCmd() *cobra.Command {
 	}
 
 	startCmd.Flags().BoolVar(&watchdog, "watchdog", false, "")
-	startCmd.Flags().MarkHidden("watchdog")
+	_ = startCmd.Flags().MarkHidden("watchdog")
 	startCmd.Flags().BoolVarP(&startInteractive, "interactive", "i", false, "")
 
 	integrity.RegisterIntegrityCheckPeriodFlag(startCmd.Flags(), &cmdCtx.Cli.IntegrityCheckPeriod)
@@ -96,7 +96,7 @@ func startInstancesInteractive(cmdCtx *cmdcontext.CmdCtx, instances []running.In
 		prefix := running.GetAppInstanceName(instCtx) + " "
 		wg.Add(1)
 		go func(inst running.InstanceCtx) {
-			running.RunInstance(ctx, cmdCtx, inst,
+			_ = running.RunInstance(ctx, cmdCtx, inst,
 				running.NewColorizedPrefixWriter(os.Stdout, clr, prefix),
 				running.NewColorizedPrefixWriter(os.Stderr, clr, prefix))
 			wg.Done()

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -65,7 +65,7 @@ Columns:
 	statusCmd.Flags().BoolVarP(&opts.details, "details", "d", false, "print detailed alerts.")
 	statusCmd.Flags().BoolVarP(&opts.pretty, "pretty", "p", false,
 		"output a pretty-formatted table (deprecated, use --format instead)")
-	statusCmd.Flags().MarkDeprecated("pretty", "use --format instead")
+	_ = statusCmd.Flags().MarkDeprecated("pretty", "use --format instead")
 
 	return statusCmd
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -30,6 +30,6 @@ func NewVersionCmd() *cobra.Command {
 
 // internalVersionModule is a default (internal) version module function.
 func internalVersionModule(cmdCtx *cmdcontext.CmdCtx, args []string) error {
-	fmt.Fprintln(os.Stdout, version.GetVersion(showShort, needCommit))
+	_, _ = fmt.Fprintln(os.Stdout, version.GetVersion(showShort, needCommit))
 	return nil
 }

--- a/cli/configure/configure.go
+++ b/cli/configure/configure.go
@@ -304,7 +304,7 @@ func GetCliOpts(configurePath string, repository integrity.Repository) (
 				return nil, "",
 					fmt.Errorf("failed to validate integrity of %q: %w", configPath, err)
 			}
-			f.Close()
+			_ = f.Close()
 		}
 		rawConfigOpts, err := util.ParseYAML(configPath)
 		if err != nil {
@@ -625,7 +625,7 @@ func switchToLocalCli(cmdCtx *cmdcontext.CmdCtx, localCli, currentCli, launchDir
 	if err != nil {
 		return err
 	}
-	f.Close()
+	_ = f.Close()
 
 	// We are not using the "RunExec" function because we have no reason to have several
 	// "tt" processes. Moreover, it looks strange when we start "tt", which starts "tt",

--- a/cli/configure/configure_test.go
+++ b/cli/configure/configure_test.go
@@ -89,7 +89,9 @@ func TestConfigureCli(t *testing.T) {
 		expectedTarantoolPath, []byte("I am [fake] local Tarantool!"), 0o777,
 	))
 
-	defer os.Remove(expectedTarantoolPath)
+	defer func() {
+		_ = os.Remove(expectedTarantoolPath)
+	}()
 
 	require.NoError(t, Cli(&cmdCtx))
 	assert.Equal(cmdCtx.Cli.ConfigPath, expectedConfigPath)
@@ -115,7 +117,9 @@ func TestConfigureCli(t *testing.T) {
 		expectedConfigPath, []byte("app:"), 0o755,
 	))
 
-	defer os.Remove(expectedConfigPath)
+	defer func() {
+		_ = os.Remove(expectedConfigPath)
+	}()
 
 	assert.Nil(Cli(&cmdCtx))
 	// I don't know why, but go tests run in /private folder (when running on MacOS).
@@ -254,7 +258,7 @@ func TestDetectLocalTarantool(t *testing.T) {
 
 	// Tarantool executable is in PATH.
 	cliOpts.Env.BinDir = "./testdata"
-	Cli(&cmdCtx)
+	_ = Cli(&cmdCtx)
 	require.NoError(t, detectLocalTarantool(&cmdCtx, &cliOpts))
 	expected, err = exec.LookPath("tarantool")
 	require.NoError(t, err)

--- a/cli/connect/commands.go
+++ b/cli/connect/commands.go
@@ -637,7 +637,7 @@ func (executor cmdExecutor) Execute(console *Console, in string) bool {
 			if err != nil {
 				log.Errorf("%s\n", err)
 			} else if msg != "" {
-				fmt.Fprintf(os.Stdout, "%s\n", msg)
+				_, _ = fmt.Fprintf(os.Stdout, "%s\n", msg)
 			}
 			return true
 		}

--- a/cli/connect/connect.go
+++ b/cli/connect/connect.go
@@ -103,7 +103,9 @@ func Eval(connectCtx ConnectCtx, connOpts connector.ConnectOpts, args []string) 
 	if err != nil {
 		return nil, fmt.Errorf("unable to establish connection: %w", err)
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	evalArgs := []any{command, connectCtx.Language == SQLLanguage}
 	if connectCtx.Language != DefaultLanguage {

--- a/cli/connect/console.go
+++ b/cli/connect/console.go
@@ -175,11 +175,11 @@ func (console *Console) Run() error {
 // Close frees up resources used by the console.
 func (console *Console) Close() {
 	for _, v := range console.validators {
-		v.Close()
+		_ = v.Close()
 	}
 	console.validators = nil
 	if console.conn != nil {
-		console.conn.Close()
+		_ = console.conn.Close()
 	}
 }
 
@@ -241,7 +241,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 					return
 				}
 
-				fmt.Fprintf(os.Stdout, "%s\n", encodedData)
+				_, _ = fmt.Fprintf(os.Stdout, "%s\n", encodedData)
 			},
 			ResData: &results,
 		}
@@ -269,7 +269,7 @@ func getExecutor(console *Console, connectCtx ConnectCtx) (func(string), error) 
 			log.Errorf("Unable to format output: %s", err)
 			log.Infof("Source YAML:\n%s", data)
 		} else {
-			fmt.Fprint(os.Stdout, output)
+			_, _ = fmt.Fprint(os.Stdout, output)
 		}
 
 		console.input = ""
@@ -404,7 +404,7 @@ func getPromptOptions(console *Console) []prompt.Option {
 				Fn: func(buf *prompt.Buffer) {
 					console.input = ""
 					console.livePrefixEnabled = false
-					fmt.Fprintln(os.Stdout, "^C")
+					_, _ = fmt.Fprintln(os.Stdout, "^C")
 				},
 			},
 		),

--- a/cli/connect/input_test.go
+++ b/cli/connect/input_test.go
@@ -15,7 +15,9 @@ func TestNewLuaValidator(t *testing.T) {
 
 func TestNewLuaValidator_implementsValidateCloser(t *testing.T) {
 	var s ValidateCloser = NewLuaValidator()
-	defer s.Close()
+	defer func() {
+		_ = s.Close()
+	}()
 }
 
 func TestLuaValidator_Close_notCreated(t *testing.T) {
@@ -31,13 +33,15 @@ func TestLuaValidator_Close_multipleTimes(t *testing.T) {
 
 func TestLuaValidator_Validate_afterClose(t *testing.T) {
 	s := NewLuaValidator()
-	s.Close()
+	_ = s.Close()
 	assert.Panics(t, func() { s.Validate("any string") })
 }
 
 func TestLuaValidator_Validate_true(t *testing.T) {
 	s := NewLuaValidator()
-	defer s.Close()
+	defer func() {
+		_ = s.Close()
+	}()
 
 	cases := []string{
 		"\"string\"",
@@ -71,7 +75,9 @@ func TestLuaValidator_Validate_true(t *testing.T) {
 
 func TestLuaValidator_Validate_false(t *testing.T) {
 	s := NewLuaValidator()
-	defer s.Close()
+	defer func() {
+		_ = s.Close()
+	}()
 
 	cases := []string{
 		"\"string",
@@ -94,7 +100,9 @@ func TestLuaValidator_Validate_false(t *testing.T) {
 
 func TestLuaValidatorValidate_mixed(t *testing.T) {
 	s := NewLuaValidator()
-	defer s.Close()
+	defer func() {
+		_ = s.Close()
+	}()
 
 	ret := s.Validate("do")
 	assert.False(t, ret)
@@ -159,7 +167,9 @@ func TestAddStmtPart(t *testing.T) {
 
 func TestAddStmtPart_luaValidator(t *testing.T) {
 	validator := NewLuaValidator()
-	defer validator.Close()
+	defer func() {
+		_ = validator.Close()
+	}()
 
 	parts := []struct {
 		str       string
@@ -187,7 +197,9 @@ func TestAddStmtPart_luaValidator(t *testing.T) {
 
 func TestAddStmtPart_luaValidator_Delimiter(t *testing.T) {
 	validator := NewLuaValidator()
-	defer validator.Close()
+	defer func() {
+		_ = validator.Close()
+	}()
 
 	parts := []struct {
 		str       string

--- a/cli/connect/language_test.go
+++ b/cli/connect/language_test.go
@@ -108,7 +108,7 @@ func TestChangeLanguage_requestInputs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.lang.String(), func(t *testing.T) {
 			evaler := &inputEvaler{}
-			ChangeLanguage(evaler, c.lang)
+			_ = ChangeLanguage(evaler, c.lang)
 			assert.Equal(t, expectedFun, evaler.fun)
 			assert.Equal(t, c.arg, evaler.args[0])
 			assert.Equal(t, expectedOpts, evaler.opts)

--- a/cli/connector/connector.go
+++ b/cli/connector/connector.go
@@ -69,13 +69,15 @@ func Connect(opts ConnectOpts) (Connector, error) {
 	}
 
 	if _, err := os.Stat(opts.Address); err == nil {
-		os.Chdir(filepath.Dir(opts.Address))
+		_ = os.Chdir(filepath.Dir(opts.Address))
 		opts.Address = "./" + filepath.Base(opts.Address)
 		if len(opts.Address)+1 > maxSocketPath {
 			return nil, fmt.Errorf("%w%d symbols: %s", errSocketNameIsLongerThanSymbols,
 				maxSocketPath-socketPathPrefixLength, filepath.Base(opts.Address))
 		}
-		defer os.Chdir(workDir)
+		defer func() {
+			_ = os.Chdir(workDir)
+		}()
 	}
 	// Connect to specified address.
 	greetingConn, err := (&net.Dialer{}).DialContext(
@@ -85,7 +87,7 @@ func Connect(opts ConnectOpts) (Connector, error) {
 	}
 
 	// Set a deadline for the greeting.
-	greetingConn.SetReadDeadline(time.Now().Add(greetingOperationTimeout))
+	_ = greetingConn.SetReadDeadline(time.Now().Add(greetingOperationTimeout))
 
 	// Detect transport and protocol.
 	ssl := opts.Ssl.KeyFile != "" || opts.Ssl.CertFile != "" ||
@@ -98,20 +100,20 @@ func Connect(opts ConnectOpts) (Connector, error) {
 			return nil, fmt.Errorf("failed to get protocol: %w", err)
 		}
 	} else if ssl {
-		greetingConn.Close()
+		_ = greetingConn.Close()
 		return nil, errEncryptionRequired
 	}
 
 	// Reset the deadline. From the SetDeadline doc:
 	// "A zero value for t means I/O operations will not time out.".
-	greetingConn.SetDeadline(time.Time{})
+	_ = greetingConn.SetDeadline(time.Time{})
 
 	// Initialize connection.
 	switch protocol {
 	case TextProtocol:
 		return NewTextConnector(greetingConn), nil
 	case BinaryProtocol:
-		greetingConn.Close()
+		_ = greetingConn.Close()
 
 		addr := fmt.Sprintf("%s://%s", opts.Network, opts.Address)
 

--- a/cli/connector/eval_plain_text.go
+++ b/cli/connector/eval_plain_text.go
@@ -214,9 +214,9 @@ func readDataPortionFromPlainTextConn(conn net.Conn, buffer *bytes.Buffer,
 	data := make([]byte, 0)
 
 	if readTimeout > 0 {
-		conn.SetReadDeadline(time.Now().Add(readTimeout))
+		_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
 	} else {
-		conn.SetReadDeadline(time.Time{})
+		_ = conn.SetReadDeadline(time.Time{})
 	}
 
 	hasYAMLOutputPrefix := false

--- a/cli/connector/integration_test.go
+++ b/cli/connector/integration_test.go
@@ -83,7 +83,9 @@ func createTestConnects(t *testing.T) []testConnect {
 func TestConnect_Eval(t *testing.T) {
 	connects := createTestConnects(t)
 	for _, c := range connects {
-		defer c.connect.Close()
+		defer func() {
+			_ = c.connect.Close()
+		}()
 	}
 
 	for _, c := range connects {
@@ -102,7 +104,9 @@ func TestConnect_Eval(t *testing.T) {
 func TestBinaryConnector_Eval_args(t *testing.T) {
 	connects := createTestConnects(t)
 	for _, c := range connects {
-		defer c.connect.Close()
+		defer func() {
+			_ = c.connect.Close()
+		}()
 	}
 
 	for _, c := range connects {
@@ -121,7 +125,9 @@ func TestBinaryConnector_Eval_args(t *testing.T) {
 func TestBinaryConnector_Eval_readTimeout(t *testing.T) {
 	connects := createTestConnects(t)
 	for _, c := range connects {
-		defer c.connect.Close()
+		defer func() {
+			_ = c.connect.Close()
+		}()
 	}
 
 	for _, c := range connects {
@@ -141,7 +147,9 @@ func TestBinaryConnector_Eval_readTimeout(t *testing.T) {
 func TestBinaryConnector_Eval_resData(t *testing.T) {
 	connects := createTestConnects(t)
 	for _, c := range connects {
-		defer c.connect.Close()
+		defer func() {
+			_ = c.connect.Close()
+		}()
 	}
 
 	for _, c := range connects {
@@ -165,7 +173,9 @@ func TestBinaryConnector_Eval_resData(t *testing.T) {
 func TestBinaryConnector_Eval_pushCallback(t *testing.T) {
 	connects := createTestConnects(t)
 	for _, c := range connects {
-		defer c.connect.Close()
+		defer func() {
+			_ = c.connect.Close()
+		}()
 	}
 
 	for _, c := range connects {
@@ -197,7 +207,9 @@ func TestConnect_binary(t *testing.T) {
 		Password: "password",
 	})
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	eval := "return 'hello', 'world'"
 	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
@@ -229,7 +241,9 @@ func TestConnect_binaryTlsToTls(t *testing.T) {
 		Ssl:      sslOpts,
 	})
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	eval := "return 'hello', 'world'"
 	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
@@ -243,7 +257,9 @@ func TestConnect_text(t *testing.T) {
 		Address: console,
 	})
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	eval := "return 'hello', 'world'"
 	ret, err := conn.Eval(eval, []any{}, RequestOpts{})
@@ -301,7 +317,7 @@ func TestPoolConnect_success(t *testing.T) {
 			pool, err := ConnectPool(tc.Opts)
 			require.NoError(t, err)
 			require.NotNil(t, pool)
-			pool.Close()
+			_ = pool.Close()
 		})
 	}
 }
@@ -312,7 +328,9 @@ func TestPoolEval_success(t *testing.T) {
 			pool, err := ConnectPool(tc.Opts)
 			require.NoError(t, err)
 			require.NotNil(t, pool)
-			defer pool.Close()
+			defer func() {
+				_ = pool.Close()
+			}()
 
 			ret, err := pool.Eval("return ...", []any{"foo"}, RequestOpts{})
 			assert.NoError(t, err)
@@ -327,7 +345,9 @@ func TestPoolEval_error(t *testing.T) {
 			pool, err := ConnectPool(tc.Opts)
 			require.NoError(t, err)
 			require.NotNil(t, pool)
-			defer pool.Close()
+			defer func() {
+				_ = pool.Close()
+			}()
 
 			for range 10 {
 				_, err = pool.Eval("error('foo')", []any{"foo"}, RequestOpts{})
@@ -340,7 +360,7 @@ func TestPoolEval_error(t *testing.T) {
 func runTestMain(m *testing.M) int {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
 		return 1
 	}
 
@@ -354,7 +374,7 @@ func runTestMain(m *testing.M) int {
 		Dialer:       dialer,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
 		return 1
 	}
 	defer test_helpers.StopTarantoolWithCleanup(inst)
@@ -363,15 +383,15 @@ func runTestMain(m *testing.M) int {
 	defer cancel()
 	conn, err := tarantool.Connect(ctx, dialer, opts)
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
 		return 1
 	}
 	req := tarantool.NewEvalRequest("return box.info.package")
 	data, err := conn.Do(req).Get()
-	conn.Close()
+	_ = conn.Close()
 
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to get box.info.package:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to get box.info.package:", err)
 		return 1
 	}
 
@@ -384,7 +404,7 @@ func runTestMain(m *testing.M) int {
 	if tarantoolEe {
 		absTLSWorkDir, err := filepath.Abs(workDir + "_tls")
 		if err != nil {
-			fmt.Fprintln(os.Stdout, "Failed to prepare TLS test work dir:", err)
+			_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare TLS test work dir:", err)
 			return 1
 		}
 
@@ -413,7 +433,7 @@ func runTestMain(m *testing.M) int {
 			Dialer:       tlsDialer,
 		})
 		if err != nil {
-			fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool with TLS:", err)
+			_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool with TLS:", err)
 			return 1
 		}
 		defer test_helpers.StopTarantoolWithCleanup(inst)

--- a/cli/connector/pool.go
+++ b/cli/connector/pool.go
@@ -54,7 +54,7 @@ func (pool *Pool) Eval(expr string, args []any, opts RequestOpts) ([]any, error)
 			return ret, nil
 		}
 
-		pool.current.Close()
+		_ = pool.current.Close()
 		pool.current = nil
 		pool.currentIndex = (pool.currentIndex + 1) % len(pool.opts)
 	}

--- a/cli/console/console.go
+++ b/cli/console/console.go
@@ -184,10 +184,10 @@ func (c *Console) execute(in string) {
 		os.Exit(0)
 	}
 
-	fmt.Fprintln(os.Stdout, "---")
+	_, _ = fmt.Fprintln(os.Stdout, "---")
 	output, err := c.impl.Format.Sprint(results)
 	if err == nil {
-		fmt.Fprintln(os.Stdout, output)
+		_, _ = fmt.Fprintln(os.Stdout, output)
 	} else {
 		log.Errorf("Unable to format output: %s", err)
 		log.Infof("Source results:\n%v", results)
@@ -252,7 +252,7 @@ func (c *Console) getPromptOptions() []prompt.Option {
 				Fn: func(buf *prompt.Buffer) {
 					c.input = ""
 					c.livePrefixEnabled = false
-					fmt.Fprintln(os.Stdout, "^C")
+					_, _ = fmt.Fprintln(os.Stdout, "^C")
 				},
 			},
 		),

--- a/cli/console/history.go
+++ b/cli/console/history.go
@@ -60,7 +60,7 @@ func (h *History) AppendCommand(input string) {
 		h.commands = h.commands[1:]
 		h.timestamps = h.timestamps[1:]
 	}
-	h.writeToFile()
+	_ = h.writeToFile()
 }
 
 // Commands implements HistoryKeeper.Commands interface method.

--- a/cli/console/history_test.go
+++ b/cli/console/history_test.go
@@ -47,7 +47,7 @@ func TestNewHistory(t *testing.T) {
 			}
 			cmds := hist.Commands()
 			if !reflect.DeepEqual(cmds, tt.want) {
-				fmt.Fprint(os.Stdout, cmds)
+				_, _ = fmt.Fprint(os.Stdout, cmds)
 				t.Errorf("NewHistory() = %v, want %v", cmds, tt.want)
 			}
 		})
@@ -102,5 +102,5 @@ func TestHistory_AppendCommand(t *testing.T) {
 			reflect.DeepEqual(tt.commands[from:], h.Commands())
 		})
 	}
-	os.RemoveAll(tmp)
+	_ = os.RemoveAll(tmp)
 }

--- a/cli/coredump/coredump.go
+++ b/cli/coredump/coredump.go
@@ -36,7 +36,9 @@ func Pack(corePath, executable, outputDir string, pid uint, time string) error {
 	if err != nil {
 		return fmt.Errorf("cannot create a temporary directory for archiving: %w", err)
 	}
-	defer os.RemoveAll(tmpDir) // Clean up on function return.
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}() // Clean up on function return.
 
 	scriptArgs := []string{"-c", corePath}
 	if executable != "" {
@@ -118,7 +120,9 @@ func Inspect(archiveOrDir, sourceDir string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create a temporary directory for unpacking: %w", err)
 		}
-		defer os.RemoveAll(tmpDir) // Clean up on function return.
+		defer func() {
+			_ = os.RemoveAll(tmpDir)
+		}() // Clean up on function return.
 
 		err = util.ExtractTarGz(archiveOrDir, tmpDir)
 		if err != nil {

--- a/cli/create/create.go
+++ b/cli/create/create.go
@@ -35,7 +35,7 @@ func FillCtx(cliOpts *config.CliOpts, createCtx *create_ctx.CreateCtx) error {
 // RollbackOnErr removes temporary application directory.
 func rollbackOnErr(templateCtx *app_template.TemplateCtx) {
 	if templateCtx.AppPath != "" {
-		os.RemoveAll(templateCtx.AppPath)
+		_ = os.RemoveAll(templateCtx.AppPath)
 	}
 	templateCtx.AppPath = ""
 }

--- a/cli/create/internal/steps/collect_template_vars.go
+++ b/cli/create/internal/steps/collect_template_vars.go
@@ -44,7 +44,7 @@ func validateExistingValue(createCtx *create_ctx.CreateCtx, varInfo app_template
 	if createCtx.SilentMode {
 		return false, fmt.Errorf("%w%s variable", errInvalidFormatOfVariable, varInfo.Name)
 	}
-	fmt.Fprintf(os.Stdout, "Invalid format of %s variable.\n", varInfo.Name)
+	_, _ = fmt.Fprintf(os.Stdout, "Invalid format of %s variable.\n", varInfo.Name)
 	return false, nil
 }
 
@@ -74,12 +74,13 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 				if createCtx.SilentMode {
 					return fmt.Errorf("%s%w", varInfo.Name, errVariableValueIsNotSet)
 				}
-				fmt.Fprintf(os.Stdout, "%s: ", varInfo.Prompt)
+				_, _ = fmt.Fprintf(os.Stdout, "%s: ", varInfo.Prompt)
 			} else {
 				if createCtx.SilentMode {
 					input = varInfo.Default
 				} else {
-					fmt.Fprintf(os.Stdout, "%s (default: %s): ", varInfo.Prompt, varInfo.Default)
+					_, _ = fmt.Fprintf(os.Stdout, "%s (default: %s): ",
+						varInfo.Prompt, varInfo.Default)
 				}
 			}
 
@@ -93,7 +94,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 
 			if input == "" {
 				if varInfo.Default == "" {
-					fmt.Fprintln(os.Stdout, "Please enter a value.")
+					_, _ = fmt.Fprintln(os.Stdout, "Please enter a value.")
 				} else {
 					input = varInfo.Default
 				}
@@ -113,7 +114,7 @@ func (collectTemplateVarsFromUser CollectTemplateVarsFromUser) Run(
 				if createCtx.SilentMode {
 					return fmt.Errorf("%w%s variable", errInvalidFormatOfVariable, varInfo.Name)
 				}
-				fmt.Fprintln(os.Stdout, "Invalid format. Try again.")
+				_, _ = fmt.Fprintln(os.Stdout, "Invalid format. Try again.")
 			}
 		}
 		templateCtx.Vars[varInfo.Name] = input

--- a/cli/create/internal/steps/copy_app_template.go
+++ b/cli/create/internal/steps/copy_app_template.go
@@ -43,13 +43,17 @@ func copyEmbedFs(srcFs fs.FS, dst string) error {
 		if err != nil {
 			return fmt.Errorf("open template file %q: %w", path, err)
 		}
-		defer inFile.Close()
+		defer func() {
+			_ = inFile.Close()
+		}()
 
 		outFile, err := os.OpenFile(filepath.Join(dst, path), os.O_CREATE|os.O_WRONLY, filePerm)
 		if err != nil {
 			return fmt.Errorf("create %q: %w", path, err)
 		}
-		defer outFile.Close()
+		defer func() {
+			_ = outFile.Close()
+		}()
 
 		if _, err := io.Copy(outFile, inFile); err != nil {
 			return fmt.Errorf("copy %q: %w", path, err)

--- a/cli/create/internal/steps/copy_app_template_test.go
+++ b/cli/create/internal/steps/copy_app_template_test.go
@@ -22,9 +22,13 @@ const subdirName = "subdir"
 
 func createArchive(buf io.Writer, files ...string) error {
 	gzipWriter := gzip.NewWriter(buf)
-	defer gzipWriter.Close()
+	defer func() {
+		_ = gzipWriter.Close()
+	}()
 	tarWriter := tar.NewWriter(gzipWriter)
-	defer tarWriter.Close()
+	defer func() {
+		_ = tarWriter.Close()
+	}()
 
 	for _, fileName := range files {
 		err := addToArchive(tarWriter, fileName)
@@ -41,7 +45,9 @@ func addToArchive(tarWriter *tar.Writer, fileName string) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	stat, err := file.Stat()
 	if err != nil {
@@ -127,7 +133,9 @@ func TestExtractTemplateArchive(t *testing.T) {
 	archivePath := filepath.Join(workDir, "tmpl.tgz")
 	archiveOut, err := os.Create(archivePath)
 	require.NoError(t, err)
-	defer archiveOut.Close()
+	defer func() {
+		_ = archiveOut.Close()
+	}()
 
 	require.NoError(t, createArchive(archiveOut, filepath.Join(srcDir, "file1.txt")))
 

--- a/cli/create/internal/steps/create_temporary_app_dir_test.go
+++ b/cli/create/internal/steps/create_temporary_app_dir_test.go
@@ -19,7 +19,9 @@ func TestCreateTmpAppDirBasic(t *testing.T) {
 	createCtx.WorkDir = workDir
 	createAppDir := CreateTemporaryAppDirectory{}
 	require.NoError(t, createAppDir.Run(&createCtx, &templateCtx))
-	defer os.RemoveAll(templateCtx.AppPath)
+	defer func() {
+		_ = os.RemoveAll(templateCtx.AppPath)
+	}()
 
 	require.Equal(t, templateCtx.TargetAppPath, filepath.Join(workDir, createCtx.AppName))
 	require.DirExists(t, templateCtx.AppPath)
@@ -38,7 +40,9 @@ func TestCreateTmpAppDirMissingAppName(t *testing.T) {
 	// Set template name.
 	createCtx.AppName = "sample"
 	require.NoError(t, createAppDir.Run(&createCtx, &templateCtx))
-	defer os.RemoveAll(templateCtx.AppPath)
+	defer func() {
+		_ = os.RemoveAll(templateCtx.AppPath)
+	}()
 
 	require.Equal(t, templateCtx.TargetAppPath, filepath.Join(workDir, createCtx.AppName))
 	require.DirExists(t, templateCtx.AppPath)
@@ -53,7 +57,9 @@ func TestCreateTmpAppDirDestinationSet(t *testing.T) {
 	createCtx.AppName = "app1"
 	createCtx.DestinationDir = workDir
 	require.NoError(t, createAppDir.Run(&createCtx, &templateCtx))
-	defer os.RemoveAll(templateCtx.AppPath)
+	defer func() {
+		_ = os.RemoveAll(templateCtx.AppPath)
+	}()
 
 	require.Equal(t, templateCtx.TargetAppPath, filepath.Join(workDir, "app1"))
 }

--- a/cli/create/internal/steps/load_vars_file.go
+++ b/cli/create/internal/steps/load_vars_file.go
@@ -32,7 +32,9 @@ func (LoadVarsFile) Run(ctx *create_ctx.CreateCtx,
 	if err != nil {
 		return fmt.Errorf("vars file loading error: %w", err)
 	}
-	defer varsFile.Close()
+	defer func() {
+		_ = varsFile.Close()
+	}()
 
 	scanner := bufio.NewScanner(varsFile)
 	for scanner.Scan() {

--- a/cli/create/internal/steps/move_app_dir_test.go
+++ b/cli/create/internal/steps/move_app_dir_test.go
@@ -73,7 +73,9 @@ func TestMoveAppDirTargetDirRemovalFailure(t *testing.T) {
 
 	// Make parent dir read-only.
 	require.NoError(t, os.Chmod(filepath.Join(dstAppDir, "parent"), 0o444))
-	defer os.Chmod(filepath.Join(dstAppDir, "parent"), 0o755)
+	defer func() {
+		_ = os.Chmod(filepath.Join(dstAppDir, "parent"), 0o755)
+	}()
 
 	templateCtx.TargetAppPath = filepath.Join(dstAppDir, "parent", "apps")
 	templateCtx.AppPath = srcAppDir
@@ -82,7 +84,7 @@ func TestMoveAppDirTargetDirRemovalFailure(t *testing.T) {
 		fmt.Sprintf("stat %[1]s: permission denied", templateCtx.TargetAppPath))
 
 	// Check subdir is still there.
-	os.Chmod(filepath.Join(dstAppDir, "parent"), 0o755)
+	_ = os.Chmod(filepath.Join(dstAppDir, "parent"), 0o755)
 	require.DirExists(t, templateCtx.TargetAppPath)
 }
 

--- a/cli/create/internal/steps/print_follow_up_msg.go
+++ b/cli/create/internal/steps/print_follow_up_msg.go
@@ -26,7 +26,7 @@ func (printFollowUpMsgStep PrintFollowUpMessage) Run(createCtx *create_ctx.Creat
 			return err
 		}
 
-		printFollowUpMsgStep.Writer.Write([]byte(followUpText + "\n"))
+		_, _ = printFollowUpMsgStep.Writer.Write([]byte(followUpText + "\n"))
 	}
 
 	return nil

--- a/cli/daemon/process.go
+++ b/cli/daemon/process.go
@@ -120,7 +120,7 @@ func (process *Process) Stop() {
 		done <- process.worker.Stop()
 	}()
 
-	os.Remove(process.pidFileName)
+	_ = os.Remove(process.pidFileName)
 	_ = os.Unsetenv(process.DaemonTag)
 
 	err := <-done

--- a/cli/daemon/process_test.go
+++ b/cli/daemon/process_test.go
@@ -27,7 +27,7 @@ func TestProcessBase(t *testing.T) {
 
 	// Kill daemon if test fails.
 	defer func() {
-		syscall.Kill(pid, syscall.SIGINT)
+		_ = syscall.Kill(pid, syscall.SIGINT)
 		waitProcessChanges()
 	}()
 
@@ -36,7 +36,7 @@ func TestProcessBase(t *testing.T) {
 	require.True(t, alive, "Can't start daemon.")
 
 	// Stop daemon.
-	syscall.Kill(pid, syscall.SIGINT)
+	_ = syscall.Kill(pid, syscall.SIGINT)
 
 	// Check is daemon alive.
 	waitProcessChanges()

--- a/cli/daemon/process_test_helpers.go
+++ b/cli/daemon/process_test_helpers.go
@@ -36,11 +36,11 @@ func waitProcessChanges() {
 // cleanupDaemonFiles cleans up daemon artifacts.
 func cleanupDaemonFiles(logFilename, pidFilename string) {
 	if _, err := os.Stat(logFilename); !os.IsNotExist(err) {
-		os.Remove(logFilename)
+		_ = os.Remove(logFilename)
 	}
 
 	if _, err := os.Stat(pidFilename); !os.IsNotExist(err) {
-		os.Remove(pidFilename)
+		_ = os.Remove(pidFilename)
 	}
 }
 

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -56,7 +56,7 @@ func interruptHandler(cancelFunc context.CancelFunc) func() {
 	go func() {
 		_, ok := <-signals
 		if ok {
-			fmt.Fprintln(os.Stdout, "Canceling operation...")
+			_, _ = fmt.Fprintln(os.Stdout, "Canceling operation...")
 			cancelFunc()
 		}
 	}()
@@ -93,7 +93,9 @@ func buildDockerImage(dockerClient *mobyclient.Client, imageTag, buildContextDir
 		return nil
 	}
 
-	defer buildResult.Body.Close()
+	defer func() {
+		_ = buildResult.Body.Close()
+	}()
 	if !verbose {
 		writer = io.Discard
 	}
@@ -151,7 +153,9 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer dockerClient.Close()
+	defer func() {
+		_ = dockerClient.Close()
+	}()
 
 	log.Infof("Building docker image '%s'.", runOptions.ImageTag)
 	if err = buildDockerImage(dockerClient, runOptions.ImageTag, runOptions.BuildCtxDir,
@@ -191,8 +195,8 @@ func RunContainer(runOptions RunOptions, writer io.Writer) error {
 	if err != nil {
 		return err
 	}
-	stdcopy.StdCopy(writer, writer, out)
-	out.Close()
+	_, _ = stdcopy.StdCopy(writer, writer, out)
+	_ = out.Close()
 
 	waitResult := dockerClient.ContainerWait(ctx, containerID,
 		mobyclient.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})

--- a/cli/docker/docker_integration_test.go
+++ b/cli/docker/docker_integration_test.go
@@ -26,7 +26,7 @@ func findAndRemoveBuiltImage(t *testing.T, dockerClient *mobyclient.Client) {
 		for _, imgTag := range img.RepoTags {
 			if imgTag == "ubuntu:tt_test" {
 				imgFound = true
-				dockerClient.ImageRemove(ctx, img.ID, mobyclient.ImageRemoveOptions{})
+				_, _ = dockerClient.ImageRemove(ctx, img.ID, mobyclient.ImageRemoveOptions{})
 			}
 		}
 	}
@@ -36,7 +36,9 @@ func findAndRemoveBuiltImage(t *testing.T, dockerClient *mobyclient.Client) {
 func TestBuildImage(t *testing.T) {
 	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
-	defer dockerClient.Close()
+	defer func() {
+		_ = dockerClient.Close()
+	}()
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", false,
 		os.Stdout))
@@ -53,7 +55,9 @@ func TestBuildImageFail(t *testing.T) {
 
 	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
-	defer dockerClient.Close()
+	defer func() {
+		_ = dockerClient.Close()
+	}()
 
 	err = buildDockerImage(dockerClient, "ubuntu:tt_test", tmpDir, false, os.Stdout)
 	require.Error(t, err)
@@ -63,19 +67,23 @@ func TestBuildImageFail(t *testing.T) {
 func TestBuildImageOutputVerbose(t *testing.T) {
 	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
-	defer dockerClient.Close()
+	defer func() {
+		_ = dockerClient.Close()
+	}()
 
 	tmpDir := t.TempDir()
 	out, err := os.Create(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", true, out))
-	out.Close()
+	_ = out.Close()
 	findAndRemoveBuiltImage(t, dockerClient)
 
 	in, err := os.Open(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)
-	defer in.Close()
+	defer func() {
+		_ = in.Close()
+	}()
 	scanner := bufio.NewScanner(in)
 	require.True(t, scanner.Scan())
 	require.Equal(t, "Step 1/1 : FROM ubuntu:16.04", scanner.Text())
@@ -89,19 +97,23 @@ func TestBuildImageOutputVerbose(t *testing.T) {
 func TestBuildImageOutput(t *testing.T) {
 	dockerClient, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
-	defer dockerClient.Close()
+	defer func() {
+		_ = dockerClient.Close()
+	}()
 
 	tmpDir := t.TempDir()
 	out, err := os.Create(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)
 
 	require.NoError(t, buildDockerImage(dockerClient, "ubuntu:tt_test", "testdata", false, out))
-	out.Close()
+	_ = out.Close()
 	findAndRemoveBuiltImage(t, dockerClient)
 
 	in, err := os.Open(filepath.Join(tmpDir, "out.log"))
 	require.NoError(t, err)
-	defer in.Close()
+	defer func() {
+		_ = in.Close()
+	}()
 	scanner := bufio.NewScanner(in)
 	require.False(t, scanner.Scan())
 }
@@ -112,7 +124,9 @@ func checkNoContainers(t *testing.T, imageTag string) {
 	ctx := context.Background()
 	cli, err := mobyclient.New(mobyclient.FromEnv)
 	require.NoError(t, err)
-	defer cli.Close()
+	defer func() {
+		_ = cli.Close()
+	}()
 
 	containerListResult, err := cli.ContainerList(ctx, mobyclient.ContainerListOptions{
 		Filters: mobyclient.Filters{

--- a/cli/formatter/format_test.go
+++ b/cli/formatter/format_test.go
@@ -361,7 +361,7 @@ func TestFormatter_MakeOutputFormat(t *testing.T) {
 			}
 			if c.panic {
 				assert.PanicsWithValue(t, "Unknown render case", func() {
-					formatter.MakeOutput(c.outputFormat, c.input, formatterOpts)
+					_, _ = formatter.MakeOutput(c.outputFormat, c.input, formatterOpts)
 				})
 			} else {
 				output, err := formatter.MakeOutput(c.outputFormat, c.input, formatterOpts)

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -161,7 +161,9 @@ func getDistroInfo() (DistroInfo, error) {
 	if err != nil {
 		return distroInfo, err
 	}
-	defer releaseFile.Close()
+	defer func() {
+		_ = releaseFile.Close()
+	}()
 
 	scanner := bufio.NewScanner(releaseFile)
 	for scanner.Scan() {
@@ -234,7 +236,7 @@ func isProgramInstalled(program string) bool {
 // isPackageInstalledDebian checks if package is installed on Debian/Ubuntu.
 func isPackageInstalledDebian(packageName string) bool {
 	cmd := exec.CommandContext(context.Background(), "dpkg", "-L", packageName)
-	cmd.Start()
+	_ = cmd.Start()
 	if cmd.Wait() == nil {
 		return true
 	} else {
@@ -248,7 +250,7 @@ func printLog(logName string) error {
 	if err != nil {
 		return err
 	}
-	os.Stdout.Write(logs)
+	_, _ = os.Stdout.Write(logs)
 	return nil
 }
 
@@ -685,7 +687,7 @@ func downloadTtSource(path, ttVersion, distfiles string, resolved resolvedInstal
 		}
 		err := gitCheckout(path, ttVersion, installCtx.verbose, logFile)
 		if err != nil {
-			printLog(logFile.Name())
+			_ = printLog(logFile.Name())
 		}
 		return err
 	}
@@ -694,26 +696,26 @@ func downloadTtSource(path, ttVersion, distfiles string, resolved resolvedInstal
 	if resolved.versionFound {
 		err := downloadRepo(search.GitRepoTT, ttVersion, path, logFile, installCtx.verbose)
 		if err != nil {
-			printLog(logFile.Name())
+			_ = printLog(logFile.Name())
 		}
 		return err
 	}
 	if err := downloadRepo(search.GitRepoTT, "master", path, logFile,
 		installCtx.verbose); err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 	if resolved.isPullRequest {
 		pullRequestCommand := "pull/" + resolved.pullRequestID + "/head:" + ttVersion
 		if err := util.ExecuteCommand("git", installCtx.verbose, logFile, path,
 			"fetch", "origin", pullRequestCommand); err != nil {
-			printLog(logFile.Name())
+			_ = printLog(logFile.Name())
 			return err
 		}
 	}
 	err := gitCheckout(path, ttVersion, installCtx.verbose, logFile)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 	}
 	return err
 }
@@ -749,7 +751,9 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 		return err
 	}
 
-	defer os.Remove(logFile.Name())
+	defer func() {
+		_ = os.Remove(logFile.Name())
+	}()
 	log.Infof("Installing tt=" + ttVersion)
 
 	// Check tt dependencies.
@@ -764,10 +768,12 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	if err != nil {
 		return err
 	}
-	os.Chmod(path, defaultDirPermissions)
+	_ = os.Chmod(path, defaultDirPermissions)
 
 	if !installCtx.KeepTemp {
-		defer os.RemoveAll(path)
+		defer func() {
+			_ = os.RemoveAll(path)
+		}()
 	}
 
 	// Download tt.
@@ -780,7 +786,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	err = util.ExecuteCommand("mage", installCtx.verbose, logFile, path,
 		"build")
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -792,7 +798,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	log.Infof("Copying executable...")
 	err = copyBuildedTT(binDir, path, versionStr, installCtx)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -800,7 +806,7 @@ func installTt(binDir string, installCtx InstallCtx, distfiles string) error {
 	symlinkPath := filepath.Join(binDir, "tt")
 	err = util.CreateSymlink(versionStr, symlinkPath, true)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -945,7 +951,9 @@ func installTarantoolInDocker(tntVersion, binDir, incDir string, installCtx Inst
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	currentUser, err := user.Current()
 	if err != nil {
@@ -1135,7 +1143,9 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	if err != nil {
 		return err
 	}
-	defer os.Remove(logFile.Name())
+	defer func() {
+		_ = os.Remove(logFile.Name())
+	}()
 
 	log.Infof("Installing tarantool=" + tarVersion)
 	// Check dependencies.
@@ -1150,16 +1160,18 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	if err != nil {
 		return err
 	}
-	os.Chmod(path, defaultDirPermissions)
+	_ = os.Chmod(path, defaultDirPermissions)
 
 	if !installCtx.KeepTemp {
-		defer os.RemoveAll(path)
+		defer func() {
+			_ = os.RemoveAll(path)
+		}()
 	}
 
 	// Download tarantool.
 	err = downloadTarantoolSource(path, tarVersion, distfiles, resolved, installCtx, logFile)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -1167,7 +1179,7 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	log.Infof("Building tarantool...")
 	buildPath, err := buildTarantool(path, installCtx, logFile)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -1181,21 +1193,21 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 				versionStr)
 			err = os.RemoveAll(filepath.Join(binDir, versionStr))
 			if err != nil {
-				printLog(logFile.Name())
+				_ = printLog(logFile.Name())
 				return err
 			}
 			err = os.RemoveAll(filepath.Join(incDir, versionStr))
 		}
 	}
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 	binPath := filepath.Join(buildPath, "tarantool-prefix", "bin", "tarantool")
 	incPath := filepath.Join(buildPath, "tarantool-prefix", "include", "tarantool")
 	err = copyBuildedTarantool(binPath, incPath, binDir, incDir, versionStr)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 
@@ -1203,7 +1215,7 @@ func installTarantool(binDir string, installCtx InstallCtx, distfiles string) er
 	log.Infof("Changing symlinks...")
 	err = changeActiveTarantoolVersion(versionStr, binDir, incDir)
 	if err != nil {
-		printLog(logFile.Name())
+		_ = printLog(logFile.Name())
 		return err
 	}
 

--- a/cli/install/install_bundle.go
+++ b/cli/install/install_bundle.go
@@ -112,11 +112,11 @@ func prepareTemporaryDirs(bp *bundleParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to create temporary install directory: %w", err)
 	}
-	os.Chmod(bp.tmpDir, defaultDirPermissions)
+	_ = os.Chmod(bp.tmpDir, defaultDirPermissions)
 
 	bp.logFile, err = os.CreateTemp("", bp.inst.Program.String()+"_install_log_*")
 	if err != nil {
-		os.RemoveAll(bp.tmpDir)
+		_ = os.RemoveAll(bp.tmpDir)
 		return fmt.Errorf("failed to create temporary log file: %w", err)
 	}
 
@@ -155,7 +155,7 @@ func copyBundle(bp *bundleParams) error {
 	log.Infof("Local files found, installing from %s...", bundleName)
 	err := util.CopyFilePreserve(localBundlePath, filepath.Join(bp.tmpDir, bundleName))
 	if err != nil {
-		fmt.Fprintf(bp.logFile, "Error copying local bundle: %v\n", err)
+		_, _ = fmt.Fprintf(bp.logFile, "Error copying local bundle: %v\n", err)
 		return fmt.Errorf("failed to copy local bundle: %w", err)
 	}
 	return nil
@@ -181,7 +181,7 @@ func downloadBundle(bp *bundleParams) error {
 	log.Infof("Downloading %s... (%s)", bp.inst.Program, bundleSource)
 	err = install_ee.DownloadBundle(searchCtx.TntIoDoer, bundleName, bundleSource, bp.tmpDir)
 	if err != nil {
-		fmt.Fprintf(bp.logFile, "Error downloading bundle: %v\n", err)
+		_, _ = fmt.Fprintf(bp.logFile, "Error downloading bundle: %v\n", err)
 		return fmt.Errorf("failed to download bundle: %w", err)
 	}
 	return nil
@@ -200,7 +200,7 @@ func unpackBundle(bundlePath string, logFile io.Writer) error {
 	log.Infof("Unpacking archive %s...", filepath.Base(bundlePath))
 	err := util.ExtractTar(bundlePath)
 	if err != nil {
-		fmt.Fprintf(logFile, "Error unpacking bundle: %v\n", err)
+		_, _ = fmt.Fprintf(logFile, "Error unpacking bundle: %v\n", err)
 		return fmt.Errorf("failed to extract bundle %s: %w", filepath.Base(bundlePath), err)
 	}
 
@@ -256,7 +256,7 @@ func prepareForReinstall(bp *bundleParams) error {
 			bp.prgVersion, bp.inst.Program)
 
 		if err := os.RemoveAll(destBinPath); err != nil {
-			fmt.Fprintf(bp.logFile, "Error removing binary: %v\n", err)
+			_, _ = fmt.Fprintf(bp.logFile, "Error removing binary: %v\n", err)
 			return fmt.Errorf("failed to remove binary %s: %w", destBinPath, err)
 		}
 	}
@@ -265,7 +265,7 @@ func prepareForReinstall(bp *bundleParams) error {
 		log.Infof("Include directory for %s version already exists, removing...",
 			bp.prgVersion)
 		if err := os.RemoveAll(destIncPath); err != nil {
-			fmt.Fprintf(bp.logFile, "Error removing include dir: %v\n", err)
+			_, _ = fmt.Fprintf(bp.logFile, "Error removing include dir: %v\n", err)
 			return fmt.Errorf("failed to remove include directory %s: %w",
 				destIncPath, err)
 		}
@@ -281,13 +281,13 @@ func prepareForReinstall(bp *bundleParams) error {
 func copyNewArtifacts(bp *bundleParams) error {
 	srcBinPath, srcIncPath, err := findBundlePathsInDir(bp.tmpDir, bp.inst.Program)
 	if err != nil {
-		fmt.Fprintf(bp.logFile, "Error finding artifacts: %v\n", err)
+		_, _ = fmt.Fprintf(bp.logFile, "Error finding artifacts: %v\n", err)
 		return fmt.Errorf("failed to locate artifacts after extraction: %w", err)
 	}
 
 	err = prepareForReinstall(bp)
 	if err != nil {
-		fmt.Fprintf(bp.logFile, "Error preparing for reinstall: %v\n", err)
+		_, _ = fmt.Fprintf(bp.logFile, "Error preparing for reinstall: %v\n", err)
 		return fmt.Errorf("failed to prepare for reinstall: %w", err)
 	}
 
@@ -402,9 +402,9 @@ func executeBundleInstallation(bp *bundleParams) (string, error) {
 
 	if !bp.inst.KeepTemp {
 		defer func() {
-			bp.logFile.Close()
-			os.Remove(bp.logFile.Name())
-			os.RemoveAll(bp.tmpDir)
+			_ = bp.logFile.Close()
+			_ = os.Remove(bp.logFile.Name())
+			_ = os.RemoveAll(bp.tmpDir)
 		}()
 	}
 
@@ -413,7 +413,7 @@ func executeBundleInstallation(bp *bundleParams) (string, error) {
 		if err != nil {
 			log.Errorf("Installation failed: %v", err)
 			log.Infof("See log for details: %s", logFilePath)
-			printLog(logFilePath) // Attempt to print log content.
+			_ = printLog(logFilePath) // Attempt to print log content.
 		}
 	}()
 
@@ -424,35 +424,35 @@ func executeBundleInstallation(bp *bundleParams) (string, error) {
 // executeBundleInstallationSteps installs the bundle using the prepared temporary files.
 func executeBundleInstallationSteps(bp *bundleParams) error {
 	log.Infof("Starting installation steps in %s...", bp.tmpDir)
-	fmt.Fprintf(bp.logFile, "Installation started for %s version %s\n",
+	_, _ = fmt.Fprintf(bp.logFile, "Installation started for %s version %s\n",
 		bp.inst.Program, bp.bundleInfo.Version.Str)
 
 	if err := checkDependencies(bp.inst.Program, bp.inst.Force); err != nil {
-		fmt.Fprintf(bp.logFile, "Dependency check failed: %v\n", err)
+		_, _ = fmt.Fprintf(bp.logFile, "Dependency check failed: %v\n", err)
 		return err
 	}
-	fmt.Fprintf(bp.logFile, "Dependency check passed.\n")
+	_, _ = fmt.Fprintf(bp.logFile, "Dependency check passed.\n")
 
 	err := obtainBundle(bp)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(bp.logFile, "Bundle obtained successfully.\n")
+	_, _ = fmt.Fprintf(bp.logFile, "Bundle obtained successfully.\n")
 	bundlePath := filepath.Join(bp.tmpDir, bp.bundleInfo.Version.Tarball)
 
 	if err = unpackBundle(bundlePath, bp.logFile); err != nil {
 		return err
 	}
-	fmt.Fprintf(bp.logFile, "Bundle unpacked successfully.\n")
+	_, _ = fmt.Fprintf(bp.logFile, "Bundle unpacked successfully.\n")
 
 	err = copyNewArtifacts(bp)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(bp.logFile, "Artifacts copied successfully.\n")
+	_, _ = fmt.Fprintf(bp.logFile, "Artifacts copied successfully.\n")
 
 	log.Infof("Core installation steps completed successfully.")
-	fmt.Fprintf(bp.logFile, "Core installation steps completed successfully.\n")
+	_, _ = fmt.Fprintf(bp.logFile, "Core installation steps completed successfully.\n")
 	return nil
 }
 

--- a/cli/install/install_test.go
+++ b/cli/install/install_test.go
@@ -139,22 +139,22 @@ func Test_installTarantoolDev(t *testing.T) {
 		tempsDir := t.TempDir()
 
 		ttBinDir := filepath.Join(tempsDir, ttBinDir)
-		os.Mkdir(ttBinDir, os.ModePerm)
+		_ = os.Mkdir(ttBinDir, os.ModePerm)
 
 		ttIncDir := filepath.Join(tempsDir, ttIncDir)
-		os.Mkdir(ttIncDir, os.ModePerm)
+		_ = os.Mkdir(ttIncDir, os.ModePerm)
 
 		buildDir1 := filepath.Join(tempsDir, "build_ce")
-		os.MkdirAll(filepath.Join(buildDir1, "src"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(buildDir1, "src"), os.ModePerm)
 		binaryPath1 := filepath.Join(buildDir1, "src/tarantool")
-		os.Create(binaryPath1)
-		os.Chmod(binaryPath1, 0o700)
+		_, _ = os.Create(binaryPath1)
+		_ = os.Chmod(binaryPath1, 0o700)
 
 		buildDir2 := filepath.Join(tempsDir, "build_invalid")
-		os.MkdirAll(filepath.Join(buildDir2, "tarantool/src"), os.ModePerm)
+		_ = os.MkdirAll(filepath.Join(buildDir2, "tarantool/src"), os.ModePerm)
 		binaryPath2 := filepath.Join(buildDir2, "tarantool/src/tarantool")
-		os.Create(binaryPath2)
-		os.Chmod(binaryPath2, 0o700)
+		_, _ = os.Create(binaryPath2)
+		_ = os.Chmod(binaryPath2, 0o700)
 
 		return tempsDir
 	}
@@ -193,13 +193,13 @@ func Test_installTarantoolDev(t *testing.T) {
 		ttIncPath := filepath.Join(tempDirectory, ttIncDir)
 
 		// Default include-dir.
-		os.MkdirAll(filepath.Join(tempDirectory, "build_ce", "tarantool-prefix", "include",
+		_ = os.MkdirAll(filepath.Join(tempDirectory, "build_ce", "tarantool-prefix", "include",
 			"tarantool"), os.ModePerm,
 		)
 
 		// Custom include-dir.
 		customIncDirectoryPath := filepath.Join(tempDirectory, "build_invalid", "custom_inc")
-		os.MkdirAll(customIncDirectoryPath, os.ModePerm)
+		_ = os.MkdirAll(customIncDirectoryPath, os.ModePerm)
 		cases := []struct {
 			buildDir        string
 			incDir          string
@@ -241,7 +241,7 @@ func Test_installTarantoolDev(t *testing.T) {
 		ttIncPath := filepath.Join(tempDirectory, ttIncDir)
 
 		buildDir := filepath.Join(tempDirectory, "build_ee")
-		os.MkdirAll(buildDir, os.ModePerm)
+		_ = os.MkdirAll(buildDir, os.ModePerm)
 		err := installTarantoolDev(ttBinPath, ttIncPath, buildDir, "")
 		assert.Error(t, err)
 	})
@@ -251,20 +251,20 @@ func TestSearchTarantoolHeaders(t *testing.T) {
 	tempsDir := t.TempDir()
 
 	buildEmptyPath := filepath.Join(tempsDir, "build_empty")
-	os.MkdirAll(buildEmptyPath, os.ModePerm)
+	_ = os.MkdirAll(buildEmptyPath, os.ModePerm)
 
 	buildBasicPath := filepath.Join(tempsDir, "build_basic")
-	os.MkdirAll(filepath.Join(buildBasicPath, "tarantool-prefix", "include", "tarantool"),
+	_ = os.MkdirAll(filepath.Join(buildBasicPath, "tarantool-prefix", "include", "tarantool"),
 		os.ModePerm)
-	os.MkdirAll(filepath.Join(buildBasicPath, "custom-prefix", "include", "tarantool"),
+	_ = os.MkdirAll(filepath.Join(buildBasicPath, "custom-prefix", "include", "tarantool"),
 		os.ModePerm)
 
 	buildInvalidPath := filepath.Join(tempsDir, "build_invalid")
-	os.MkdirAll(buildInvalidPath, os.ModePerm)
-	os.MkdirAll(filepath.Join(buildInvalidPath, "tarantool-prefix", "include"),
+	_ = os.MkdirAll(buildInvalidPath, os.ModePerm)
+	_ = os.MkdirAll(filepath.Join(buildInvalidPath, "tarantool-prefix", "include"),
 		os.ModePerm)
-	os.Create(filepath.Join(buildInvalidPath, "tarantool-prefix", "include", "tarantool"))
-	os.Create(filepath.Join(buildInvalidPath, "invalid_inc"))
+	_, _ = os.Create(filepath.Join(buildInvalidPath, "tarantool-prefix", "include", "tarantool"))
+	_, _ = os.Create(filepath.Join(buildInvalidPath, "invalid_inc"))
 
 	cases := []struct {
 		buildDir           string

--- a/cli/install_ee/install_ee.go
+++ b/cli/install_ee/install_ee.go
@@ -49,7 +49,9 @@ func (d *httpDoer) Do(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w%s", errHTTPRequestError, http.StatusText(res.StatusCode))
@@ -120,8 +122,8 @@ func saveResponseBodyToFile(body []byte, destFilePath string) (errRet error) {
 
 	_, err = file.Write(body)
 	if err != nil {
-		file.Close()
-		os.Remove(destFilePath)
+		_ = file.Close()
+		_ = os.Remove(destFilePath)
 		return fmt.Errorf("failed to write downloaded content to %s: %w", destFilePath, err)
 	}
 

--- a/cli/install_ee/install_ee_test.go
+++ b/cli/install_ee/install_ee_test.go
@@ -135,7 +135,7 @@ func TestDownloadBundle(t *testing.T) {
 				file, err := os.CreateTemp(baseDir, "destination_as_file_*")
 				require.NoError(t, err)
 				filePath := file.Name()
-				file.Close()
+				_ = file.Close()
 				return filePath
 			},
 			doer: &mockBundleDoer{
@@ -163,7 +163,7 @@ func TestDownloadBundle(t *testing.T) {
 				conflictingFile := filepath.Join(baseDir, "conflict_dir")
 				f, err := os.Create(conflictingFile)
 				require.NoError(t, err)
-				f.Close()
+				_ = f.Close()
 				return baseDir
 			},
 			doer: &mockBundleDoer{

--- a/cli/modules/modules_test.go
+++ b/cli/modules/modules_test.go
@@ -200,7 +200,7 @@ func TestGetModulesInfo(t *testing.T) {
 		},
 	}
 
-	os.Unsetenv("TT_CLI_MODULES_PATH")
+	_ = os.Unsetenv("TT_CLI_MODULES_PATH")
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			cmdCtx := cmdcontext.CmdCtx{
@@ -223,7 +223,7 @@ func TestGetModulesInfo(t *testing.T) {
 			}()
 
 			got, err := modules.GetModulesInfo(&cmdCtx, "root", &cliOpts)
-			os.Unsetenv("TT_CLI_MODULES_PATH")
+			_ = os.Unsetenv("TT_CLI_MODULES_PATH")
 			t.Log(buf.String())
 
 			if err != nil || tt.err != "" {

--- a/cli/modules/run.go
+++ b/cli/modules/run.go
@@ -49,7 +49,7 @@ func RunCmd(cmdCtx *cmdcontext.CmdCtx, cmdPath string, modulesInfo *ModulesInfo,
 	if err != nil {
 		return fmt.Errorf("integrity check failed for %q: %w", manifest.Main, err)
 	}
-	f.Close()
+	_ = f.Close()
 	if rc := RunExec(manifest.Main, args); rc != 0 {
 		os.Exit(rc)
 	}

--- a/cli/process_utils/process_utils.go
+++ b/cli/process_utils/process_utils.go
@@ -87,7 +87,9 @@ func GetPIDFromFile(pidFileName string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf(`can't open the PID file. Error: "%w"`, err)
 	}
-	defer pidFile.Close()
+	defer func() {
+		_ = pidFile.Close()
+	}()
 
 	pidBytes, err := io.ReadAll(pidFile)
 	if err != nil {
@@ -116,7 +118,7 @@ func CheckPIDFile(pidFileName string) error {
 		if res, _ := IsProcessAlive(pid); res {
 			return fmt.Errorf("%w%d", errTheProcessAlreadyExistsPID, pid)
 		} else {
-			os.Remove(pidFileName)
+			_ = os.Remove(pidFileName)
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf(`something went wrong while trying to read the PID file. Error: "%w"`,
@@ -176,7 +178,9 @@ func CreatePIDFile(pidFileName string, pid int) error {
 	if err != nil {
 		return fmt.Errorf(`can't create a new PID file. Error: "%w"`, err)
 	}
-	defer pidFile.Close()
+	defer func() {
+		_ = pidFile.Close()
+	}()
 
 	if _, err = pidFile.WriteString(strconv.Itoa(pid)); err != nil {
 		return err

--- a/cli/process_utils/process_utils_test.go
+++ b/cli/process_utils/process_utils_test.go
@@ -14,7 +14,7 @@ func Test_ExistsAndRecord(t *testing.T) {
 	cmd := exec.CommandContext(t.Context(), "sleep", "10")
 
 	t.Cleanup(func() {
-		os.Remove(testFile)
+		_ = os.Remove(testFile)
 	})
 
 	err := cmd.Start()

--- a/cli/replicaset/cconfig.go
+++ b/cli/replicaset/cconfig.go
@@ -634,7 +634,7 @@ func reloadCConfig(instances []running.InstanceCtx) error {
 		opts := connector.RequestOpts{}
 		_, err := evaler.Eval("require('config'):reload()", args, opts)
 		if err != nil {
-			fmt.Fprintln(os.Stdout, err)
+			_, _ = fmt.Fprintln(os.Stdout, err)
 			errored = append(errored, instance.InstName)
 		}
 		return false, nil

--- a/cli/replicaset/cmd/bootstrap.go
+++ b/cli/replicaset/cmd/bootstrap.go
@@ -74,8 +74,8 @@ func Bootstrap(ctx BootstrapCtx) error {
 		if err != nil {
 			return err
 		}
-		statusReplicasets(replicasets)
-		fmt.Fprintln(os.Stdout)
+		_ = statusReplicasets(replicasets)
+		_, _ = fmt.Fprintln(os.Stdout)
 		log.Info("Done.")
 	}
 	return err

--- a/cli/replicaset/cmd/demote.go
+++ b/cli/replicaset/cmd/demote.go
@@ -49,15 +49,15 @@ func Demote(ctx DemoteCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}
-	statusReplicasets(replicasets)
-	fmt.Fprintln(os.Stdout)
+	_ = statusReplicasets(replicasets)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	if ctx.InstName != "" {
 		log.Infof("Demote instance: %s", ctx.InstName)

--- a/cli/replicaset/cmd/downgrade.go
+++ b/cli/replicaset/cmd/downgrade.go
@@ -68,10 +68,10 @@ func internalDowngrade(replicasets []replicaset.Replicaset, lsnTimeout int, vers
 	for _, replicaset := range replicasets {
 		err := downgradeReplicaset(replicaset, lsnTimeout, version, connOpts)
 		if err != nil {
-			fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
+			_, _ = fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
 			return fmt.Errorf("replicaset %s: %w", replicaset.Alias, err)
 		}
-		fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
+		_, _ = fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
 	}
 	return nil
 }

--- a/cli/replicaset/cmd/expel.go
+++ b/cli/replicaset/cmd/expel.go
@@ -49,16 +49,16 @@ func Expel(expelCtx ExpelCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Fprintln(os.Stdout, "")
+	_, _ = fmt.Fprintln(os.Stdout, "")
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}
-	statusReplicasets(replicasets)
+	_ = statusReplicasets(replicasets)
 
-	fmt.Fprintln(os.Stdout, "")
+	_, _ = fmt.Fprintln(os.Stdout, "")
 	log.Infof("Expel instance: %s", expelCtx.Instance)
 
 	// Try to expel the instance.

--- a/cli/replicaset/cmd/promote.go
+++ b/cli/replicaset/cmd/promote.go
@@ -60,15 +60,15 @@ func Promote(ctx PromoteCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}
-	statusReplicasets(replicasets)
-	fmt.Fprintln(os.Stdout)
+	_ = statusReplicasets(replicasets)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	if ctx.InstName != "" {
 		log.Infof("Promote instance: %s", ctx.InstName)

--- a/cli/replicaset/cmd/roles.go
+++ b/cli/replicaset/cmd/roles.go
@@ -67,15 +67,15 @@ func RolesChange(ctx RolesChangeCtx, changeRoleAction replicaset.RolesChangerAct
 	}
 
 	log.Info("Discovery application...")
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	// Get and print status.
 	replicasets, err := orchestrator.Discovery(replicaset.SkipCache)
 	if err != nil {
 		return err
 	}
-	statusReplicasets(replicasets)
-	fmt.Fprintln(os.Stdout)
+	_ = statusReplicasets(replicasets)
+	_, _ = fmt.Fprintln(os.Stdout)
 
 	action := []string{"Add", "to"}
 	if changeRoleAction.Action() == replicaset.RemoveAction {

--- a/cli/replicaset/cmd/status.go
+++ b/cli/replicaset/cmd/status.go
@@ -70,17 +70,17 @@ func statusReplicasets(replicasets replicaset.Replicasets) error {
 		return errUnknownOrEmptyReplicasetsConfiguration
 	}
 
-	fmt.Fprintln(os.Stdout, "Orchestrator:     ", replicasets.Orchestrator)
-	fmt.Fprintln(os.Stdout, "Replicasets state:", replicasets.State)
+	_, _ = fmt.Fprintln(os.Stdout, "Orchestrator:     ", replicasets.Orchestrator)
+	_, _ = fmt.Fprintln(os.Stdout, "Replicasets state:", replicasets.State)
 
 	replicasets = fillAliases(replicasets)
 	replicasets = sortAliases(replicasets)
 
 	if len(replicasets.Replicasets) > 0 {
-		fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout)
 	}
 	for _, replicaset := range replicasets.Replicasets {
-		fmt.Fprint(os.Stdout, replicasetToString(replicaset))
+		_, _ = fmt.Fprint(os.Stdout, replicasetToString(replicaset))
 	}
 	return nil
 }

--- a/cli/replicaset/cmd/upgrade.go
+++ b/cli/replicaset/cmd/upgrade.go
@@ -97,20 +97,20 @@ func internalUpgrade(replicasets []replicaset.Replicaset, lsnTimeout int,
 	for _, replicaset := range replicasets {
 		err := upgradeReplicaset(replicaset, lsnTimeout, connOpts)
 		if err != nil {
-			fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
+			_, _ = fmt.Fprintf(os.Stdout, "• %s: error\n", replicaset.Alias)
 			return fmt.Errorf("replicaset %s: %w", replicaset.Alias, err)
 		}
-		fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
+		_, _ = fmt.Fprintf(os.Stdout, "• %s: ok\n", replicaset.Alias)
 	}
 	return nil
 }
 
 func closeConnectors(master *instanceMeta, replicas []instanceMeta) {
 	if master != nil {
-		master.conn.Close()
+		_ = master.conn.Close()
 	}
 	for _, replica := range replicas {
-		replica.conn.Close()
+		_ = replica.conn.Close()
 	}
 }
 
@@ -178,7 +178,7 @@ func collectRwRoInfo(rs replicaset.Replicaset,
 			}
 			isReadOnly, ok := res[0].(bool)
 			if !ok {
-				conn.Close()
+				_ = conn.Close()
 				closeConnectors(master, replicas)
 				return nil, nil, fmt.Errorf(
 					"%w %s: expected bool, got %T",

--- a/cli/replicaset/cmd/vshard.go
+++ b/cli/replicaset/cmd/vshard.go
@@ -47,7 +47,7 @@ func discoverApp(orchestrator replicasetOrchestrator) error {
 		return err
 	}
 
-	statusReplicasets(replicasets)
+	_ = statusReplicasets(replicasets)
 
 	return nil
 }
@@ -74,7 +74,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 	}
 
 	log.Info("Discovery application...")
-	fmt.Fprintln(os.Stdout, "")
+	_, _ = fmt.Fprintln(os.Stdout, "")
 
 	retryOpts := []retry.Option{
 		retry.Delay(1 * time.Second),
@@ -88,7 +88,7 @@ func BootstrapVShard(ctx VShardCmdCtx) error {
 		return fmt.Errorf("failed to bootstrap vshard: %w", err)
 	}
 
-	fmt.Fprintln(os.Stdout, "")
+	_, _ = fmt.Fprintln(os.Stdout, "")
 	log.Info("Bootstrapping vshard")
 
 	err = orchestrator.BootstrapVShard(replicaset.VShardBootstrapCtx{Timeout: ctx.Timeout})

--- a/cli/replicaset/configsource_test.go
+++ b/cli/replicaset/configsource_test.go
@@ -527,7 +527,7 @@ func TestCConfigSource_Promote_many_keys_choose_affects(t *testing.T) {
 	source := replicaset.NewCConfigSource(collector, publisher, picker)
 	err := source.Promote(replicaset.PromoteCtx{InstName: "instance-002"})
 	require.NoError(t, err)
-	fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
+	_, _ = fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
 	assertPublished(t, publisher, "b", expected)
 }
 
@@ -695,7 +695,7 @@ func TestCConfigSource_Demote_many_keys(t *testing.T) {
 			source := replicaset.NewCConfigSource(collector, publisher, picker)
 			err := source.Demote(replicaset.DemoteCtx{InstName: "instance-002"})
 			require.NoError(t, err)
-			fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
+			_, _ = fmt.Fprintln(os.Stdout, string(publisher.Data[0]))
 			assertPublished(t, publisher, tc.keys[0], expected)
 		})
 	}

--- a/cli/replicaset/eval.go
+++ b/cli/replicaset/eval.go
@@ -113,7 +113,7 @@ func evalForeach(instances []running.InstanceCtx,
 
 		connected++
 		done, err := iEvaler.Eval(instance, conn)
-		conn.Close()
+		_ = conn.Close()
 
 		if err != nil {
 			return err

--- a/cli/replicaset/integration_test.go
+++ b/cli/replicaset/integration_test.go
@@ -45,7 +45,9 @@ func doRequest(req tarantool.Request) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	_, err = conn.Do(req).Get()
 	return err
@@ -97,7 +99,9 @@ func TestEvalOrchestrator_cconfig(t *testing.T) {
 	defer reset()
 
 	conn := testConnect(t)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	evaled, err := replicaset.EvalOrchestrator(conn)
 	require.NoError(t, err)
@@ -111,7 +115,9 @@ func TestEvalOrchestrator_custom(t *testing.T) {
 			defer reset()
 
 			conn := testConnect(t)
-			defer conn.Close()
+			defer func() {
+				_ = conn.Close()
+			}()
 
 			evaled, err := replicaset.EvalOrchestrator(conn)
 			require.NoError(t, err)
@@ -517,7 +523,7 @@ func TestEvalAny_error(t *testing.T) {
 func runTestMain(m *testing.M) int {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare test work dir:", err)
 		return 1
 	}
 
@@ -531,21 +537,21 @@ func runTestMain(m *testing.M) int {
 		RetryTimeout: 100 * time.Millisecond,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to prepare test tarantool:", err)
 		return 1
 	}
 	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	conn, err := tarantool.Connect(context.Background(), dialer, opts)
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to check tarantool version:", err)
 		return 1
 	}
 
 	_, err = conn.Do(tarantool.NewPingRequest()).Get()
-	conn.Close()
+	_ = conn.Close()
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Failed to ping tarantool server:", err)
+		_, _ = fmt.Fprintln(os.Stdout, "Failed to ping tarantool server:", err)
 		return 1
 	}
 

--- a/cli/replicaset/orchestrators_test.go
+++ b/cli/replicaset/orchestrators_test.go
@@ -87,7 +87,7 @@ func TestReplicasetGetter_Discovery_panics_with_invalid_evaler(t *testing.T) {
 			t.Run(oc.Name+"_"+tc.Name, func(t *testing.T) {
 				getter := oc.New(tc.Evaler)
 				assert.Panics(t, func() {
-					getter.Discovery(replicaset.SkipCache)
+					_, _ = getter.Discovery(replicaset.SkipCache)
 				})
 			})
 		}

--- a/cli/rocks/rocks.go
+++ b/cli/rocks/rocks.go
@@ -156,11 +156,11 @@ func Exec(cmdCtx *cmdcontext.CmdCtx, cliOpts *config.CliOpts, args []string) err
 	// build/local.go) read these at compile time via extra/hardcoded.lua's
 	// contract. The library never sets process env; only this shim does,
 	// mirroring the previous embedded-luarocks behavior.
-	os.Setenv("TT_CLI_TARANTOOL_VERSION", version.Str)
-	os.Setenv("TT_CLI_TARANTOOL_PREFIX", tarantoolPrefixDir)
-	os.Setenv("TT_CLI_TARANTOOL_INCLUDE", tarantoolIncludeDir)
-	os.Setenv("TARANTOOL_DIR", filepath.Dir(tarantoolIncludeDir))
-	os.Setenv("TT_CLI_TARANTOOL_PATH", filepath.Dir(cmdCtx.Cli.TarantoolCli.Executable))
+	_ = os.Setenv("TT_CLI_TARANTOOL_VERSION", version.Str)
+	_ = os.Setenv("TT_CLI_TARANTOOL_PREFIX", tarantoolPrefixDir)
+	_ = os.Setenv("TT_CLI_TARANTOOL_INCLUDE", tarantoolIncludeDir)
+	_ = os.Setenv("TARANTOOL_DIR", filepath.Dir(tarantoolIncludeDir))
+	_ = os.Setenv("TT_CLI_TARANTOOL_PATH", filepath.Dir(cmdCtx.Cli.TarantoolCli.Executable))
 
 	cfg := luarocks.Config{
 		Tree:       filepath.Join(workingDir, ".rocks"),

--- a/cli/rocks/rocks_test.go
+++ b/cli/rocks/rocks_test.go
@@ -103,7 +103,7 @@ func TestAddLuarocksRepoOpts(t *testing.T) {
 }
 
 func TestGetRocksRepoPath(t *testing.T) {
-	os.Unsetenv(repoRocksPathEnvVarName)
+	_ = os.Unsetenv(repoRocksPathEnvVarName)
 	assert.EqualValues(t, "./testdata/repo", getRocksRepoPath("./testdata/repo"))
 	assert.EqualValues(t, "./testdata/emptyrepo", getRocksRepoPath("./testdata/emptyrepo"))
 
@@ -112,7 +112,7 @@ func TestGetRocksRepoPath(t *testing.T) {
 	assert.EqualValues(t, "./other_repo", getRocksRepoPath("./testdata/emptyrepo"))
 	// Return passed repo path, since manifest exists. Env var is ignored.
 	assert.EqualValues(t, "./testdata/repo", getRocksRepoPath("./testdata/repo"))
-	os.Unsetenv(repoRocksPathEnvVarName)
+	_ = os.Unsetenv(repoRocksPathEnvVarName)
 }
 
 func TestSetupTarantoolPrefix(t *testing.T) {
@@ -205,13 +205,13 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 	}
 
 	for input, output := range testCases {
-		os.Unsetenv(tarantoolPrefixEnvVarName)
+		_ = os.Unsetenv(tarantoolPrefixEnvVarName)
 		tntFile, err := os.Create(tntBinPath)
 		require.NoError(t, err)
 
 		_, err = tntFile.Write(*input.data)
 		require.NoError(t, err)
-		tntFile.Close()
+		_ = tntFile.Close()
 
 		err = os.Chmod(tntFile.Name(), 0o755)
 		require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 			t.Setenv(tarantoolPrefixEnvVarName, input.tntPrefixEnv)
 		}
 		tarantoolPrefix, err := GetTarantoolPrefix(&input.cli, input.cliOpts)
-		os.Unsetenv(tarantoolPrefixEnvVarName)
+		_ = os.Unsetenv(tarantoolPrefixEnvVarName)
 		if err == nil {
 			assert.Nil(err)
 			assert.Equal(output.prefix, tarantoolPrefix)
@@ -228,6 +228,6 @@ func TestSetupTarantoolPrefix(t *testing.T) {
 			assert.Equal(output.err, err)
 		}
 
-		os.Remove(tntBinPath)
+		_ = os.Remove(tntBinPath)
 	}
 }

--- a/cli/running/base_instance.go
+++ b/cli/running/base_instance.go
@@ -78,7 +78,7 @@ func newBaseInstance(tarantoolPath string, instanceCtx InstanceCtx,
 		stdErr:        os.Stderr,
 	}
 	for _, opt := range opts {
-		opt(&baseInst)
+		_ = opt(&baseInst)
 	}
 	return baseInst
 }
@@ -162,7 +162,7 @@ func (inst *baseInstance) Run(opts RunOpts) error {
 		}
 		return err
 	}
-	f.Close()
+	_ = f.Close()
 	newInstanceEnv := os.Environ()
 	args := make([]string, 0, 1+len(opts.RunArgs))
 	args = append(args, inst.tarantoolPath)

--- a/cli/running/cluster_instance_test.go
+++ b/cli/running/cluster_instance_test.go
@@ -63,7 +63,9 @@ func TestClusterInstance_Start(t *testing.T) {
 	tmpDir := t.TempDir()
 	cancelChdir, err := util.Chdir(tmpDir)
 	require.NoError(t, err)
-	defer cancelChdir()
+	defer func() {
+		_ = cancelChdir()
+	}()
 
 	outputBuf := bytes.Buffer{}
 	outputBuf.Grow(1024)
@@ -97,7 +99,9 @@ func TestClusterInstance_StartChangeDefaults(t *testing.T) {
 	tmpDir := t.TempDir()
 	cancelChdir, err := util.Chdir(tmpDir)
 	require.NoError(t, err)
-	defer cancelChdir()
+	defer func() {
+		_ = cancelChdir()
+	}()
 
 	tmpAppDir := filepath.Join(tmpDir, "appdir")
 	require.NoError(t, os.Mkdir(tmpAppDir, 0o755))
@@ -142,7 +146,9 @@ func TestClusterInstance_StartChangeSomeDefaults(t *testing.T) {
 	tmpDir := t.TempDir()
 	cancelChdir, err := util.Chdir(tmpDir)
 	require.NoError(t, err)
-	defer cancelChdir()
+	defer func() {
+		_ = cancelChdir()
+	}()
 
 	tmpAppDir := filepath.Join(tmpDir, "appdir")
 	require.NoError(t, os.Mkdir(tmpAppDir, 0o755))
@@ -194,7 +200,9 @@ func TestClusterInstance_StopByContext(t *testing.T) {
 	tmpDir := t.TempDir()
 	cancelChdir, err := util.Chdir(tmpDir)
 	require.NoError(t, err)
-	defer cancelChdir()
+	defer func() {
+		_ = cancelChdir()
+	}()
 
 	outputBuf := bytes.Buffer{}
 	outputBuf.Grow(1024)

--- a/cli/running/process_controller_test.go
+++ b/cli/running/process_controller_test.go
@@ -22,7 +22,7 @@ func TestProcessController(t *testing.T) {
 	dpc, err := newProcessController(cmd)
 	require.NoError(t, err)
 
-	dpc.Wait()
+	_ = dpc.Wait()
 	require.NoError(t, err)
 	assert.False(t, dpc.IsAlive())
 	assert.Equal(t, "hello\n", out.String())
@@ -42,7 +42,7 @@ func TestProcessController(t *testing.T) {
 
 	// Test sending signal.
 	require.NoError(t, waitForMsgInBuffer(&outBuf, "started", 5*time.Second))
-	dpc.SendSignal(syscall.SIGUSR1)
+	_ = dpc.SendSignal(syscall.SIGUSR1)
 	require.NoError(t, waitForMsgInBuffer(&outBuf, "sigusr1", 5*time.Second))
 	assert.True(t, dpc.IsAlive())
 

--- a/cli/running/running.go
+++ b/cli/running/running.go
@@ -236,7 +236,7 @@ func (provider *providerImpl) UpdateLogger(logger ttlog.Logger) (ttlog.Logger, e
 		return logger, err
 	}
 	if updateLogger {
-		logger.Close()
+		_ = logger.Close()
 		return createLogger(provider.instanceCtx)
 	}
 	return logger, nil
@@ -422,7 +422,7 @@ func collectInstancesFromAppDir(appDir, selectedInstName string,
 	if err != nil {
 		return nil, fmt.Errorf("can't check integrity of %q: %w", appDirFiles.instCfgPath, err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	instParams, err := util.ParseYAML(appDirFiles.instCfgPath)
 	if err != nil {
@@ -503,11 +503,11 @@ func collectInstances(appName, applicationDir string,
 // cleanup removes runtime artifacts.
 func cleanup(run *InstanceCtx) {
 	if _, err := os.Stat(run.PIDFile); err == nil {
-		os.Remove(run.PIDFile)
+		_ = os.Remove(run.PIDFile)
 	}
 
 	if _, err := os.Stat(run.ConsoleSocket); err == nil {
-		os.Remove(run.ConsoleSocket)
+		_ = os.Remove(run.ConsoleSocket)
 	}
 
 	if _, err := os.Stat(run.BinaryPort); err == nil {
@@ -750,7 +750,7 @@ func RunInstance(ctx context.Context, cmdCtx *cmdcontext.CmdCtx, inst InstanceCt
 	}()
 
 	if err := process_utils.CreatePIDFile(inst.PIDFile, instance.GetPid()); err != nil {
-		instance.Stop(instanceCleanupTimeout)
+		_ = instance.Stop(instanceCleanupTimeout)
 		return fmt.Errorf("cannot create the pid file %q: %w", inst.PIDFile, err)
 	}
 
@@ -880,7 +880,7 @@ func Logrotate(run *InstanceCtx) error {
 // Check returns the result of checking the syntax of the application file.
 func Check(cmdCtx *cmdcontext.CmdCtx, run *InstanceCtx) error {
 	var errBuff bytes.Buffer
-	os.Setenv("TT_CLI_INSTANCE", run.InstanceScript)
+	_ = os.Setenv("TT_CLI_INSTANCE", run.InstanceScript)
 
 	cmd := exec.CommandContext(
 		context.Background(), cmdCtx.Cli.TarantoolCli.Executable, "-e", checkSyntax)
@@ -949,7 +949,7 @@ func StartWatchdog(cmdCtx *cmdcontext.CmdCtx, ttExecutable string, instance Inst
 	if err != nil {
 		return err
 	}
-	f.Close()
+	_ = f.Close()
 
 	log.Infof("Starting an instance [%s]...", appName)
 

--- a/cli/running/running_test.go
+++ b/cli/running/running_test.go
@@ -217,7 +217,7 @@ func Test_collectAppDirFiles(t *testing.T) {
 	expectedClusterConfig := filepath.Join(tmpdir, "config.yml")
 
 	// Cluster config exists, but no instances config.
-	os.Create(expectedClusterConfig)
+	_, _ = os.Create(expectedClusterConfig)
 	appDirFiles, err := collectAppDirFiles(tmpdir)
 	require.NoError(t, err)
 	require.Equal(t, expectedClusterConfig, appDirFiles.clusterCfgPath)
@@ -225,7 +225,7 @@ func Test_collectAppDirFiles(t *testing.T) {
 	require.Equal(t, "", appDirFiles.instCfgPath)
 
 	// Cluster config and default instance script exist, but no instances config.
-	os.Create(expectedDefaultScript)
+	_, _ = os.Create(expectedDefaultScript)
 	appDirFiles, err = collectAppDirFiles(tmpdir)
 	require.NoError(t, err)
 	require.Equal(t, expectedClusterConfig, appDirFiles.clusterCfgPath)
@@ -233,7 +233,7 @@ func Test_collectAppDirFiles(t *testing.T) {
 	require.Equal(t, "", appDirFiles.instCfgPath)
 
 	// All files exist.
-	os.Create(expectedInstancesConfig)
+	_, _ = os.Create(expectedInstancesConfig)
 	appDirFiles, err = collectAppDirFiles(tmpdir)
 	require.NoError(t, err)
 	require.Equal(t, expectedClusterConfig, appDirFiles.clusterCfgPath)
@@ -241,7 +241,7 @@ func Test_collectAppDirFiles(t *testing.T) {
 	require.Equal(t, expectedInstancesConfig, appDirFiles.instCfgPath)
 
 	// No default script.
-	os.Remove(expectedDefaultScript)
+	_ = os.Remove(expectedDefaultScript)
 	appDirFiles, err = collectAppDirFiles(tmpdir)
 	require.NoError(t, err)
 	require.Equal(t, expectedClusterConfig, appDirFiles.clusterCfgPath)
@@ -249,7 +249,7 @@ func Test_collectAppDirFiles(t *testing.T) {
 	require.Equal(t, expectedInstancesConfig, appDirFiles.instCfgPath)
 
 	// Only instances config.
-	os.Remove(expectedClusterConfig)
+	_ = os.Remove(expectedClusterConfig)
 	appDirFiles, err = collectAppDirFiles(tmpdir)
 	require.NoError(t, err)
 	require.Equal(t, "", appDirFiles.clusterCfgPath)

--- a/cli/running/script_instance.go
+++ b/cli/running/script_instance.go
@@ -91,7 +91,7 @@ func (inst *scriptInstance) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		f.Close()
+		_ = f.Close()
 	}
 
 	cmdArgs := []string{}
@@ -161,8 +161,8 @@ func (inst *scriptInstance) Start(ctx context.Context) error {
 	if inst.processController, err = newProcessController(cmd); err != nil {
 		return err
 	}
-	StdinPipe.Write(instanceLauncher)
-	StdinPipe.Close()
+	_, _ = StdinPipe.Write(instanceLauncher)
+	_ = StdinPipe.Close()
 
 	return nil
 }

--- a/cli/running/script_instance_test.go
+++ b/cli/running/script_instance_test.go
@@ -53,7 +53,9 @@ func startTestInstance(t *testing.T, ctx context.Context, app, consoleSock strin
 
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
 	t.Setenv("started_flag_file", filepath.Join(binDir, app))
-	defer os.Remove(os.Getenv("started_flag_file"))
+	defer func() {
+		_ = os.Remove(os.Getenv("started_flag_file"))
+	}()
 	err = inst.Start(ctx)
 	assert.Nilf(err, `Can't start the instance. Error: "%v".`, err)
 
@@ -74,7 +76,7 @@ func cleanupTestInstance(t *testing.T, inst *scriptInstance) {
 		assert.NoError(t, err)
 	}
 	if _, err := os.Stat(inst.consoleSocket); err == nil {
-		os.Remove(inst.consoleSocket)
+		_ = os.Remove(inst.consoleSocket)
 	}
 }
 
@@ -93,7 +95,7 @@ func TestInstanceBase(t *testing.T) {
 
 	conn, err := (&net.Dialer{}).DialContext(t.Context(), "unix", consoleSock)
 	assert.Nilf(err, `Can't connect to console socket. Error: "%v".`, err)
-	conn.Close()
+	_ = conn.Close()
 }
 
 func TestInstanceLogger(t *testing.T) {
@@ -105,8 +107,12 @@ func TestInstanceLogger(t *testing.T) {
 	inst := startTestInstance(t, context.Background(), "log_check_test_app", consoleSock, "",
 		logger)
 	t.Cleanup(func() {
-		defer reader.Close()
-		defer writer.Close()
+		defer func() {
+			_ = reader.Close()
+		}()
+		defer func() {
+			_ = writer.Close()
+		}()
 		cleanupTestInstance(t, inst)
 	})
 
@@ -239,7 +245,9 @@ func TestInstanceLogs(t *testing.T) {
 
 	require.NoErrorf(t, err, `Can't get the path to the executable. Error: "%v".`, err)
 	t.Setenv("started_flag_file", filepath.Join(binDir, app))
-	defer os.Remove(os.Getenv("started_flag_file"))
+	defer func() {
+		_ = os.Remove(os.Getenv("started_flag_file"))
+	}()
 	err = inst.Start(context.Background())
 	require.NoError(t, err)
 

--- a/cli/running/watchdog.go
+++ b/cli/running/watchdog.go
@@ -211,18 +211,18 @@ func (wd *Watchdog) sendSignal(sig os.Signal) bool {
 	switch sig {
 	case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
 		if wd.instance.IsAlive() {
-			wd.instance.StopWithSignal(signalStopTimeout, sig)
+			_ = wd.instance.StopWithSignal(signalStopTimeout, sig)
 		}
 		return true
 	case syscall.SIGHUP:
 		// Rotate the log files.
-		wd.logger.Rotate()
+		_ = wd.logger.Rotate()
 		if wd.instance.IsAlive() {
-			wd.instance.SendSignal(sig)
+			_ = wd.instance.SendSignal(sig)
 		}
 	default:
 		if wd.instance.IsAlive() {
-			wd.instance.SendSignal(sig)
+			_ = wd.instance.SendSignal(sig)
 		}
 	}
 
@@ -245,7 +245,7 @@ func (wd *Watchdog) startIntegrityChecks(ctx context.Context) {
 				if err != nil {
 					// Integrity check failed.
 					wd.logger.Printf("(ERROR): periodic integrity check failed: %q.", err)
-					wd.instance.SendSignal(syscall.SIGKILL)
+					_ = wd.instance.SendSignal(syscall.SIGKILL)
 					return
 				}
 			case <-ctx.Done():

--- a/cli/running/watchdog_test.go
+++ b/cli/running/watchdog_test.go
@@ -92,8 +92,8 @@ func killAndCheckRestart(t *testing.T, wd *Watchdog, signal syscall.Signal) {
 	t.Helper()
 
 	// Remove the file. It must be created again by the restarted instance.
-	os.Remove(os.Getenv("started_flag_file"))
-	wd.instance.SendSignal(signal)
+	_ = os.Remove(os.Getenv("started_flag_file"))
+	_ = wd.instance.SendSignal(signal)
 	// No need to check for PID changes. If the file is created again, new process is started.
 	require.NotZero(t, waitForFile(os.Getenv("started_flag_file")), "Instance is not started")
 	assert.True(t, wd.instance.IsAlive(), "Instance doesn't restart.")
@@ -106,9 +106,9 @@ func cleanupWatchdog(t *testing.T, wd *Watchdog) {
 	require.True(t, ok, "unexpected watchdog provider type: %T", wd.provider)
 	provider.restartable = false
 	if wd.instance != nil && wd.instance.IsAlive() {
-		wd.instance.Stop(5 * time.Second)
+		_ = wd.instance.Stop(5 * time.Second)
 	}
-	os.Remove(os.Getenv("started_flag_file"))
+	_ = os.Remove(os.Getenv("started_flag_file"))
 }
 
 func TestWatchdogBase(t *testing.T) {
@@ -136,7 +136,7 @@ func TestWatchdogBase(t *testing.T) {
 	killAndCheckRestart(t, wd, syscall.SIGKILL)
 
 	// Let's try to stop the watchdog by a signal.
-	syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	select {
 	case <-time.After(wdTestStopTimeout):
 		assert.Fail("Can't stop the watchdog.")
@@ -164,7 +164,7 @@ func TestWatchdogNotRestartable(t *testing.T) {
 	alive := wd.instance.IsAlive()
 	assert.True(alive, "Can't start the instance under watchdog.")
 
-	wd.instance.SendSignal(syscall.SIGINT)
+	_ = wd.instance.SendSignal(syscall.SIGINT)
 
 	// The watchdog should stop because the instance was killed and
 	// the "Restartable" flag is false.

--- a/cli/running/writer.go
+++ b/cli/running/writer.go
@@ -43,16 +43,16 @@ func NewColorizedPrefixWriter(writer io.Writer, color color.Color, prefix string
 
 			// spell-checker:ignore submatch
 			if submatch := logLevelRgx.FindSubmatch(line); submatch != nil {
-				color.Fprint(&buf, prefix)
-				logLevelColors[string(submatch[1])].Fprintln(&buf, string(line))
-				writer.Write(buf.Bytes())
+				_, _ = color.Fprint(&buf, prefix)
+				_, _ = logLevelColors[string(submatch[1])].Fprintln(&buf, string(line))
+				_, _ = writer.Write(buf.Bytes())
 				continue
 			}
 
-			color.Fprint(&buf, prefix)
+			_, _ = color.Fprint(&buf, prefix)
 			buf.Write(line)
 			buf.WriteByte('\n')
-			writer.Write(buf.Bytes())
+			_, _ = writer.Write(buf.Bytes())
 		}
 		return len(msg), nil
 	})

--- a/cli/running/writer_test.go
+++ b/cli/running/writer_test.go
@@ -11,17 +11,17 @@ import (
 func TestNewColorizedPrefixWriter(t *testing.T) {
 	var buf bytes.Buffer
 	wr := NewColorizedPrefixWriter(&buf, *color.New(color.FgGreen), "prefix ")
-	wr.Write([]byte("hello\n"))
-	wr.Write([]byte(" E> world\n"))
+	_, _ = wr.Write([]byte("hello\n"))
+	_, _ = wr.Write([]byte(" E> world\n"))
 
 	var expected bytes.Buffer
 	clr := color.New(color.FgGreen)
 
-	clr.Fprint(&expected, "prefix ")
+	_, _ = clr.Fprint(&expected, "prefix ")
 	expected.WriteString("hello\n")
 
-	clr.Fprint(&expected, "prefix ")
+	_, _ = clr.Fprint(&expected, "prefix ")
 	clr.Add(color.FgRed, color.Bold)
-	clr.Fprint(&expected, " E> world\n")
+	_, _ = clr.Fprint(&expected, " E> world\n")
 	assert.Equal(t, expected.Bytes(), buf.Bytes())
 }

--- a/cli/search/bundle_test.go
+++ b/cli/search/bundle_test.go
@@ -14,8 +14,12 @@ import (
 func TestFetchBundlesInfo(t *testing.T) {
 	t.Setenv("TT_CLI_EE_USERNAME", testingUsername)
 	t.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
-	defer os.Unsetenv("TT_CLI_EE_USERNAME")
-	defer os.Unsetenv("TT_CLI_EE_PASSWORD")
+	defer func() {
+		_ = os.Unsetenv("TT_CLI_EE_USERNAME")
+	}()
+	defer func() {
+		_ = os.Unsetenv("TT_CLI_EE_PASSWORD")
+	}()
 
 	tests := map[string]struct {
 		program         search.Program

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -62,12 +62,12 @@ func printVersion(bindir string, program Program, versionStr string) {
 		target, _ := util.ResolveSymlink(filepath.Join(bindir, program.Exec()))
 
 		if path.Base(target) == program.String()+version.FsSeparator+versionStr {
-			fmt.Fprintf(os.Stdout, "%s [active]\n", versionStr)
+			_, _ = fmt.Fprintf(os.Stdout, "%s [active]\n", versionStr)
 		} else {
-			fmt.Fprintf(os.Stdout, "%s [installed]\n", versionStr)
+			_, _ = fmt.Fprintf(os.Stdout, "%s [installed]\n", versionStr)
 		}
 	} else {
-		fmt.Fprintln(os.Stdout, versionStr)
+		_, _ = fmt.Fprintln(os.Stdout, versionStr)
 	}
 }
 

--- a/cli/search/search_git.go
+++ b/cli/search/search_git.go
@@ -124,7 +124,9 @@ func GetCommitFromGitRemote(repo, input string) (string, error) {
 		return "", fmt.Errorf("failed to get commits from %q: %w", repo, err)
 	}
 
-	defer os.RemoveAll(tempRepoPath)
+	defer func() {
+		_ = os.RemoveAll(tempRepoPath)
+	}()
 
 	cmd := exec.CommandContext(context.Background(), "git", "clone",
 		"--filter=blob:none", "--no-checkout", repo, tempRepoPath)

--- a/cli/search/tntio_api.go
+++ b/cli/search/tntio_api.go
@@ -89,7 +89,9 @@ func (d *httpDoer) Do(req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("failed to send API request: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)

--- a/cli/search/tntio_api_test.go
+++ b/cli/search/tntio_api_test.go
@@ -155,8 +155,12 @@ func checkOutputVersionOrder(t *testing.T, got string, expected []string) {
 func TestSearchVersions_TntIo(t *testing.T) {
 	t.Setenv("TT_CLI_EE_USERNAME", testingUsername)
 	t.Setenv("TT_CLI_EE_PASSWORD", testingPassword)
-	defer os.Unsetenv("TT_CLI_EE_USERNAME")
-	defer os.Unsetenv("TT_CLI_EE_PASSWORD")
+	defer func() {
+		_ = os.Unsetenv("TT_CLI_EE_USERNAME")
+	}()
+	defer func() {
+		_ = os.Unsetenv("TT_CLI_EE_PASSWORD")
+	}()
 
 	tests := map[string]struct {
 		program          search.Program
@@ -432,7 +436,7 @@ func TestSearchVersions_TntIo(t *testing.T) {
 
 			err := search.SearchVersions(sCtx, &opts)
 
-			w.Close()
+			_ = w.Close()
 			var outBuf bytes.Buffer
 			_, readErr := outBuf.ReadFrom(r)
 			require.NoError(t, readErr, "Failed to read from stdout pipe")

--- a/cli/status/json_printer.go
+++ b/cli/status/json_printer.go
@@ -20,6 +20,6 @@ func (j JSONPrinter) Print(instances map[string]*instanceStatus) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal instances to JSON: %w", err)
 	}
-	fmt.Fprintln(os.Stdout, string(jsonData))
+	_, _ = fmt.Fprintln(os.Stdout, string(jsonData))
 	return nil
 }

--- a/cli/status/table_printer.go
+++ b/cli/status/table_printer.go
@@ -127,7 +127,7 @@ func (t TablePrinter) Print(instances map[string]*instanceStatus) error {
 		msg := "\nThe status of some instances requires attention.\n" +
 			"Please rerun the command with the --details flag to see " +
 			"more information"
-		fmt.Fprintln(os.Stdout, msg)
+		_, _ = fmt.Fprintln(os.Stdout, msg)
 	}
 
 	return nil
@@ -138,9 +138,9 @@ func (t TablePrinter) printInstanceAlerts(instanceName string, instStatus *insta
 	if len(instStatus.Alerts) == 0 {
 		return
 	}
-	fmt.Fprintf(os.Stdout, "Alerts for %s:\n", instanceName)
+	_, _ = fmt.Fprintf(os.Stdout, "Alerts for %s:\n", instanceName)
 	for _, alert := range instStatus.Alerts {
-		fmt.Fprintf(os.Stdout, "  • %s\n", formatAlert(alert))
+		_, _ = fmt.Fprintf(os.Stdout, "  • %s\n", formatAlert(alert))
 	}
-	fmt.Fprintln(os.Stdout)
+	_, _ = fmt.Fprintln(os.Stdout)
 }

--- a/cli/status/yaml_printer.go
+++ b/cli/status/yaml_printer.go
@@ -21,6 +21,6 @@ func (y YAMLPrinter) Print(instances map[string]*instanceStatus) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal instances to YAML: %w", err)
 	}
-	fmt.Fprintln(os.Stdout, string(yamlData))
+	_, _ = fmt.Fprintln(os.Stdout, string(yamlData))
 	return nil
 }

--- a/cli/tail/follow.go
+++ b/cli/tail/follow.go
@@ -138,7 +138,7 @@ func (f *fileFollower) handleTailerStopStatus(ctx context.Context, curT *tail.Ta
 		}
 
 		if ctx.Err() != nil {
-			t.Stop()
+			_ = t.Stop()
 			return nil, fmt.Errorf("context (%w) while reopening tailer %q",
 				ctx.Err(), f.name)
 		}
@@ -215,7 +215,9 @@ func (f *fileFollower) startFollowing(ctx context.Context, out chan<- string, li
 	if err != nil {
 		return fmt.Errorf("cannot open %q: %w", f.name, err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	_, startPos, err := newTailReader(ctx, file, lines)
 	if err != nil {

--- a/cli/tail/follow_test.go
+++ b/cli/tail/follow_test.go
@@ -56,7 +56,9 @@ func createTmpLogFile(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	writeLogLines(t, f, linesPerStep, logLineFormat)
 
@@ -136,7 +138,7 @@ func TestFollow2_FollowNewContent(t *testing.T) {
 
 	writeLogLines(t, appendFile, linesPerStep, logNewLineFormat)
 
-	appendFile.Close()
+	_ = appendFile.Close()
 
 	err = checksLinesInFile(t, outCh, logNewLineFormat)
 	if err != nil {
@@ -232,9 +234,9 @@ func rotationTest(t *testing.T, useDelay bool) {
 
 	writeLogLines(t, newFile, linesPerStep, logNewLineFormat)
 
-	newFile.Close()
+	_ = newFile.Close()
 
-	newFile.Close()
+	_ = newFile.Close()
 
 	err = checksLinesInFile(t, outCh, logNewLineFormat)
 	if err != nil {

--- a/cli/tail/tail.go
+++ b/cli/tail/tail.go
@@ -58,7 +58,7 @@ func NewLogFormatter(prefix string, color color.Color) LogFormatter {
 	buf.Grow(formatterBufferCapacity)
 	return func(str string) string {
 		buf.Reset()
-		color.Fprint(&buf, prefix)
+		_, _ = color.Fprint(&buf, prefix)
 		buf.WriteString(str)
 		return buf.String()
 	}
@@ -120,10 +120,10 @@ func newTailReader(ctx context.Context, reader io.ReadSeeker, count int) (io.Rea
 		}
 	}
 	if linesFound == count {
-		reader.Seek(startPos, io.SeekStart)
+		_, _ = reader.Seek(startPos, io.SeekStart)
 		return &io.LimitedReader{R: reader, N: end - startPos}, startPos, nil
 	}
-	reader.Seek(0, io.SeekStart)
+	_, _ = reader.Seek(0, io.SeekStart)
 	return &io.LimitedReader{R: reader, N: end}, 0, nil
 }
 
@@ -142,7 +142,7 @@ func TailN(ctx context.Context, logFormatter LogFormatter, fileName string,
 
 	reader, _, err := newTailReader(ctx, file, n)
 	if err != nil {
-		file.Close()
+		_ = file.Close()
 		return nil, err
 	}
 
@@ -150,7 +150,9 @@ func TailN(ctx context.Context, logFormatter LogFormatter, fileName string,
 	out := make(chan string, outputChannelCapacity)
 	go func() {
 		defer close(out)
-		defer file.Close()
+		defer func() {
+			_ = file.Close()
+		}()
 		for scanner.Scan() {
 			select {
 			case <-ctx.Done():
@@ -170,7 +172,9 @@ func Follow(ctx context.Context, out chan<- string, logFormatter LogFormatter, f
 	if err != nil {
 		return fmt.Errorf("cannot open %q: %w", fileName, err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	_, startPos, err := newTailReader(ctx, file, n)
 	if err != nil {
@@ -196,8 +200,8 @@ func Follow(ctx context.Context, out chan<- string, logFormatter LogFormatter, f
 		for {
 			select {
 			case <-ctx.Done():
-				t.Stop()
-				t.Wait()
+				_ = t.Stop()
+				_ = t.Wait()
 				return
 			case line, more := <-t.Lines:
 				if !more {

--- a/cli/tail/tail_test.go
+++ b/cli/tail/tail_test.go
@@ -215,9 +215,11 @@ five
 		t.Run(tt.name, func(t *testing.T) {
 			outFile, err := os.CreateTemp(tmpDir, "*.txt")
 			require.NoError(t, err)
-			defer outFile.Close()
-			outFile.WriteString(tt.text)
-			outFile.Close()
+			defer func() {
+				_ = outFile.Close()
+			}()
+			_, _ = outFile.WriteString(tt.text)
+			_ = outFile.Close()
 
 			in, err := TailN(context.Background(), func(str string) string {
 				return str
@@ -303,9 +305,11 @@ five
 			outFile, err := os.CreateTemp(tmpDir, "*.txt")
 			require.NoError(t, err)
 
-			defer outFile.Close()
-			outFile.WriteString(tt.text)
-			outFile.Close()
+			defer func() {
+				_ = outFile.Close()
+			}()
+			_, _ = outFile.WriteString(tt.text)
+			_ = outFile.Close()
 
 			r := NewTailReader(outFile.Name())
 			in, err := r.Read(context.Background(), tt.args.n)
@@ -380,10 +384,12 @@ func TestFollow(t *testing.T) {
 			t.Parallel()
 			outFile, err := os.CreateTemp(tmpDir, "*.txt")
 			require.NoError(t, err)
-			defer outFile.Close()
+			defer func() {
+				_ = outFile.Close()
+			}()
 
-			outFile.WriteString(tt.initialText)
-			outFile.Sync()
+			_, _ = outFile.WriteString(tt.initialText)
+			_ = outFile.Sync()
 
 			ctx, stop := context.WithTimeout(context.Background(), time.Second*2)
 			defer stop()
@@ -410,7 +416,7 @@ func TestFollow(t *testing.T) {
 			// Need some time to start watching for changes after reading last lines.
 			time.Sleep(time.Millisecond * 500)
 			for _, line := range tt.linesToAppend {
-				outFile.WriteString(line + "\n")
+				_, _ = outFile.WriteString(line + "\n")
 			}
 			assert.NoError(t, outFile.Sync())
 

--- a/cli/tcm/log_printer.go
+++ b/cli/tcm/log_printer.go
@@ -74,10 +74,10 @@ func (l *logPrinter) Print(ctx context.Context, in <-chan string) error {
 				return nil
 			}
 
-			fmt.Fprintln(l.out, l.format(line))
+			_, _ = fmt.Fprintln(l.out, l.format(line))
 
 			if l.sync != nil {
-				l.sync()
+				_ = l.sync()
 			}
 		}
 	}

--- a/cli/tcm/log_test.go
+++ b/cli/tcm/log_test.go
@@ -87,7 +87,7 @@ func (mf *mockFollower) Wait() {
 	select {
 	case <-mf.done:
 		// Got notification about finished reading file lines.
-		syscall.Kill(os.Getpid(), syscall.SIGINT)
+		_ = syscall.Kill(os.Getpid(), syscall.SIGINT)
 
 	case <-mf.ctxDone:
 		return
@@ -121,7 +121,9 @@ func fileReaderByLine(
 		if err != nil {
 			return
 		}
-		defer log.Close()
+		defer func() {
+			_ = log.Close()
+		}()
 
 		scanner := bufio.NewScanner(log)
 
@@ -352,8 +354,8 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	if *updateTestdata {
-		fmt.Fprintln(os.Stdout, "Updating testdata files...")
-		os.RemoveAll(filepath.Join(testDataDir, expectedSubDir))
+		_, _ = fmt.Fprintln(os.Stdout, "Updating testdata files...")
+		_ = os.RemoveAll(filepath.Join(testDataDir, expectedSubDir))
 	}
 
 	os.Exit(m.Run())

--- a/cli/templates/internal/engines/go_text_engine.go
+++ b/cli/templates/internal/engines/go_text_engine.go
@@ -51,8 +51,8 @@ func (GoTextEngine) RenderFile(srcPath, dstPath string, data any) error {
 		return fmt.Errorf("error creating %s: %w", dstPath, err)
 	}
 	defer func() {
-		outFile.Close()
-		os.Chmod(outFile.Name(), originFileMode)
+		_ = outFile.Close()
+		_ = os.Chmod(outFile.Name(), originFileMode)
 	}()
 
 	if err := parsedTemplate.Execute(outFile, data); err != nil {

--- a/cli/ttlog/logger_test.go
+++ b/cli/ttlog/logger_test.go
@@ -24,16 +24,16 @@ func TestLoggerBase(t *testing.T) {
 	// Check the count of the log files (must be 1).
 	assert.FileExists(t, fileName)
 
-	logger.Rotate()
+	_ = logger.Rotate()
 
 	// Check that the rotation does not create new file.
 	files, _ := os.ReadDir(tmpDir)
 	assert.Equal(t, len(files), 1)
 
-	os.Rename(fileName, fileName+".old")
+	_ = os.Rename(fileName, fileName+".old")
 	assert.NoFileExists(t, fileName)
 	logger.Println(`Test msg 2`)
-	logger.Rotate()
+	_ = logger.Rotate()
 
 	// Check that file is re-created.
 	assert.FileExists(t, fileName)

--- a/cli/uninstall/uninstall_test.go
+++ b/cli/uninstall/uninstall_test.go
@@ -45,7 +45,7 @@ func TestGetList(t *testing.T) {
 	for _, file := range files {
 		f, err := os.Create(filepath.Join(binDir, file))
 		require.NoError(t, err)
-		f.Close()
+		_ = f.Close()
 	}
 
 	cliOpts, _, err := configure.GetCliOpts(cfgPath, &mockRepository{})

--- a/cli/util/compress.go
+++ b/cli/util/compress.go
@@ -26,7 +26,9 @@ func ExtractTarGz(tarName, dstDir string) error {
 	if err != nil {
 		return err
 	}
-	defer archive.Close()
+	defer func() {
+		_ = archive.Close()
+	}()
 	tarReader, err := makeTarGzReader(archive)
 	if err != nil {
 		return err
@@ -53,7 +55,7 @@ func ExtractTarGz(tarName, dstDir string) error {
 				//    user:   read/write/execute
 				//    group:  read/execute
 				//    others: read/execute
-				os.MkdirAll(filepath.Join(dstDir, dirName), archiveDirectoryMode)
+				_ = os.MkdirAll(filepath.Join(dstDir, dirName), archiveDirectoryMode)
 			}
 			outFile, err := os.OpenFile(filepath.Join(dstDir, header.Name),
 				os.O_CREATE|os.O_WRONLY, header.FileInfo().Mode().Perm())
@@ -61,10 +63,10 @@ func ExtractTarGz(tarName, dstDir string) error {
 				return err
 			}
 			if _, err := io.Copy(outFile, tarReader); err != nil {
-				outFile.Close()
+				_ = outFile.Close()
 				return err
 			}
-			outFile.Close()
+			_ = outFile.Close()
 		case tar.TypeSymlink:
 			if err := os.Symlink(header.Linkname, filepath.Join(dstDir, header.Name)); err != nil {
 				return err

--- a/cli/util/crypto.go
+++ b/cli/util/crypto.go
@@ -16,7 +16,9 @@ func FileSHA256Hex(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {
@@ -33,7 +35,9 @@ func FileSHA1Hex(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	hasher := sha1.New()
 	if _, err := io.Copy(hasher, file); err != nil {
@@ -50,7 +54,9 @@ func FileMD5(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	hasher := md5.New()
 	if _, err := io.Copy(hasher, file); err != nil {

--- a/cli/util/execute.go
+++ b/cli/util/execute.go
@@ -98,8 +98,12 @@ func RunCommand(cmd *exec.Cmd, workingDir string, showOutput bool) error {
 		}
 		cmd.Stdout = outputBuf
 		cmd.Stderr = outputBuf
-		defer outputBuf.Close()
-		defer os.Remove(outputBuf.Name())
+		defer func() {
+			_ = outputBuf.Close()
+		}()
+		defer func() {
+			_ = os.Remove(outputBuf.Name())
+		}()
 
 		if isatty.IsTerminal(os.Stdout.Fd()) {
 			workGroup.Add(1)
@@ -199,8 +203,8 @@ func ExecuteCommandGetOutput(program, workDir string, stdinData []byte,
 		return out.Bytes(), err
 	}
 
-	stdin.Write(stdinData)
-	stdin.Close()
+	_, _ = stdin.Write(stdinData)
+	_ = stdin.Close()
 
 	err = cmd.Wait()
 	return out.Bytes(), err

--- a/cli/util/util.go
+++ b/cli/util/util.go
@@ -91,7 +91,9 @@ func GetFileContentBytes(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	fileContent, err := io.ReadAll(file)
 	if err != nil {
@@ -208,7 +210,9 @@ func GetLastNLinesBegin(filepath string, lines int) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to open file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	var fileSize int64
 	if fileInfo, err := os.Stat(filepath); err != nil {
@@ -304,7 +308,7 @@ func AskConfirm(ioReader io.Reader, question string) (bool, error) {
 	reader := bufio.NewReader(ioReader)
 
 	for {
-		fmt.Fprintf(os.Stdout, "%s [y/n]: ", question)
+		_, _ = fmt.Fprintf(os.Stdout, "%s [y/n]: ", question)
 
 		resp, err := reader.ReadString('\n')
 		resp = strings.ToLower(strings.TrimSpace(resp))
@@ -471,7 +475,7 @@ func Chdir(newPath string) (func() error, error) {
 		if err = os.Chdir(cwd); err != nil {
 			return nil, fmt.Errorf("failed to change directory back: %w", err)
 		}
-		os.Setenv("PWD", cwd) // Return PWD back.
+		_ = os.Setenv("PWD", cwd) // Return PWD back.
 		return nil, fmt.Errorf("failed to change PWD environment variable: %w", err)
 	}
 
@@ -566,7 +570,9 @@ func ExtractTar(tarName string) error {
 	if err != nil {
 		return err
 	}
-	defer archive.Close()
+	defer func() {
+		_ = archive.Close()
+	}()
 
 	uncompressedStream, err := gzip.NewReader(archive)
 	if err != nil {
@@ -603,18 +609,18 @@ func ExtractTar(tarName string) error {
 				//    user:   read/write/execute
 				//    group:  read/execute
 				//    others: read/execute
-				os.MkdirAll(dir+header.Name[0:pos], archiveDirectoryMode)
+				_ = os.MkdirAll(dir+header.Name[0:pos], archiveDirectoryMode)
 			}
 			outFile, err := os.Create(dir + header.Name)
 			if err != nil {
-				outFile.Close()
+				_ = outFile.Close()
 				return err
 			}
 			if _, err := io.Copy(outFile, tarReader); err != nil {
-				outFile.Close()
+				_ = outFile.Close()
 				return err
 			}
-			outFile.Close()
+			_ = outFile.Close()
 
 		default:
 			return fmt.Errorf("%w%b in %s",
@@ -687,8 +693,8 @@ func ExecuteCommandStdin(program string, isVerbose bool, logFile *os.File, workD
 		return err
 	}
 
-	stdin.Write(stdinData)
-	stdin.Close()
+	_, _ = stdin.Write(stdinData)
+	_ = stdin.Close()
 
 	err = cmd.Wait()
 	return err
@@ -805,7 +811,9 @@ func MergeFiles(destFilePath string, srcFilePaths ...string) error {
 		_ = os.Remove(destFilePath)
 		return fmt.Errorf("failed to create result file %s: %w", destFilePath, err)
 	}
-	defer destFile.Close()
+	defer func() {
+		_ = destFile.Close()
+	}()
 
 	for _, srcFilePath := range srcFilePaths {
 		srcFile, err := os.Open(srcFilePath)
@@ -815,7 +823,7 @@ func MergeFiles(destFilePath string, srcFilePaths ...string) error {
 		}
 
 		_, err = io.Copy(destFile, srcFile)
-		srcFile.Close()
+		_ = srcFile.Close()
 
 		if err != nil {
 			return err
@@ -875,7 +883,9 @@ func InstantiateFileFromTemplate(templatePath, templateContent string, params an
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	unitContent, err := GetTextTemplatedStr(&templateContent, params)
 	if err != nil {
@@ -933,7 +943,7 @@ func HandleCmdErr(cmd *cobra.Command, err error) {
 		var argError *ArgError
 		if errors.As(err, &argError) {
 			log.Error(argError.Error())
-			cmd.Usage()
+			_ = cmd.Usage()
 			os.Exit(1)
 		}
 		if errors.Is(err, ErrCmdAbort) {

--- a/cli/util/util_test.go
+++ b/cli/util/util_test.go
@@ -65,7 +65,9 @@ func TestIsDir(t *testing.T) {
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
 
 	assert.False(IsDir(tmpFile.Name()))
 	assert.False(IsDir("./non-existing-dir"))
@@ -76,7 +78,9 @@ func TestIsRegularFile(t *testing.T) {
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
 
 	require.True(t, IsRegularFile(tmpFile.Name()))
 
@@ -99,12 +103,16 @@ func TestCreateDirectory(t *testing.T) {
 
 	f, err := os.Create(filepath.Join(tempDir, "file"))
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	assert.Error(t, CreateDirectory(f.Name(), 0o750))
 
 	// Permissions denied.
 	require.NoError(t, os.Chmod(tempDir, 0o444))
-	defer os.Chmod(tempDir, 0o777)
+	defer func() {
+		_ = os.Chmod(tempDir, 0o777)
+	}()
 	assert.Error(t, CreateDirectory(filepath.Join(tempDir, "dir3"), 0o750))
 }
 
@@ -128,7 +136,9 @@ func TestWriteYaml(t *testing.T) {
 	require.NoError(t, WriteYaml(filepath.Join(tempDir, "library"), &lib))
 	f, err := os.Open(filepath.Join(tempDir, "library"))
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Scan()
@@ -185,7 +195,7 @@ func TestCreateSymlink(t *testing.T) {
 	tempDir := t.TempDir()
 	targetFile, err := os.Create(filepath.Join(tempDir, "tgtFile.txt"))
 	require.NoError(t, err)
-	targetFile.Close()
+	_ = targetFile.Close()
 
 	// No overwrite.
 	require.NoError(t, CreateSymlink(targetFile.Name(), filepath.Join(tempDir, "first_link"),

--- a/lib/cluster/file.go
+++ b/lib/cluster/file.go
@@ -36,7 +36,9 @@ func (collector FileCollector) Collect() ([]Data, error) {
 	if err != nil {
 		return nil, fmt.Errorf(fmtErr, collector.path, err)
 	}
-	defer reader.Close()
+	defer func() {
+		_ = reader.Close()
+	}()
 
 	data, err := io.ReadAll(reader)
 	if err != nil {

--- a/lib/cluster/integration_test.go
+++ b/lib/cluster/integration_test.go
@@ -117,7 +117,9 @@ func startEtcd(t *testing.T) *etcdtest.LazyCluster {
 		Endpoints: inst.EndpointsGRPC(),
 	})
 	require.NoError(t, err)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	if err := doWithCtx(func(ctx context.Context) error {
 		_, err := etcd.UserAdd(ctx, opts.Username, opts.Password)
@@ -171,7 +173,7 @@ func etcdPut(t *testing.T, etcd *clientv3.Client, key, value string) {
 		pResp *clientv3.PutResponse
 		err   error
 	)
-	doWithCtx(func(ctx context.Context) error {
+	_ = doWithCtx(func(ctx context.Context) error {
 		pResp, err = etcd.Put(ctx, key, value)
 		return nil
 	})
@@ -185,7 +187,7 @@ func etcdGet(t *testing.T, etcd *clientv3.Client, key string) ([]byte, int64) {
 		resp *clientv3.GetResponse
 		err  error
 	)
-	doWithCtx(func(ctx context.Context) error {
+	_ = doWithCtx(func(ctx context.Context) error {
 		resp, err = etcd.Get(ctx, key)
 		return nil
 	})
@@ -229,7 +231,9 @@ func TestEtcdCollectors_single(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/bar", "foo: bar")
 
@@ -262,7 +266,9 @@ func TestEtcdAllCollector_merge(t *testing.T) {
 	require.NoError(t, err)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
 	require.NotNil(t, etcd)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/a", "foo: bar")
 	etcdPut(t, etcd, "/foo/config/b", "foo: car\nzoo: car")
@@ -292,7 +298,9 @@ func TestEtcdCollectors_empty(t *testing.T) {
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	cases := []struct {
 		Name      string
@@ -320,7 +328,9 @@ func TestEtcdDataPublishers_Publish_single(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	data := []byte("foo bar")
 	cases := []struct {
@@ -352,7 +362,9 @@ func TestEtcdDataPublishers_Publish_rewrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	oldData := []byte("foo bar zoo")
 	newData := []byte("zoo bar foo")
@@ -386,7 +398,9 @@ func TestEtcdAllDataPublisher_Publish_rewrite_prefix(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/foo", "foo")
 	etcdPut(t, etcd, "/foo/config/zoo", "zoo")
@@ -414,7 +428,9 @@ func TestEtcdKeyDataPublisher_Publish_modRevision_specified(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/key", "bar")
 	_, modRevision := etcdGet(t, etcd, "/foo/config/key")
@@ -444,7 +460,9 @@ func TestEtcdAllDataPublisher_Publish_ignore_prefix(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/", "foo")
 	etcdPut(t, etcd, "/foo/config/foo", "zoo")
@@ -473,7 +491,9 @@ func TestEtcdAllDataPublisher_collect_publish_collect(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, etcd)
 	stor := pkgstorage.NewStorage(etcddriver.New(etcd))
-	defer etcd.Close()
+	defer func() {
+		_ = etcd.Close()
+	}()
 
 	etcdPut(t, etcd, "/foo/config/foo", "zoo: bar")
 
@@ -574,7 +594,7 @@ var testsIntegrity = []struct {
 			)
 			require.NoError(t, err)
 
-			return pub, func() { conn.Close() }
+			return pub, func() { _ = conn.Close() }
 		},
 		NewCollector: func(
 			t *testing.T,
@@ -616,7 +636,7 @@ var testsIntegrity = []struct {
 			)
 			require.NoError(t, err)
 
-			return coll, func() { conn.Close() }
+			return coll, func() { _ = conn.Close() }
 		},
 	},
 	{
@@ -664,7 +684,7 @@ var testsIntegrity = []struct {
 			pub, err := publisherFactory.NewRemoteStorage(stor, prefix, key, 10*time.Second, "etcd")
 			require.NoError(t, err)
 
-			return pub, func() { etcd.Close() }
+			return pub, func() { _ = etcd.Close() }
 		},
 		NewCollector: func(
 			t *testing.T,
@@ -697,7 +717,7 @@ var testsIntegrity = []struct {
 			)
 			require.NoError(t, err)
 
-			return coll, func() { etcd.Close() }
+			return coll, func() { _ = etcd.Close() }
 		},
 	},
 }

--- a/lib/connect/credentials.go
+++ b/lib/connect/credentials.go
@@ -37,21 +37,21 @@ func getCredsInteractive() (UserCredentials, error) {
 	res := UserCredentials{}
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Fprintln(os.Stdout, "Signing in to Customer zone.")
-	fmt.Fprintf(os.Stdout, "Enter Email: ")
+	_, _ = fmt.Fprintln(os.Stdout, "Signing in to Customer zone.")
+	_, _ = fmt.Fprintf(os.Stdout, "Enter Email: ")
 	resp, err := reader.ReadString('\n')
 	if err != nil {
 		return res, err
 	}
 	res.Username = strings.TrimSpace(resp)
 
-	fmt.Fprintf(os.Stdout, "Enter Password: ")
+	_, _ = fmt.Fprintf(os.Stdout, "Enter Password: ")
 	bytePass, err := term.ReadPassword(syscall.Stdin)
 	if err != nil {
 		return res, err
 	}
 	res.Password = strings.TrimSpace(string(bytePass))
-	fmt.Fprintln(os.Stdout, "")
+	_, _ = fmt.Fprintln(os.Stdout, "")
 
 	return res, nil
 }
@@ -64,7 +64,9 @@ func getCredsFromFile(path string) (UserCredentials, error) {
 	if err != nil {
 		return res, err
 	}
-	defer fh.Close()
+	defer func() {
+		_ = fh.Close()
+	}()
 
 	info, err := fh.Stat()
 	if err != nil {

--- a/lib/connect/credentials_test.go
+++ b/lib/connect/credentials_test.go
@@ -37,8 +37,10 @@ func TestGetCredsFromFile(t *testing.T) {
 
 	file, err := os.CreateTemp("/tmp", "tt-unittest-*.bat")
 	assert.Nil(err)
-	file.WriteString("user\npass")
-	defer os.Remove(file.Name())
+	_, _ = file.WriteString("user\npass")
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 
 	testCases[getCredsFromFileInputValue{path: file.Name()}] = getCredsFromFileOutputValue{
 		result: UserCredentials{
@@ -50,8 +52,10 @@ func TestGetCredsFromFile(t *testing.T) {
 
 	file, err = os.CreateTemp("/tmp", "tt-unittest-*.bat")
 	assert.Nil(err)
-	file.WriteString("")
-	defer os.Remove(file.Name())
+	_, _ = file.WriteString("")
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 
 	testCases[getCredsFromFileInputValue{path: file.Name()}] = getCredsFromFileOutputValue{
 		result: UserCredentials{},
@@ -60,8 +64,10 @@ func TestGetCredsFromFile(t *testing.T) {
 
 	file, err = os.CreateTemp("/tmp", "tt-unittest-*.bat")
 	assert.Nil(err)
-	file.WriteString("user")
-	defer os.Remove(file.Name())
+	_, _ = file.WriteString("user")
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 
 	testCases[getCredsFromFileInputValue{path: file.Name()}] = getCredsFromFileOutputValue{
 		result: UserCredentials{},

--- a/lib/connect/help.go
+++ b/lib/connect/help.go
@@ -127,6 +127,6 @@ The command supports the following environment variables:
 	params["env_vars"] = envVars
 
 	var sb strings.Builder
-	t.Execute(&sb, params)
+	_ = t.Execute(&sb, params)
 	return sb.String()
 }

--- a/lib/watchdog/watchdog_test.go
+++ b/lib/watchdog/watchdog_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func cleanupPidFiles() {
-	os.Remove("test.pid")
-	os.Remove("wd.pid")
+	_ = os.Remove("test.pid")
+	_ = os.Remove("wd.pid")
 }
 
 func verifyProcessRunning(t *testing.T, wd *Watchdog) {

--- a/magefile.go
+++ b/magefile.go
@@ -107,7 +107,7 @@ func init() {
 	}
 	// We want to use Go 1.11 modules even if the source lives inside GOPATH.
 	// The default is "auto".
-	os.Setenv("GO111MODULE", "on")
+	_ = os.Setenv("GO111MODULE", "on")
 }
 
 type optsUpdater func([]string) ([]string, error)
@@ -184,34 +184,34 @@ type Build mg.Namespace
 
 // Release builds the release tt executable without debug info.
 func (Build) Release() error {
-	fmt.Fprintln(os.Stdout, "Building release tt...")
+	_, _ = fmt.Fprintln(os.Stdout, "Building release tt...")
 
 	return buildTt(appendTags, appendLdFlags("-s", "-w"))
 }
 
 // Debug builds the debug tt executable.
 func (Build) Debug() error {
-	fmt.Fprintln(os.Stdout, "Building debug tt...")
+	_, _ = fmt.Fprintln(os.Stdout, "Building debug tt...")
 
 	return buildTt(appendTags, appendLdFlags())
 }
 
 // Coverage builds the tt executable with coverage.
 func (Build) Coverage() error {
-	fmt.Fprintln(os.Stdout, "Building release tt with coverage...")
+	_, _ = fmt.Fprintln(os.Stdout, "Building release tt with coverage...")
 
 	err := buildTt(appendFlags("-cover"), appendTags, appendLdFlags("-s", "-w"))
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stdout, `Set coverage data destination directory (must exist) and run tt:
+	_, _ = fmt.Fprintln(os.Stdout, `Set coverage data destination directory (must exist) and run tt:
 	GOCOVERDIR=./<coverage_dest_dir> tt <opts>`)
 	return nil
 }
 
 // CheckLicenses runs the license checker.
 func CheckLicenses() error {
-	fmt.Fprintln(os.Stdout, "Running license checker...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running license checker...")
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -240,7 +240,7 @@ func (Lint) Golang() error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "Running %s over %s...\n", linter, lintConfig)
+	_, _ = fmt.Fprintf(os.Stdout, "Running %s over %s...\n", linter, lintConfig)
 
 	root, err := os.Getwd()
 	if err != nil {
@@ -312,7 +312,7 @@ func linterVersionOf(exe string) (string, error) {
 
 // Python runs python linters.
 func (Lint) Python() error {
-	fmt.Fprintln(os.Stdout, "Running Ruff...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running Ruff...")
 
 	if err := sh.RunV(pythonExecutableName, "-m", "ruff", "check", "test"); err != nil {
 		return err
@@ -345,28 +345,28 @@ func runUnitTests(flags []string) error {
 
 // Default runs unit tests.
 func (Unit) Default() error {
-	fmt.Fprintln(os.Stdout, "Running unit tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running unit tests...")
 
 	return runUnitTests([]string{})
 }
 
 // Full runs unit tests with Tarantool instance integration.
 func (Unit) Full() error {
-	fmt.Fprintln(os.Stdout, "Running full unit tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running full unit tests...")
 
 	return runUnitTests([]string{"-tags", "integration,integration_docker"})
 }
 
 // FullSkipDocker runs unit tests with Tarantool instance integration, excluding docker tests.
 func (Unit) FullSkipDocker() error {
-	fmt.Fprintln(os.Stdout, "Running full unit tests, excluding docker...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running full unit tests, excluding docker...")
 
 	return runUnitTests([]string{"-tags", "integration"})
 }
 
 // Coverage runs the full unit test set with code coverage.
 func (Unit) Coverage() error {
-	fmt.Fprintln(os.Stdout, "Running full unit tests with code coverage...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running full unit tests with code coverage...")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -389,8 +389,8 @@ func (Unit) Coverage() error {
 	if err != nil {
 		relCoverDir = coverDir
 	}
-	fmt.Fprintf(os.Stdout, "Coverage data is saved to %q\n", relCoverDir)
-	fmt.Fprintf(os.Stdout, `Example command for analysis:
+	_, _ = fmt.Fprintf(os.Stdout, "Coverage data is saved to %q\n", relCoverDir)
+	_, _ = fmt.Fprintf(os.Stdout, `Example command for analysis:
 	go tool covdata func -i %q
 `, relCoverDir)
 
@@ -415,7 +415,7 @@ func ensureCoverageDir(coverDir string) error {
 
 // Integration runs integration tests, excluding slow tests.
 func Integration() error {
-	fmt.Fprintln(os.Stdout, "Running integration tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow and not slow_ee "+
 		"and not notarantool", "test/integration")
@@ -423,7 +423,7 @@ func Integration() error {
 
 // IntegrationFull runs the full set of integration tests.
 func IntegrationFull() error {
-	fmt.Fprintln(os.Stdout, "Running all integration tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running all integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "not slow_ee and not notarantool",
 		"test/integration")
@@ -431,7 +431,7 @@ func IntegrationFull() error {
 
 // IntegrationFullSkipDocker runs the full set of integration tests, excluding docker tests.
 func IntegrationFullSkipDocker() error {
-	fmt.Fprintln(os.Stdout, "Running all integration tests, excluding docker...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running all integration tests, excluding docker...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m",
 		"not slow_ee and not notarantool and not docker", "test/integration")
@@ -439,7 +439,7 @@ func IntegrationFullSkipDocker() error {
 
 // IntegrationFullDocker runs only docker tests from the full set.
 func IntegrationFullDocker() error {
-	fmt.Fprintln(os.Stdout, "Running docker integration tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running docker integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m",
 		"not slow_ee and not notarantool and docker", "test/integration")
@@ -447,14 +447,14 @@ func IntegrationFullDocker() error {
 
 // IntegrationEE runs the set of EE integration tests.
 func IntegrationEE() error {
-	fmt.Fprintln(os.Stdout, "Running all EE integration tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running all EE integration tests...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "test/integration/ee")
 }
 
 // IntegrationNoTarantool runs integration tests without a system-wide Tarantool installation.
 func IntegrationNoTarantool() error {
-	fmt.Fprintln(os.Stdout, "Running integration tests without Tarantool...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running integration tests without Tarantool...")
 
 	return sh.RunV(pythonExecutableName, "-m", "pytest", "-m", "notarantool",
 		"test/integration")
@@ -462,7 +462,7 @@ func IntegrationNoTarantool() error {
 
 // CodeSpell runs code spell checks.
 func CodeSpell() error {
-	fmt.Fprintln(os.Stdout, "Running code spell tests...")
+	_, _ = fmt.Fprintln(os.Stdout, "Running code spell tests...")
 
 	return sh.RunV("codespell", ".") // spell-checker:disable-line
 }
@@ -479,9 +479,9 @@ func TestFull() {
 
 // Clean cleans up the directory.
 func Clean() {
-	fmt.Fprintln(os.Stdout, "Cleaning directory...")
+	_, _ = fmt.Fprintln(os.Stdout, "Cleaning directory...")
 
-	os.Remove(ttExecutableName)
+	_ = os.Remove(ttExecutableName)
 }
 
 // Generate generates code as usual `go generate` command. To work properly you

--- a/magefile.publish.go
+++ b/magefile.publish.go
@@ -99,10 +99,11 @@ func getPatterns(distro Distro) ([]string, error) {
 
 // PublishRWS puts packages to RWS (Repository Web Service).
 func PublishRWS() error {
-	fmt.Fprintf(os.Stdout, "Publish packages to RWS...\n")
+	_, _ = fmt.Fprintf(os.Stdout, "Publish packages to RWS...\n")
 
 	for _, targetDistro := range targetDistros {
-		fmt.Fprintf(os.Stdout, "Publish package for %s/%s...\n", targetDistro.OS, targetDistro.Dist)
+		_, _ = fmt.Fprintf(os.Stdout, "Publish package for %s/%s...\n",
+			targetDistro.OS, targetDistro.Dist)
 
 		patterns, err := getPatterns(targetDistro)
 		if err != nil {
@@ -132,7 +133,7 @@ func PublishRWS() error {
 			flags = append(flags, "-F", fmt.Sprintf("%s=@./%s", filepath.Base(file), file))
 		}
 
-		fmt.Fprintf(os.Stdout, "curl flags (excluding secrets): %s\n", flags)
+		_, _ = fmt.Fprintf(os.Stdout, "curl flags (excluding secrets): %s\n", flags)
 
 		rwsAuth := os.Getenv("RWS_AUTH")
 		if rwsAuth == "" {

--- a/test/integration/aeon/server/service/server.go
+++ b/test/integration/aeon/server/service/server.go
@@ -50,7 +50,7 @@ func (s *Server) SQLStream(in *pb.SQLRequest, stream pb.SQLService_SQLStreamServ
 		return errSQLStreamRequestIsNil
 	}
 	res := makeSQLResponse(in.GetQuery())
-	stream.Send(&res)
+	_ = stream.Send(&res)
 	return nil
 }
 


### PR DESCRIPTION
- Enable: errcheck, wrapcheck, goconst, testifylint, varnamelen, depguard, noinlineerr, exhaustruct_v5, gosec, testpackage, wsl_v5
- Keep intentionally disabled: 
  - paralleltest, tparallel
  - deprecated exhaustruct, replaced by exhaustruct_v5
  - deprecated gomodguard, replaced by gomodguard_v2
  - deprecated wsl, replaced by wsl_v5
- Explicitly acknowledge intentionally ignored return values.
- Avoid redundant wrapping at internal tt package boundaries.
- Retain focused compatibility exclusions for existing manifest fixtures and findings introduced by the golangci-lint 2.13.2 upgrade.

Closes TNTP-9993